### PR TITLE
Setting msrun_protocol per file in the loading.yaml file was broken

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -109,7 +109,7 @@ you used when setting up Postgres.
 
 ### (Optional) Load Some Example Data
 
-    python manage.py load_compounds DataRepo/example_data/obob_compounds.tsv
+    python manage.py load_compounds --compounds DataRepo/example_data/consolidated_tracebase_compound_list.tsv
     python manage.py loaddata DataRepo/fixtures/tissues.yaml
     python manage.py load_animals_and_samples --animal-and-sample-table-filename DataRepo/example_data/small_dataset/small_obob_animal_and_sample_table.xlsx --table-headers DataRepo/example_data/sample_and_animal_tables_headers.yaml
     python manage.py load_animals_and_samples --sample-table-filename DataRepo/example_data/obob_samples_table.tsv --animal-table-filename DataRepo/example_data/obob_animals_table.tsv --table-headers DataRepo/example_data/sample_and_animal_tables_headers.yaml

--- a/DataRepo/management/commands/load_study.py
+++ b/DataRepo/management/commands/load_study.py
@@ -112,8 +112,8 @@ class Command(BaseCommand):
                     )
                 )
                 # Get parameters specific to each accucor file
-                if "protocol" in accucor_file:
-                    protocol = accucor_file["protocol"]
+                if "msrun_protocol" in accucor_file:
+                    protocol = accucor_file["msrun_protocol"]
                 if "date" in accucor_file:
                     date = accucor_file["date"]
                 if "researcher" in accucor_file:


### PR DESCRIPTION
## Summary Change Description

load_study wasn't overriding the parent because the key was wrong.  I corrected the key [based on the yaml schema](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/9db1217c6b61a1de55cee2057e9c7cfd85ac88f3/DataRepo/schemas/load_study.yaml#L33).

I also updated the load compounds command in CONTRIB.

Encountered when trying to create a yaml to load the KR infusion data.  Kept getting the error:
```
Mass spectrometry run with this Researcher, Date, Protocol and Sample already exists.
```
The only msrun_protocol that was loading was the unused parent one:
```
Found msrun_protocol protocol 2 'Default'
```

## Affected Issue Numbers

- Resolves no issue

## Code Review Notes

Once I made the change, I stopped getting the error and the studies loaded with the protocols I was setting per file, e.g.:
```
Finding or inserting msrun_protocol protocol for 'LC-MS, high-mz mode'...
```
You can test with [the files I was working on](https://drive.google.com/drive/folders/1B4F8-kLJ7csmmHi3LM-j2K71zATXHzK4?usp=sharing).

## Checklist

- [x] All issue requirements satisfied (or no linked issues)
- [x] [Linting passes](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#linting).
- [x] [Migrations created & committed *(or no model changes)*](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#migration-process)
- [ ] [Tests implemented *(or no code changes)*](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#test-implementation)
- [x] [All tests pass](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#quality-control)
