### PR TITLE
add 3 views and templates to test web page rendering speed

### DIFF
--- a/DataRepo/templates/DataRepo/selected_data_list.html
+++ b/DataRepo/templates/DataRepo/selected_data_list.html
@@ -28,15 +28,15 @@
             <td>{{ item.labeled_element }}:{{ item.labeled_count }}</td>
             <td>{{ item.peak_group.ms_run.sample }}</td>
             <td>{{ item.fraction }}</td>
-            <td>{{ item.peak_group.ms_run.sample.tissue }}</td>
-            <td>{{ item.peak_group.ms_run.sample.animal }}</td>
+            <td>{{ item.peak_group.msrun.sample.tissue }}</td>
+            <td>{{ item.peak_group.msrun.sample.animal }}</td>
             <td>{{ item.peak_group.total_abundance }}</td>
             <td>{{ item.peak_group.normalized_labeling }}</td>
-            <td>{{ item.peak_group.ms_run.sample.animal.tracer_compound.name }}</td>
+            <td>{{ item.peak_group.msrun.sample.animal.tracer_compound.name }}</td>
             <td>{{ study }}</td>
-            <td>{{ item.peak_group.ms_run.sample.animal.feeding_status }}</td>
-            <td>{{ item.peak_group.ms_run.sample.animal.tracer_infusion_rate }}</td>
-            <td>{{ item.peak_group.ms_run.sample.animal.tracer_infusion_concentration }}</td>          
+            <td>{{ item.peak_group.msrun.sample.animal.feeding_status }}</td>
+            <td>{{ item.peak_group.msrun.sample.animal.tracer_infusion_rate }}</td>
+            <td>{{ item.peak_group.msrun.sample.animal.tracer_infusion_concentration }}</td>          
         </tr> 
     {% endfor %}
 </table>

--- a/DataRepo/templates/DataRepo/selected_data_list.html
+++ b/DataRepo/templates/DataRepo/selected_data_list.html
@@ -1,0 +1,49 @@
+{% extends "base.html" %}
+
+{% block title %}Selected Data{% endblock %}
+
+{% block content %}
+
+{% if selected_data_list %}
+<br>
+<table class="table table-sm table-hover table-bordered table-striped w-auto mw-100">
+    <tr>
+    <th>Peak Group Name</th>
+    <th>Atom:Label</th>
+    <th>Sample</th>
+    <th>Fraction</th>
+    <th>Tissue</th>
+    <th>Animal</th>
+    <th>TIC</th>
+    <th>NormFraction</th>
+    <th>Infusate</th>
+    <th>Experiment</th>
+    <th>Feeding Status</th>
+    <th>Infusion Rate</th>
+    <th>[Infusate]</th>
+    <tr>
+    {% for item in selected_data_list %}
+        <tr>
+            <td>{{ item.peak_group.name }}</td>
+            <td>{{ item.labeled_element }}:{{ item.labeled_count }}</td>
+            <td>{{ item.peak_group.ms_run.sample }}</td>
+            <td>{{ item.fraction }}</td>
+            <td>{{ item.peak_group.ms_run.sample.tissue }}</td>
+            <td>{{ item.peak_group.ms_run.sample.animal }}</td>
+            <td>{{ item.peak_group.total_abundance }}</td>
+            <td>{{ item.peak_group.normalized_labeling }}</td>
+            <td>{{ item.peak_group.ms_run.sample.animal.tracer_compound.name }}</td>
+            <td>{{ study }}</td>
+            <td>{{ item.peak_group.ms_run.sample.animal.feeding_status }}</td>
+            <td>{{ item.peak_group.ms_run.sample.animal.tracer_infusion_rate }}</td>
+            <td>{{ item.peak_group.ms_run.sample.animal.tracer_infusion_concentration }}</td>          
+        </tr> 
+    {% endfor %}
+</table>
+{% else %}
+<p>There are no selected data.</p>
+{% endif %}
+</ul>
+</div>
+{% endblock %}
+        

