### PR TITLE
Configure GitHub Actions to run Super-Linter

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,4 @@
+[flake8]
+max-line-length = 120
+ignore =
+    E231  # There should be whitespace after the characters ,, ;, and :. black; fixed in black 20 (https://github.com/psf/black/issues/1289)

--- a/.github/workflows/superlinter.yml
+++ b/.github/workflows/superlinter.yml
@@ -1,0 +1,25 @@
+name: Super-Linter
+
+# Run this workflow every time a new commit pushed to your repository
+on: push
+
+jobs:
+  # Set the job key. The key is displayed as the job name
+  # when a job name is not provided
+  super-lint:
+    # Name the Job
+    name: Lint code base
+    # Set the type of machine to run on
+    runs-on: ubuntu-latest
+
+    steps:
+      # Checks out a copy of your repository on the ubuntu-latest machine
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      # Runs the Super-Linter action
+      - name: Run Super-Linter
+        uses: github/super-linter@v3
+        env:
+          DEFAULT_BRANCH: main
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/superlinter.yml
+++ b/.github/workflows/superlinter.yml
@@ -23,3 +23,4 @@ jobs:
         env:
           DEFAULT_BRANCH: main
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          LINTER_RULES_PATH: /

--- a/.github/workflows/superlinter.yml
+++ b/.github/workflows/superlinter.yml
@@ -1,6 +1,6 @@
 name: Super-Linter
 
-# Run this workflow every time a new commit pushed to your repository
+# Run this workflow every time a new commit is pushed to your repository
 on: push
 
 jobs:

--- a/.isort.cfg
+++ b/.isort.cfg
@@ -4,7 +4,7 @@ profile=
 ; vertical hanging indent mode also used in black configuration
 multi_line_output = 3
 
-; necessary because black expect the trailing comma
+; necessary because black expects the trailing comma
 include_trailing_comma = true
 
 ; include our Django apps as first part

--- a/.isort.cfg
+++ b/.isort.cfg
@@ -1,0 +1,11 @@
+[settings]
+profile=
+
+; vertical hanging indent mode also used in black configuration
+multi_line_output = 3
+
+; necessary because black expect the trailing comma
+include_trailing_comma = true
+
+; include our Django apps as first part
+known_first_party = TraceBase,DataRepo

--- a/.markdown-lint.yml
+++ b/.markdown-lint.yml
@@ -1,0 +1,35 @@
+---
+###########################
+###########################
+## Markdown Linter rules ##
+###########################
+###########################
+
+# Linter rules doc:
+# - https://github.com/DavidAnson/markdownlint
+#
+# Note:
+# To comment out a single error:
+#   <!-- markdownlint-disable -->
+#   any violations you want
+#   <!-- markdownlint-restore -->
+#
+
+###############
+# Rules by id #
+###############
+MD004: false                  # Unordered list style
+MD007:
+  indent: 2                   # Unordered list indentation
+MD013:
+  line_length: 400            # Line length 80 is far to short
+MD026:
+  punctuation: ".,;:!。，；:"  # List of not allowed
+MD029: false                  # Ordered list item prefix
+MD033: false                  # Allow inline HTML
+MD036: false                  # Emphasis used instead of a heading
+
+#################
+# Rules by tags #
+#################
+blank_lines: false  # Error on blank lines

--- a/.markdown-lint.yml
+++ b/.markdown-lint.yml
@@ -22,7 +22,7 @@ MD004: false                  # Unordered list style
 MD007:
   indent: 2                   # Unordered list indentation
 MD013:
-  line_length: 400            # Line length 80 is far to short
+  line_length: 400            # Line length 80 is far too short
 MD026:
   punctuation: ".,;:!。，；:"  # List of not allowed
 MD029: false                  # Ordered list item prefix

--- a/.pylintrc
+++ b/.pylintrc
@@ -1,0 +1,1 @@
+.python-lint

