### PR TITLE
Exclude migrations from Super Linter checks

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,2 +1,3 @@
 [flake8]
 max-line-length = 120
+extend-exclude = .venv, migrations

--- a/.github/workflows/superlinter.yml
+++ b/.github/workflows/superlinter.yml
@@ -25,4 +25,4 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           LINTER_RULES_PATH: /
           IGNORE_GITIGNORED_FILES: true
-          FILTER_REGEX_EXCLUDE: (\.pylintrc)
+          FILTER_REGEX_EXCLUDE: (\.pylintrc|migrations)


### PR DESCRIPTION
<!-- markdownlint-disable-next-line first-line-heading -->
## Summary Change Description

Auto-generated migrations files do benefit from linting

## Affected Issue Numbers

- Resolves #56 

## Code Review Notes

Also exclude `.venv` and `migrations` in `.flake8` config to make it
simpler to run flake8 on the entire repo from the commandline

## Checklist

- [x] All issue requirements satisfied (or no linked issues)
- [x] [Linting passes](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#linting).
- [x] [Migrations created & committed *(or no model changes)*](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#migration-process)
- [x] [Tests implemented *(or no code changes)*](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#test-implementation)
- [x] [All tests pass](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#quality-control)
