### PR TITLE
Draft/WIP : Django CAS ng trial

### DIFF
--- a/DataRepo/views.py
+++ b/DataRepo/views.py
@@ -39,9 +39,16 @@ def home(request):
 
 def index(request):
     if request.user.is_authenticated:
-        return HttpResponse('<p>Welcome to <a href="https://djangocas.dev">django-cas-ng</a>.</p><p>You logged in as <strong>%s</strong>.</p><p><a href="/accounts/logout">Logout</a></p>' % request.user)
+        return HttpResponse(
+            '<p>Welcome to <a href="https://djangocas.dev">django-cas-ng</a>.</p>'
+            '<p>You logged in as <strong>%s</strong>.</p><p><a href="/accounts/logout">Logout</a></p>'
+            % request.user
+        )
     else:
-        return HttpResponse('<p>Welcome to <a href="https://djangocas.dev">django-cas-ng</a>.</p><p><a href="/accounts/login">Login</a></p>')
+        return HttpResponse(
+            '<p>Welcome to <a href="https://djangocas.dev">django-cas-ng</a>.</p>'
+            '<p><a href="/accounts/login">Login</a></p>'
+        )
 
 
 def upload(request):

--- a/DataRepo/views.py
+++ b/DataRepo/views.py
@@ -5,7 +5,7 @@ from typing import List
 from django.conf import settings
 from django.core.management import call_command
 from django.db.models import Q
-from django.http import Http404
+from django.http import Http404, HttpResponse
 from django.shortcuts import get_object_or_404, render
 from django.test import TestCase
 from django.test.utils import setup_databases, setup_test_environment
@@ -35,6 +35,13 @@ from DataRepo.utils import MissingSamplesError, ResearcherError
 
 def home(request):
     return render(request, "home.html")
+
+
+def index(request):
+    if request.user.is_authenticated:
+        return HttpResponse('<p>Welcome to <a href="https://djangocas.dev">django-cas-ng</a>.</p><p>You logged in as <strong>%s</strong>.</p><p><a href="/accounts/logout">Logout</a></p>' % request.user)
+    else:
+        return HttpResponse('<p>Welcome to <a href="https://djangocas.dev">django-cas-ng</a>.</p><p><a href="/accounts/login">Login</a></p>')
 
 
 def upload(request):

--- a/TraceBase/settings.py
+++ b/TraceBase/settings.py
@@ -159,29 +159,32 @@ DEFAULT_AUTO_FIELD = 'django.db.models.AutoField'
 
 ALLOWED_HOSTS = ['localhost.princeton.edu']
 
-# Logging settings
-# This logging level was added to show the number of SQL queries in the server console
-# Left this commented code here to prompt a conversation about how we should control this debug mode activation
-# - probably via an environment setting
-
-# LOGGING = {
-#    "version": 1,
-#    "filters": {
-#        "require_debug_true": {
-#            "()": "django.utils.log.RequireDebugTrue",
-#        }
-#    },
-#    "handlers": {
-#        "console": {
-#            "level": "DEBUG",
-#            "filters": ["require_debug_true"],
-#            "class": "logging.StreamHandler",
-#        }
-#    },
-#    "loggers": {
-#        "django.db.backends": {
-#            "level": "DEBUG",
-#            "handlers": ["console"],
-#        }
-#    },
-# }
+"""
+Logging settings
+This logging level was added to show the number of SQL queries in the server
+console Left this commented code here toprompt a conversation about how we 
+should control this debug mode activation - probably via an environment setting
+"""
+"""
+LOGGING = {
+    "version": 1,
+    "filters": {
+        "require_debug_true": {
+            "()": "django.utils.log.RequireDebugTrue",
+        }
+    },
+    "handlers": {
+        "console": {
+            "level": "DEBUG",
+            "filters": ["require_debug_true"],
+            "class": "logging.StreamHandler",
+        }
+    },
+    "loggers": {
+        "django.db.backends": {
+            "level": "DEBUG",
+            "handlers": ["console"],
+        }
+    },
+}
+ """

