### PR TITLE
Fix value_from_choices_label

### DIFF
--- a/DataRepo/models.py
+++ b/DataRepo/models.py
@@ -12,8 +12,8 @@ def value_from_choices_label(label, choices):
     Return the choices value for a given label
     """
     dictionary = {}
-    for value, label in choices:
-        dictionary[label] = value
+    for choices_value, choices_label in choices:
+        dictionary[choices_label] = choices_value
     result = None
     result = dictionary.get(label)
     return result

--- a/DataRepo/tests.py
+++ b/DataRepo/tests.py
@@ -15,6 +15,7 @@ from .models import (
     Sample,
     Study,
     Tissue,
+    TracerLabeledClass,
 )
 from .utils import AccuCorDataLoader
 
@@ -255,6 +256,13 @@ class DataLoadingTests(TestCase):
         # and the animals should be in the study
         study = Study.objects.get(name="obob_fasted")
         self.assertEqual(study.animals.count(), ANIMALS_COUNT)
+
+    def test_animal_tracers(self):
+        a = Animal.objects.get(name="969")
+        c = Compound.objects.get(name="C16:0")
+        self.assertEqual(a.tracer_compound, c)
+        self.assertEqual(a.tracer_labeled_atom, TracerLabeledClass.CARBON)
+        self.assertEqual(a.sex, None)
 
     def test_peak_groups_loaded(self):
         # inf data file: 7 compounds and 56 samples, 7 * 56 = 392


### PR DESCRIPTION
<!-- markdownlint-disable-next-line first-line-heading -->
## Summary Change Description

Ensure that the value_from_choices_label function returns the value
corresponding to the label passed as a parameter

Add test to check the data loaded is correct

## Affected Issue Numbers

- Resolves #89 

## Code Review Notes

The variable name `label` was overwritten while looping through the choices.

## Checklist

- [x] All issue requirements satisfied (or no linked issues)
- [x] [Linting passes](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#linting).
- [x] [Migrations created & committed *(or no model changes)*](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#migration-process)
- [x] [Tests implemented *(or no code changes)*](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#test-implementation)
- [x] [All tests pass](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#quality-control)
