### PR TITLE
Fix Super Linter excludes

### DIFF
--- a/.github/workflows/superlinter.yml
+++ b/.github/workflows/superlinter.yml
@@ -24,4 +24,5 @@ jobs:
           DEFAULT_BRANCH: main
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           LINTER_RULES_PATH: /
+          IGNORE_GITIGNORED_FILES: true
           FILTER_REGEX_EXCLUDE: (\.pylintrc|\.github)

--- a/.github/workflows/superlinter.yml
+++ b/.github/workflows/superlinter.yml
@@ -24,4 +24,4 @@ jobs:
           DEFAULT_BRANCH: main
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           LINTER_RULES_PATH: /
-          FILTER_REGEX_EXCLUDE: (\.venv|__pycache__|migrations|\.pylintrc|.github)
+          FILTER_REGEX_EXCLUDE: (\.pylintrc|\.github)

--- a/.jscpd.json
+++ b/.jscpd.json
@@ -1,0 +1,12 @@
+{
+  "threshold": 0,
+  "reporters": [
+    "consoleFull"
+  ],
+  "ignore": [
+    "**/__snapshots__/**",
+    "**/migrations/**"
+  ],
+  "absolute": true
+}
+

--- a/.mypy.ini
+++ b/.mypy.ini
@@ -1,0 +1,7 @@
+# Global options:
+
+[mypy]
+ignore_missing_imports = True
+
+[mypy-DataRepo.*.migrations.*]
+ignore_errors = True

