### PR TITLE
Form field text entry delay fix

### DIFF
--- a/DataRepo/forms.py
+++ b/DataRepo/forms.py
@@ -69,7 +69,8 @@ class BaseAdvSearchForm(forms.Form):
 
     # TODO: Currently, I am only providing this one field type.  Eventually, I will work out a way to dynamically
     # update this based on the model's field type
-    val = forms.CharField(widget=forms.TextInput())
+    # Note: the placeholder attribute solves issue #135
+    val = forms.CharField(widget=forms.TextInput(attrs={"placeholder": "search term"}))
 
     def clean(self):
         """This override of super.clean is so we can reconstruct the search inputs upon form_invalid in views.py"""

--- a/static/js/hierarchical_formsets.js
+++ b/static/js/hierarchical_formsets.js
@@ -32,9 +32,11 @@ const pluspluspngpath = '/static/images/plusplus.png'
 // }
 // Linting is disabled for the disallowance of 'no-var' because let and const don't work here
 var rootGroup = {} // eslint-disable-line no-var
+var formErrLabel // eslint-disable-line no-var
 
 function init (rootGroup) { // eslint-disable-line no-unused-vars
   globalThis.rootGroup = rootGroup
+  globalThis.formErrLabel = document.getElementById('formerror')
 }
 
 function appendSearchQuery (element, query) { // eslint-disable-line no-unused-vars
@@ -113,8 +115,7 @@ function appendInnerSearchQuery (element, templateId, query, copyQuery, parentGr
   } else if (('' + query.type) === 'query') {
     addSearchFieldForm(myDiv, query, copyQuery, isInit, templateId)
   } else {
-    const label = document.getElementById('formerror')
-    label.innerHTML = 'Error: Unrecognized query type: ' + query.type
+    formErrLabel.innerHTML = 'Error: Unrecognized query type: ' + query.type
   }
 
   if (!isRoot) {
@@ -180,8 +181,7 @@ function addSearchFieldForm (myDiv, query, copyQuery, isInit, templateId) {
 
     // Dismiss any previous error (that was previously presented and prevented)
     clones[i].addEventListener('click', function (event) {
-      const label = document.getElementById('formerror')
-      label.innerHTML = ''
+      formErrLabel.innerHTML = ''
     })
 
     // Keep the value of the hierarchy structure up to date when the user changes the form value
@@ -256,8 +256,7 @@ function addFormatSelectList (myDiv, query, copyQuery) {
   // Use a change as an opportunity to dismiss previous errors
   // And keep the selected value up to date in the object
   select.addEventListener('change', function (event) {
-    const label = document.getElementById('formerror')
-    label.innerHTML = ''
+    formErrLabel.innerHTML = ''
     query.selectedtemplate = event.target.value
     showOutputFormatSearch(query.selectedtemplate)
     updateBrowseLink(query.selectedtemplate)
@@ -292,8 +291,7 @@ function addGroupSelectList (myDiv, query, copyQuery, isInit) {
 
   // Use a change as an opportunity to dismiss previous errors
   select.addEventListener('change', function (event) {
-    const label = document.getElementById('formerror')
-    label.innerHTML = ''
+    formErrLabel.innerHTML = ''
     query.val = event.target.value
   })
 
@@ -314,12 +312,11 @@ function addRemoveButton (myDiv, query, parentGroup) {
   btnImg.src = minuspngpath
   rmBtn.appendChild(btnImg)
   rmBtn.addEventListener('click', function (event) {
-    const label = document.getElementById('formerror')
-    label.innerHTML = ''
+    formErrLabel.innerHTML = ''
 
     const size = parentGroup.queryGroup.length
     if (size <= 1) {
-      label.innerHTML = 'A match group must have at least 1 query.'
+      formErrLabel.innerHTML = 'A match group must have at least 1 query.'
     } else {
       event.target.parentNode.parentNode.remove()
       const index = parentGroup.queryGroup.indexOf(query)
@@ -340,8 +337,7 @@ function addQueryAndGroupAddButtons (myDiv, query, parentGroup, templateId) {
   pBtnImg.src = pluspngpath
   termbtn.appendChild(pBtnImg)
   termbtn.addEventListener('click', function (event) {
-    const label = document.getElementById('formerror')
-    label.innerHTML = ''
+    formErrLabel.innerHTML = ''
 
     const sibQuery = {
       type: 'query',
@@ -362,8 +358,7 @@ function addQueryAndGroupAddButtons (myDiv, query, parentGroup, templateId) {
   ppBtnImg.src = pluspluspngpath
   grpbtn.appendChild(ppBtnImg)
   grpbtn.addEventListener('click', function (event) {
-    const label = document.getElementById('formerror')
-    label.innerHTML = ''
+    formErrLabel.innerHTML = ''
 
     const sibGroup = {
       type: 'group',


### PR DESCRIPTION
## Summary Change Description

- Added a placeholder attribute to the text input field of the advanced search.
- Reduced the number of calls to getElementById

## Affected Issue Numbers

- Resolves #135

## Code Review Notes

The real fix/workaround was the addition of the placeholder input attribute, which prevents Safari Autofill from causing a delay after clicking in the field and also results in suggesting phone numbers to enter into the field from their contact card on macOS.  Note, other browsers I tested did not have these issues.  Many suggested solutions on google/stack were tried and this was the only one that worked.

I also reduced the number of calls to getElementById in the javascript, thinking initially that it was that that caused the lag.  It did not end up being the cause of the lag, but is more efficient none-the-less, so I kept it.

## Checklist

- [x] All issue requirements satisfied (or no linked issues)
- [x] [Linting passes](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#linting).
- [x] [Migrations created & committed *(or no model changes)*](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#migration-process)
- [ ] [Tests implemented *(or no code changes)*](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#test-implementation)
    - There's no way to test the effectiveness of the fix since it solves a browser issue in the specific case where a user has enabled autofill 
- [x] [All tests pass](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#quality-control)