--- a/TraceBase/settings.py
+++ b/TraceBase/settings.py
@@ -43,6 +43,7 @@ INSTALLED_APPS = [
     "django.contrib.sessions",
     "django.contrib.messages",
     "django.contrib.staticfiles",
+    'django_cas_ng',
 ]
 
 MIDDLEWARE = [
@@ -53,7 +54,13 @@ MIDDLEWARE = [
     "django.contrib.auth.middleware.AuthenticationMiddleware",
     "django.contrib.messages.middleware.MessageMiddleware",
     "django.middleware.clickjacking.XFrameOptionsMiddleware",
+    'django_cas_ng.middleware.CASMiddleware',
 ]
+
+AUTHENTICATION_BACKENDS = (
+    'django.contrib.auth.backends.ModelBackend',
+    'django_cas_ng.backends.CASBackend',
+)
 
 ROOT_URLCONF = "TraceBase.urls"
 
@@ -143,6 +150,12 @@ FILE_UPLOAD_HANDLERS = [
 DATA_SUBMISSION_URL = "https://forms.gle/Jyp94aiGmhBNLZh6A"
 DATA_SUBMISSION_EMAIL = "csgenome@princeton.edu"
 
+# https://sp2016.princeton.edu/oit/eis/iam/authentication/CAS/CAS%20Developer%20KB.aspx
+CAS_SERVER_URL = "https://fed.princeton.edu/cas/login"
+CAS_VERSION = 3
+CAS_CREATE_USER = False
+
+DEFAULT_AUTO_FIELD = 'django.db.models.AutoField'
 
 # Logging settings
 # This logging level was added to show the number of SQL queries in the server console

--- a/TraceBase/settings.py
+++ b/TraceBase/settings.py
@@ -157,6 +157,8 @@ CAS_CREATE_USER = False
 
 DEFAULT_AUTO_FIELD = 'django.db.models.AutoField'
 
+ALLOWED_HOSTS = ['localhost.princeton.edu']
+
 # Logging settings
 # This logging level was added to show the number of SQL queries in the server console
 # Left this commented code here to prompt a conversation about how we should control this debug mode activation

--- a/TraceBase/settings.py
+++ b/TraceBase/settings.py
@@ -43,7 +43,7 @@ INSTALLED_APPS = [
     "django.contrib.sessions",
     "django.contrib.messages",
     "django.contrib.staticfiles",
-    'django_cas_ng',
+    "django_cas_ng",
 ]
 
 MIDDLEWARE = [
@@ -54,12 +54,12 @@ MIDDLEWARE = [
     "django.contrib.auth.middleware.AuthenticationMiddleware",
     "django.contrib.messages.middleware.MessageMiddleware",
     "django.middleware.clickjacking.XFrameOptionsMiddleware",
-    'django_cas_ng.middleware.CASMiddleware',
+    "django_cas_ng.middleware.CASMiddleware",
 ]
 
 AUTHENTICATION_BACKENDS = (
-    'django.contrib.auth.backends.ModelBackend',
-    'django_cas_ng.backends.CASBackend',
+    "django.contrib.auth.backends.ModelBackend",
+    "django_cas_ng.backends.CASBackend",
 )
 
 ROOT_URLCONF = "TraceBase.urls"
@@ -155,14 +155,14 @@ CAS_SERVER_URL = "https://fed.princeton.edu/cas/login"
 CAS_VERSION = 3
 CAS_CREATE_USER = False
 
-DEFAULT_AUTO_FIELD = 'django.db.models.AutoField'
+DEFAULT_AUTO_FIELD = "django.db.models.AutoField"
 
-ALLOWED_HOSTS = ['localhost.princeton.edu']
+ALLOWED_HOSTS = ["localhost.princeton.edu"]
 
 """
 Logging settings
 This logging level was added to show the number of SQL queries in the server
-console Left this commented code here toprompt a conversation about how we 
+console Left this commented code here toprompt a conversation about how we
 should control this debug mode activation - probably via an environment setting
 """
 """

--- a/TraceBase/urls.py
+++ b/TraceBase/urls.py
@@ -13,9 +13,9 @@ Including another URLconf
     1. Import the include() function: from django.urls import include, path
     2. Add a URL to urlpatterns:  path('blog/', include('blog.urls'))
 """
+import django_cas_ng.views
 from django.contrib import admin
 from django.urls import include, path
-import django_cas_ng.views
 
 from DataRepo import views
 
@@ -23,6 +23,12 @@ urlpatterns = [
     path("admin/", admin.site.urls),
     path("", views.home, name="home"),
     path("DataRepo/", include("DataRepo.urls"), name="home"),
-    path('accounts/login', django_cas_ng.views.LoginView.as_view(), name='cas_ng_login'),
-    path('accounts/logout', django_cas_ng.views.LogoutView.as_view(), name='cas_ng_logout'),
+    path(
+        "accounts/login", django_cas_ng.views.LoginView.as_view(), name="cas_ng_login"
+    ),
+    path(
+        "accounts/logout",
+        django_cas_ng.views.LogoutView.as_view(),
+        name="cas_ng_logout",
+    ),
 ]

--- a/TraceBase/urls.py
+++ b/TraceBase/urls.py
@@ -15,6 +15,7 @@ Including another URLconf
 """
 from django.contrib import admin
 from django.urls import include, path
+import django_cas_ng.views
 
 from DataRepo import views
 
@@ -22,4 +23,6 @@ urlpatterns = [
     path("admin/", admin.site.urls),
     path("", views.home, name="home"),
     path("DataRepo/", include("DataRepo.urls"), name="home"),
+    path('accounts/login', django_cas_ng.views.LoginView.as_view(), name='cas_ng_login'),
+    path('accounts/logout', django_cas_ng.views.LogoutView.as_view(), name='cas_ng_logout'),
 ]

--- a/requirements/common.txt
+++ b/requirements/common.txt
@@ -1,6 +1,7 @@
 Django==3.2.5
 psycopg2-binary==2.8.6
 django-environ==0.4.5
+django-cas-ng==4.2.1
 django-validators==1.0.1
 python-dateutil==2.8.1
 pyyaml==5.4.1


### PR DESCRIPTION
<!-- markdownlint-disable-next-line first-line-heading -->
## Summary Change Description

This is just a proof-of-concept CAS authentication, in case someone want to take it to the next level (authenticate all views, different levels of user-privileges, etc).  All this particular PR does is hook the Admin tools to Princeton CAS, _provided a matching superuser already exists_.

## Affected Issue Numbers

Work towards #202 , but needs more specification/work/polishing

## Code Review Notes

This PR does **_NOT_** create database users by default; see settings:
`CAS_CREATE_USER = False`

In order to test this, 

1) you will need to install requirements to pick up `django-cas-ng`
`python -m pip install -r requirements/dev.txt`

2) I believe `django-cas-ng` manages its own sessions and tickets in internal models, but I believe this migration file is stored in the `.venv` directory.
`./manage.py makemigrations`
`python manage.py migrate`

3) [you will first have to create your own superuser](https://docs.djangoproject.com/en/1.8/intro/tutorial02/), matching your Princeton NetID
`python manage.py createsuperuser`

4) Princeton requires the CAS-requesting domains to be from Princeton, so the run server command must be executed as
`./manage.py runserver "localhost.princeton.edu:8000"`
This is also why there was an `ALLOWED_HOSTS` addition to the settings.

## Checklist

- [ ] All issue requirements satisfied (or no linked issues)
- [ ] [Linting passes](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#linting).
- [ ] [Migrations created & committed *(or no model changes)*](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#migration-process)
- [ ] [Tests implemented *(or no code changes)*](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#test-implementation)
- [ ] [All tests pass](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#quality-control)
