### PR TITLE
Restore linting to .github directory

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -7,6 +7,7 @@ assignees: ''
 
 ---
 
+<!-- markdownlint-disable-next-line first-line-heading -->
 ## BUG DESCRIPTION
 
 ### Problem

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -7,6 +7,7 @@ assignees: ''
 
 ---
 
+<!-- markdownlint-disable-next-line first-line-heading -->
 ## FEATURE DESCRIPTION
 
 ### Feature Inspiration

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,3 +1,4 @@
+<!-- markdownlint-disable-next-line first-line-heading -->
 ## Summary Change Description
 
 Briefly describe the changes in this pull request (not intended as a full

--- a/.github/workflows/superlinter.yml
+++ b/.github/workflows/superlinter.yml
@@ -25,4 +25,4 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           LINTER_RULES_PATH: /
           IGNORE_GITIGNORED_FILES: true
-          FILTER_REGEX_EXCLUDE: (\.pylintrc|\.github)
+          FILTER_REGEX_EXCLUDE: (\.pylintrc)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -185,7 +185,7 @@ This is most easily accomplished using Docker.
     docker pull github/super-linter:latest
 
     docker run \
-        -e FILTER_REGEX_EXCLUDE="(\.pylintrc|\.github)" \
+        -e FILTER_REGEX_EXCLUDE="(\.pylintrc)" \
         -e LINTER_RULES_PATH="/" \
         -e IGNORE_GITIGNORED_FILES=true \
         -e RUN_LOCAL=true \


### PR DESCRIPTION
## Summary Change Description

Comments were added to to have `markdownlint` skip the MD041
first-line-heading errors on the github issues and pr templates. This
allows us to have the rest of the templates linted and explicitly
indicates the exception we decided to make. It also simplifies to the
superlinter config.

## Affected Issue Numbers

None

## Code Review Notes

None

## Checklist

- [x] All issue requirements satisfied (or no linked issues)
- [x] [Linting passes](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#linting).
- [x] [Migrations created & committed *(or no model changes)*](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#migration-process)
- [x] [Tests implemented *(or no code changes)*](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#test-implementation)
- [x] [All tests pass](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#quality-control)
