### PR TITLE
Add load_study management command

### DIFF
--- a/DataRepo/example_data/small_dataset/small_obob_study_params.yaml
+++ b/DataRepo/example_data/small_dataset/small_obob_study_params.yaml
@@ -1,0 +1,15 @@
+---
+compounds: "../obob_compounds.tsv"
+animals_samples_treatments:
+  table: "small_obob_animal_and_sample_table.xlsx"
+  headers: "../sample_and_animal_tables_headers.yaml"
+accucor_data:
+  accucor_files:
+    - name: "small_obob_maven_6eaas_inf_blank_sample.xlsx"
+  msrun_protocol: "Default"
+  date: "2021-04-29"
+  researcher: "Michael Neinast"
+  new_researcher: True
+  skip_samples:
+    - "blank"
+

--- a/DataRepo/management/commands/load_study.py
+++ b/DataRepo/management/commands/load_study.py
@@ -1,0 +1,125 @@
+import argparse
+import os
+
+import jsonschema
+import yaml  # type: ignore
+from django.apps import apps
+from django.core.management import BaseCommand, call_command
+
+
+class Command(BaseCommand):
+
+    # Show this when the user types help
+    help = (
+        "Loads compounds, animals, samples, and accucor data using a YAML "
+        "file to specify parameters."
+        "Example usage : manage.py load_study my_study/my_study.yaml"
+    )
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "study_params",
+            type=argparse.FileType("r"),
+            help="file containing the parameters used to load the study data.",
+        )
+
+    def get_current_app_path(self):
+        return apps.get_app_config("DataRepo").path
+
+    def handle(self, *args, **options):
+
+        # Read load study parameters
+        study_params = yaml.safe_load(options["study_params"])
+        study_dir = os.path.dirname(os.path.realpath(options["study_params"].name))
+
+        # Read load study config schema
+        app_path = self.get_current_app_path()
+        schema_path = os.path.join(app_path, "schemas", "load_study.yaml")
+
+        with open(schema_path, "r") as stream:
+            schema = yaml.safe_load(stream)
+
+        # Validate the configuration
+        jsonschema.validate(study_params, schema)
+        self.stdout.write(
+            self.style.SUCCESS(
+                f"Validated study parameters {options['study_params'].name}"
+            )
+        )
+        if "compounds" in study_params:
+            compounds_file = os.path.join(study_dir, study_params["compounds"])
+            self.stdout.write(
+                self.style.MIGRATE_HEADING(f"Loading compounds from {compounds_file}")
+            )
+            call_command("load_compounds", compounds_file)
+
+        if "animals_samples_treatments" in study_params:
+            # Read in animals and samples file
+            animals_samples_table_file = os.path.join(
+                study_dir, study_params["animals_samples_treatments"]["table"]
+            )
+            self.stdout.write(
+                self.style.MIGRATE_HEADING(
+                    f"Loading animals and samples from {animals_samples_table_file}"
+                )
+            )
+            if "headers" in study_params["animals_samples_treatments"]:
+                headers_file = os.path.join(
+                    study_dir, study_params["animals_samples_treatments"]["headers"]
+                )
+            else:
+                headers_file = None
+            call_command(
+                "load_animals_and_samples",
+                animal_and_sample_table_filename=animals_samples_table_file,
+                table_headers=headers_file,
+            )
+
+        if "accucor_data" in study_params:
+
+            # Get parameters for all accucor files
+            protocol = study_params["accucor_data"]["msrun_protocol"]
+            date = study_params["accucor_data"]["date"]
+            researcher = study_params["accucor_data"]["researcher"]
+            new_researcher = study_params["accucor_data"]["new_researcher"]
+            skip_samples = None
+            if "skip_samples" in study_params["accucor_data"]:
+                skip_samples = study_params["accucor_data"]["skip_samples"]
+            sample_name_prefix = None
+            if "sample_name_prefix" in study_params["accucor_data"]:
+                sample_name_prefix = study_params["accucor_data"]["sample_name_prefix"]
+
+            # Read in accucor data files
+            for accucor_file in study_params["accucor_data"]["accucor_files"]:
+                accucor_file_name = accucor_file["name"]
+                self.stdout.write(
+                    self.style.MIGRATE_HEADING(
+                        f"Loading accucor_data from {accucor_file_name}"
+                    )
+                )
+                # Get parameters specific to each accucor file
+                if "protocol" in accucor_file:
+                    protocol = accucor_file["protocol"]
+                if "date" in accucor_file:
+                    date = accucor_file["date"]
+                if "researcher" in accucor_file:
+                    researcher = accucor_file["researcher"]
+                if "new_researcher" in accucor_file:
+                    new_researcher = accucor_file["new_researcher"]
+                if "skip_samples" in accucor_file:
+                    skip_samples = accucor_file["skip_samples"]
+                if "sample_name_prefix" in accucor_file:
+                    sample_name_prefix = accucor_file["sample_name_prefix"]
+
+                call_command(
+                    "load_accucor_msruns",
+                    accucor_file=os.path.join(study_dir, accucor_file_name),
+                    protocol=protocol,
+                    date=date,
+                    researcher=researcher,
+                    new_researcher=new_researcher,
+                    skip_samples=skip_samples,
+                    sample_name_prefix=sample_name_prefix,
+                )
+
+        self.stdout.write(self.style.SUCCESS("Done loading study"))

