### PR TITLE
Specify Python 3.8 for GitHub Actions Testing

### DIFF
--- a/.github/workflows/tracebase-tests.yml
+++ b/.github/workflows/tracebase-tests.yml
@@ -27,17 +27,17 @@ jobs:
       HMDB_CPD_URL: https://hmdb.ca/metabolites
     steps:
     - uses: actions/checkout@v1
-    - name: Set up Python 3.7
+    - name: Set up Python 3.8
       uses: actions/setup-python@v1
       with:
-        python-version: 3.7
+        python-version: 3.8
     - name: psycopg2 prerequisites
       run: |
         sudo apt-get update
         sudo apt-get install python-dev libpq-dev
     - name: Install dependencies
       run: |
-        python -m pip install --upgrade pip
+        python -m pip install --upgrade pip wheel
         pip install -r requirements.txt
     - name: Check makemigrations are complete
       run: python manage.py makemigrations --check --dry-run


### PR DESCRIPTION
<!-- markdownlint-disable-next-line first-line-heading -->
## Summary Change Description

Our current deploy server uses ~~3.6~~ 3.8, so test with that version.

Also, ensure the wheel package is installed for faster installation of requirements.

## Affected Issue Numbers

## Code Review Notes

I have a request in to update the Python version on `tracebase-dev` ([RT #47075](https://gen-help.princeton.edu/Ticket/Display.html?id=47075)). When that happens, we should update the version that GitHub tests with.

## Checklist

- [x] All issue requirements satisfied (or no linked issues)
- [x] [Linting passes](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#linting).
- [x] [Migrations created & committed *(or no model changes)*](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#migration-process)
- [x] [Tests implemented *(or no code changes)*](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#test-implementation)
- [x] [All tests pass](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#quality-control)
