### PR TITLE
Ensure id is not converted to float

### DIFF
--- a/DataRepo/utils.py
+++ b/DataRepo/utils.py
@@ -1386,6 +1386,9 @@ class QuerysetToPandasDataFrame:
         anim_list_df["treatment_id"] = (
             anim_list_df["treatment_id"].fillna(0).astype(int)
         )
+        anim_list_df["tracer_compound_id"] = (
+            anim_list_df["tracer_compound_id"].fillna(0).astype(int)
+        )
         return anim_list_df
 
     @classmethod
@@ -1400,6 +1403,7 @@ class QuerysetToPandasDataFrame:
         # add a column by joining id and name for each study
         stud_anim_df["study_id_name"] = (
             stud_anim_df["study_id"]
+            .astype(int)
             .astype(str)
             .str.cat(stud_anim_df["study"], sep="||")
         )
@@ -1633,12 +1637,14 @@ class QuerysetToPandasDataFrame:
         # add a column to join id and name for each tracer
         all_stud_msrun_df["tracer_id_name"] = (
             all_stud_msrun_df["tracer_compound_id"]
+            .astype(int)
             .astype(str)
             .str.cat(all_stud_msrun_df["tracer"], sep="||")
         )
         # add a column to join treatment_id and treatment
         all_stud_msrun_df["treatment_id_name"] = (
             all_stud_msrun_df["treatment_id"]
+            .astype(int)
             .astype(str)
             .str.cat(all_stud_msrun_df["treatment"], sep="||")
         )


### PR DESCRIPTION
<!-- markdownlint-disable-next-line first-line-heading -->
## Summary Change Description

The tracer_compound_id column can sometimes be converted to a float,
then to a string, and then passed as lookup.

## Affected Issue Numbers

Possibly related to #255 (at least this issue stems from the conversion
of objects to values in the dataframe).

## Code Review Notes

This is not a comprehensive fix, but did address the issues I was running into. Ideally, there would be some tests to reproduce this issue, but this is just a quick fix for now.

## Checklist

- [x] All issue requirements satisfied (or no linked issues)
- [x] [Linting passes](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#linting).
- [x] [Migrations created & committed *(or no model changes)*](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#migration-process)
- [ ] [Tests implemented *(or no code changes)*](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#test-implementation)
- [x] [All tests pass](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#quality-control)