--- a/DataRepo/schemas/load_study.yaml
+++ b/DataRepo/schemas/load_study.yaml
@@ -1,0 +1,73 @@
+$schema: "https://json-schema.org/draft-06/schema#"
+description: dataset loading parameters
+properties:
+  compounds:
+    type: string
+    description: filename for compounds to load
+  animals_samples_treatments:
+    type: object
+    description: animals, samples, and treatments table as well as header definitions
+    properties:
+      table:
+        type: string
+        description: filename of Excel file with animals, samples, treatments worksheets
+      headers:
+        type: string
+        description: filename of yaml file defining headers for Excel worksheets
+    required:
+      - table
+  accucor_data:
+    type: object
+    properties:
+      accucor_files:
+        type: array
+        description: list of accucor filenames and parameters specific to that file
+        items:
+          type: object
+          properties:
+            name:
+              type: string
+              description: accucor filename
+            sample_name_prefix:
+              type: string
+            msrun_protocol:
+              type: string
+            date:
+              type: string
+            researcher:
+              type: string
+            new_researcher:
+              type: boolean
+              default: False
+            skip_samples:
+              type: array
+              items:
+                type: string
+          required:
+            - name
+    msrun_protocol:
+      type: string
+      description: name of ms run protocol
+    date:
+      type: string
+      description: date of ms run
+    researcher:
+      type: string
+      description: name of resercher who performed ms run
+    new_researcher:
+      type: boolean
+      default: False
+      description: flag to indiciate the researcher should be added
+    skip_samples:
+      type: array
+      description: list of sample names to skip when loading
+      items:
+        type: string
+    sample_name_prefix:
+      type: string
+      description: prefix to append to sample names prior to searching
+    required:
+      - accucor_files
+      - msrun_protocol
+      - date
+      - researcher

--- a/DataRepo/tests/test_models.py
+++ b/DataRepo/tests/test_models.py
@@ -840,6 +840,23 @@ class AccuCorDataLoadingTests(TestCase):
             )
 
 
+@tag("load_study")
+class StudyLoadingTests(TestCase):
+    def test_load_small_obob_study(self):
+        call_command(
+            "load_study",
+            "DataRepo/example_data/small_dataset/small_obob_study_params.yaml",
+        )
+        COMPOUNDS_COUNT = 2
+        SAMPLES_COUNT = 14
+        PEAKDATA_ROWS = 11
+
+        self.assertEqual(
+            PeakGroup.objects.all().count(), COMPOUNDS_COUNT * SAMPLES_COUNT
+        )
+        self.assertEqual(PeakData.objects.all().count(), PEAKDATA_ROWS * SAMPLES_COUNT)
+
+
 class ParseIsotopeLabelTests(TestCase):
     @classmethod
     def setUpTestData(cls):


### PR DESCRIPTION
<!-- markdownlint-disable-next-line first-line-heading -->
## Summary Change Description

The `load_study` management command allows one to specify compounds,
animals, samples, and accucor files, along with the associated
parameters required to load them in a config file and load them all in
one command.

The config YAML file schema is specified using [JSON
Schema](https://json-schema.org/) and validated during the run of
`load_study`.

## Affected Issue Numbers

- Resolves #164

## Code Review Notes


## Checklist

- [x] All issue requirements satisfied (or no linked issues)
- [x] [Linting passes](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#linting).
- [x] [Migrations created & committed *(or no model changes)*](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#migration-process)
- [x] [Tests implemented *(or no code changes)*](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#test-implementation)
- [x] [All tests pass](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#quality-control)
