### PR TITLE
Pin jedi package version for compat with py3.6

### DIFF
--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -7,3 +7,7 @@ isort==5.9.3
 pylint==2.11.1
 mypy==0.910
 mypy-extensions==0.4.3
+
+# Need to keep old version until we move past python 3.6
+# https://github.com/ipython/ipython/issues/12677#issuecomment-826312842
+jedi==0.17.2


### PR DESCRIPTION
<!-- markdownlint-disable-next-line first-line-heading -->
## Summary Change Description

To ensure ipython works with python 3.6, we need to pin the jedi package
at an old version
https://github.com/ipython/ipython/issues/12677#issuecomment-826312842

## Affected Issue Numbers

None
## Code Review Notes

This only affects development dependencies and is relevant for running ipython (`python manage.py shell`) under python 3.6.

## Checklist

- [ ] All issue requirements satisfied (or no linked issues)
- [ ] [Linting passes](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#linting).
- [ ] [Migrations created & committed *(or no model changes)*](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#migration-process)
- [ ] [Tests implemented *(or no code changes)*](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#test-implementation)
- [ ] [All tests pass](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#quality-control)
