### PR TITLE
Added record names to detail page titles and headers

### DIFF
--- a/DataRepo/templates/DataRepo/animal_detail.html
+++ b/DataRepo/templates/DataRepo/animal_detail.html
@@ -1,10 +1,10 @@
 {% extends "base.html" %}
 
-{% block title %}Animal Details{% endblock %}
+{% block title %}Animal Record - {{ animal.name }}{% endblock %}
 
 {% block content %}
 <div>
-    <h4>Animal Details:</h4>
+    <h4>Animal Record - {{ animal.name }}</h4>
     <p>Name: {{ animal.name }}</p>
     <p>
         <a href="{% url 'sample_list' %}?animal_id={{ animal.id }}">
@@ -14,7 +14,7 @@
     <h5>Tracer Information:</h5>
     <table class="table table-bordered table-hover w-auto mw-100">
         <tr>
-            <td>Compound Name</td>
+            <td>Compound</td>
             <td>
                 <a href="{% url 'compound_detail' animal.tracer_compound.id %}">
                     {{ animal.tracer_compound.name }}

--- a/DataRepo/templates/DataRepo/compound_detail.html
+++ b/DataRepo/templates/DataRepo/compound_detail.html
@@ -1,10 +1,10 @@
 {% extends "base.html" %}
 
-{% block title %}Compound Details{% endblock %}
+{% block title %}Compound Record - {{ compound.name }}{% endblock %}
 
 {% block content %}
 <div>
-    <h4>Compound Details:</h4>
+    <h4>Compound Record - {{ compound.name }}</h4>
     <br>
     <table class="table table-bordered table-hover w-auto mw-100">
         <tr>

--- a/DataRepo/templates/DataRepo/msrun_detail.html
+++ b/DataRepo/templates/DataRepo/msrun_detail.html
@@ -1,22 +1,18 @@
 {% extends "base.html" %}
 
-{% block title %}MS Run Details{% endblock %}
+{% block title %}MS Run Record - {{ msrun.researcher }}, {{ msrun.date }}{% endblock %}
 
 {% block content %}
 <div>
-    <h4>MS Run Details:</h4>
+    <h4>MS Run Record - {{ msrun.researcher }}, {{ msrun.date }}</h4>
     <br>
     <table class="table  table-bordered table-hover w-auto mw-100">
         <tr>
-            <td>MS Run ID</td>
-            <td>{{ msrun.id }}</td>
-        </tr>
-        <tr>
-            <td>Sample Name</td>
+            <td>Sample</td>
             <td><a href="{% url 'sample_detail' msrun.sample.id %}">{{ msrun.sample.name }}</a></td>
         </tr>
         <tr>
-            <td>Protocol Name</td>
+            <td>Protocol</td>
             <td><a href="{% url 'protocol_detail' msrun.protocol.id %}">{{ msrun.protocol.name }}</a></td>
         </tr>
         <tr>

--- a/DataRepo/templates/DataRepo/msrun_list.html
+++ b/DataRepo/templates/DataRepo/msrun_list.html
@@ -11,15 +11,15 @@
         <br>
         <table class="table table-sm table-hover table-bordered table-responsive table-striped w-auto mw-100">
             <tr>
-            <th>MSRun ID</th>
-            <th>Sample Name</th>
+            <th>MSRun Detail Page</th>
+            <th>Sample</th>
             <th>Date</th>
-            <th>Protocol Name</th>
+            <th>Protocol</th>
             <th>Researcher</th>
             </tr>
             {% for msrun in msrun_list %}
             <tr>
-            <td><a href="{% url 'msrun_detail' msrun.id %}">{{ msrun.id }}</a></td>
+            <td><a href="{% url 'msrun_detail' msrun.id %}">detail page</a></td>
             <td><a href="{% url 'sample_detail' msrun.sample.id %}">{{ msrun.sample.name }}</a></td>
             <td>{{ msrun.date }}</td>
             <td><a href="{% url 'protocol_detail' msrun.protocol.id %}">{{ msrun.protocol.name }}</a></td>