--- a/.python-lint
+++ b/.python-lint
@@ -1,0 +1,544 @@
+[MASTER]
+errors-only=
+
+# A comma-separated list of package or module names from where C extensions may
+# be loaded. Extensions are loading into the active Python interpreter and may
+# run arbitrary code
+extension-pkg-whitelist=
+
+# Add files or directories to the blacklist. They should be base names, not
+# paths.
+ignore=CVS
+
+# Add files or directories matching the regex patterns to the blacklist. The
+# regex matches against base names, not paths.
+ignore-patterns=
+
+# Python code to execute, usually for sys.path manipulation such as
+# pygtk.require().
+#init-hook=
+
+# Use multiple processes to speed up Pylint.
+jobs=1
+
+# List of plugins (as comma separated values of python modules names) to load,
+# usually to register additional checkers.
+load-plugins=
+
+# Pickle collected data for later comparisons.
+persistent=yes
+
+# Specify a configuration file.
+#rcfile=
+
+# When enabled, pylint would attempt to guess common misconfiguration and emit
+# user-friendly hints instead of false-positive error messages
+suggestion-mode=yes
+
+# Allow loading of arbitrary C extensions. Extensions are imported into the
+# active Python interpreter and may run arbitrary code.
+unsafe-load-any-extension=no
+
+
+[MESSAGES CONTROL]
+
+# Only show warnings with the listed confidence levels. Leave empty to show
+# all. Valid levels: HIGH, INFERENCE, INFERENCE_FAILURE, UNDEFINED
+confidence=
+
+# Disable the message, report, category or checker with the given id(s). You
+# can either give multiple identifiers separated by comma (,) or put this
+# option multiple times (only on the command line, not in the configuration
+# file where it should appear only once).You can also use "--disable=all" to
+# disable everything first and then reenable specific checks. For example, if
+# you want to run only the similarities checker, you can use "--disable=all
+# --enable=similarities". If you want to run only the classes checker, but have
+# no Warning level messages displayed, use"--disable=all --enable=classes
+# --disable=W"
+disable=print-statement,
+        parameter-unpacking,
+        unpacking-in-except,
+        old-raise-syntax,
+        backtick,
+        long-suffix,
+        old-ne-operator,
+        old-octal-literal,
+        import-star-module-level,
+        non-ascii-bytes-literal,
+        raw-checker-failed,
+        bad-inline-option,
+        locally-disabled,
+        locally-enabled,
+        file-ignored,
+        suppressed-message,
+        useless-suppression,
+        deprecated-pragma,
+        apply-builtin,
+        basestring-builtin,
+        buffer-builtin,
+        cmp-builtin,
+        coerce-builtin,
+        execfile-builtin,
+        file-builtin,
+        long-builtin,
+        raw_input-builtin,
+        reduce-builtin,
+        standarderror-builtin,
+        unicode-builtin,
+        xrange-builtin,
+        coerce-method,
+        delslice-method,
+        getslice-method,
+        setslice-method,
+        no-absolute-import,
+        old-division,
+        dict-iter-method,
+        dict-view-method,
+        next-method-called,
+        metaclass-assignment,
+        indexing-exception,
+        raising-string,
+        reload-builtin,
+        oct-method,
+        hex-method,
+        nonzero-method,
+        cmp-method,
+        input-builtin,
+        round-builtin,
+        intern-builtin,
+        unichr-builtin,
+        map-builtin-not-iterating,
+        zip-builtin-not-iterating,
+        range-builtin-not-iterating,
+        filter-builtin-not-iterating,
+        using-cmp-argument,
+        eq-without-hash,
+        div-method,
+        idiv-method,
+        rdiv-method,
+        exception-message-attribute,
+        invalid-str-codec,
+        sys-max-int,
+        bad-python3-import,
+        deprecated-string-function,
+        deprecated-str-translate-call,
+        deprecated-itertools-function,
+        deprecated-types-field,
+        next-method-defined,
+        dict-items-not-iterating,
+        dict-keys-not-iterating,
+        dict-values-not-iterating,
+        import-error
+
+# Enable the message, report, category or checker with the given id(s). You can
+# either give multiple identifier separated by comma (,) or put this option
+# multiple time (only on the command line, not in the configuration file where
+# it should appear only once). See also the "--disable" option for examples.
+enable=c-extension-no-member
+
+
+[REPORTS]
+
+# Python expression which should return a note less than 10 (10 is the highest
+# note). You have access to the variables errors warning, statement which
+# respectively contain the number of errors / warnings messages and the total
+# number of statements analyzed. This is used by the global evaluation report
+# (RP0004).
+evaluation=10.0 - ((float(5 * error + warning + refactor + convention) / statement) * 10)
+
+# Template used to display messages. This is a python new-style format string
+# used to format the message information. See doc for all details
+#msg-template=
+
+# Set the output format. Available formats are text, parseable, colorized, json
+# and msvs (visual studio).You can also give a reporter class, eg
+# mypackage.mymodule.MyReporterClass.
+output-format=text
+
+# Tells whether to display a full report or only the messages
+reports=no
+
+# Activate the evaluation score.
+score=no
+
+
+[REFACTORING]
+
+# Maximum number of nested blocks for function / method body
+max-nested-blocks=5
+
+# Complete name of functions that never returns. When checking for
+# inconsistent-return-statements if a never returning function is called then
+# it will be considered as an explicit return statement and no message will be
+# printed.
+never-returning-functions=optparse.Values,sys.exit
+
+
+[VARIABLES]
+
+# List of additional names supposed to be defined in builtins. Remember that
+# you should avoid to define new builtins when possible.
+additional-builtins=
+
+# Tells whether unused global variables should be treated as a violation.
+allow-global-unused-variables=yes
+
+# List of strings which can identify a callback function by name. A callback
+# name must start or end with one of those strings.
+callbacks=cb_,
+          _cb
+
+# A regular expression matching the name of dummy variables (i.e. expectedly
+# not used).
+dummy-variables-rgx=_+$|(_[a-zA-Z0-9_]*[a-zA-Z0-9]+?$)|dummy|^ignored_|^unused_
+
+# Argument names that match this expression will be ignored. Default to name
+# with leading underscore
+ignored-argument-names=_.*|^ignored_|^unused_
+
+# Tells whether we should check for unused import in __init__ files.
+init-import=no
+
+# List of qualified module names which can have objects that can redefine
+# builtins.
+redefining-builtins-modules=six.moves,past.builtins,future.builtins
+
+
+[LOGGING]
+
+# Logging modules to check that the string format arguments are in logging
+# function parameter format
+logging-modules=logging
+
+
+[TYPECHECK]
+
+# List of decorators that produce context managers, such as
+# contextlib.contextmanager. Add to this list to register other decorators that
+# produce valid context managers.
+contextmanager-decorators=contextlib.contextmanager
+
+# List of members which are set dynamically and missed by pylint inference
+# system, and so shouldn't trigger E1101 when accessed. Python regular
+# expressions are accepted.
+generated-members=
+
+# Tells whether missing members accessed in mixin class should be ignored. A
+# mixin class is detected if its name ends with "mixin" (case insensitive).
+ignore-mixin-members=yes
+
+# This flag controls whether pylint should warn about no-member and similar
+# checks whenever an opaque object is returned when inferring. The inference
+# can return multiple potential results while evaluating a Python object, but
+# some branches might not be evaluated, which results in partial inference. In
+# that case, it might be useful to still emit no-member and other checks for
+# the rest of the inferred objects.
+ignore-on-opaque-inference=yes
+
+# List of class names for which member attributes should not be checked (useful
+# for classes with dynamically set attributes). This supports the use of
+# qualified names.
+ignored-classes=optparse.Values,thread._local,_thread._local
+
+# List of module names for which member attributes should not be checked
+# (useful for modules/projects where namespaces are manipulated during runtime
+# and thus existing member attributes cannot be deduced by static analysis. It
+# supports qualified module names, as well as Unix pattern matching.
+ignored-modules=
+
+# Show a hint with possible names when a member name was not found. The aspect
+# of finding the hint is based on edit distance.
+missing-member-hint=yes
+
+# The minimum edit distance a name should have in order to be considered a
+# similar match for a missing member name.
+missing-member-hint-distance=1
+
+# The total number of similar names that should be taken in consideration when
+# showing a hint for a missing member.
+missing-member-max-choices=1
+
+
+[MISCELLANEOUS]
+
+# List of note tags to take in consideration, separated by a comma.
+notes=FIXME,
+      XXX,
+      TODO
+
+
+[BASIC]
+
+# Naming style matching correct argument names
+argument-naming-style=snake_case
+
+# Regular expression matching correct argument names. Overrides argument-
+# naming-style
+#argument-rgx=
+
+# Naming style matching correct attribute names
+attr-naming-style=snake_case
+
+# Regular expression matching correct attribute names. Overrides attr-naming-
+# style
+#attr-rgx=
+
+# Bad variable names which should always be refused, separated by a comma
+bad-names=foo,
+          bar,
+          baz,
+          toto,
+          tutu,
+          tata
+
+# Naming style matching correct class attribute names
+class-attribute-naming-style=any
+
+# Regular expression matching correct class attribute names. Overrides class-
+# attribute-naming-style
+#class-attribute-rgx=
+
+# Naming style matching correct class names
+class-naming-style=PascalCase
+
+# Regular expression matching correct class names. Overrides class-naming-style
+#class-rgx=
+
+# Naming style matching correct constant names
+const-naming-style=UPPER_CASE
+
+# Regular expression matching correct constant names. Overrides const-naming-
+# style
+#const-rgx=
+
+# Minimum line length for functions/classes that require docstrings, shorter
+# ones are exempt.
+docstring-min-length=-1
+
+# Naming style matching correct function names
+function-naming-style=snake_case
+
+# Regular expression matching correct function names. Overrides function-
+# naming-style
+#function-rgx=
+
+# Good variable names which should always be accepted, separated by a comma
+good-names=i,
+            j,
+            k,
+            ex,
+            Run,
+            _
+
+# Include a hint for the correct naming format with invalid-name
+include-naming-hint=no
+
+# Naming style matching correct inline iteration names
+inlinevar-naming-style=any
+
+# Regular expression matching correct inline iteration names. Overrides
+# inlinevar-naming-style
+#inlinevar-rgx=
+
+# Naming style matching correct method names
+method-naming-style=snake_case
+
+# Regular expression matching correct method names. Overrides method-naming-
+# style
+#method-rgx=
+
+# Naming style matching correct module names
+module-naming-style=snake_case
+
+# Regular expression matching correct module names. Overrides module-naming-
+# style
+#module-rgx=
+
+# Colon-delimited sets of names that determine each other's naming style when
+# the name regexes allow several styles.
+name-group=
+
+# Regular expression which should only match function or class names that do
+# not require a docstring.
+no-docstring-rgx=^_
+
+# List of decorators that produce properties, such as abc.abstractproperty. Add
+# to this list to register other decorators that produce valid properties.
+property-classes=abc.abstractproperty
+
+# Naming style matching correct variable names
+variable-naming-style=snake_case
+
+# Regular expression matching correct variable names. Overrides variable-
+# naming-style
+#variable-rgx=
+
+
+[SPELLING]
+
+# Limits count of emitted suggestions for spelling mistakes
+max-spelling-suggestions=4
+
+# Spelling dictionary name. Available dictionaries: none. To make it working
+# install python-enchant package.
+spelling-dict=
+
+# List of comma separated words that should not be checked.
+spelling-ignore-words=
+
+# A path to a file that contains private dictionary; one word per line.
+spelling-private-dict-file=
+
+# Tells whether to store unknown words to indicated private dictionary in
+# --spelling-private-dict-file option instead of raising a message.
+spelling-store-unknown-words=no
+
+
+[FORMAT]
+
+# Expected format of line ending, e.g. empty (any line ending), LF or CRLF.
+expected-line-ending-format=
+
+# Regexp for a line that is allowed to be longer than the limit.
+ignore-long-lines=^\s*(# )?<?https?://\S+>?$
+
+# Number of spaces of indent required inside a hanging  or continued line.
+indent-after-paren=4
+
+# String used as indentation unit. This is usually "    " (4 spaces) or "\t" (1
+# tab).
+indent-string='    '
+
+# Maximum number of characters on a single line.
+max-line-length=100
+
+# Maximum number of lines in a module
+max-module-lines=1000
+
+# List of optional constructs for which whitespace checking is disabled. `dict-
+# separator` is used to allow tabulation in dicts, etc.: {1  : 1,\n222: 2}.
+# `trailing-comma` allows a space between comma and closing bracket: (a, ).
+# `empty-line` allows space-only lines.
+no-space-check=trailing-comma,dict-separator
+
+# Allow the body of a class to be on the same line as the declaration if body
+# contains single statement.
+single-line-class-stmt=no
+
+# Allow the body of an if to be on the same line as the test if there is no
+# else.
+single-line-if-stmt=no
+
+
+[SIMILARITIES]
+
+# Ignore comments when computing similarities.
+ignore-comments=yes
+
+# Ignore docstrings when computing similarities.
+ignore-docstrings=yes
+
+# Ignore imports when computing similarities.
+ignore-imports=no
+
+# Minimum lines number of a similarity.
+min-similarity-lines=4
+
+
+[DESIGN]
+
+# Maximum number of arguments for function / method
+max-args=5
+
+# Maximum number of attributes for a class (see R0902).
+max-attributes=7
+
+# Maximum number of boolean expressions in a if statement
+max-bool-expr=5
+
+# Maximum number of branch for function / method body
+max-branches=12
+
+# Maximum number of locals for function / method body
+max-locals=15
+
+# Maximum number of parents for a class (see R0901).
+max-parents=7
+
+# Maximum number of public methods for a class (see R0904).
+max-public-methods=20
+
+# Maximum number of return / yield for function / method body
+max-returns=6
+
+# Maximum number of statements in function / method body
+max-statements=50
+
+# Minimum number of public methods for a class (see R0903).
+min-public-methods=2
+
+
+[IMPORTS]
+
+# Allow wildcard imports from modules that define __all__.
+allow-wildcard-with-all=no
+
+# Analyse import fallback blocks. This can be used to support both Python 2 and
+# 3 compatible code, which means that the block might have code that exists
+# only in one or another interpreter, leading to false positives when analysed.
+analyse-fallback-blocks=no
+
+# Deprecated modules which should not be used, separated by a comma
+deprecated-modules=regsub,
+                  TERMIOS,
+                  Bastion,
+                  rexec
+
+# Create a graph of external dependencies in the given file (report RP0402 must
+# not be disabled)
+ext-import-graph=
+
+# Create a graph of every (i.e. internal and external) dependencies in the
+# given file (report RP0402 must not be disabled)
+import-graph=
+
+# Create a graph of internal dependencies in the given file (report RP0402 must
+# not be disabled)
+int-import-graph=
+
+# Force import order to recognize a module as part of the standard
+# compatibility libraries.
+known-standard-library=
+
+# Force import order to recognize a module as part of a third party library.
+known-third-party=enchant
+
+
+[CLASSES]
+
+# List of method names used to declare (i.e. assign) instance attributes.
+defining-attr-methods=__init__,
+                      __new__,
+                      setUp
+
+# List of member names, which should be excluded from the protected access
+# warning.
+exclude-protected=_asdict,
+                  _fields,
+                  _replace,
+                  _source,
+                  _make
+
+# List of valid names for the first argument in a class method.
+valid-classmethod-first-arg=cls
+
+# List of valid names for the first argument in a metaclass class method.
+valid-metaclass-classmethod-first-arg=mcs
+
+
+[EXCEPTIONS]
+
+# Exceptions that will emit a warning when being caught. Defaults to
+# "Exception"
+overgeneral-exceptions=Exception
+

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -104,7 +104,7 @@ Then go to this site in your web browser:
 
 All Pull Requests must pass linting prior to being merged.
 
-Currently, linting is using by [GitHub's
+Currently, all pushed are linted using [GitHub's
 Super-Linter](https://github.com/github/super-linter). The configuration files
 for the most used linters have been setup in the project root to facilitate
 linting on developers machines. These include:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,8 +1,13 @@
-This document described the basics of how to set up the TraceBase Project Repo in order to start developing/contributing.
+# Contributing to the TraceBase project
 
-# Requirements
+This document described the basics of how to set up the TraceBase Project Repo
+in order to start developing/contributing.
 
-## Python
+## Getting Started
+
+### Install Python and Postgres Dependencies
+
+#### Python
 
 Install the latest Python (version 3.9.1), and make sure it is in your path:
 
@@ -14,9 +19,12 @@ Test to make sure that the `python` command now shows your latest python install
     $ python --version
     Python 3.9.1
 
-## Postgres
+#### Postgres
 
-Install Postgres via package installer from https://www.postgresql.org.  Be sure to make note of where it installes the `psql` command line utility, so you can add it to your PATH, e.g. if you see:
+Install Postgres via package installer from
+[https://www.postgresql.org](https://www.postgresql.org).  Be sure to make note
+of where it installs the `psql` command line utility, so you can add it to your
+PATH, e.g. if you see:
 
     Command Line Tools Installation Directory: /Library/PostgreSQL/13
 
@@ -30,7 +38,9 @@ Configuration:
     Password: tracebase
     Port: 5432
 
-In the Postgres app interface, you can find where the `postgresql.conf` file is located.  Open it in a text editor and make sure these settings are uncommented & correct:
+In the Postgres app interface, you can find where the `postgresql.conf` file is
+located.  Open it in a text editor and make sure these settings are uncommented
+& correct:
 
     client_encoding: 'UTF8'
     default_transaction_isolation: 'read committed'
@@ -46,24 +56,28 @@ Create a tracebase postgres user:
     > create user tracebase with encrypted password 'mypass';
     > grant all privileges on database tracebase to tracebase;
 
-## Clone the repository
+### Setup the TraceBase project
+
+#### Clone the repository
 
     git clone https://github.com/Princeton-LSI-ResearchComputing/tracebase.git
     cd tracebase
 
-## Virtual Environment
+#### Create a virtual environment
 
 Create a virtual environment (from a bash shell) and activate it, for example:
 
     python3 -m venv .venv
     source .venv/bin/activate
 
-Install Django and psycopg2 dependencies
+Install Django and psycopg2 dependencies as well as linters and other
+development related tools. Use `requirements/prod.txt` for production
+dependencies.
 
     python -m pip install -U pip  # Upgrade pip
-    pip install -r requirements.txt  # Install requirements
+    python -m pip install -r requirements/dev.txt  # Install requirements
 
-## Verify Installations
+#### Verify Installations
 
 Django:
 
@@ -72,11 +86,7 @@ Django:
     > print(django.get_version())
     3.1.6
 
-Postgres:
-
-    psql -U postgres
-
-## Setup TraceBase and run the development server
+### Start TraceBase
 
 Set up the project's postgres database:
 
@@ -89,3 +99,18 @@ Verify you can run the development server.  Run:
 Then go to this site in your web browser:
 
     http://127.0.0.1:8000/
+
+## Code Formatting Standards
+
+All Pull Requests must pass linting prior to being merged.
+
+Currently, linting is using by [GitHub's
+Super-Linter](https://github.com/github/super-linter). The configuration files
+for the most used linters have been setup in the project root to facilitate
+linting on developers machines. These include:
+
+* [Markdown-lint](https://github.com/igorshubovych/markdownlint-cli#readme) - `.markdown-lint.yml`
+* [Flake8](https://flake8.pycqa.org/en/latest/) - `.flake8`
+* [Pylint](https://www.pylint.org/) - `.python-lint` -> `.pylintrc`
+* [Black](https://black.readthedocs.io/en/stable/) - `.python-black`
+* [isort](https://pycqa.github.io/isort/) - `.isort.cfg`

--- a/DataRepo/admin.py
+++ b/DataRepo/admin.py
@@ -1,3 +1,3 @@
-from django.contrib import admin
+# from django.contrib import admin
 
 # Register your models here.

--- a/DataRepo/apps.py
+++ b/DataRepo/apps.py
@@ -2,4 +2,4 @@ from django.apps import AppConfig
 
 
 class DatarepoConfig(AppConfig):
-    name = 'DataRepo'
+    name = "DataRepo"

--- a/DataRepo/models.py
+++ b/DataRepo/models.py
@@ -1,3 +1,3 @@
-from django.db import models
+# from django.db import models
 
 # Create your models here.

--- a/DataRepo/tests.py
+++ b/DataRepo/tests.py
@@ -1,3 +1,3 @@
-from django.test import TestCase
+# from django.test import TestCase
 
 # Create your tests here.

--- a/DataRepo/urls.py
+++ b/DataRepo/urls.py
@@ -3,5 +3,5 @@ from django.urls import path
 from . import views
 
 urlpatterns = [
-    path('', views.index, name='index'),
+    path("", views.index, name="index"),
 ]

--- a/DataRepo/views.py
+++ b/DataRepo/views.py
@@ -1,10 +1,11 @@
-from django.shortcuts import render
-
 from django.http import HttpResponse
+
+# from django.shortcuts import render
 
 
 def index(request):
     return HttpResponse("Hello, world. You're at the DataRepo index.")
+
 
 def home(request):
     return HttpResponse("Hello, world. You're at the DataRepo Home.")

--- a/README.md
+++ b/README.md
@@ -1,2 +1,3 @@
-# tracebase
+# TraceBase
+
 Mouse Metabolite Tracing Data Repository for the Rabinowitz Lab

--- a/TraceBase/asgi.py
+++ b/TraceBase/asgi.py
@@ -11,6 +11,6 @@ import os
 
 from django.core.asgi import get_asgi_application
 
-os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'TraceBase.settings')
+os.environ.setdefault("DJANGO_SETTINGS_MODULE", "TraceBase.settings")
 
 application = get_asgi_application()

--- a/TraceBase/settings.py
+++ b/TraceBase/settings.py
@@ -20,7 +20,7 @@ BASE_DIR = Path(__file__).resolve().parent.parent
 # See https://docs.djangoproject.com/en/3.1/howto/deployment/checklist/
 
 # SECURITY WARNING: keep the secret key used in production secret!
-SECRET_KEY = '3ape(s8i7@l!#*s0qi-cg_oxv=n%uf-6&)xd2zdd5n5@om)fx$'
+SECRET_KEY = "3ape(s8i7@l!#*s0qi-cg_oxv=n%uf-6&)xd2zdd5n5@om)fx$"
 
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = True
@@ -31,57 +31,57 @@ ALLOWED_HOSTS = []
 # Application definition
 
 INSTALLED_APPS = [
-    'DataRepo.apps.DatarepoConfig',
-    'django.contrib.admin',
-    'django.contrib.auth',
-    'django.contrib.contenttypes',
-    'django.contrib.sessions',
-    'django.contrib.messages',
-    'django.contrib.staticfiles',
+    "DataRepo.apps.DatarepoConfig",
+    "django.contrib.admin",
+    "django.contrib.auth",
+    "django.contrib.contenttypes",
+    "django.contrib.sessions",
+    "django.contrib.messages",
+    "django.contrib.staticfiles",
 ]
 
 MIDDLEWARE = [
-    'django.middleware.security.SecurityMiddleware',
-    'django.contrib.sessions.middleware.SessionMiddleware',
-    'django.middleware.common.CommonMiddleware',
-    'django.middleware.csrf.CsrfViewMiddleware',
-    'django.contrib.auth.middleware.AuthenticationMiddleware',
-    'django.contrib.messages.middleware.MessageMiddleware',
-    'django.middleware.clickjacking.XFrameOptionsMiddleware',
+    "django.middleware.security.SecurityMiddleware",
+    "django.contrib.sessions.middleware.SessionMiddleware",
+    "django.middleware.common.CommonMiddleware",
+    "django.middleware.csrf.CsrfViewMiddleware",
+    "django.contrib.auth.middleware.AuthenticationMiddleware",
+    "django.contrib.messages.middleware.MessageMiddleware",
+    "django.middleware.clickjacking.XFrameOptionsMiddleware",
 ]
 
-ROOT_URLCONF = 'TraceBase.urls'
+ROOT_URLCONF = "TraceBase.urls"
 
 TEMPLATES = [
     {
-        'BACKEND': 'django.template.backends.django.DjangoTemplates',
-        'DIRS': [],
-        'APP_DIRS': True,
-        'OPTIONS': {
-            'context_processors': [
-                'django.template.context_processors.debug',
-                'django.template.context_processors.request',
-                'django.contrib.auth.context_processors.auth',
-                'django.contrib.messages.context_processors.messages',
+        "BACKEND": "django.template.backends.django.DjangoTemplates",
+        "DIRS": [],
+        "APP_DIRS": True,
+        "OPTIONS": {
+            "context_processors": [
+                "django.template.context_processors.debug",
+                "django.template.context_processors.request",
+                "django.contrib.auth.context_processors.auth",
+                "django.contrib.messages.context_processors.messages",
             ],
         },
     },
 ]
 
-WSGI_APPLICATION = 'TraceBase.wsgi.application'
+WSGI_APPLICATION = "TraceBase.wsgi.application"
 
 
 # Database
 # https://docs.djangoproject.com/en/3.1/ref/settings/#databases
 
 DATABASES = {
-    'default': {
-        'ENGINE': 'django.db.backends.postgresql',
-        'NAME': 'tracebase',
-        'USER': 'tracebase',
-        'PASSWORD': 'tracebase',
-        'HOST': 'localhost',
-        'PORT': '5432'
+    "default": {
+        "ENGINE": "django.db.backends.postgresql",
+        "NAME": "tracebase",
+        "USER": "tracebase",
+        "PASSWORD": "tracebase",
+        "HOST": "localhost",
+        "PORT": "5432",
     }
 }
 
@@ -91,26 +91,20 @@ DATABASES = {
 
 AUTH_PASSWORD_VALIDATORS = [
     {
-        'NAME': 'django.contrib.auth.password_validation.UserAttributeSimilarityValidator',
+        "NAME": "django.contrib.auth.password_validation.UserAttributeSimilarityValidator",
     },
-    {
-        'NAME': 'django.contrib.auth.password_validation.MinimumLengthValidator',
-    },
-    {
-        'NAME': 'django.contrib.auth.password_validation.CommonPasswordValidator',
-    },
-    {
-        'NAME': 'django.contrib.auth.password_validation.NumericPasswordValidator',
-    },
+    {"NAME": "django.contrib.auth.password_validation.MinimumLengthValidator",},
+    {"NAME": "django.contrib.auth.password_validation.CommonPasswordValidator",},
+    {"NAME": "django.contrib.auth.password_validation.NumericPasswordValidator",},
 ]
 
 
 # Internationalization
 # https://docs.djangoproject.com/en/3.1/topics/i18n/
 
-LANGUAGE_CODE = 'en-us'
+LANGUAGE_CODE = "en-us"
 
-TIME_ZONE = 'America/New_York'
+TIME_ZONE = "America/New_York"
 
 USE_I18N = True
 
@@ -122,4 +116,4 @@ USE_TZ = True
 # Static files (CSS, JavaScript, Images)
 # https://docs.djangoproject.com/en/3.1/howto/static-files/
 
-STATIC_URL = '/static/'
+STATIC_URL = "/static/"

--- a/TraceBase/urls.py
+++ b/TraceBase/urls.py
@@ -19,7 +19,7 @@ from django.urls import include, path
 from DataRepo import views
 
 urlpatterns = [
-    path('admin/', admin.site.urls),
-    path('',views.home, name='TraceBase Home'),
-    path('DataRepo/', include('DataRepo.urls'), name='TraceBase DataRepo'),
+    path("admin/", admin.site.urls),
+    path("", views.home, name="TraceBase Home"),
+    path("DataRepo/", include("DataRepo.urls"), name="TraceBase DataRepo"),
 ]

--- a/TraceBase/wsgi.py
+++ b/TraceBase/wsgi.py
@@ -11,6 +11,6 @@ import os
 
 from django.core.wsgi import get_wsgi_application
 
-os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'TraceBase.settings')
+os.environ.setdefault("DJANGO_SETTINGS_MODULE", "TraceBase.settings")
 
 application = get_wsgi_application()

--- a/manage.py
+++ b/manage.py
@@ -6,7 +6,7 @@ import sys
 
 def main():
     """Run administrative tasks."""
-    os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'TraceBase.settings')
+    os.environ.setdefault("DJANGO_SETTINGS_MODULE", "TraceBase.settings")
     try:
         from django.core.management import execute_from_command_line
     except ImportError as exc:
@@ -18,5 +18,5 @@ def main():
     execute_from_command_line(sys.argv)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-Django==3.1.6
-psycopg2-binary
+# Mirrors prod
+-r requirements/prod.txt

--- a/requirements/common.txt
+++ b/requirements/common.txt
@@ -1,0 +1,2 @@
+Django==3.1.6
+psycopg2-binary

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -1,0 +1,7 @@
+# Specifies only dev-specific requirements
+# But imports the common ones too
+-r common.txt
+flake8
+black==19.10b0
+isort
+pylint

--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -1,0 +1,3 @@
+# Specifies only prod-specific requirements
+# But imports the common ones too
+-r common.txt


### PR DESCRIPTION
This Pull Request sets up a GitHub Actions workflow that runs the GitHub Super-Linter on the entire codebase. It also formats the files according to the standards specified by the linters.

Super-Linter is a collection of `bash` scripts that run various "standard" linters for many different types of files. The hope is that this helps to:

* Prevent broken code from being uploaded to the default branch (main)
* Help establish coding best practices across multiple languages
* Build guidelines for code layout and format
* Automate the process to help streamline code reviews

The linters that are in use right now are:

* [Markdown-lint](https://github.com/igorshubovych/markdownlint-cli#readme) - `.markdown-lint.yml`
* [Flake8](https://flake8.pycqa.org/en/latest/) - `.flake8`
* [Pylint](https://www.pylint.org/) - `.python-lint` -> `.pylintrc`
* [Black](https://black.readthedocs.io/en/stable/) - `.python-black` - Note that `black` will actually reformat your code for you, so just run `black .` before committing to fix everything up.
* [isort](https://pycqa.github.io/isort/) - `.isort.cfg` - `isort` also automatically formats files for you (`isort .`)

The python linters can all be installed via `pip`. To make it simpler to install them on a development machine, this PR creates a `requirements/dev.txt` file that can be used to create a virtual environment with the linters installed in addition to the core dependencies. Using `requirements.txt` or `requirements/prod.txt` will install only those things needed for production.

Finally, the configuration for the linters is borrowed from Super-Linter which attempts to provide some "best-practices" and also help ensure the linters all get along. There are two changes to the defaults:

* `.isort.cfg`
    * Added config to include our Django apps as first party packages. For some reason running under Super-Linter didn't do this in GitHub actions.
* `.flake8`
    * ignore E231 There should be whitespace after the characters ,, ;, and :. black; fixed in black 20 (https://github.com/psf/black/issues/1289)