### PR TITLE
Edited initial show/hide state of animal metadata columns in the fcirc template

### DIFF
--- a/DataRepo/templates/DataRepo/search/results/fcirc.html
+++ b/DataRepo/templates/DataRepo/search/results/fcirc.html
@@ -290,28 +290,28 @@
                 <th colspan="2" data-valign="top" data-sortable="false" data-switchable="true" data-field="Mouse_Normalized2" class="intact nonorm">Mouse<br>Normalized<br>(nM/m)</th>
             </tr>
             <tr>
-                <th data-valign="top" data-sortable="true" data-field="Animal">Animal</th>
-                <th data-valign="top" data-sortable="true" data-field="Studies">Studies</th>
-                <th data-valign="top" data-sortable="true" data-field="Genotype">Genotype</th>
-                <th data-valign="top" data-sortable="true" data-field="Body_Weight">Body<br>Weight<br>(g)</th>
-                <th data-valign="top" data-sortable="true" data-field="Age">Age<br>(weeks)</th>
-                <th data-valign="top" data-sortable="true" data-field="Sex">Sex</th>
-                <th data-valign="top" data-sortable="true" data-field="Diet">Diet</th>
-                <th data-valign="top" data-sortable="true" data-field="Feeding_Status">Feeding<br>Status</th>
-                <th data-valign="top" data-sortable="true" data-field="Treatment">Treatment</th>
-                <th data-valign="top" data-sortable="true" data-field="Tracer_Compound">Tracer<br>Compound</th>
-                <th data-valign="top" data-sortable="true" data-field="Labeled_Element">Labeled<br>Element</th>
-                <th data-valign="top" data-sortable="true" data-field="Tracer_Infusion_Rate">Tracer<br>Infusion<br>Rate<br>(ul/m/g)</th>
-                <th data-valign="top" data-sortable="true" data-field="Tracer_Infusion_Concentration">Tracer Infusion<br>Concentration<br>(mM)</th>
-                <th data-valign="top" data-sortable="true" data-field="Time_Collected">Time<br>Collected<br>(m)</th>
-                <th data-valign="top" data-sortable="true" data-switchable="false" data-field="Average_Weight_Normalized_Ra" data-title-tooltip="Average_Weight_Normalized_Ra" class="average weight ra">Ra</th>
-                <th data-valign="top" data-sortable="true" data-switchable="false" data-field="Average_Weight_Normalized_Rd" data-title-tooltip="Average_Weight_Normalized_Rd" class="average weight rd">Rd</th>
-                <th data-valign="top" data-sortable="true" data-switchable="false" data-field="Average_Mouse_Normalized_Ra" data-title-tooltip="Average_Mouse_Normalized_Ra" class="average nonorm ra">Ra</th>
-                <th data-valign="top" data-sortable="true" data-switchable="false" data-field="Average_Mouse_Normalized_Rd" data-title-tooltip="Average_Mouse_Normalized_Rd" class="average nonorm rd">Rd</th>
-                <th data-valign="top" data-sortable="true" data-switchable="false" data-field="Intact_Weight_Normalized_Ra" data-title-tooltip="Intact_Weight_Normalized_Ra" class="intact weight ra">Ra</th>
-                <th data-valign="top" data-sortable="true" data-switchable="false" data-field="Intact_Weight_Normalized_Rd" data-title-tooltip="Intact_Weight_Normalized_Rd" class="intact weight rd">Rd</th>
-                <th data-valign="top" data-sortable="true" data-switchable="false" data-field="Intact_Mouse_Normalized_Ra" data-title-tooltip="Intact_Mouse_Normalized_Ra" class="intact nonorm ra">Ra</th>
-                <th data-valign="top" data-sortable="true" data-switchable="false" data-field="Intact_Mouse_Normalized_Rd" data-title-tooltip="Intact_Mouse_Normalized_Rd" class="intact nonorm rd">Rd</th>
+                <th data-valign="top" data-sortable="true" data-visible="true" data-field="Animal">Animal</th>
+                <th data-valign="top" data-sortable="true" data-visible="true" data-field="Studies">Studies</th>
+                <th data-valign="top" data-sortable="true" data-visible="true" data-field="Genotype">Genotype</th>
+                <th data-valign="top" data-sortable="true" data-visible="false" data-field="Body_Weight">Body<br>Weight<br>(g)</th>
+                <th data-valign="top" data-sortable="true" data-visible="false" data-field="Age">Age<br>(weeks)</th>
+                <th data-valign="top" data-sortable="true" data-visible="false" data-field="Sex">Sex</th>
+                <th data-valign="top" data-sortable="true" data-visible="false" data-field="Diet">Diet</th>
+                <th data-valign="top" data-sortable="true" data-visible="true" data-field="Feeding_Status">Feeding<br>Status</th>
+                <th data-valign="top" data-sortable="true" data-visible="true" data-field="Treatment">Treatment</th>
+                <th data-valign="top" data-sortable="true" data-visible="true" data-field="Tracer_Compound">Tracer<br>Compound</th>
+                <th data-valign="top" data-sortable="true" data-visible="false" data-field="Labeled_Element">Labeled<br>Element</th>
+                <th data-valign="top" data-sortable="true" data-visible="true" data-field="Tracer_Infusion_Rate">Tracer<br>Infusion<br>Rate<br>(ul/m/g)</th>
+                <th data-valign="top" data-sortable="true" data-visible="true" data-field="Tracer_Infusion_Concentration">Tracer Infusion<br>Concentration<br>(mM)</th>
+                <th data-valign="top" data-sortable="true" data-visible="true" data-field="Time_Collected">Time<br>Collected<br>(m)</th>
+                <th data-valign="top" data-sortable="true" data-visible="true" data-switchable="false" data-field="Average_Weight_Normalized_Ra" data-title-tooltip="Average_Weight_Normalized_Ra" class="average weight ra">Ra</th>
+                <th data-valign="top" data-sortable="true" data-visible="true" data-switchable="false" data-field="Average_Weight_Normalized_Rd" data-title-tooltip="Average_Weight_Normalized_Rd" class="average weight rd">Rd</th>
+                <th data-valign="top" data-sortable="true" data-visible="true" data-switchable="false" data-field="Average_Mouse_Normalized_Ra" data-title-tooltip="Average_Mouse_Normalized_Ra" class="average nonorm ra">Ra</th>
+                <th data-valign="top" data-sortable="true" data-visible="true" data-switchable="false" data-field="Average_Mouse_Normalized_Rd" data-title-tooltip="Average_Mouse_Normalized_Rd" class="average nonorm rd">Rd</th>
+                <th data-valign="top" data-sortable="true" data-visible="true" data-switchable="false" data-field="Intact_Weight_Normalized_Ra" data-title-tooltip="Intact_Weight_Normalized_Ra" class="intact weight ra">Ra</th>
+                <th data-valign="top" data-sortable="true" data-visible="true" data-switchable="false" data-field="Intact_Weight_Normalized_Rd" data-title-tooltip="Intact_Weight_Normalized_Rd" class="intact weight rd">Rd</th>
+                <th data-valign="top" data-sortable="true" data-visible="true" data-switchable="false" data-field="Intact_Mouse_Normalized_Ra" data-title-tooltip="Intact_Mouse_Normalized_Ra" class="intact nonorm ra">Ra</th>
+                <th data-valign="top" data-sortable="true" data-visible="true" data-switchable="false" data-field="Intact_Mouse_Normalized_Rd" data-title-tooltip="Intact_Mouse_Normalized_Rd" class="intact nonorm rd">Rd</th>
             </tr>
         </thead>
 


### PR DESCRIPTION
## Summary Change Description

Edited initial show/hide state of animal metadata columns in the fcirc template

## Affected Issue Numbers

- Resolves #270 (when combined with previous PR)

## Code Review Notes

Note I noticed & reposted a [bootstrap-table bug](https://github.com/wenzhixin/bootstrap-table/issues/5991) when testing this.  `Toggle all` leaves the first column checkbox (Animal) checked and grayed out even though the column is hidden.

This PR is configured to merge into the previous PR's branch so that you don't re-review the same code.

For some reason, I thought this was going to be more involved than it turned out to be, which is why I separated the effort.

## Checklist

- [x] All issue requirements satisfied (or no linked issues)
- [x] [Linting passes](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#linting).
- [x] [Migrations created & committed *(or no model changes)*](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#migration-process)
- [x] [Tests implemented *(or no code changes)*](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#test-implementation)
- [x] [All tests pass](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#quality-control)