--- a/DataRepo/templates/DataRepo/peakdata_list.html
+++ b/DataRepo/templates/DataRepo/peakdata_list.html
@@ -11,7 +11,7 @@
         <br>
         <table class="table table-sm table-hover table-bordered table-responsive table-striped w-auto mw-100">
             <tr>
-            <th>Peak Group Name</th>
+            <th>Peak Group</th>
             <th>Labeled Element</th>
             <th>Labeled Count</th>
             <th>Raw Abundance</th>

--- a/DataRepo/templates/DataRepo/peakgroup_detail.html
+++ b/DataRepo/templates/DataRepo/peakgroup_detail.html
@@ -1,14 +1,14 @@
 {% extends "base.html" %}
 
-{% block title %}Peak Group Details{% endblock %}
+{% block title %}Peak Group Record - {{ peakgroup.name }}{% endblock %}
 
 {% block content %}
 <div>
-    <h4>Peak Group Details:</h4>
+    <h4>Peak Group Record - {{ peakgroup.name }}</h4>
     <br>
     <table class="table table-bordered table-hover w-auto mw-100">
         <tr>
-            <td>Peak Group Name</td>
+            <td>Name</td>
             <td>{{ peakgroup.name }}</td>
         </tr>
         <tr>
@@ -16,7 +16,7 @@
             <td>{{ peakgroup.formula }}</td>
         </tr>
         <tr>
-            <td>Peak Group Set (Accucor File Name)</td>
+            <td>Peak Group Set (Accucor File)</td>
             <td>
                 <a href="{% url 'peakgroupset_detail' peakgroup.peak_group_set.id %}">
                     {{ peakgroup.peak_group_set.filename }}
@@ -24,11 +24,11 @@
             </td>
         </tr>
         <tr>
-            <td>MS Run ID</td>
-            <td><a href="{% url 'msrun_detail' peakgroup.msrun.id %}">{{ peakgroup.msrun.id }}</a></td>
+            <td>MS Run</td>
+            <td><a href="{% url 'msrun_detail' peakgroup.msrun.id %}">{{ peakgroup.msrun.researcher }}, {{ peakgroup.msrun.date }}</a></td>
         </tr>
         <tr>
-            <td>MS Run Sample Name</td>
+            <td>Sample</td>
             <td>
                 <a href="{% url 'sample_detail' peakgroup.msrun.sample.id %}">
                     {{ peakgroup.msrun.sample.name }}

--- a/DataRepo/templates/DataRepo/peakgroup_list.html
+++ b/DataRepo/templates/DataRepo/peakgroup_list.html
@@ -11,11 +11,11 @@
         <br>
         <table class="table table-sm table-hover table-bordered table-responsive table-striped w-auto mw-100">
             <tr>
-            <th>Peak Group Name</th>
+            <th>Peak Group</th>
             <th>Formula</th>
-            <th>MS Run Sample Name</th>
-            <th>MS Run ID</th>
-            <th>AccuCor File Name</th>
+            <th>Sample</th>
+            <th>MS Run</th>
+            <th>AccuCor File</th>
             </tr>
             {% for peakgroup in peakgroup_list %}
             <tr>
@@ -26,7 +26,7 @@
                     {{ peakgroup.msrun.sample.name }}
                 </a>
             </td>
-            <td><a href="{% url 'msrun_detail' peakgroup.msrun.id %}">{{ peakgroup.msrun.id }}</a></td>
+            <td><a href="{% url 'msrun_detail' peakgroup.msrun.id %}">{{ peakgroup.msrun.researcher }}, {{ peakgroup.msrun.date }}</a></td>
             <td>
                 <a href="{% url 'peakgroupset_detail' peakgroup.peak_group_set.id %}">
                     {{ peakgroup.peak_group_set.filename }}

