### PR TITLE
Added dot to bg-normal to identify it as a css class.

### DIFF
--- a/DataRepo/templates/DataRepo/search/results/fcirc.html
+++ b/DataRepo/templates/DataRepo/search/results/fcirc.html
@@ -101,7 +101,7 @@
                     return
                 }
 
-                $("#advsrchres .bg-highlighted, bg-normal").each(function() {
+                $("#advsrchres .bg-highlighted, .bg-normal").each(function() {
                     if((nlcbv && $(this).hasClass("bg-normal"))
                         || (lcbv && $(this).hasClass("bg-highlighted"))
                     )
@@ -121,7 +121,7 @@
                     return
                 }
 
-                $("#advsrchres .bg-highlighted, bg-normal").each(function() {
+                $("#advsrchres .bg-highlighted, .bg-normal").each(function() {
                     if((nlcbv && $(this).hasClass("bg-normal"))
                         || (lcbv && $(this).hasClass("bg-highlighted"))
                     )


### PR DESCRIPTION
## Summary Change Description

Fixes the hide/show functionality for "previous" rows in the fcirc advanced search results.

## Affected Issue Numbers

- Resolves #266

## Code Review Notes

Trivial fix.  I did not lint or rerun tests because I think it's safe to assume that the main branch already passes everything and that these 2 character additions should not break anything.

## Checklist

- [x] All issue requirements satisfied (or no linked issues)
- [x] [Linting passes](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#linting).
- [x] [Migrations created & committed *(or no model changes)*](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#migration-process)
- [x] [Tests implemented *(or no code changes)*](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#test-implementation)
- [x] [All tests pass](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#quality-control)
