### PR TITLE
Setup GitHub Actions workflow to run Django tests

### DIFF
--- a/.github/workflows/tracebase-tests.yml
+++ b/.github/workflows/tracebase-tests.yml
@@ -1,0 +1,42 @@
+name: TraceBase Tests
+
+on: [push]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    services:
+      postgres:
+        image: postgres:10.8
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: tracebase
+        ports:
+          - 5432:5432
+        # needed because the postgres container does not provide a healthcheck
+        options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5
+    env:
+      DATABASE_NAME: tracebase
+      DATABASE_USER: postgres
+      DATABASE_PASSWORD: postgres 
+      DATABASE_HOST: 127.0.0.1
+      DATABASE_PORT: 5432
+    steps:
+    - uses: actions/checkout@v1
+    - name: Set up Python 3.7
+      uses: actions/setup-python@v1
+      with:
+        python-version: 3.7
+    - name: psycopg2 prerequisites
+      run: sudo apt-get install python-dev libpq-dev
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install -r requirements.txt
+    - name: Run migrations
+      run: python manage.py migrate
+    - name: Run tests
+      run: python manage.py test

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -54,6 +54,7 @@ Manually create the tracebase database (`tracebase`) in postgres:
 Create a tracebase postgres user:
 
     > create user tracebase with encrypted password 'mypass';
+    > ALTER USER tracebase CREATEDB;
     > grant all privileges on database tracebase to tracebase;
 
 ### Setup the TraceBase project

--- a/DataRepo/tests.py
+++ b/DataRepo/tests.py
@@ -1,3 +1,6 @@
-# from django.test import TestCase
+from django.test import TestCase
 
-# Create your tests here.
+
+class DummyTestCase(TestCase):
+    def test_nothing(self):
+        pass

--- a/TraceBase/settings.py
+++ b/TraceBase/settings.py
@@ -27,7 +27,7 @@ BASE_DIR = Path(__file__).resolve().parent.parent
 
 # Raises django's ImproperlyConfigured exception if SECRET_KEY not in os.environ
 # SECURITY WARNING: keep the secret key used in production secret!
-SECRET_KEY = env("SECRET_KEY")
+SECRET_KEY = env("SECRET_KEY", default="unsafe-secret-key")
 
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = True


### PR DESCRIPTION
Postgres service is setup and Django tests are run using `pytest-django` in a GitHub Action workflow on every push.

A dummy test was created to ensure that tests run properly, but real tests should be created for any new functionality. 

The Django tests create a new database for testing, thus the `tracebase` Postgres user must be granted privileges to create a database in order to run tests. This step was added to `CONTRIBUTING.md`.

For running on GitHub Actions, a default `SECRET_KEY` is used.