--- a/DataRepo/templates/DataRepo/selected_data_t1.html
+++ b/DataRepo/templates/DataRepo/selected_data_t1.html
@@ -1,0 +1,48 @@
+{% extends "base.html" %}
+
+{% block title %}Selected Data -- test1{% endblock %}
+
+{% block content %}
+
+{% if selected_data_t1 %}
+<br>
+<table class="table table-sm table-hover table-bordered table-striped w-auto mw-100">
+    <tr>
+    <th>Peak Group Name</th>
+    <th>Atom:Label</th>
+    <th>Sample</th>
+    <!--th>Fraction</th-->
+    <th>Tissue</th>
+    <th>Animal</th>
+    <!--th>TIC</th-->
+    <!--th>NormFraction</th-->
+    <th>Infusate</th>
+    <th>Experiment</th>
+    <th>Feeding Status</th>
+    <th>Infusion Rate</th>
+    <th>[Infusate]</th>
+    <tr>
+    {% for item in selected_data_t1 %}
+        <tr>
+            <td>{{ item.peak_group.name }}</td>
+            <td>{{ item.labeled_element }}:{{ item.labeled_count }}</td>
+            <td>{{ item.peak_group.ms_run.sample }}</td>
+            <!--td>{{ item.fraction }}</td-->
+            <td>{{ item.peak_group.ms_run.sample.tissue }}</td>
+            <td>{{ item.peak_group.ms_run.sample.animal }}</td>
+            <!--td>{{ item.peak_group.total_abundance }}</td-->
+            <!--td>{{ item.peak_group.normalized_labeling }}</td-->
+            <td>{{ item.peak_group.ms_run.sample.animal.tracer_compound.name }}</td>
+            <td>{{ study }}</td>
+            <td>{{ item.peak_group.ms_run.sample.animal.feeding_status }}</td>
+            <td>{{ item.peak_group.ms_run.sample.animal.tracer_infusion_rate }}</td>
+            <td>{{ item.peak_group.ms_run.sample.animal.tracer_infusion_concentration }}</td>          
+        </tr> 
+    {% endfor %}
+</table>
+{% else %}
+<p>There are no selected data.</p>
+{% endif %}
+</ul>
+</div>
+{% endblock %}

--- a/DataRepo/templates/DataRepo/selected_data_t1.html
+++ b/DataRepo/templates/DataRepo/selected_data_t1.html
@@ -26,17 +26,17 @@
         <tr>
             <td>{{ item.peak_group.name }}</td>
             <td>{{ item.labeled_element }}:{{ item.labeled_count }}</td>
-            <td>{{ item.peak_group.ms_run.sample }}</td>
+            <td>{{ item.peak_group.msrun.sample }}</td>
             <!--td>{{ item.fraction }}</td-->
-            <td>{{ item.peak_group.ms_run.sample.tissue }}</td>
-            <td>{{ item.peak_group.ms_run.sample.animal }}</td>
+            <td>{{ item.peak_group.msrun.sample.tissue }}</td>
+            <td>{{ item.peak_group.msrun.sample.animal }}</td>
             <!--td>{{ item.peak_group.total_abundance }}</td-->
             <!--td>{{ item.peak_group.normalized_labeling }}</td-->
-            <td>{{ item.peak_group.ms_run.sample.animal.tracer_compound.name }}</td>
+            <td>{{ item.peak_group.msrun.sample.animal.tracer_compound.name }}</td>
             <td>{{ study }}</td>
-            <td>{{ item.peak_group.ms_run.sample.animal.feeding_status }}</td>
-            <td>{{ item.peak_group.ms_run.sample.animal.tracer_infusion_rate }}</td>
-            <td>{{ item.peak_group.ms_run.sample.animal.tracer_infusion_concentration }}</td>          
+            <td>{{ item.peak_group.msrun.sample.animal.feeding_status }}</td>
+            <td>{{ item.peak_group.msrun.sample.animal.tracer_infusion_rate }}</td>
+            <td>{{ item.peak_group.msrun.sample.animal.tracer_infusion_concentration }}</td>          
         </tr> 
     {% endfor %}
 </table>

