### PR TITLE
Upgrade Django to 3.1.8

### DIFF
--- a/requirements/common.txt
+++ b/requirements/common.txt
@@ -1,4 +1,4 @@
-Django==3.1.6
+Django==3.1.8
 psycopg2-binary
 django-environ
 django-validators


### PR DESCRIPTION
## Summary Change Description

Upgrade to patched version of Django 3.1.8
Address [CVE-2021-28658](https://github.com/advisories/GHSA-xgxc-v2qg-chmh)

Developers should update their virtual environment:

    pip install -r requirements/dev.txt

## Affected Issue Numbers

None

## Code Review Notes

None

## Checklist

- [x] All issue requirements satisfied (or no linked issues)
- [x] [Linting passes](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#linting).
- [x] [Migrations created & committed *(or no model changes)*](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#migration-process)
- [x] [Tests implemented *(or no code changes)*](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#test-implementation)
- [x] [All tests pass](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#quality-control)
