### PR TITLE
Update to superlinter v4

### DIFF
--- a/.github/workflows/superlinter.yml
+++ b/.github/workflows/superlinter.yml
@@ -19,7 +19,7 @@ jobs:
 
       # Runs the Super-Linter action
       - name: Run Super-Linter
-        uses: github/super-linter@v3
+        uses: github/super-linter@v4
         env:
           DEFAULT_BRANCH: main
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/DataRepo/management/commands/load_samples.py
+++ b/DataRepo/management/commands/load_samples.py
@@ -1,6 +1,6 @@
 from csv import DictReader
 
-import yaml
+import yaml  # type: ignore
 from django.core.management import BaseCommand
 
 from DataRepo.utils import SampleTableLoader

--- a/DataRepo/utils.py
+++ b/DataRepo/utils.py
@@ -3,7 +3,7 @@ import re
 from collections import namedtuple
 from datetime import datetime, timedelta
 
-import dateutil.parser
+import dateutil.parser  # type: ignore
 from django.db import transaction
 
 from DataRepo.models import (

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -3,7 +3,7 @@
 -r common.txt
 flake8==3.9.2
 black==20.8b1
-isort==5.8.0
-pylint==2.8.2
-mypy==0.812
+isort==5.9.1
+pylint==2.9.0
+mypy==0.910
 mypy-extensions==0.4.3


### PR DESCRIPTION

<!-- markdownlint-disable-next-line first-line-heading -->
## Summary Change Description

* Update to superlinter v4
* Update linters in requirements/dev.txt to versions used by superlinter v4
* Set mypy type ignore on imports

Some imports are not PEP 561 compliant and thus mypy does not have the
proper type hints. One option is to install PEP 561 compliant stub
packages, however, it is not practical to install packages when
running superlinter, thus we'll just have mypy ignore these for now.

See
https://mypy.readthedocs.io/en/stable/running_mypy.html#missing-type-hints-for-third-party-library
for more information.

## Affected Issue Numbers

None

## Code Review Notes

None

## Checklist

- [x] All issue requirements satisfied (or no linked issues)
- [x] [Linting passes](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#linting).
- [x] [Migrations created & committed *(or no model changes)*](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#migration-process)
- [x] [Tests implemented *(or no code changes)*](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#test-implementation)
- [x] [All tests pass](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#quality-control)