--- a/DataRepo/templates/DataRepo/selected_data_t2.html
+++ b/DataRepo/templates/DataRepo/selected_data_t2.html
@@ -26,17 +26,17 @@
         <tr>
             <td>{{ item.peak_group__name }}</td>
             <td>{{ item.labeled_element }}:{{ item.labeled_count }}</td>
-            <td>{{ item.peak_group.ms_run.sample }}</td>
+            <td>{{ item.peak_group.msrun.sample }}</td>
             <!--td>{{ item.fraction }}</td-->
-            <td>{{ item.peak_group__ms_run__sample__tissue__name }}</td>
-            <td>{{ item.peak_group__ms_run__sample__animal__name }}</td>
+            <td>{{ item.peak_group__msrun__sample__tissue__name }}</td>
+            <td>{{ item.peak_group__msrun__sample__animal__name }}</td>
             <!--td>{{ item.peak_group.total_abundance }}</td-->
             <!--td>{{ item.peak_group.normalized_labeling }}</td-->
-            <td>{{ item.peak_group__ms_run__sample__animal__tracer_compound__name }}</td>
+            <td>{{ item.peak_group__msrun__sample__animal__tracer_compound__name }}</td>
             <td>{{ study }}</td>
-            <td>{{ item.peak_group__ms_run__sample__animal__feeding_status }}</td>
-            <td>{{ item.peak_group__ms_run__sample__animal__tracer_infusion_rate}}</td>
-            <td>{{ item.peak_group__ms_run__sample__animal__tracer_infusion_concentration }}</td>          
+            <td>{{ item.peak_group__msrun__sample__animal__feeding_status }}</td>
+            <td>{{ item.peak_group__msrun__sample__animal__tracer_infusion_rate}}</td>
+            <td>{{ item.peak_group__msrun__sample__animal__tracer_infusion_concentration }}</td>          
         </tr> 
     {% endfor %}
 </table>

--- a/DataRepo/templates/DataRepo/selected_data_t2.html
+++ b/DataRepo/templates/DataRepo/selected_data_t2.html
@@ -1,0 +1,48 @@
+{% extends "base.html" %}
+
+{% block title %}Selected Data -- test2 using Values() {% endblock %}
+
+{% block content %}
+
+{% if selected_data_t2 %}
+<br>
+<table class="table table-sm table-hover table-bordered table-striped w-auto mw-100">
+    <tr>
+    <th>Peak Group Name</th>
+    <th>Atom:Label</th>
+    <th>Sample</th>
+    <!--th>Fraction</th-->
+    <th>Tissue</th>
+    <th>Animal</th>
+    <!--th>TIC</th-->
+    <!--th>NormFraction</th-->
+    <th>Infusate</th>
+    <th>Experiment</th>
+    <th>Feeding Status</th>
+    <th>Infusion Rate</th>
+    <th>[Infusate]</th>
+    <tr>
+    {% for item in selected_data_t2 %}
+        <tr>
+            <td>{{ item.peak_group__name }}</td>
+            <td>{{ item.labeled_element }}:{{ item.labeled_count }}</td>
+            <td>{{ item.peak_group.ms_run.sample }}</td>
+            <!--td>{{ item.fraction }}</td-->
+            <td>{{ item.peak_group__ms_run__sample__tissue__name }}</td>
+            <td>{{ item.peak_group__ms_run__sample__animal__name }}</td>
+            <!--td>{{ item.peak_group.total_abundance }}</td-->
+            <!--td>{{ item.peak_group.normalized_labeling }}</td-->
+            <td>{{ item.peak_group__ms_run__sample__animal__tracer_compound__name }}</td>
+            <td>{{ study }}</td>
+            <td>{{ item.peak_group__ms_run__sample__animal__feeding_status }}</td>
+            <td>{{ item.peak_group__ms_run__sample__animal__tracer_infusion_rate}}</td>
+            <td>{{ item.peak_group__ms_run__sample__animal__tracer_infusion_concentration }}</td>          
+        </tr> 
+    {% endfor %}
+</table>
+{% else %}
+<p>There are no selected data.</p>
+{% endif %}
+</ul>
+</div>
+{% endblock %}