--- a/DataRepo/templates/DataRepo/peakgroupset_detail.html
+++ b/DataRepo/templates/DataRepo/peakgroupset_detail.html
@@ -1,10 +1,10 @@
 {% extends "base.html" %}
 
-{% block title %}Peak Group Set Details{% endblock %}
+{% block title %}Peak Group Set Record - {{ peakgroupset.filename }}{% endblock %}
 
 {% block content %}
 <div>
-    <h4>Peak Group Set Details :</h4>
+    <h4>Peak Group Set Record - {{ peakgroupset.filename }}</h4>
     <br>
     <table class="table  table-bordered table-hover w-auto mw-100">
         <tr>

--- a/DataRepo/templates/DataRepo/protocol_detail.html
+++ b/DataRepo/templates/DataRepo/protocol_detail.html
@@ -1,10 +1,10 @@
 {% extends "base.html" %}
 
-{% block title %}Protocol Details{% endblock %}
+{% block title %}Protocol Record - {{ protocol.name }}{% endblock %}
 
 {% block content %}
 <div>
-    <h4>Protocol Details:</h4>
+    <h4>Protocol Record - {{ protocol.name }}</h4>
     <table class="table table-bordered table-hover w-auto mw-100">
         <tr>
             <td>Name</td>

--- a/DataRepo/templates/DataRepo/sample_detail.html
+++ b/DataRepo/templates/DataRepo/sample_detail.html
@@ -1,10 +1,10 @@
 {% extends "base.html" %}
 
-{% block title %}Sample Details{% endblock %}
+{% block title %}Sample Record - {{ sample.name }}{% endblock %}
 
 {% block content %}
 <div>
-    <h4>Sample Details</h4>
+    <h4>Sample Record - {{ sample.name }}</h4>
     <br>
     <table class="table  table-bordered table-hover w-auto mw-100">
         <tr>
@@ -20,11 +20,11 @@
             <td>{{ sample.researcher }}</td>
         </tr>
         <tr>
-            <td>Animal Name</td>
+            <td>Animal</td>
             <td><a href="{% url 'animal_detail' sample.animal.id %}">{{ sample.animal.name }}</a></td>
         </tr>
         <tr>
-            <td>Tissue Name</td>
+            <td>Tissue</td>
             <td>{{ sample.tissue}}</td>
         </tr>
         <tr>

--- a/DataRepo/templates/DataRepo/study_detail.html
+++ b/DataRepo/templates/DataRepo/study_detail.html
@@ -1,10 +1,10 @@
 {% extends "base.html" %}
 
-{% block title %}Study Details{% endblock %}
+{% block title %}Study Record - {{ study.name }}{% endblock %}
 
 {% block content %}
 <div>
-    <h4>Study Details:</h4>
+    <h4>Study Record - {{ study.name }}</h4>
     <table class="table table-bordered table-hover w-auto mw-100">
         <tr>
             <td>Name</td>


### PR DESCRIPTION
## Summary Change Description

I also took the liberty to:
- Added record names to detail page titles and headers
- streamline some field names
- obfuscate MSRun record IDs from the user (since they are autofields and can change).

## Affected Issue Numbers

- Resolves #152

## Code Review Notes

For the MS Run "name", I used researcher and date, which is most likely unique, though not technically unique.  I didn't figure it would be critical to also show the protocol and sample, but invite feedback on changing that.

I arbitrarily changed "details" to "record".  Feel free to ask me to change that back.  I just thought it flowed better with adding the name to the header/title.

I also took the liberty to streamline some of the field names in the column headers and detail field headers, just to avoid a bit of redundancy.  I'll restore them if that's the consensus.

## Checklist

- [x] All issue requirements satisfied (or no linked issues)
- [x] [Linting passes](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#linting).
- [x] [Migrations created & committed *(or no model changes)*](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#migration-process)
- [x] [Tests implemented *(or no code changes)*](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#test-implementation)
- [x] [All tests pass](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#quality-control)
