### PR TITLE
Added Animal methods/tests for serum tracer calculations

### DIFF
--- a/.python-lint
+++ b/.python-lint
@@ -224,11 +224,11 @@ contextmanager-decorators=contextlib.contextmanager
 generated-members=
     objects,
     DoesNotExist,
-    *.final_serum_sample,
-    *.animal,
-    *.all_serum_samples,
-    *.final_serum_sample_tracer_peak_group,
-    *.final_serum_sample_tracer_peak_data,
+    .*\.final_serum_sample,
+    .*\.animal,
+    .*\.all_serum_samples,
+    .*\.peak_data,
+    .*\.filter
 
 # Tells whether missing members accessed in mixin class should be ignored. A
 # mixin class is detected if its name ends with "mixin" (case insensitive).

--- a/.python-lint
+++ b/.python-lint
@@ -221,7 +221,14 @@ contextmanager-decorators=contextlib.contextmanager
 # List of members which are set dynamically and missed by pylint inference
 # system, and so shouldn't trigger E1101 when accessed. Python regular
 # expressions are accepted.
-generated-members=objects,DoesNotExist
+generated-members=
+    objects,
+    DoesNotExist,
+    *.final_serum_sample,
+    *.animal,
+    *.all_serum_samples,
+    *.final_serum_sample_tracer_peak_group,
+    *.final_serum_sample_tracer_peak_data,
 
 # Tells whether missing members accessed in mixin class should be ignored. A
 # mixin class is detected if its name ends with "mixin" (case insensitive).

--- a/DataRepo/models.py
+++ b/DataRepo/models.py
@@ -468,35 +468,50 @@ class Animal(models.Model, TracerLabeledClass):
         return final_peak_data.filter(labeled_count=self.tracer_labeled_count).get()
 
     @cached_property
-    def tracer_Rd_intact_g(self):
-        """Rate of Disappearance (intact)"""
+    def final_serum_tracer_rate_disappearance_intact_per_gram(self):
+        """
+        Rate of Disappearance (intact), also referred to as Rd_intact_g. This is
+        calculated on the Animal's final serum sample tracer's PeakGroup.
+        """
         return (
             self.final_serum_sample_tracer_peak_group.rate_disappearance_intact_per_gram
         )
 
     @cached_property
-    def tracer_Ra_intact_g(self):
-        """Rate of Appearance (intact)"""
+    def final_serum_tracer_rate_appearance_intact_per_gram(self):
+        """
+        Rate of Appearance (intact), also referred to as Ra_intact_g, or
+        sometimes Fcirc_intact. This is calculated on the Animal's
+        final serum sample tracer's PeakGroup.
+        """
         return self.final_serum_sample_tracer_peak_group.rate_appearance_intact_per_gram
 
     @cached_property
-    def tracer_Rd_intact(self):
-        """Rate of Disappearance (intact), normalized by body weight"""
+    def final_serum_tracer_rate_disappearance_intact_weight_normalized(self):
+        """
+        Rate of Disappearance (intact), normalized by body weight, also referred
+        to as Rd_intact. This is calculated on the Animal's final
+        serum sample tracer's PeakGroup.
+        """
         return (
             self.final_serum_sample_tracer_peak_group.rate_disappearance_intact_weight_normalized
         )
 
     @cached_property
-    def tracer_Ra_intact(self):
-        """Rate of Appearance (intact), normalized by body weight"""
+    def final_serum_tracer_rate_appearance_intact_weight_normalized(self):
+        """
+        Rate of Appearance (intact), normalized by body weight, also referred to
+        as Ra_intact, or sometimes Fcirc_intact_per_mouse. This is calculated on
+        the Animal's final serum sample tracer's PeakGroup.
+        """
         return (
             self.final_serum_sample_tracer_peak_group.rate_appearance_intact_weight_normalized
         )
 
     @cached_property
-    def tracer_Rd_avg_g(self):
+    def final_serum_tracer_rate_disappearance_average_per_gram(self):
         """
-        Rd_avg_g = [Infusate] * 'Infusion Rate' / 'Enrichment Fraction' in
+        Also referred to as Rd_avg_g = [Infusate] * 'Infusion Rate' / 'Enrichment Fraction' in
         nmol/min/g
         Calculated for the last serum sample collected, for the last tracer
         peakgroup analyzed.
@@ -506,117 +521,40 @@ class Animal(models.Model, TracerLabeledClass):
         )
 
     @cached_property
-    def tracer_Ra_avg_g(self):
+    def final_serum_tracer_rate_appearance_average_per_gram(self):
         """
-        Ra_avg_g = Rd_avg_g - [Infusate] * 'Infusion Rate' in nmol/min/g
+        Also referred to as Ra_avg_g, and sometimes referred to as Fcirc_avg.
+        Equivalent to Rd_avg_g - [Infusate] * 'Infusion Rate' in nmol/min/g
+        Calculated for the last serum sample collected, for the last tracer
+        peakgroup analyzed.
         """
         return (
             self.final_serum_sample_tracer_peak_group.rate_appearance_average_per_gram
         )
 
     @cached_property
-    def tracer_Rd_avg(self):
+    def final_serum_tracer_rate_disappearance_average_weight_normalized(self):
         """
-        Rate of Disappearance (avg)
+        Rate of Disappearance (avg), also referred to as Rd_avg
         Rd_avg = Rd_avg_g * 'Body Weight' in nmol/min
+        Calculated for the last serum sample collected, for the last tracer
+        peakgroup analyzed.
         """
         return (
             self.final_serum_sample_tracer_peak_group.rate_disappearance_average_weight_normalized
         )
 
     @cached_property
-    def tracer_Ra_avg(self):
+    def final_serum_tracer_rate_appearance_average_weight_normalized(self):
         """
-        Rate of Appearance (avg)
-        Ra_avg = Ra_avg_g * 'Body Weight'' in nmol/min
+        Rate of Appearance (avg), also referred to as Ra_avg or sometimes
+        Fcirc_avg_per_mouse. Ra_avg = Ra_avg_g * 'Body Weight'' in nmol/min
+        Calculated for the last serum sample collected, for the last tracer
+        peakgroup analyzed.
         """
         return (
             self.final_serum_sample_tracer_peak_group.rate_appearance_average_weight_normalized
         )
-
-    @cached_property
-    def tracer_Fcirc_intact(self):
-        """
-        tracer_Fcirc_intact - turnover of the tracer compound for this animal, as
-        rate of appearance of any modified form of the tracer compound (nmol/min/gram
-        body weight) = calculated using the infusion rate of tracer in this animal and
-        the labeling in the tracer compound from the final serum timepoint =
-        (Animal:tracer_infusion_rate * Animal:tracer_infusion_concentration) /
-        (PeakData:fraction) - (Animal:tracer_infusion_rate *
-        Animal:tracer_infusion_concentration)
-        """
-        intact_tracer_peak_data = self.intact_tracer_peak_data
-        if not intact_tracer_peak_data:
-            warnings.warn(f"Animal {self.name} has no fully labeled serum sample data.")
-            return None
-
-        if (
-            self.tracer_infusion_rate
-            and self.tracer_infusion_concentration
-            and intact_tracer_peak_data.fraction
-            and intact_tracer_peak_data.fraction > 0
-        ):
-            return (
-                self.tracer_infusion_rate * self.tracer_infusion_concentration
-            ) / intact_tracer_peak_data.fraction - (
-                self.tracer_infusion_rate * self.tracer_infusion_concentration
-            )
-        else:
-            warnings.warn("Cannot calculate tracer_Fcirc_intact.")
-            return None
-
-    @cached_property
-    def tracer_Fcirc_avg(self):
-        """
-        tracer_Fcirc_avg - turnover of the tracer compound for this animal, as the rate
-        of appearance of unlabeled atoms in the tracer compound calculated using the
-        infusion rate of tracer in this animal and the labeling in the tracer compound
-        from the final serum timepoint. (Animal:tracer_infusion_rate *
-        Animal:tracer_infusion_concentration) / (PeakGroup:enrichment_fraction) -
-        (Animal:infusion_rate * Animal:infusion_concentration)
-        """
-
-        last_tracer_peak_group = self.final_serum_sample_tracer_peak_group
-        if not last_tracer_peak_group:
-            warnings.warn(f"Animal {self.name} has no serum sample data.")
-            return None
-        return (
-            self.tracer_infusion_rate * self.tracer_infusion_concentration
-        ) / last_tracer_peak_group.enrichment_fraction - (
-            self.tracer_infusion_rate * self.tracer_infusion_concentration
-        )
-
-    @cached_property
-    def tracer_Fcirc_intact_per_mouse(self):
-        """
-        tracer_Fcirc_intact_per_mouse - tracer_Fcirc_intact * Animal:body_weight =
-        nmol/min/mouse
-        """
-        try:
-            return self.tracer_Fcirc_intact * self.body_weight
-        except Exception as e:
-            estr = str(e)
-            if "unsupported operand type(s) for *: 'float' and 'NoneType'" in estr:
-                warnings.warn(f"Animal {self.name} has no annotated body_weight.")
-                return None
-            else:
-                raise (e)
-
-    @cached_property
-    def tracer_Fcirc_avg_per_mouse(self):
-        """
-        tracer_Fcirc_avg_per_mouse - tracer_Fcirc_avg * Animal:body_weight =
-        nmol/min/mouse
-        """
-        try:
-            return self.tracer_Fcirc_avg * self.body_weight
-        except Exception as e:
-            estr = str(e)
-            if "unsupported operand type(s) for *: 'float' and 'NoneType'" in estr:
-                warnings.warn(f"Animal {self.name} has no annotated body_weight.")
-                return None
-            else:
-                raise (e)
 
     @cached_property
     def tracer_Fcirc_avg_atom(self):

--- a/DataRepo/models.py
+++ b/DataRepo/models.py
@@ -453,6 +453,7 @@ class Animal(models.Model, TracerLabeledClass):
             return None
         return final_peak_group.peak_data
 
+    @cached_property
     def intact_tracer_peak_data(self):
         """
         intact_tracer_peak_data is an instance method that returns the peak data