--- a/DataRepo/urls.py
+++ b/DataRepo/urls.py
@@ -44,4 +44,7 @@ urlpatterns = [
         name="peakgroup_detail",
     ),
     path("peakdata/", views.PeakDataListView.as_view(), name="peakdata_list"),
+    path("selected_data/", views.selected_data, name="selected_data"),
+    path("selected_t1/", views.selected_t1, name="selected_t1"),
+    path("selected_t2/", views.selected_t2, name="selected_t2"),
 ]

--- a/DataRepo/views.py
+++ b/DataRepo/views.py
@@ -265,3 +265,91 @@ class PeakDataListView(ListView):
             self.peakgroup = get_object_or_404(PeakGroup, id=peakgroup_pk)
             queryset = PeakData.objects.filter(peak_group_id=peakgroup_pk)
         return queryset
+
+
+def selected_data(request):
+    context = {}
+    template_name = "DataRepo/selected_data_list.html"
+
+    study_pk = 1
+    study_name = Study.objects.get(id=study_pk).name
+    sub_qs = Sample.objects.select_related("animal").filter(
+        animal__id__in=Animal.objects.values_list("id").filter(studies__id=study_pk)
+    )
+    sample_set = sub_qs.values_list("name")
+    # print(sample_set[0])
+    # sample_count = sub_qs.count()
+    qs = (
+        PeakData.objects.select_related("peak_group")
+        .filter(peak_group__ms_run__sample__name__in=sample_set)
+        .all()
+    )
+
+    print(qs.count())
+
+    context = {"study": study_name, "selected_data_list": qs}
+    return render(request, template_name, context)
+
+
+def selected_t1(request):
+    context = {}
+    template_name = "DataRepo/selected_data_t1.html"
+
+    study_pk = 1
+    study_name = Study.objects.get(id=study_pk).name
+    sub_qs = Sample.objects.select_related("animal").filter(
+        animal__id__in=Animal.objects.values_list("id").filter(studies__id=study_pk)
+    )
+    sample_set = sub_qs.values_list("name")
+    # print(sample_set[0])
+    # sample_count = sub_qs.count()
+    qs = (
+        PeakData.objects.select_related("peak_group")
+        .filter(peak_group__ms_run__sample__name__in=sample_set)
+        .all()
+    )
+
+    print(qs.count())
+
+    context = {"study": study_name, "selected_data_t1": qs}
+    return render(request, template_name, context)
+
+
+def selected_t2(request):
+    context = {}
+    template_name = "DataRepo/selected_data_t2.html"
+
+    study_pk = 1
+    study_name = Study.objects.get(id=study_pk).name
+    sub_qs = Sample.objects.select_related("animal").filter(
+        animal__id__in=Animal.objects.values_list("id").filter(studies__id=study_pk)
+    )
+    sample_set = sub_qs.values_list("name")
+    # print(sample_set[0])
+    # sample_count = sub_qs.count()
+    qs = (
+        PeakData.objects.select_related("peak_group")
+        .filter(peak_group__ms_run__sample__name__in=sample_set)
+        .all()
+    )
+
+    fields = [
+        "peak_group",
+        "peak_group__name",
+        "labeled_element",
+        "labeled_count",
+        "peak_group__ms_run__sample__animal__name",
+        "peak_group__ms_run__sample__tissue__name",
+        "peak_group__ms_run__sample__name",
+        "peak_group__ms_run__sample__animal__feeding_status",
+        "peak_group__ms_run__sample__animal__tracer_infusion_rate",
+        "peak_group__ms_run__sample__animal__tracer_infusion_concentration",
+        "peak_group__ms_run__sample__animal__tracer_compound__name",
+    ]
+
+    # qs = qs.values_list(*fields)
+    qs = qs.values(*fields)
+    print(qs.count())
+
+    context = {"study": study_name, "selected_data_t2": qs}
+    return render(request, template_name, context)

