### PR TITLE
Removed get_absolute_url.

### DIFF
--- a/DataRepo/templates/DataRepo/animal_list.html
+++ b/DataRepo/templates/DataRepo/animal_list.html
@@ -27,8 +27,8 @@
             </tr>
             {% for animal in animal_list %}
             <tr>
-            <td><a href="{{ animal.get_absolute_url }}">{{animal.name }}</a></td>          
-            <td><a href="{{ animal.tracer_compound.get_absolute_url }}">{{ animal.tracer_compound.name }}</a></td>
+            <td><a href="{% url 'animal_detail' animal.id %}">{{ animal.name }}</a></td>          
+            <td><a href="{% url 'compound_detail' animal.tracer_compound.id %}">{{ animal.tracer_compound.name }}</a></td>
             <td>{{ animal.tracer_labeled_atom }}</td>
             <td>{{ animal.tracer_labeled_count }}</td>
             <td>{{ animal.tracer_infusion_rate }}</td>


### PR DESCRIPTION
This is just to provide Fan an example usage of the url tag for creating links without using `get_absolute_url`.  I branched off of fkt1 and modified your code to not use `get_absolute_url`.  Please try this out.  Commit any changes you're currently working on, then:

```
git fetch
git checkout  --track "origin/fkt1-rob1"
python manage.py runserver
```

You'll see the links work just fine.