### PR TITLE
Performance improvement of basic search

### DIFF
--- a/DataRepo/templates/peakgroups_results.html
+++ b/DataRepo/templates/peakgroups_results.html
@@ -71,7 +71,7 @@
 
                         <!-- NormFraction -->
                         <td class="text-end">
-                            {{ pd.peak_group.normalized_labeling }}
+                            <p title="{{ pd.peak_group.normalized_labeling }}">{{ pd.peak_group.normalized_labeling|floatformat:4 }}</p>
                         </td>
 
                         <!-- Infusate -->

--- a/DataRepo/views.py
+++ b/DataRepo/views.py
@@ -78,7 +78,7 @@ def search_basic(request, mdl, fld, cmp, val, fmt):
         fld_cmp += fld + "__" + cmp
 
         try:
-            peakdata = PeakData.objects.filter(**{fld_cmp: val})
+            peakdata = PeakData.objects.filter(**{fld_cmp: val}).prefetch_related("peak_group__ms_run__sample__animal__studies")
         except FieldError as fe:
             raise Http404(
                 "Table ["

--- a/DataRepo/views.py
+++ b/DataRepo/views.py
@@ -78,7 +78,9 @@ def search_basic(request, mdl, fld, cmp, val, fmt):
         fld_cmp += fld + "__" + cmp
 
         try:
-            peakdata = PeakData.objects.filter(**{fld_cmp: val}).prefetch_related("peak_group__ms_run__sample__animal__studies")
+            peakdata = PeakData.objects.filter(**{fld_cmp: val}).prefetch_related(
+                "peak_group__ms_run__sample__animal__studies"
+            )
         except FieldError as fe:
             raise Http404(
                 "Table ["


### PR DESCRIPTION
## Summary Change Description

Added a prefetch_related after the filter of the search term.

## Affected Issue Numbers

none

## Code Review Notes

The run time of the search is less than halved.  Initial testing was done without serum data and resulted in a load of around 12 seconds.  With serum data, it takes anywhere from 27 to 55 seconds (not sure what the factor is which determines the variability).

Searching all other models is reasonably fast.

The remaining bottleneck seems to be the cached_property fields.

## Checklist

- [x] All issue requirements satisfied (or no linked issues)
- [x] [Linting passes](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#linting).
- [x] [Migrations created & committed *(or no model changes)*](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#migration-process)
- [ ] [Tests implemented *(or no code changes)*](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#test-implementation)
- [x] [All tests pass](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#quality-control)