--- a/DataRepo/views.py
+++ b/DataRepo/views.py
@@ -281,7 +281,7 @@ def selected_data(request):
     # sample_count = sub_qs.count()
     qs = (
         PeakData.objects.select_related("peak_group")
-        .filter(peak_group__ms_run__sample__name__in=sample_set)
+        .filter(peak_group__msrun__sample__name__in=sample_set)
         .all()
     )
 
@@ -305,7 +305,7 @@ def selected_t1(request):
     # sample_count = sub_qs.count()
     qs = (
         PeakData.objects.select_related("peak_group")
-        .filter(peak_group__ms_run__sample__name__in=sample_set)
+        .filter(peak_group__msrun__sample__name__in=sample_set)
         .all()
     )
 
@@ -329,7 +329,7 @@ def selected_t2(request):
     # sample_count = sub_qs.count()
     qs = (
         PeakData.objects.select_related("peak_group")
-        .filter(peak_group__ms_run__sample__name__in=sample_set)
+        .filter(peak_group__msrun__sample__name__in=sample_set)
         .all()
     )
 
@@ -338,13 +338,13 @@ def selected_t2(request):
         "peak_group__name",
         "labeled_element",
         "labeled_count",
-        "peak_group__ms_run__sample__animal__name",
-        "peak_group__ms_run__sample__tissue__name",
-        "peak_group__ms_run__sample__name",
-        "peak_group__ms_run__sample__animal__feeding_status",
-        "peak_group__ms_run__sample__animal__tracer_infusion_rate",
-        "peak_group__ms_run__sample__animal__tracer_infusion_concentration",
-        "peak_group__ms_run__sample__animal__tracer_compound__name",
+        "peak_group__msrun__sample__animal__name",
+        "peak_group__msrun__sample__tissue__name",
+        "peak_group__msrun__sample__name",
+        "peak_group__msrun__sample__animal__feeding_status",
+        "peak_group__msrun__sample__animal__tracer_infusion_rate",
+        "peak_group__msrun__sample__animal__tracer_infusion_concentration",
+        "peak_group__msrun__sample__animal__tracer_compound__name",
     ]
 
     # qs = qs.values_list(*fields)


### PR DESCRIPTION
<!-- markdownlint-disable-next-line first-line-heading -->
## Summary Change Description

I am not asking for a formal review, just want to share a few test cases for displaying peak data for a study.

- function based view "selected_data":

  page title: "Selected Data"
url: http://127.0.0.1:8000/DataRepo/selected_data/
notes: 
filter and display peak data  for a study (imitating Rob's basic search page)
used "select_related" for queryset,  instead of "prefetch_related"
template: selected_data_list.html
SQL query used join and subquery, should be fast
web content rendering was very slow (slower than Rob's basic search page)

- function based view "selected_t1":
  tried to demonstrate that the slowness was not due to displaying calculated values

  page title: ""Selected Data --test 1"
url: http://127.0.0.1:8000/DataRepo/selected_t1/
notes: 
The view is more or less the same as "selected_data" 
template: selected_data_t1.html (omitted the fields for calculated values based on functions)
web content rendering was as slow as "Selected Data"

- function based view "selected_t2":

  page title: "Selected Data -- test2 using values()"
url: http://127.0.0.1:8000/DataRepo/selected_t2/
The subquery is the same as used for "selected_data" and "selected_t1"
The queryset for peakdata used "values() " and defined field list
template: selected_data_t2.html  
web content rendering was very fast
Big issue: I don't know how to retrieve and display calculated values (e.g. fraction) using values().


## Affected Issue Numbers

## Code Review Notes

- Both "selected_data" and "selected_t1" were slow - with or without displaying values based on functions (e.g. fraction)
- "selected_t2" was fast, but I don't know how to handle the values based on functions (e.g. fraction)


## Checklist

- [ ] All issue requirements satisfied (or no linked issues)
- [ ] [Linting passes](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#linting).
- [ ] [Migrations created & committed *(or no model changes)*](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#migration-process)
- [ ] [Tests implemented *(or no code changes)*](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#test-implementation)
- [ ] [All tests pass](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#quality-control)