@@ -544,7 +545,7 @@ class Animal(models.Model, TracerLabeledClass):
         (PeakData:fraction) - (Animal:tracer_infusion_rate *
         Animal:tracer_infusion_concentration)
         """
-        intact_tracer_peak_data = self.intact_tracer_peak_data()
+        intact_tracer_peak_data = self.intact_tracer_peak_data
         if not intact_tracer_peak_data:
             warnings.warn(f"Animal {self.name} has no fully labeled serum sample data.")
             return None

--- a/DataRepo/models.py
+++ b/DataRepo/models.py
@@ -417,7 +417,7 @@ class Animal(models.Model, TracerLabeledClass):
 
     def intact_tracer_peak_data(self):
         """
-        intact_tracer_peak_data is a instance method that returns the peak data
+        intact_tracer_peak_data is an instance method that returns the peak data
         matching the intact tracer (labeled_count filtered)
         """
         if not self.tracer_labeled_count:
@@ -431,7 +431,7 @@ class Animal(models.Model, TracerLabeledClass):
 
     def final_serum_sample_tracer_peak_group(self):
         """
-        final_serum_sample_tracer_peak_data is a instance method that returns
+        final_serum_sample_tracer_peak_data is an instance method that returns
         the peak group encompassing the final serum sample's peak data
         """
         return self.final_serum_sample_tracer_peak_data().first().peak_group
@@ -564,9 +564,9 @@ class Animal(models.Model, TracerLabeledClass):
     def tracer_Fcirc_avg(self):
         """
         tracer_Fcirc_avg - turnover of the tracer compound for this animal, as the rate
-        of appearance of unlabeled atoms in the tracer compound = calculated using the
+        of appearance of unlabeled atoms in the tracer compound calculated using the
         infusion rate of tracer in this animal and the labeling in the tracer compound
