### PR TITLE
More consolidation of the composite view metadata.

### DIFF
--- a/DataRepo/compositeviews.py
+++ b/DataRepo/compositeviews.py
@@ -1,5 +1,7 @@
 from typing import Dict, List
 
+from DataRepo.models import PeakData, PeakGroup
+
 
 class BaseSearchView:
     """
@@ -98,6 +100,7 @@ class PeakGroupsSearchView(BaseSearchView):
         "msrun__sample__animal__tracer_compound",
         "msrun__sample__animal__studies",
     ]
+    rootmodel = PeakGroup()
     models = {
         "PeakGroup": {
             "path": "",
@@ -226,6 +229,7 @@ class PeakDataSearchView(BaseSearchView):
         "peak_group__msrun__sample__tissue",
         "peak_group__msrun__sample__animal__tracer_compound",
     ]
+    rootmodel = PeakData()
     models = {
         "PeakData": {
             "path": "",

--- a/DataRepo/forms.py
+++ b/DataRepo/forms.py
@@ -1,6 +1,7 @@
-from typing import Optional
+from typing import Dict, Optional
 
 from django import forms
+from django.forms import formset_factory
 
 from DataRepo.compositeviews import (
     BaseSearchView,
@@ -29,7 +30,7 @@ from DataRepo.compositeviews import (
 # mixed-form environment.
 
 
-class AdvSearchForm(forms.Form):
+class BaseAdvSearchForm(forms.Form):
     """
     Advanced search form base class that will be used inside a formset.
     """
@@ -92,7 +93,7 @@ class AdvSearchForm(forms.Form):
         self.fields["fld"].choices = self.composite_view_class.getSearchFieldChoices()
 
 
-class AdvSearchPeakGroupsForm(AdvSearchForm):
+class AdvSearchPeakGroupsForm(BaseAdvSearchForm):
     """
     Advanced search form for the peakgroups output format that will be used inside a formset.
     """
@@ -100,12 +101,28 @@ class AdvSearchPeakGroupsForm(AdvSearchForm):
     composite_view_class = PeakGroupsSearchView()
 
 
-class AdvSearchPeakDataForm(AdvSearchForm):
+class AdvSearchPeakDataForm(BaseAdvSearchForm):
     """
     Advanced search form for the peakdata output format that will be used inside a formset.
     """
 
     composite_view_class = PeakDataSearchView()
+
+
+class AdvSearchForm:
+    """
+    A group of advanced search form classes
+    """
+
+    form_classes: Dict[str, BaseAdvSearchForm] = {}
+    # These form field elements are actually (currently) created in javascript.
+    format_select_list_name = "fmt"
+    hierarchy_path_field_name = "pos"
+
+    def __init__(self, *args, **kwargs):
+        for form_class in (AdvSearchPeakGroupsForm(), AdvSearchPeakDataForm()):
+            id = form_class.composite_view_class.id
+            self.form_classes[id] = formset_factory(form_class.__class__)
 
 
 class AdvSearchDownloadForm(forms.Form):

--- a/DataRepo/tests/test_views.py
+++ b/DataRepo/tests/test_views.py
@@ -455,9 +455,10 @@ class ViewTests(TestCase):
         """
         Test that test_getAllBrowseData returns all data for the selected format.
         """
+        basv_metadata = BaseAdvancedSearchView()
         pf = "msrun__sample__animal__studies"
         qs = PeakGroup.objects.all().prefetch_related(pf)
-        res = getAllBrowseData("pgtemplate", [pf])
+        res = getAllBrowseData("pgtemplate", basv_metadata)
         self.assertEqual(res.count(), qs.count())
 
     def test_createNewAdvancedQuery(self):
@@ -584,12 +585,13 @@ class ViewTests(TestCase):
         """
         [ignoreas, qry, ignoredl] = self.get_advanced_search_inputs()
         q_exp = constructAdvancedQuery(qry)
+        basv_metadata = BaseAdvancedSearchView()
         pf = [
             "msrun__sample__tissue",
             "msrun__sample__animal__tracer_compound",
             "msrun__sample__animal__studies",
         ]
-        res = performQuery(qry, q_exp, pf)
+        res = performQuery(q_exp, "pgtemplate", basv_metadata)
         qs = PeakGroup.objects.filter(
             msrun__sample__tissue__name__iexact="Brain"
         ).prefetch_related(*pf)


### PR DESCRIPTION
## Summary Change Description

There was some metadata for the composite views still in views.py.  This effort extracted that and consolidated those things in the advanced search composite view.  I also created a composite form view to have it be able to create the form_classes dict using the keys derived from the metadata class.

## Affected Issue Numbers

- Resolves N/A - it's an addendum to the last advanced search consolidation PR.

## Code Review Notes

The goal here was to make it so no code changes are required in views.py to add a new search output format.

Basically, the output format keys "pgtemplate" and "pdtemplate" are no longer in views.py.  The root model class for each output format is now saved in each advanced search derived class in compositeviews.py.

I did not address metadata inside the javascript code.  I might do that eventually.  So currently, to add a new output format, changes need to be made to compositeviews.py, hierarchical_formsets.js, advanced_search.html, and advanced_search.tsv.

I edited affected tests.  Existing tests should be sufficient, since this is just a refactor.

## Checklist

- [x] All issue requirements satisfied (or no linked issues)
- [x] [Linting passes](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#linting).
- [x] [Migrations created & committed *(or no model changes)*](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#migration-process)
- [x] [Tests implemented *(or no code changes)*](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#test-implementation)
- [x] [All tests pass](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#quality-control)
