### PR TITLE
Remove spaces from data-field names

### DIFF
--- a/DataRepo/templates/DataRepo/animal_list.html
+++ b/DataRepo/templates/DataRepo/animal_list.html
@@ -28,16 +28,16 @@
                 <tr>
                 <th data-field="Name" data-filter-control="input" data-sortable="true">Name</th>
                 <th data-field="Tracer" data-filter-control="input" data-sortable="true">Tracer(Infusate)</th>
-                <th data-field="Labeled Atom" data-filter-control="input" data-sortable="true">Labeled Atom</th>
-                <th data-field="Labeled Count" data-filter-control="input" data-sortable="true">Labeled Count</th>
-                <th data-field="Infusion Rate" data-filter-control="input" data-sortable="true">Infusion Rate</th>
-                <th data-field="Infusion Concentration" data-filter-control="input" data-sortable="true">Infusion Concentration </th>
+                <th data-field="Labeled_Atom" data-filter-control="select" data-sortable="true">Labeled Atom</th>
+                <th data-field="Labeled_Count" data-filter-control="input" data-sortable="true">Labeled Count</th>
+                <th data-field="Infusion_Rate" data-filter-control="input" data-sortable="true">Infusion Rate</th>
+                <th data-field="Infusion_Concentration" data-filter-control="input" data-sortable="true">Infusion Concentration </th>
                 <th data-field="Genotype" data-filter-control="select" data-sortable="true">Genotype</th>
-                <th data-field="Body Weight" data-filter-control="input" data-sortable="true">Body Weight</th>
+                <th data-field="Body_Weight" data-filter-control="input" data-sortable="true">Body Weight</th>
                 <th data-field="Age" data-filter-control="input" data-sortable="true">Age</th>
-                <th data-field="Sex" data-filter-control="input" data-sortable="true">Sex</th>
+                <th data-field="Sex" data-filter-control="select" data-sortable="true">Sex</th>
                 <th data-field="Diet" data-filter-control="input" data-sortable="true">Diet</th>
-                <th data-field="Feeding Status" data-filter-control="input" data-sortable="true">Feeding Status</th>
+                <th data-field="Feeding_Status" data-filter-control="input" data-sortable="true">Feeding Status</th>
                 </tr>
             </thead>
             <tbody>

--- a/DataRepo/templates/DataRepo/sample_list.html
+++ b/DataRepo/templates/DataRepo/sample_list.html
@@ -30,8 +30,8 @@
                     <th data-field="Animal" data-filter-control="input" data-sortable="true">Animal</th>
                     <th data-field="Tissue" data-filter-control="select" data-sortable="true">Tissue</th>
                     <th data-field="Researcher" data-filter-control="select" data-sortable="true">Researcher</th>
-                    <th data-field="Collection Date" data-filter-control="input" data-sortable="true">Collection Date</th>
-                    <th data-field="Time Collected After Infusion" data-filter-control="input" data-sortable="true">Time Collected After Infusion (hh:mm:ss)</th>
+                    <th data-field="Collection_Date" data-filter-control="input" data-sortable="true">Collection Date</th>
+                    <th data-field="Time-Collected_After_Infusion" data-filter-control="input" data-sortable="true">Time Collected After Infusion (hh:mm:ss)</th>
                 </tr>
             </thead>
             <tbody>


### PR DESCRIPTION
<!-- markdownlint-disable-next-line first-line-heading -->
## Summary Change Description

Remove spaces from data-field names

## Code Review Notes

By removing spaces from the data field name, we can use the "select" type filter on other fields.

## Checklist

- [x] All issue requirements satisfied (or no linked issues)
- [x] [Linting passes](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#linting).
- [x] [Migrations created & committed *(or no model changes)*](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#migration-process)
- [x] [Tests implemented *(or no code changes)*](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#test-implementation)
- [x] [All tests pass](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#quality-control)