-        from the final serum timepoint. = (Animal:tracer_infusion_rate *
+        from the final serum timepoint. (Animal:tracer_infusion_rate *
         Animal:tracer_infusion_concentration) / (PeakGroup:enrichment_fraction) -
         (Animal:infusion_rate * Animal:infusion_concentration)
         """
@@ -621,7 +621,7 @@ class Animal(models.Model, TracerLabeledClass):
     def tracer_Fcirc_avg_atom(self):
         """
         tracer_Fcirc_avg_atom - tracer_Fcirc_avg * PeakData:label_count = nmol atom / min /
-        gram = turnover of atoms in this compound = "nmol carbon / min / g
+        gram = turnover of atoms in this compound, e.g. "nmol carbon / min / g"
         """
         try:
             return self.tracer_Fcirc_avg * self.tracer_labeled_count

--- a/DataRepo/tests/test_models.py
+++ b/DataRepo/tests/test_models.py
@@ -1162,7 +1162,7 @@ class TracerRateTests(TestCase):
         labelless_animal.tracer_labeled_count = None
         # we won't save this edit back to the database
         with self.assertWarns(UserWarning):
-            self.assertIsNone(labelless_animal.intact_tracer_peak_data())
+            self.assertIsNone(labelless_animal.intact_tracer_peak_data)
             self.assertIsNone(labelless_animal.tracer_Fcirc_avg_atom)
 
 

--- a/DataRepo/tests/test_models.py
+++ b/DataRepo/tests/test_models.py
@@ -400,6 +400,12 @@ class DataLoadingTests(TestCase):
         self.assertEqual(sample.animal.name, "969")
         self.assertEqual(sample.tissue.name, "BAT")
 
+    def test_sample_is_serum(self):
+        serum = Sample.objects.get(name="serum-xz971")
+        self.assertTrue(serum.is_serum_sample)
+        nonserum = Sample.objects.get(name="bat-xz969")
+        self.assertTrue(nonserum.is_serum_sample)
+
     def test_peak_groups_set_loaded(self):
 
         # 2 peak group sets , 1 for each call to load_accucor_msruns

--- a/DataRepo/tests/test_models.py
+++ b/DataRepo/tests/test_models.py
@@ -1,4 +1,5 @@
 from datetime import datetime, timedelta
+from unittest import skip
 
 import pandas as pd
 from django.core.exceptions import ValidationError
@@ -404,7 +405,7 @@ class DataLoadingTests(TestCase):
         serum = Sample.objects.get(name="serum-xz971")
         self.assertTrue(serum.is_serum_sample)
         nonserum = Sample.objects.get(name="bat-xz969")
-        self.assertTrue(nonserum.is_serum_sample)
+        self.assertFalse(nonserum.is_serum_sample)
 
     def test_peak_groups_set_loaded(self):
 
@@ -432,7 +433,7 @@ class DataLoadingTests(TestCase):
 
     def test_animal_serum_sample_methods(self):
         animal = self.MAIN_SERUM_ANIMAL
-        serum_samples = animal.all_serum_samples()
+        serum_samples = animal.all_serum_samples
         self.assertEqual(serum_samples.count(), 1)
         final_serum_sample = animal.final_serum_sample
         self.assertEqual(final_serum_sample.name, "serum-xz971")
@@ -442,19 +443,19 @@ class DataLoadingTests(TestCase):
         animal = self.MAIN_SERUM_ANIMAL
         final_serum_sample = animal.final_serum_sample
         peak_groups = final_serum_sample.peak_groups()
-        # ALL the sample's groupgroup/compound objects total 13
+        # ALL the sample's PeakGroup objects in the QuerySet total 13
         self.assertEqual(peak_groups.count(), self.SERUM_COMPOUNDS_COUNT)
-        # but if limited to only the tracer, it is just 1 objects
+        # but if limited to only the tracer, it is just 1 object in the QuerySet
         sample_tracer_peak_groups = final_serum_sample.peak_groups(
             animal.tracer_compound
         )
         self.assertEqual(sample_tracer_peak_groups.count(), 1)
-        # and test that the Animal convenience method is equivalent to the above
-        animal_tracer_peak_groups = animal.final_serum_sample_tracer_peak_groups()
+        # and test that the Animal convenience method is equivalent for this
+        # particular sample/animal
+        animal_tracer_peak_group = animal.final_serum_sample_tracer_peak_group
         self.assertEqual(
-            sample_tracer_peak_groups.count(), animal_tracer_peak_groups.count()
+            sample_tracer_peak_groups.get().id, animal_tracer_peak_group.id
         )
-        self.assertQuerysetEqual(sample_tracer_peak_groups, animal_tracer_peak_groups)
 
     def test_sample_peak_data(self):
         animal = self.MAIN_SERUM_ANIMAL
@@ -466,9 +467,8 @@ class DataLoadingTests(TestCase):
         peakdata = final_serum_sample.peak_data(animal.tracer_compound)
         self.assertEqual(peakdata.count(), 7)
         # and test that the Animal convenience method is equivalent to the above
-        peakdata2 = animal.final_serum_sample_tracer_peak_data()
-        self.assertEqual(peakdata.count(), peakdata2.count())
-        self.assertQuerysetEqual(peakdata, peakdata2)
+        peakdata2 = animal.final_serum_sample_tracer_peak_data
+        self.assertEqual(peakdata.last().id, peakdata2.last().id)
 
     def test_missing_time_collected_warning(self):
         final_serum_sample = self.MAIN_SERUM_ANIMAL.final_serum_sample
@@ -498,184 +498,12 @@ class DataLoadingTests(TestCase):
         # with the sample deleted, there are no more serum records...
         # so if we refresh, with no cached final serum values...
         refeshed_animal = Animal.objects.get(name="971")
-        serum_samples = refeshed_animal.all_serum_samples()
+        serum_samples = refeshed_animal.all_serum_samples
         # so zero length list
         self.assertEqual(serum_samples.count(), 0)
         with self.assertWarns(UserWarning):
             # and attempts to retrieve the final_serum_sample get None
             self.assertIsNone(refeshed_animal.final_serum_sample)
-
-    @tag("pg_fcirc")
-    def test_nontracer_peakgroup_calculation_attempts(self):
-        animal = self.MAIN_SERUM_ANIMAL
-        nontracer_compound = Compound.objects.get(name="tryptophan")
-        # but let's get a peakgroup for a compound we know is not the tracer
-        pgs = animal.final_serum_sample.peak_groups(nontracer_compound)
-        # should only be one in this specific case
-        non_tracer_pg = pgs[0]
-        with self.assertWarns(UserWarning):
-            # tryptophan is not the tracer
-            self.assertFalse(non_tracer_pg.is_tracer_compound_group)
-        # and none of these should return a value
-        with self.assertWarns(UserWarning):
-            self.assertIsNone(non_tracer_pg.rate_disappearance_intact_per_gram)
-        with self.assertWarns(UserWarning):
-            self.assertIsNone(non_tracer_pg.rate_appearance_intact_per_gram)
-        with self.assertWarns(UserWarning):
-            self.assertIsNone(non_tracer_pg.rate_disappearance_intact_normalized)
-        with self.assertWarns(UserWarning):
-            self.assertIsNone(non_tracer_pg.rate_appearance_intact_normalized)
-        with self.assertWarns(UserWarning):
-            self.assertIsNone(non_tracer_pg.rate_disappearance_average_per_gram)
-        with self.assertWarns(UserWarning):
-            self.assertIsNone(non_tracer_pg.rate_appearance_average_per_gram)
-        with self.assertWarns(UserWarning):
-            self.assertIsNone(non_tracer_pg.rate_disappearance_average_normalized)
-        with self.assertWarns(UserWarning):
-            self.assertIsNone(non_tracer_pg.rate_appearance_average_normalized)
-
-    @tag("pg_fcirc")
-    def test_tracer_peakgroup_calc_equivalence(self):
-        animal = self.MAIN_SERUM_ANIMAL
-        tracer_peak_groups = animal.all_serum_samples_tracer_peak_groups()
-        # lets just try computational equivalence of the previous
-        # implementation, for now
-        last_pg = tracer_peak_groups[-1]
-        self.assertEqual(
-            last_pg.rate_disappearance_intact_per_gram, animal.tracer_Rd_intact_g
-        )
-        self.assertEqual(
-            last_pg.rate_appearance_intact_per_gram, animal.tracer_Ra_intact_g
-        )
-        self.assertEqual(
-            last_pg.rate_disappearance_intact_normalized, animal.tracer_Rd_intact
-        )
-        self.assertEqual(
-            last_pg.rate_appearance_intact_normalized, animal.tracer_Ra_intact
-        )
-        self.assertEqual(
-            last_pg.rate_disappearance_average_per_gram, animal.tracer_Rd_avg_g
-        )
-        self.assertEqual(
-            last_pg.rate_appearance_average_per_gram, animal.tracer_Ra_avg_g
-        )
-        self.assertEqual(
-            last_pg.rate_disappearance_average_normalized, animal.tracer_Rd_avg
-        )
-        self.assertEqual(
-            last_pg.rate_appearance_average_normalized, animal.tracer_Ra_avg
-        )
-
-    @tag("fcirc")
-    def test_tracer_Rd_intact_g(self):
-        animal = self.MAIN_SERUM_ANIMAL
-        self.assertAlmostEqual(animal.tracer_Rd_intact_g, 14.96, places=2)
-
-    @tag("fcirc")
-    def test_tracer_Ra_intact_g(self):
-        animal = self.MAIN_SERUM_ANIMAL
-        self.assertAlmostEqual(animal.tracer_Ra_intact_g, 12.41, places=2)
-
-    @tag("fcirc")
-    def test_tracer_Rd_intact(self):
-        animal = self.MAIN_SERUM_ANIMAL
-        self.assertAlmostEqual(animal.tracer_Rd_intact, 393.50, places=2)
-
-    @tag("fcirc")
-    def test_tracer_Ra_intact(self):
-        animal = self.MAIN_SERUM_ANIMAL
-        self.assertAlmostEqual(animal.tracer_Ra_intact, 326.38, places=2)
-
-    @tag("fcirc")
-    def test_tracer_Rd_avg_g(self):
-        animal = self.MAIN_SERUM_ANIMAL
-        self.assertAlmostEqual(animal.tracer_Rd_avg_g, 14.96, places=2)
-
-    @tag("fcirc")
-    def test_tracer_Ra_avg_g(self):
-        animal = self.MAIN_SERUM_ANIMAL
-        self.assertAlmostEqual(animal.tracer_Ra_avg_g, 12.41, places=2)
-
-    @tag("fcirc")
-    def test_tracer_Rd_avg(self):
-        animal = self.MAIN_SERUM_ANIMAL
-        self.assertAlmostEqual(animal.tracer_Rd_avg, 393.50, places=2)
-
-    @tag("fcirc")
-    def test_tracer_Ra_avg(self):
-        animal = self.MAIN_SERUM_ANIMAL
-        self.assertAlmostEqual(animal.tracer_Ra_avg, 326.38, places=2)
-
-    @tag("fcirc")
-    def test_tracer_Fcirc_intact(self):
-        """
-        The test load file DataRepo/example_data/obob_maven_6eaas_serum.xlsx
-        only has serum sample data for serum-xz971 (i.e. MAIN_SERUM_ANIMAL),
-        serum-xz972, serum-xz981, serum-xz982 (so those are the only animals
-        (971,972,981,982)/samples we can test, here)
-        """
-        animal = self.MAIN_SERUM_ANIMAL
-        self.assertAlmostEqual(animal.tracer_Fcirc_intact, 12.41, places=2)
-
-    @tag("fcirc")
-    def test_tracer_Fcirc_avg(self):
-        animal = self.MAIN_SERUM_ANIMAL
-        self.assertAlmostEqual(animal.tracer_Fcirc_avg, 12.41, places=2)
-
-    @tag("fcirc")
-    def test_tracer_Fcirc_intact_per_mouse(self):
-        animal = self.MAIN_SERUM_ANIMAL
-        self.assertAlmostEqual(animal.tracer_Fcirc_intact_per_mouse, 326.38, places=2)
-
-    @tag("fcirc")
-    def test_tracer_Fcirc_avg_per_mouse(self):
-        animal = self.MAIN_SERUM_ANIMAL
-        self.assertAlmostEqual(animal.tracer_Fcirc_avg_per_mouse, 326.38, places=2)
-
-    @tag("fcirc")
-    def test_tracer_Fcirc_avg_atom(self):
-        animal = self.MAIN_SERUM_ANIMAL
-        self.assertAlmostEqual(animal.tracer_Fcirc_avg_atom, 74.46, places=2)
-
-    @tag("fcirc")
-    def test_animal_tracer_Fcirc_intact_missing_serum(self):
-        """
-        The test load file DataRepo/example_data/obob_maven_6eaas_serum.xlsx
-        only has serum sample data for serum-xz971, serum-xz972, serum-xz981,
-        serum-xz982 (so those are the only animals (971,972,981,982)/samples we
-        can test, here)
-        """
-        animal = Animal.objects.get(name="970")
-        with self.assertWarns(UserWarning):
-            self.assertIsNone(animal.tracer_Fcirc_intact)
-
-    @tag("fcirc")
-    def test_animal_tracer_Fcirc_avg_missing_serum(self):
-        animal = Animal.objects.get(name="970")
-        with self.assertWarns(UserWarning):
-            self.assertIsNone(animal.tracer_Fcirc_avg)
-
-    @tag("fcirc")
-    def test_animal_tracer_Fcirc_missing_body_weight(self):
-        weightless_animal = self.MAIN_SERUM_ANIMAL
-        weightless_animal.body_weight = None
-        # we won't save this edit back to the database
-        with self.assertWarns(UserWarning):
-            self.assertIsNone(weightless_animal.tracer_Rd_avg)
-            self.assertIsNone(weightless_animal.tracer_Ra_avg)
-            self.assertIsNone(weightless_animal.tracer_Rd_intact)
-            self.assertIsNone(weightless_animal.tracer_Ra_intact)
-            self.assertIsNone(weightless_animal.tracer_Fcirc_intact_per_mouse)
-            self.assertIsNone(weightless_animal.tracer_Fcirc_avg_per_mouse)
-
-    @tag("fcirc")
-    def test_animal_tracer_Fcirc_missing_labeled_count(self):
-        labelless_animal = self.MAIN_SERUM_ANIMAL
-        labelless_animal.tracer_labeled_count = None
-        # we won't save this edit back to the database
-        with self.assertWarns(UserWarning):
-            self.assertIsNone(labelless_animal.intact_tracer_peak_data())
-            self.assertIsNone(labelless_animal.tracer_Fcirc_avg_atom)
 
     def test_restricted_animal_treatment_deletion(self):
         treatment = Animal.objects.get(name="exp024f_M2").treatment
@@ -797,7 +625,7 @@ class DataLoadingTests(TestCase):
             time_collected=first_serum_sample.time_collected + timedelta(minutes=1),
         )
 
-        serum_samples = first_serum_sample.animal.all_serum_samples()
+        serum_samples = first_serum_sample.animal.all_serum_samples
         # there should now be 2 serum samples for this animal
         self.assertEqual(serum_samples.count(), 2)
         final_serum_sample = first_serum_sample.animal.final_serum_sample
@@ -996,6 +824,346 @@ class DataLoadingTests(TestCase):
         )
         # Test that basically, no exception occurred
         self.assertTrue(True)
+
+    @tag("fcirc")
+    def test_peakgroup_is_tracer_compound_group_false(self):
+        # get a non tracer compound from a serum sample
+        compound = Compound.objects.get(name="tryptophan")
+        sample = Sample.objects.get(name="serum-xz971")
+        pg = sample.peak_groups(compound).last()
+        with self.assertWarns(UserWarning):
+            self.assertFalse(pg.is_tracer_compound_group)
+
+    @tag("fcirc")
+    def test_peakgroup_from_serum_sample_false(self):
+        # get a tracer compound from a non-serum sample
+        compound = Compound.objects.get(name="glucose")
+        sample = Sample.objects.get(name="Liv-xz982")
+        pg = sample.peak_groups(compound).last()
+        with self.assertWarns(UserWarning):
+            self.assertFalse(pg.from_serum_sample)
+
+    @tag("fcirc")
+    def test_peakgroup_can_compute_tracer_rates_true(self):
+        # get a tracer compound from a  sample
+        compound = Compound.objects.get(name="lysine")
+        sample = Sample.objects.get(name="serum-xz971")
+        pg = sample.peak_groups(compound).last()
+        self.assertTrue(pg.can_compute_tracer_rates)
+
+    @tag("fcirc")
+    def test_peakgroup_can_compute_tracer_rates_false_no_rate(self):
+        # get a tracer compound from a  sample
+        compound = Compound.objects.get(name="lysine")
+        sample = Sample.objects.get(name="serum-xz971")
+        pg = sample.peak_groups(compound).last()
+        animal = pg.animal
+        # but if the animal tracer_infusion_rate is not defined...
+        orig_tir = animal.tracer_infusion_rate
+        animal.tracer_infusion_rate = None
+        animal.save()
+        pgf = animal.final_serum_sample_tracer_peak_group
+        with self.assertWarns(UserWarning):
+            self.assertFalse(pgf.can_compute_tracer_rates)
+        # revert
+        animal.tracer_infusion_rate = orig_tir
+        animal.save()
+
+    @tag("fcirc")
+    def test_peakgroup_can_compute_tracer_rates_false_no_conc(self):
+        # get a tracer compound from a sample
+        compound = Compound.objects.get(name="lysine")
+        sample = Sample.objects.get(name="serum-xz971")
+        pg = sample.peak_groups(compound).last()
+        animal = pg.animal
+        # but if the animal tracer_infusion_concentration is not defined...
+        orig_tic = animal.tracer_infusion_concentration
+        animal.tracer_infusion_concentration = None
+        animal.save()
+        pgf = animal.final_serum_sample_tracer_peak_group
+        with self.assertWarns(UserWarning):
+            self.assertFalse(pgf.can_compute_tracer_rates)
+        # revert
+        animal.tracer_infusion_concentration = orig_tic
+        animal.save()
+
+    @tag("fcirc")
+    def test_peakgroup_can_compute_weight_normalized_tracer_rates_true(self):
+        animal = self.MAIN_SERUM_ANIMAL
+        pg = animal.final_serum_sample_tracer_peak_group
+        self.assertTrue(pg.can_compute_weight_normalized_tracer_rates)
+
+    @tag("fcirc")
+    def test_peakgroup_can_compute_weight_normalized_tracer_rates_false(self):
+        animal = self.MAIN_SERUM_ANIMAL
+        orig_bw = animal.body_weight
+        animal.body_weight = None
+        animal.save()
+        pg = animal.final_serum_sample_tracer_peak_group
+        with self.assertWarns(UserWarning):
+            self.assertFalse(pg.can_compute_weight_normalized_tracer_rates)
+        # revert
+        animal.body_weight = orig_bw
+        animal.save()
+
+    @tag("fcirc")
+    def test_peakgroup_can_compute_intact_tracer_rates_true(self):
+        pg = self.MAIN_SERUM_ANIMAL.final_serum_sample_tracer_peak_group
+        self.assertTrue(pg.can_compute_intact_tracer_rates)
+
+    @tag("fcirc")
+    def test_peakgroup_can_compute_intact_tracer_rates_false(self):
+        pg = self.MAIN_SERUM_ANIMAL.final_serum_sample_tracer_peak_group
+        pgid = pg.id
+        intact_peakdata = pg.peak_data.filter(
+            labeled_count=self.MAIN_SERUM_ANIMAL.tracer_labeled_count
+        ).get()
+        orig_lc = intact_peakdata.labeled_count
+        # set to something crazy, or None
+        intact_peakdata.labeled_count = 42
+        intact_peakdata.save()
+        pgf = PeakGroup.objects.get(id=pgid)
+        with self.assertWarns(UserWarning):
+            self.assertFalse(pgf.can_compute_intact_tracer_rates)
+        # revert
+        intact_peakdata.labeled_count = orig_lc
+        intact_peakdata.save()
+
+    @tag("fcirc")
+    def test_peakgroup_can_compute_average_tracer_rates_true(self):
+        pg = self.MAIN_SERUM_ANIMAL.final_serum_sample_tracer_peak_group
+        self.assertTrue(pg.can_compute_average_tracer_rates)
+
+    @tag("fcirc")
+    def test_peakgroup_can_compute_average_tracer_rates_false(self):
+        # need to invalidate the computed/cached enrichment_fraction, somehow
+        pg = self.MAIN_SERUM_ANIMAL.final_serum_sample_tracer_peak_group
+        # simplest way?
+        pg.enrichment_fraction = None
+        with self.assertWarns(UserWarning):
+            self.assertFalse(pg.can_compute_average_tracer_rates)
+
+
+class TracerRateTests(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        call_command("load_compounds", "DataRepo/example_data/obob_compounds.tsv")
+
+        call_command(
+            "load_animals_and_samples",
+            sample_table_filename="DataRepo/example_data/obob_samples_table.tsv",
+            animal_table_filename="DataRepo/example_data/obob_animals_table.tsv",
+            table_headers="DataRepo/example_data/sample_and_animal_tables_headers.yaml",
+        )
+
+        # for the fcirc and rate-calculation tests
+        call_command(
+            "load_accucor_msruns",
+            protocol="Default",
+            accucor_file="DataRepo/example_data/obob_maven_c160_serum.xlsx",
+            date="2021-04-29",
+            researcher="Xianfeng Zhang",
+        )
+
+        # defining a primary animal object for repeated tests
+        cls.MAIN_SERUM_ANIMAL = Animal.objects.get(name="970")
+
+    @tag("fcirc")
+    def test_peakgroup_is_tracer_compound_group(self):
+        pg = self.MAIN_SERUM_ANIMAL.final_serum_sample_tracer_peak_group
+        self.assertTrue(pg.is_tracer_compound_group)
+        self.assertEqual(pg.name, "C16:0")
+
+    @tag("fcirc")
+    def test_peakgroup_from_serum_sample(self):
+        pg = self.MAIN_SERUM_ANIMAL.final_serum_sample_tracer_peak_group
+        self.assertTrue(pg.from_serum_sample)
+
+    @tag("fcirc")
+    def test_peakgroup_can_compute_tracer_rates(self):
+        pg = self.MAIN_SERUM_ANIMAL.final_serum_sample_tracer_peak_group
+        self.assertTrue(pg.can_compute_tracer_rates)
+
+    @tag("fcirc")
+    def test_peakgroup_can_compute_weight_normalized_tracer_rates(self):
+        pg = self.MAIN_SERUM_ANIMAL.final_serum_sample_tracer_peak_group
+        self.assertTrue(pg.can_compute_weight_normalized_tracer_rates)
+
+    @tag("fcirc")
+    def test_peakgroup_can_compute_intact_tracer_rates(self):
+        pg = self.MAIN_SERUM_ANIMAL.final_serum_sample_tracer_peak_group
+        self.assertTrue(pg.can_compute_intact_tracer_rates)
+
+    @tag("fcirc")
+    def test_peakgroup_can_compute_average_tracer_rates(self):
+        pg = self.MAIN_SERUM_ANIMAL.final_serum_sample_tracer_peak_group
+        self.assertTrue(pg.can_compute_average_tracer_rates)
+
+    @tag("fcirc")
+    def test_nontracer_peakgroup_calculation_attempts(self):
+        animal = self.MAIN_SERUM_ANIMAL
+        nontracer_compound = Compound.objects.get(name="succinate")
+        # but let's get a peakgroup for a compound we know is not the tracer
+        pgs = animal.final_serum_sample.peak_groups(nontracer_compound)
+        # should only be one in this specific case
+        non_tracer_pg = pgs[0]
+        with self.assertWarns(UserWarning):
+            # tryptophan is not the tracer
+            self.assertFalse(non_tracer_pg.is_tracer_compound_group)
+        # and none of these should return a value
+        with self.assertWarns(UserWarning):
+            self.assertIsNone(non_tracer_pg.rate_disappearance_intact_per_gram)
+        with self.assertWarns(UserWarning):
+            self.assertIsNone(non_tracer_pg.rate_appearance_intact_per_gram)
+        with self.assertWarns(UserWarning):
+            self.assertIsNone(non_tracer_pg.rate_disappearance_intact_weight_normalized)
+        with self.assertWarns(UserWarning):
+            self.assertIsNone(non_tracer_pg.rate_appearance_intact_weight_normalized)
+        with self.assertWarns(UserWarning):
+            self.assertIsNone(non_tracer_pg.rate_disappearance_average_per_gram)
+        with self.assertWarns(UserWarning):
+            self.assertIsNone(non_tracer_pg.rate_appearance_average_per_gram)
+        with self.assertWarns(UserWarning):
+            self.assertIsNone(
+                non_tracer_pg.rate_disappearance_average_weight_normalized
+            )
+        with self.assertWarns(UserWarning):
+            self.assertIsNone(non_tracer_pg.rate_appearance_average_weight_normalized)
+
+    @tag("fcirc")
+    def test_tracer_Rd_intact_g(self):
+        animal = self.MAIN_SERUM_ANIMAL
+        self.assertAlmostEqual(animal.tracer_Rd_intact_g, 38.83966501, places=2)
+
+    @tag("fcirc")
+    def test_tracer_Ra_intact_g(self):
+        animal = self.MAIN_SERUM_ANIMAL
+        self.assertAlmostEqual(animal.tracer_Ra_intact_g, 34.35966501, places=2)
+
+    @tag("fcirc")
+    def test_tracer_Rd_intact(self):
+        animal = self.MAIN_SERUM_ANIMAL
+        self.assertAlmostEqual(animal.tracer_Rd_intact, 1040.903022, places=2)
+
+    @tag("fcirc")
+    def test_tracer_Ra_intact(self):
+        animal = self.MAIN_SERUM_ANIMAL
+        self.assertAlmostEqual(animal.tracer_Ra_intact, 920.8390222, places=2)
+
+    @tag("fcirc")
+    def test_tracer_Rd_avg_g(self):
+        animal = self.MAIN_SERUM_ANIMAL
+        self.assertAlmostEqual(animal.tracer_Rd_avg_g, 37.36671487, places=2)
+
+    @tag("fcirc")
+    def test_tracer_Ra_avg_g(self):
+        animal = self.MAIN_SERUM_ANIMAL
+        self.assertAlmostEqual(animal.tracer_Ra_avg_g, 32.88671487, places=2)
+
+    @tag("fcirc")
+    def test_tracer_Rd_avg(self):
+        animal = self.MAIN_SERUM_ANIMAL
+        # doublecheck weight, because test is not exact but test_tracer_Rd_avg_g was fine
+        self.assertAlmostEqual(animal.tracer_Rd_avg, 1001.427958, places=2)
+
+    @tag("fcirc")
+    def test_tracer_Ra_avg(self):
+        animal = self.MAIN_SERUM_ANIMAL
+        self.assertAlmostEqual(animal.tracer_Ra_avg, 881.3639585, places=2)
+
+    @tag("fcirc")
+    @skip(
+        "No independent calculation of Fcirc variant values provided. Skipping for now..."
+    )
+    def test_tracer_Fcirc_intact(self):
+        """
+        The test load file DataRepo/example_data/obob_maven_c160_serum.xlsx only
+        has serum sample data for serum-xz969, serum-xz970, (from
+        MAIN_SERUM_ANIMAL), serum-xz979 (so those are the only
+        animals(969,970,979) and samples we can test, here)
+        """
+        animal = self.MAIN_SERUM_ANIMAL
+        self.assertAlmostEqual(animal.tracer_Fcirc_intact, 34.36, places=2)
+
+    @tag("fcirc")
+    @skip(
+        "No independent calculation of Fcirc variant values provided. Skipping for now..."
+    )
+    def test_tracer_Fcirc_avg(self):
+        animal = self.MAIN_SERUM_ANIMAL
+        self.assertAlmostEqual(animal.tracer_Fcirc_avg, 32.89, places=2)
+
+    @tag("fcirc")
+    @skip(
+        "No independent calculation of Fcirc variant values provided. Skipping for now..."
+    )
+    def test_tracer_Fcirc_intact_per_mouse(self):
+        animal = self.MAIN_SERUM_ANIMAL
+        self.assertAlmostEqual(animal.tracer_Fcirc_intact_per_mouse, 920.84, places=2)
+
+    @tag("fcirc")
+    @skip(
+        "No independent calculation of Fcirc variant values provided. Skipping for now..."
+    )
+    def test_tracer_Fcirc_avg_per_mouse(self):
+        animal = self.MAIN_SERUM_ANIMAL
+        self.assertAlmostEqual(animal.tracer_Fcirc_avg_per_mouse, 881.36, places=2)
+
+    @tag("fcirc")
+    @skip(
+        "No independent calculation of Fcirc variant values provided. Skipping for now..."
+    )
+    def test_tracer_Fcirc_avg_atom(self):
+        animal = self.MAIN_SERUM_ANIMAL
+        self.assertAlmostEqual(animal.tracer_Fcirc_avg_atom, 526.19, places=2)
+
+    @tag("fcirc")
+    def test_animal_tracer_Fcirc_intact_missing_serum(self):
+        """
+        The test load file DataRepo/example_data/obob_maven_c160_serum.xlsx only
+        has serum sample data for serum-xz969  serum-xz970 serum-xz979 (so those
+        are the only animals(969,970,979) and samples we can test, here)
+        """
+        animal = Animal.objects.get(name="971")
+        with self.assertWarns(UserWarning):
+            self.assertIsNone(animal.tracer_Fcirc_intact)
+
+    @tag("fcirc")
+    def test_animal_tracer_Fcirc_avg_missing_serum(self):
+        animal = Animal.objects.get(name="971")
+        with self.assertWarns(UserWarning):
+            self.assertIsNone(animal.tracer_Fcirc_avg)
+
+    @tag("fcirc")
+    def test_animal_tracer_Fcirc_missing_body_weight(self):
+        weightless_animal = self.MAIN_SERUM_ANIMAL
+        revert_weight = weightless_animal.body_weight
+        weightless_animal.body_weight = None
+        weightless_animal.save()
+        with self.assertWarns(UserWarning):
+            self.assertIsNone(weightless_animal.tracer_Rd_avg)
+        with self.assertWarns(UserWarning):
+            self.assertIsNone(weightless_animal.tracer_Ra_avg)
+        with self.assertWarns(UserWarning):
+            self.assertIsNone(weightless_animal.tracer_Rd_intact)
+        with self.assertWarns(UserWarning):
+            self.assertIsNone(weightless_animal.tracer_Ra_intact)
+        with self.assertWarns(UserWarning):
+            self.assertIsNone(weightless_animal.tracer_Fcirc_intact_per_mouse)
+        with self.assertWarns(UserWarning):
+            self.assertIsNone(weightless_animal.tracer_Fcirc_avg_per_mouse)
+        # revert this change
+        weightless_animal.body_weight = revert_weight
+        weightless_animal.save()
+
+    @tag("fcirc")
+    def test_animal_tracer_Fcirc_missing_labeled_count(self):
+        labelless_animal = self.MAIN_SERUM_ANIMAL
+        labelless_animal.tracer_labeled_count = None
+        # we won't save this edit back to the database
+        with self.assertWarns(UserWarning):
+            self.assertIsNone(labelless_animal.intact_tracer_peak_data())
+            self.assertIsNone(labelless_animal.tracer_Fcirc_avg_atom)
 
 
 class AnimalAndSampleLoadingTests(TestCase):

--- a/DataRepo/tests/test_models.py
+++ b/DataRepo/tests/test_models.py
@@ -1,5 +1,4 @@
 from datetime import datetime, timedelta
-from unittest import skip
 
 import pandas as pd
 from django.core.exceptions import ValidationError
@@ -1031,139 +1030,77 @@ class TracerRateTests(TestCase):
             self.assertIsNone(non_tracer_pg.rate_appearance_average_weight_normalized)
 
     @tag("fcirc")
-    def test_tracer_Rd_intact_g(self):
+    def test_final_serum_tracer_rate_disappearance_intact_per_gram(self):
         animal = self.MAIN_SERUM_ANIMAL
-        self.assertAlmostEqual(animal.tracer_Rd_intact_g, 38.83966501, places=2)
+        self.assertAlmostEqual(
+            animal.final_serum_tracer_rate_disappearance_intact_per_gram,
+            38.83966501,
+            places=2,
+        )
 
     @tag("fcirc")
-    def test_tracer_Ra_intact_g(self):
+    def test_final_serum_tracer_rate_appearance_intact_per_gram(self):
         animal = self.MAIN_SERUM_ANIMAL
-        self.assertAlmostEqual(animal.tracer_Ra_intact_g, 34.35966501, places=2)
+        self.assertAlmostEqual(
+            animal.final_serum_tracer_rate_appearance_intact_per_gram,
+            34.35966501,
+            places=2,
+        )
 
     @tag("fcirc")
-    def test_tracer_Rd_intact(self):
+    def test_final_serum_tracer_rate_disappearance_intact_weight_normalized(self):
         animal = self.MAIN_SERUM_ANIMAL
-        self.assertAlmostEqual(animal.tracer_Rd_intact, 1040.903022, places=2)
+        self.assertAlmostEqual(
+            animal.final_serum_tracer_rate_disappearance_intact_weight_normalized,
+            1040.903022,
+            places=2,
+        )
 
     @tag("fcirc")
-    def test_tracer_Ra_intact(self):
+    def test_final_serum_tracer_rate_appearance_intact_weight_normalized(self):
         animal = self.MAIN_SERUM_ANIMAL
-        self.assertAlmostEqual(animal.tracer_Ra_intact, 920.8390222, places=2)
+        self.assertAlmostEqual(
+            animal.final_serum_tracer_rate_appearance_intact_weight_normalized,
+            920.8390222,
+            places=2,
+        )
 
     @tag("fcirc")
-    def test_tracer_Rd_avg_g(self):
+    def test_final_serum_tracer_rate_disappearance_average_per_gram(self):
         animal = self.MAIN_SERUM_ANIMAL
-        self.assertAlmostEqual(animal.tracer_Rd_avg_g, 37.36671487, places=2)
+        self.assertAlmostEqual(
+            animal.final_serum_tracer_rate_disappearance_average_per_gram,
+            37.36671487,
+            places=2,
+        )
 
     @tag("fcirc")
-    def test_tracer_Ra_avg_g(self):
+    def test_final_serum_tracer_rate_appearance_average_per_gram(self):
         animal = self.MAIN_SERUM_ANIMAL
-        self.assertAlmostEqual(animal.tracer_Ra_avg_g, 32.88671487, places=2)
+        self.assertAlmostEqual(
+            animal.final_serum_tracer_rate_appearance_average_per_gram,
+            32.88671487,
+            places=2,
+        )
 
     @tag("fcirc")
-    def test_tracer_Rd_avg(self):
+    def test_final_serum_tracer_rate_disappearance_average_weight_normalized(self):
         animal = self.MAIN_SERUM_ANIMAL
         # doublecheck weight, because test is not exact but test_tracer_Rd_avg_g was fine
-        self.assertAlmostEqual(animal.tracer_Rd_avg, 1001.427958, places=2)
+        self.assertAlmostEqual(
+            animal.final_serum_tracer_rate_disappearance_average_weight_normalized,
+            1001.427958,
+            places=2,
+        )
 
     @tag("fcirc")
-    def test_tracer_Ra_avg(self):
+    def test_final_serum_tracer_rate_appearance_average_weight_normalized(self):
         animal = self.MAIN_SERUM_ANIMAL
-        self.assertAlmostEqual(animal.tracer_Ra_avg, 881.3639585, places=2)
-
-    @tag("fcirc")
-    @skip(
-        "No independent calculation of Fcirc variant values provided. Skipping for now..."
-    )
-    def test_tracer_Fcirc_intact(self):
-        """
-        The test load file DataRepo/example_data/obob_maven_c160_serum.xlsx only
-        has serum sample data for serum-xz969, serum-xz970, (from
-        MAIN_SERUM_ANIMAL), serum-xz979 (so those are the only
-        animals(969,970,979) and samples we can test, here)
-        """
-        animal = self.MAIN_SERUM_ANIMAL
-        self.assertAlmostEqual(animal.tracer_Fcirc_intact, 34.36, places=2)
-
-    @tag("fcirc")
-    @skip(
-        "No independent calculation of Fcirc variant values provided. Skipping for now..."
-    )
-    def test_tracer_Fcirc_avg(self):
-        animal = self.MAIN_SERUM_ANIMAL
-        self.assertAlmostEqual(animal.tracer_Fcirc_avg, 32.89, places=2)
-
-    @tag("fcirc")
-    @skip(
-        "No independent calculation of Fcirc variant values provided. Skipping for now..."
-    )
-    def test_tracer_Fcirc_intact_per_mouse(self):
-        animal = self.MAIN_SERUM_ANIMAL
-        self.assertAlmostEqual(animal.tracer_Fcirc_intact_per_mouse, 920.84, places=2)
-
-    @tag("fcirc")
-    @skip(
-        "No independent calculation of Fcirc variant values provided. Skipping for now..."
-    )
-    def test_tracer_Fcirc_avg_per_mouse(self):
-        animal = self.MAIN_SERUM_ANIMAL
-        self.assertAlmostEqual(animal.tracer_Fcirc_avg_per_mouse, 881.36, places=2)
-
-    @tag("fcirc")
-    @skip(
-        "No independent calculation of Fcirc variant values provided. Skipping for now..."
-    )
-    def test_tracer_Fcirc_avg_atom(self):
-        animal = self.MAIN_SERUM_ANIMAL
-        self.assertAlmostEqual(animal.tracer_Fcirc_avg_atom, 526.19, places=2)
-
-    @tag("fcirc")
-    def test_animal_tracer_Fcirc_intact_missing_serum(self):
-        """
-        The test load file DataRepo/example_data/obob_maven_c160_serum.xlsx only
-        has serum sample data for serum-xz969  serum-xz970 serum-xz979 (so those
-        are the only animals(969,970,979) and samples we can test, here)
-        """
-        animal = Animal.objects.get(name="971")
-        with self.assertWarns(UserWarning):
-            self.assertIsNone(animal.tracer_Fcirc_intact)
-
-    @tag("fcirc")
-    def test_animal_tracer_Fcirc_avg_missing_serum(self):
-        animal = Animal.objects.get(name="971")
-        with self.assertWarns(UserWarning):
-            self.assertIsNone(animal.tracer_Fcirc_avg)
-
-    @tag("fcirc")
-    def test_animal_tracer_Fcirc_missing_body_weight(self):
-        weightless_animal = self.MAIN_SERUM_ANIMAL
-        revert_weight = weightless_animal.body_weight
-        weightless_animal.body_weight = None
-        weightless_animal.save()
-        with self.assertWarns(UserWarning):
-            self.assertIsNone(weightless_animal.tracer_Rd_avg)
-        with self.assertWarns(UserWarning):
-            self.assertIsNone(weightless_animal.tracer_Ra_avg)
-        with self.assertWarns(UserWarning):
-            self.assertIsNone(weightless_animal.tracer_Rd_intact)
-        with self.assertWarns(UserWarning):
-            self.assertIsNone(weightless_animal.tracer_Ra_intact)
-        with self.assertWarns(UserWarning):
-            self.assertIsNone(weightless_animal.tracer_Fcirc_intact_per_mouse)
-        with self.assertWarns(UserWarning):
-            self.assertIsNone(weightless_animal.tracer_Fcirc_avg_per_mouse)
-        # revert this change
-        weightless_animal.body_weight = revert_weight
-        weightless_animal.save()
-
-    @tag("fcirc")
-    def test_animal_tracer_Fcirc_missing_labeled_count(self):
-        labelless_animal = self.MAIN_SERUM_ANIMAL
-        labelless_animal.tracer_labeled_count = None
-        # we won't save this edit back to the database
-        with self.assertWarns(UserWarning):
-            self.assertIsNone(labelless_animal.intact_tracer_peak_data)
-            self.assertIsNone(labelless_animal.tracer_Fcirc_avg_atom)
+        self.assertAlmostEqual(
+            animal.final_serum_tracer_rate_appearance_average_weight_normalized,
+            881.3639585,
+            places=2,
+        )
 
 
 class AnimalAndSampleLoadingTests(TestCase):

--- a/DataRepo/tests/test_models.py
+++ b/DataRepo/tests/test_models.py
@@ -477,6 +477,117 @@ class DataLoadingTests(TestCase):
             # and attempts to retrieve the final_serum_sample get None
             self.assertIsNone(animal.final_serum_sample())
 
+    @tag("fcirc")
+    def test_tracer_Rd_intact_g(self):
+        animal = self.MAIN_SERUM_ANIMAL
+        self.assertAlmostEqual(animal.tracer_Rd_intact_g, 14.96, places=2)
+
+    @tag("fcirc")
+    def test_tracer_Ra_intact_g(self):
+        animal = self.MAIN_SERUM_ANIMAL
+        self.assertAlmostEqual(animal.tracer_Ra_intact_g, 12.41, places=2)
+
+    @tag("fcirc")
+    def test_tracer_Rd_intact(self):
+        animal = self.MAIN_SERUM_ANIMAL
+        self.assertAlmostEqual(animal.tracer_Rd_intact, 393.50, places=2)
+
+    @tag("fcirc")
+    def test_tracer_Ra_intact(self):
+        animal = self.MAIN_SERUM_ANIMAL
+        self.assertAlmostEqual(animal.tracer_Ra_intact, 326.38, places=2)
+
+    @tag("fcirc")
+    def test_tracer_Rd_avg_g(self):
+        animal = self.MAIN_SERUM_ANIMAL
+        self.assertAlmostEqual(animal.tracer_Rd_avg_g, 14.96, places=2)
+
+    @tag("fcirc")
+    def test_tracer_Ra_avg_g(self):
+        animal = self.MAIN_SERUM_ANIMAL
+        self.assertAlmostEqual(animal.tracer_Ra_avg_g, 12.41, places=2)
+
+    @tag("fcirc")
+    def test_tracer_Rd_avg(self):
+        animal = self.MAIN_SERUM_ANIMAL
+        self.assertAlmostEqual(animal.tracer_Rd_avg, 393.50, places=2)
+
+    @tag("fcirc")
+    def test_tracer_Ra_avg(self):
+        animal = self.MAIN_SERUM_ANIMAL
+        self.assertAlmostEqual(animal.tracer_Ra_avg, 326.38, places=2)
+
+    @tag("fcirc")
+    def test_tracer_Fcirc_intact(self):
+        """
+        The test load file DataRepo/example_data/obob_maven_6eaas_serum.xlsx
+        only has serum sample data for serum-xz971 (i.e. MAIN_SERUM_ANIMAL),
+        serum-xz972, serum-xz981, serum-xz982 (so those are the only animals
+        (971,972,981,982)/samples we can test, here)
+        """
+        animal = self.MAIN_SERUM_ANIMAL
+        self.assertAlmostEqual(animal.tracer_Fcirc_intact, 12.41, places=2)
+
+    @tag("fcirc")
+    def test_tracer_Fcirc_avg(self):
+        animal = self.MAIN_SERUM_ANIMAL
+        self.assertAlmostEqual(animal.tracer_Fcirc_avg, 12.41, places=2)
+
+    @tag("fcirc")
+    def test_tracer_Fcirc_intact_per_mouse(self):
+        animal = self.MAIN_SERUM_ANIMAL
+        self.assertAlmostEqual(animal.tracer_Fcirc_intact_per_mouse, 326.38, places=2)
+
+    @tag("fcirc")
+    def test_tracer_Fcirc_avg_per_mouse(self):
+        animal = self.MAIN_SERUM_ANIMAL
+        self.assertAlmostEqual(animal.tracer_Fcirc_avg_per_mouse, 326.38, places=2)
+
+    @tag("fcirc")
+    def test_tracer_Fcirc_avg_atom(self):
+        animal = self.MAIN_SERUM_ANIMAL
+        self.assertAlmostEqual(animal.tracer_Fcirc_avg_atom, 74.46, places=2)
+
+    @tag("fcirc")
+    def test_animal_tracer_Fcirc_intact_missing_serum(self):
+        """
+        The test load file DataRepo/example_data/obob_maven_6eaas_serum.xlsx
+        only has serum sample data for serum-xz971, serum-xz972, serum-xz981,
+        serum-xz982 (so those are the only animals (971,972,981,982)/samples we
+        can test, here)
+        """
+        animal = Animal.objects.get(name="970")
+        with self.assertWarns(UserWarning):
+            self.assertIsNone(animal.tracer_Fcirc_intact)
+
+    @tag("fcirc")
+    def test_animal_tracer_Fcirc_avg_missing_serum(self):
+        animal = Animal.objects.get(name="970")
+        with self.assertWarns(UserWarning):
+            self.assertIsNone(animal.tracer_Fcirc_avg)
+
+    @tag("fcirc")
+    def test_animal_tracer_Fcirc_missing_body_weight(self):
+        weightless_animal = self.MAIN_SERUM_ANIMAL
+        weightless_animal.body_weight = None
+        # we won't save this edit back to the database
+        with self.assertWarns(UserWarning):
+            self.assertIsNone(weightless_animal.tracer_Rd_avg)
+            self.assertIsNone(weightless_animal.tracer_Ra_avg)
+            self.assertIsNone(weightless_animal.tracer_Rd_intact)
+            self.assertIsNone(weightless_animal.tracer_Ra_intact)
+            self.assertIsNone(weightless_animal.tracer_Fcirc_intact_per_mouse)
+            self.assertIsNone(weightless_animal.tracer_Fcirc_avg_per_mouse)
+
+    @tag("fcirc")
+    def test_animal_tracer_Fcirc_missing_labeled_count(self):
+        labelless_animal = self.MAIN_SERUM_ANIMAL
+        labelless_animal.tracer_labeled_count = None
+        # we won't save this edit back to the database
+        with self.assertWarns(UserWarning):
+            self.assertIsNone(labelless_animal.intact_tracer_peak_data())
+            self.assertIsNone(labelless_animal.tracer_Fcirc_avg_atom)
+
     def test_restricted_animal_treatment_deletion(self):
         treatment = Animal.objects.get(name="exp024f_M2").treatment
         with self.assertRaises(RestrictedError):

--- a/DataRepo/tests/test_models.py
+++ b/DataRepo/tests/test_models.py
@@ -479,6 +479,7 @@ class DataLoadingTests(TestCase):
         with self.assertWarns(UserWarning):
             final_serum_sample = refeshed_animal.final_serum_sample
 
+    @tag("fcirc")
     def test_missing_serum_sample_peak_data(self):
         animal = self.MAIN_SERUM_ANIMAL
         final_serum_sample = animal.final_serum_sample
@@ -503,6 +504,38 @@ class DataLoadingTests(TestCase):
         with self.assertWarns(UserWarning):
             # and attempts to retrieve the final_serum_sample get None
             self.assertIsNone(refeshed_animal.final_serum_sample)
+        with self.assertWarns(UserWarning):
+            self.assertIsNone(
+                refeshed_animal.final_serum_tracer_rate_disappearance_intact_per_gram
+            )
+        with self.assertWarns(UserWarning):
+            self.assertIsNone(
+                refeshed_animal.final_serum_tracer_rate_appearance_intact_per_gram
+            )
+        with self.assertWarns(UserWarning):
+            self.assertIsNone(
+                refeshed_animal.final_serum_tracer_rate_disappearance_intact_weight_normalized
+            )
+        with self.assertWarns(UserWarning):
+            self.assertIsNone(
+                refeshed_animal.final_serum_tracer_rate_appearance_intact_weight_normalized
+            )
+        with self.assertWarns(UserWarning):
+            self.assertIsNone(
+                refeshed_animal.final_serum_tracer_rate_disappearance_average_per_gram
+            )
+        with self.assertWarns(UserWarning):
+            self.assertIsNone(
+                refeshed_animal.final_serum_tracer_rate_appearance_average_per_gram
+            )
+        with self.assertWarns(UserWarning):
+            self.assertIsNone(
+                refeshed_animal.final_serum_tracer_rate_disappearance_average_weight_normalized
+            )
+        with self.assertWarns(UserWarning):
+            self.assertIsNone(
+                refeshed_animal.final_serum_tracer_rate_appearance_average_weight_normalized
+            )
 
     def test_restricted_animal_treatment_deletion(self):
         treatment = Animal.objects.get(name="exp024f_M2").treatment

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -3,7 +3,7 @@
 -r common.txt
 flake8==3.9.2
 black==20.8b1
-isort==5.9.1
-pylint==2.9.0
+isort==5.9.3
+pylint==2.11.1
 mypy==0.910
 mypy-extensions==0.4.3


### PR DESCRIPTION
Added 2 new convenience methods: intact_tracer_peak_data, final_serum_sample_tracer_peak_group
Added 13 new methods for serum tracer calculations
Added preliminary tests for serum tracer calculations.

<!-- markdownlint-disable-next-line first-line-heading -->
## Summary Change Description

Briefly describe the changes in this pull request (not intended as a full
recounting of the issue description).

**Animal instance methods added:**
intact_tracer_peak_data
final_serum_sample_tracer_peak_group
tracer_Rd_intact_g
tracer_Ra_intact_g
tracer_Rd_intact
tracer_Ra_intact
tracer_Rd_avg_g
tracer_Ra_avg_g
tracer_Rd_avg
tracer_Ra_avg
tracer_Fcirc_intact
tracer_Fcirc_avg
tracer_Fcirc_intact_per_mouse
tracer_Fcirc_avg_per_mouse
tracer_Fcirc_avg_atom

**Tests added:**
test_tracer_Rd_intact_g
test_tracer_Ra_intact_g
test_tracer_Rd_intact
test_tracer_Ra_intact
test_tracer_Rd_avg_g
test_tracer_Ra_avg_g
test_tracer_Rd_avg
test_tracer_Ra_avg
test_tracer_Fcirc_intact
test_tracer_Fcirc_avg
test_tracer_Fcirc_intact_per_mouse
test_tracer_Fcirc_avg_per_mouse
test_tracer_Fcirc_avg_atom
test_animal_tracer_Fcirc_intact_missing_serum
test_animal_tracer_Fcirc_avg_missing_serum
test_animal_tracer_Fcirc_missing_body_weight
test_animal_tracer_Fcirc_missing_labeled_count
test_animal_tracer_Fcirc_missing_labeled_count

## Affected Issue Numbers

- Resolves #43

## Code Review Notes

I prefixed most (all?) of the computed methods with `tracer_` , because they are a function of the sole/1 intrinsic animal tracer attributes.  If we ever moved to >1 tracer, these names would need to change, or the API should change to accept a variable tracer argument.

Something else that concerned me personally, was the method names often only different by 1-2 characters, so mistakes are pretty easy to make, currently (`Ra` vs. `Rd`,` _g` suffixes).

Similarly, if we change from 1 serum tissue type to multiple serum tissue types, changes would need to be made.

You can test (almost all of) the methods using
`manage.py test --tag=fcirc`
 
These are all new computational methods and cached values.  Unfortunately, the sample calculations [kindly provided to us](https://docs.google.com/spreadsheets/d/1b4H5rZDfzGHzvVZsmgHHUWG_u3esAhxSYF2PVgi9_zk/edit#gid=2095042101) were from animals **_not within our testing current data_**, so I tried to match the calculations by eye, and could use other developer confirmation OR we could find those data, and load them as a test files/example, if we want an independent validation. [i.e. the tests are self-referential, unfortunately]

The other concern to vet closely are that the method calcs/tests that I did match grouped up with equivalent asserts, so that _could_ be a cause for concern, or confirmation that alternative calculations are very close to one another (i.e. closely related).  I will be going over this again, but extra eyes would be helpful.  Anyway, I thought I would get these in front of more eyes, in case another direction, data, or another approach were required.

I paste the following assertion equivalent groups, for the test Animal/data I had.

**groups of "equivalent calcs"**

```
        self.assertAlmostEqual(animal.tracer_Ra_intact, 326.38, places=2)
        self.assertAlmostEqual(animal.tracer_Ra_avg, 326.38, places=2)
        self.assertAlmostEqual(animal.tracer_Fcirc_intact_per_mouse, 326.38, places=2)
        self.assertAlmostEqual(animal.tracer_Fcirc_avg_per_mouse, 326.38, places=2)

```
```
        self.assertAlmostEqual(animal.tracer_Ra_intact_g, 12.41, places=2)
        self.assertAlmostEqual(animal.tracer_Ra_avg_g, 12.41, places=2)
        self.assertAlmostEqual(animal.tracer_Fcirc_intact, 12.41, places=2)
        self.assertAlmostEqual(animal.tracer_Fcirc_avg, 12.41, places=2)

```
```
        self.assertAlmostEqual(animal.tracer_Rd_intact, 393.50, places=2)
        self.assertAlmostEqual(animal.tracer_Rd_avg, 393.50, places=2)

```


## Checklist

- [x] All issue requirements satisfied (or no linked issues)
- [x] [Linting passes](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#linting).
- [x] [Migrations created & committed *(or no model changes)*](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#migration-process)
- [x] [Tests implemented *(or no code changes)*](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#test-implementation)
- [x] [All tests pass](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#quality-control)
