### PR TITLE
Ignore false-positive E1101 pylint errors

### DIFF
--- a/.python-lint
+++ b/.python-lint
@@ -221,7 +221,11 @@ contextmanager-decorators=contextlib.contextmanager
 # List of members which are set dynamically and missed by pylint inference
 # system, and so shouldn't trigger E1101 when accessed. Python regular
 # expressions are accepted.
-generated-members=objects,DoesNotExist
+generated-members=
+    objects,
+    DoesNotExist,
+    self.final_serum_sample,
+    self.animal
 
 # Tells whether missing members accessed in mixin class should be ignored. A
 # mixin class is detected if its name ends with "mixin" (case insensitive).

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -3,7 +3,7 @@
 -r common.txt
 flake8==3.9.2
 black==20.8b1
-isort==5.9.1
-pylint==2.9.0
+isort==5.9.3
+pylint==2.11.1
 mypy==0.910
 mypy-extensions==0.4.3


### PR DESCRIPTION
<!-- markdownlint-disable-next-line first-line-heading -->
## Summary Change Description

Some dynamically generated properties can cause E1101 errors, adding
these to `generated_members` in pylint config gets rid of those errors.

Also bumped pylint version to match current one used by superlinter.

## Affected Issue Numbers

## Code Review Notes

## Checklist

- [ ] All issue requirements satisfied (or no linked issues)
- [ ] [Linting passes](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#linting).
- [ ] [Migrations created & committed *(or no model changes)*](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#migration-process)
- [ ] [Tests implemented *(or no code changes)*](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#test-implementation)
- [ ] [All tests pass](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#quality-control)