--- a/.python-black
+++ b/.python-black
@@ -1,1 +1,0 @@
-exclude = 'migrations'

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -135,7 +135,6 @@ linting on developers machines. These include:
 * [Markdown-lint](https://github.com/igorshubovych/markdownlint-cli#readme) - `.markdown-lint.yml`
 * [Flake8](https://flake8.pycqa.org/en/latest/) - `.flake8`
 * [Pylint](https://www.pylint.org/) - `.python-lint` -> `.pylintrc`
-* [Black](https://black.readthedocs.io/en/stable/) - `.python-black`
 * [isort](https://pycqa.github.io/isort/) - `.isort.cfg`
 
 #### Linting
@@ -168,7 +167,7 @@ It is recommended to run superlinter (described below) routinely or
 automatically before submitting a PR, but if you want a quick check while
 developing, you can run these example linting commands on the command line:
 
-    black --config .python-black .
+    black .
     isort .
     markdownlint .
     flake8 .

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -174,11 +174,13 @@ This is most easily accomplished using Docker.
     docker run \
         -e FILTER_REGEX_EXCLUDE="(\.pylintrc|\.github)" \
         -e LINTER_RULES_PATH="/" \
+        -e IGNORE_GITIGNORED_FILES=true \
         -e RUN_LOCAL=true \
         -v /full/path/to/tracebase/:/tmp/lint github/super-linter
 
-Note: The two options `FILTER_REGEX_EXCLUDE` and `LINTER_RULES_PATH` should
-match the settings in the GitHub Action in `.github/workflows/superlinter.yml`
+Note: The options `FILTER_REGEX_EXCLUDE`, `LINTER_RULES_PATH`, and
+`IGNORE_GITIGNORED_FILES` should match the settings in the GitHub Action in
+`.github/workflows/superlinter.yml`
 
 ### Testing
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -138,9 +138,12 @@ linting on developers machines. These include:
 * [Black](https://black.readthedocs.io/en/stable/) - `.python-black`
 * [isort](https://pycqa.github.io/isort/) - `.isort.cfg`
 
-#### Linting locally
+#### Linting
 
-##### Linting on the fly
+Linting for this project runs automatically on github when a PR is submitted,
+but this section describes how to lint your changes locally.
+
+##### Individual linters
 
 For the most commonly used linters (*e.g.* for python, html, and markdown
 files) it is recommended to install linters locally and run them in your
@@ -161,7 +164,18 @@ editor. Some linters that may be useful to install locally include:
   * [jscpd](https://github.com/kucherenko/jscpd) - Copy/paste detector for
     programming source code
 
-#### Running Superlinter locally
+It is recommended to run superlinter (described below) routinely or
+automatically before submitting a PR, but if you want a quick check while
+developing, you can run these example linting commands on the command line:
+
+    black --config .python-black .
+    isort .
+    markdownlint .
+    flake8 .
+    pylint TraceBase DataRepo *.py
+    dotenv-linter TraceBase DataRepo
+
+##### Superlinter
 
 In addition to linting files as you write them, developers may wish to [run
 Superlinter on the entire repository

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -138,21 +138,47 @@ linting on developers machines. These include:
 * [Black](https://black.readthedocs.io/en/stable/) - `.python-black`
 * [isort](https://pycqa.github.io/isort/) - `.isort.cfg`
 
-#### Linting
+#### Linting locally
 
-To lint prior to submitting a pull request, you may need to install
-`markdownlint` and `dotenv-linter`, linked above (the rest should have been
-installed in your environment (see Create a virtual environment)).  Then run:
+##### Linting on the fly
 
-    markdownlint .
-    flake8 .
-    pylint TraceBase DataRepo *.py
-    black .
-    isort .
-    dotenv-linter TraceBase DataRepo
+For the most commonly used linters (*e.g.* for python, html, and markdown
+files) it is recommended to install linters locally and run them in your
+editor. Some linters that may be useful to install locally include:
 
-`black` and `isort` will automatically fix any issues they find.  The others
-will require manual edits.
+* Python
+  * [Flake8](https://flake8.pycqa.org/en/latest/) - python style checker
+  * [Pylint](https://www.pylint.org/) - python code analysis
+  * [Black](https://black.readthedocs.io/en/stable/) - code formatter
+  * [isort](https://pycqa.github.io/isort/) - sort imports
+  * [mypy](https://mypy.readthedocs.io/) - static type checker
+* HTML
+  * [HTMLHint](https://htmlhint.com/) - static analysis for HTML
+* Markdown
+  * [Markdown-lint](https://github.com/igorshubovych/markdownlint-cli#readme)
+    \- style checker for Markdown
+* General
+  * [jscpd](https://github.com/kucherenko/jscpd) - Copy/paste detector for
+    programming source code
+
+#### Running Superlinter locally
+
+In addition to linting files as you write them, developers may wish to [run
+Superlinter on the entire repository
+locally](https://github.com/github/super-linter/blob/master/docs/run-linter-locally.md).
+This is most easily accomplished using Docker.
+
+    #!/usr/bin/env sh
+    docker pull github/super-linter:latest
+    
+    docker run \
+        -e FILTER_REGEX_EXCLUDE="(\.pylintrc|\.github)" \
+        -e LINTER_RULES_PATH="/" \
+        -e RUN_LOCAL=true \
+        -v /full/path/to/tracebase/:/tmp/lint github/super-linter
+
+Note: The two options `FILTER_REGEX_EXCLUDE` and `LINTER_RULES_PATH` should
+match the settings in the GitHub Action in `.github/workflows/superlinter.yml`
 
 ### Testing
 
@@ -165,8 +191,10 @@ the TestCase framework.
 
 See these resources for help implementing tests:
 
-* [Testing in Django (Part 1) - Best Practices and Examples](https://realpython.com/testing-in-django-part-1-best-practices-and-examples/)
-* [Django Tutorial Part 10: Testing a Django web application](https://developer.mozilla.org/en-US/docs/Learn/Server-side/Django/Testing)
+* [Testing in Django (Part 1) - Best Practices and
+  Examples](https://realpython.com/testing-in-django-part-1-best-practices-and-examples/)
+* [Django Tutorial Part 10: Testing a Django web
+  application](https://developer.mozilla.org/en-US/docs/Learn/Server-side/Django/Testing)
 
 #### Quality Control
 

--- a/TraceBase/settings.py
+++ b/TraceBase/settings.py
@@ -33,8 +33,6 @@ SECRET_KEY = env("SECRET_KEY", default="unsafe-secret-key")
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = True
 
-ALLOWED_HOSTS = []
-
 
 # Application definition
 

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -5,3 +5,4 @@ flake8
 black==20.8b1
 isort
 pylint
+mypy


### PR DESCRIPTION
## Summary Change Description

Having the `.github` regular expression seemed to exclude all files from linting, instead `\.github` is used.

Super Linter ignores files in the `.gitignore` by default now, so some exclusions were not needed (`.venv`, `__pycache__`)

Running linters on all python files (including migrations) does not cause any harm, and simplifies the configuration, thus `migrations` is no longer excluded.

There are two exceptions to this, the `jscpd` and `mypy` linters do complain about the migrations, thus they are configured to ignore those files.

## Affected Issue Numbers

None

## Code Review Notes

There was considerable duplication in `tests.py` which caused jscpd to complain, thus the tests for sample related data was consolidated into a single setup method with multiple test functions instead of spread over various classes.

Since the files in the `migrations` folder are generated, I don't feel that running static type checking or copy/paste detection is necessary. This PR excludes `migrations` from just those two linters, allowing other thinks like `flake8` and `black` to run on those files. Running some linting on the `migrations` folder could be useful if we ever have to write custom code in the migrations.

Both `mypy` and `jscpd` are recent additions to Superlinter, and I feel warrant some discussion:

* Static type checking with `mypy` is a somewhat new, and optional part of python. For the most part, `mypy` won't complain about code that does use static type checking. Running it regularly gives us the option to add it gradually to the codebase. While I haven't used it before, I feel it's worth learning and using, at least in some cases. RealPython has a fairly good [introduction to static type checking in Python](https://realpython.com/python-type-checking/) that includes some pros and cons of using it. I feel there is very little downside to including `mypy` in the linting, with some potential benefits.
* Copy/Paste detection with `jscpd` has the potential to help us avoid maintenance issues and bugs down the line by ensuring there aren't large blocks of copy/pasted code. I feel that this check, is in general, rather beneficial. To me, it would be ideal to run the copy/paste detection and then have to justify any sections that fail. If devs agree, we can always use some [ignore comments](https://www.npmjs.com/package/jscpd#ignored-blocks) to allow specific sections to pass. 

I see a few options:
1. Turn off `mypy` and `jscpd` entirely, but setting `VALIDATE_JSCPD` and `VALIDATE_PYTHON_MYPY` to `false`.
2. Turn off `mypy` and `jscpd` for just the `migrations` folder by editing the individual linter config files. This is what I've done in this PR.
3. Allow all linters to lint the `migrations` folder and either fix any `mypy` warnings or add some `ignore` blocks for `jscpd`. 
 
## Checklist

- [x] All issue requirements satisfied (or no linked issues)
- [x] [Linting passes](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#linting).
- [x] [Migrations created & committed *(or no model changes)*](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#migration-process)
- [x] [Tests implemented *(or no code changes)*](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#test-implementation)
- [x] [All tests pass](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#quality-control)
