### PR TITLE
Associate PeakGroups with mutiple compounds

### DIFF
--- a/DataRepo/tests/test_models.py
+++ b/DataRepo/tests/test_models.py
@@ -415,6 +415,16 @@ class DataLoadingTests(TestCase):
         pgs = PeakGroupSet.objects.all().first()
         self.assertEqual(pgs.filename, "obob_maven_6eaas_inf.xlsx")
 
+    def test_peak_groups_multiple_compounds(self):
+        """
+        Test that a peakgroup that is named with two compounds separated by a
+        slash ("/") is properly associated with two compounds
+        """
+        pg = PeakGroup.objects.filter(name="citrate/isocitrate").first()
+        self.assertEqual(pg.compounds.count(), 2)
+        self.assertEqual(pg.compounds.first().name, "citrate")
+        self.assertEqual(pg.compounds.last().name, "isocitrate")
+
     def test_animal_tracers(self):
         a = Animal.objects.get(name="969")
         c = Compound.objects.get(name="C16:0")

--- a/DataRepo/utils.py
+++ b/DataRepo/utils.py
@@ -667,35 +667,29 @@ class AccuCorDataLoader:
             peak_group_formula = row["formula"]
             if peak_group_name not in self.peak_group_dict:
 
+                # cache it for later; note, if the first row encountered
+                # is missing a formula, there will be issues later
+                self.peak_group_dict[peak_group_name] = {
+                    "name": peak_group_name,
+                    "formula": peak_group_formula,
+                }
+
                 """
                 cross validate in database;  this is a mapping of peak group
                 name to one or more compounds. peak groups sometimes detect
                 multiple compounds delimited by slash
                 """
 
+                self.peak_group_dict[peak_group_name]["compounds"] = []
                 compounds_input = peak_group_name.split("/")
-
                 for compound_input in compounds_input:
                     try:
-                        # cache it for later; note, if the first row encountered
-                        # is missing a formula, there will be issues later
-                        self.peak_group_dict[peak_group_name] = {
-                            "name": peak_group_name,
-                            "formula": peak_group_formula,
-                        }
-
-                        # peaks can contain more than 1 compound
                         mapped_compound = Compound.objects.get(
                             name__iexact=compound_input
                         )
-                        if "compounds" in self.peak_group_dict[peak_group_name]:
-                            self.peak_group_dict[peak_group_name]["compounds"].append(
-                                mapped_compound
-                            )
-                        else:
-                            self.peak_group_dict[peak_group_name]["compounds"] = [
-                                mapped_compound
-                            ]
+                        self.peak_group_dict[peak_group_name]["compounds"].append(
+                            mapped_compound
+                        )
                     except Compound.DoesNotExist:
                         missing_compounds += 1
                         print(f"Could not find compound {compound_input}")


### PR DESCRIPTION


<!-- markdownlint-disable-next-line first-line-heading -->
## Summary Change Description

Fix some logic that was overwriting a dictionary of compounds so that Peakgroups that are named with two compounds separated by a slash ("/") are properly associated with two compounds

## Affected Issue Numbers

- Resolves #208

## Code Review Notes

Note, this PR does **not** perform a data migration for the affected compounds, thus a database reload is necessary. A data migration can be added if we deem it necessary, but at this time, I thought the reload would be simpler, however, that does require work for all developers.

## Checklist

- [x] All issue requirements satisfied (or no linked issues)
- [x] [Linting passes](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#linting).
- [x] [Migrations created & committed *(or no model changes)*](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#migration-process)
- [x] [Tests implemented *(or no code changes)*](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#test-implementation)
- [x] [All tests pass](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#quality-control)
