### PR TITLE
Draft methods to retrieve tracer samples/peakdata

### DIFF
--- a/DataRepo/models.py
+++ b/DataRepo/models.py
@@ -372,6 +372,13 @@ class Animal(models.Model, TracerLabeledClass):
     )
 
     def all_serum_samples(self):
+        """
+        all_serum_samples() in an instance method that returns all the serum
+        samples removed from the calling animal object, ordered by the time they
+        were collected from the animal, which is recorded as the time
+        elapsed/duration from the initiation of infusion or treatment,
+        typically.
+        """
         return (
             self.samples.filter(tissue__name=Tissue.SERUM_TISSUE_NAME)
             .order_by("time_collected")
@@ -379,6 +386,13 @@ class Animal(models.Model, TracerLabeledClass):
         )
 
     def final_serum_sample(self):
+        """
+        final_serum_sample() in an instance method that returns the last single
+        serum sample removed from the animal, based on the time elapsed/duration
+        from the initiation of infusion or treatment, typically.  If the animal
+        has no serum samples or if the retrieved serum sample has no annotated
+        time_collected, a warning will be issued.
+        """
 
         final_serum_sample = (
             self.samples.filter(tissue__name=Tissue.SERUM_TISSUE_NAME)

--- a/DataRepo/tests/test_models.py
+++ b/DataRepo/tests/test_models.py
@@ -446,7 +446,7 @@ class DataLoadingTests(TestCase):
         final_serum_sample.delete()
         # with the sample deleted, there are no more serum records...
         serum_samples = animal.all_serum_samples()
-        # soe zero length list
+        # so zero length list
         self.assertEqual(serum_samples.count(), 0)
         with self.assertWarns(UserWarning):
             # and None for final


### PR DESCRIPTION

Added Sample.peak_data_queryset, with optional compound filter
Added Animal methods for serum sample(s) retrieval, and serum tracer peakdata
Added some rudimentary tests for the above

<!-- markdownlint-disable-next-line first-line-heading -->
## Summary Change Description

These are methods I thought might be useful for a first-step on the road to fcirc (and related) serum data calculations.  They could probably be expanded on.

## Affected Issue Numbers

This does not resolve any issues, _per se,_ but add some methods that might be usefully employed in #43 (groundwork)

## Code Review Notes

If the naming or labeling of the methods can be improved, or you think they are not particularly useful, speak up (just a draft idea).  I just though they might be useful , prior to a subsequent calculation-based PR.

## Checklist

- [x] All issue requirements satisfied (or no linked issues)
- [x] [Linting passes](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#linting).
- [x] [Migrations created & committed *(or no model changes)*](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#migration-process)
- [x] [Tests implemented *(or no code changes)*](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#test-implementation)
- [x] [All tests pass](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#quality-control)
