### PR TITLE
Now a model can be in a composite view more than once.

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -10,15 +10,16 @@ This document will serve to guide developers on implementing new code.
    - Copy and rename PeakGroupsSearchView and make the following edits
       - Set a new ID and name.
       - Set a root model
-      - Determine the root queryset.  If it's not all records of the root model (e.g. PeakData.objects.all()), and a filter is required, add a method to the class called getRootQuerySet() that overrides the base class version, and returns the filtered queryset.  See FluxCircSearchView for an example.
+      - Determine the root queryset.  If you don't want the browse functionality to return all records of the root model (e.g. PeakData.objects.all()) (i.e. a filter is required), add a method to the class called getRootQuerySet() that overrides the base class version, and returns the filtered queryset.  See FluxCircSearchView for an example.
          - Note that if you want your pre-filter to be transparent to the user, you can alternatively override the base class's value for `static_filter`.  Any searches you set there, as the value of the `tree` member of the qry object (see the static_filter commented example), will show in the hierarchical search form, but will not be editable to the user.
-      - Fill in all the prefetch paths from (but not including) the root model to every model leaf.  The path strings are the foreign key field names in the parent model.
-      - Fill in the models data: every model, it's path (from the prefetches, the root model will be an empty string), and all its fields.
+      - Fill in all the prefetch paths from (but not including) the root model to every model_instance leaf.  The path strings are the foreign key field names in the parent model.
+      - Fill in the model_instances data: every model, it's path (from the prefetches, the root model will be an empty string), and all its fields.
+         - Note that the model_instances key can be the model name, but if you need 2 instances of the the same model in the composite view (e.g. "Tracer Compound" linked from Animal and "Measured Compund" linked from PeakGroup, a different instance name must be used.  It may contain no spaces, and is what would be used to create a link for the model from `search_basic` to the advanced search.
          - Cached properties should not be searchable.
          - AutoFields (like IDs) should not be displayed (because they can change depending on how the data is loaded from scratch, thus, they should be obfuscated from the user).
          - If `displayed` is False, set a `handoff` key whose value is a unique field (e.g. `name`).  See any `id` field in the copied class's models data.
    - If not already there, add the root model to the DataRepo.models import at the top of the file.
-   - Set each model's many-to-many value based on whether it is in a many-to-many relatioship with the root model.
+   - Set each model's many-to-many value based on whether it is in a many-to-many relatioship with the root model.  Any many-to-many relationship on the key path necessitates a many-to-many status for that model instance.
    - Add the new class to the for loop in BaseAdvancedSearchView.__init__
 
 2. `DataRepo/forms.py`
@@ -30,8 +31,11 @@ This document will serve to guide developers on implementing new code.
 3. `DataRepo/templates/results/<format name>.html`
    - Copy `DataRepo/templates/results/peakgroups.html` to a new file with a name that indicates the format and edit as you wish, following these guidelines:
       - If a field's path includes a many-to-many relationship, e.g. `models.ManyToManyField`
-         - A nested `for` loop will be necessary in the template, e.g. `{% for study in pg.msrun.sample.animal.studies.all %}`.  If there are no M:M relationships, the nested `for` loop in the copied template may be removed.
-         - The record from the inner loop must be added to the `mm_lookup` dict using addToDict, e.g. `{% addToDict mm_lookup "peak_group__msrun__sample__animal__studies" study %}`.  Here, a "study" record object is added.  The key must be the model's path from compositeviews for the M:M model (e.g. the Study model).
+         - A nested `for` loop will be necessary in the template, e.g. `{% for study in pg.msrun.sample.animal.studies.all %}`.
+         - Each nested loop must maintain a `keeping` dict and conditionally include a row based on the value of `keeping.keep`.
+         - The record count at the top is updated by javascript using a hidden div element (with the ID `realcount`) at the bottom of the table to accurately reflect the the number of rows in the table.
+         - The record from the inner loop must be added to the `mm_lookup` dict using addToDict, e.g. `{% addToDict mm_lookup "peak_group__msrun__sample__animal__studies" study %}`.  The key must be the model's path from compositeviews for the M:M model .  A call to the `shouldKeepManyToMany` tag should be made at the inner-most loop after all M:M relationships have been recorded in `mm_lookup`.
+      - If there are no M:M relationships, the nested `for` loop in the copied template may be removed.
       - Use column headers that match the field's displayname set in step 1 so that they match the field select list.  (A reference to this value may be supplied in the future.)
       - Numeric values should use `<td class="text-end">`
       - Numeric values that have long decimal strings should be formatted with a tooltip like this: `<p title="{{ rec.longval }}">{{ rec.longval|floatformat:4 }}</p>`
@@ -40,8 +44,10 @@ This document will serve to guide developers on implementing new code.
 4. `DataRepo/templates/downloads/<format name>.tsv`
    - Copy `DataRepo/templates/downloads/peakgroups.tsv` to a new file with a name that indicates the format (e.g., same name as in step 3 with a different extension) and edit as you wish, following these guidelines:
       - If a field's path includes a many-to-many relationship, e.g. `models.ManyToManyField`
-         - A nested `for` loop will be necessary in the template, e.g. `{% for study in pg.msrun.sample.animal.studies.all %}`.  If there are no M:M relationships, the nested `for` loop in the copied template may be removed.
-         - The record from the inner loop must be added to the `mm_lookup` dict using addToDict, e.g. `{% addToDict mm_lookup "peak_group__msrun__sample__animal__studies" study %}`.  Here, a "study" record object is added.  The key must be the model's path from compositeviews for the M:M model (e.g. the Study model).
+         - A nested `for` loop will be necessary in the template, e.g. `{% for study in pg.msrun.sample.animal.studies.all %}`.
+         - Each nested loop must maintain a `keeping` dict and conditionally include a row based on the value of `keeping.keep`.
+         - The record from the inner loop must be added to the `mm_lookup` dict using addToDict, e.g. `{% addToDict mm_lookup "peak_group__msrun__sample__animal__studies" study %}`.  The key must be the model's path from compositeviews for the M:M model.  A call to the `shouldKeepManyToMany` tag should be made at the inner-most loop after all M:M relationships have been recorded in `mm_lookup`.
+      - If there are no M:M relationships, the nested `for` loop in the copied template may be removed.
       - Use column headers that match the field's displayname set in step 1 so that they match the field select list.  (A reference to this value may be supplied in the future.)
 
 5. `DataRepo/templates/DataRepo/search/results/display.html`

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -33,7 +33,7 @@ This document will serve to guide developers on implementing new code.
       - If a field's path includes a many-to-many relationship, e.g. `models.ManyToManyField`
          - A nested `for` loop will be necessary in the template, e.g. `{% for study in pg.msrun.sample.animal.studies.all %}`.
          - Each nested loop must maintain a `keeping` dict and conditionally include a row based on the value of `keeping.keep`.
-         - The record count at the top is updated by javascript using a hidden div element (with the ID `realcount`) at the bottom of the table to accurately reflect the the number of rows in the table.
+         - The record count at the top is updated by JavaScript using a hidden div element (with the ID `realcount`) at the bottom of the table to accurately reflect the the number of rows in the table.
          - The record from the inner loop must be added to the `mm_lookup` dict using addToDict, e.g. `{% addToDict mm_lookup "peak_group__msrun__sample__animal__studies" study %}`.  The key must be the model's path from compositeviews for the M:M model .  A call to the `shouldKeepManyToMany` tag should be made at the inner-most loop after all M:M relationships have been recorded in `mm_lookup`.
       - If there are no M:M relationships, the nested `for` loop in the copied template may be removed.
       - Use column headers that match the field's displayname set in step 1 so that they match the field select list.  (A reference to this value may be supplied in the future.)

--- a/DataRepo/compositeviews.py
+++ b/DataRepo/compositeviews.py
@@ -172,30 +172,26 @@ class BaseSearchView:
         return list(self.model_instances.keys())
 
     def getModelInstance(self, mdl):
-        mis = self.getModelInstances()
-        if mdl not in mis:
+        """
+        Given a string that is either a model instance name or a model name, return the corresponding model instance
+        name or report an error if it is ambiguous or not found.
+        """
+        mdl_instance_names = self.getModelInstances()
+        if mdl not in mdl_instance_names:
             # Look through the actual model names (instead of the instance names) to see if there's a unique match.
-            instances = []
-            for mi in mis:
-                if self.model_instances[mi]["model"] == mdl:
-                    instances.append(mi)
-            if len(instances) == 1:
-                return instances[0]
-            elif len(instances) > 1:
+            inst_names = []
+            for inst_name in mdl_instance_names:
+                if self.model_instances[inst_name]["model"] == mdl:
+                    inst_names.append(inst_name)
+            if len(inst_names) == 1:
+                return inst_names[0]
+            elif len(inst_names) > 1:
                 raise KeyError(
-                    "Ambiguous model instance ["
-                    + mdl
-                    + "].  Must specify one of ["
-                    + ",".join(instances)
-                    + "]."
+                    f"Ambiguous model instance [{mdl}].  Must specify one of [{','.join(inst_names)}]."
                 )
             else:
                 raise KeyError(
-                    "Invalid model instance ["
-                    + mdl
-                    + "].  Must be one of ["
-                    + ",".join(mis)
-                    + "]."
+                    f"Invalid model instance [{mdl}].  Must be one of [{','.join(mdl_instance_names)}]."
                 )
         return mdl
 

--- a/DataRepo/compositeviews.py
+++ b/DataRepo/compositeviews.py
@@ -183,7 +183,7 @@ class BaseSearchView:
                 return instances[0]
             elif len(instances) > 1:
                 raise KeyError(
-                    "Ambigous model instance ["
+                    "Ambiguous model instance ["
                     + mdl
                     + "].  Must specify one of ["
                     + ",".join(instances)

--- a/DataRepo/templates/DataRepo/search/results/peakgroups.html
+++ b/DataRepo/templates/DataRepo/search/results/peakgroups.html
@@ -76,6 +76,9 @@
                     {% addToDict keeping "keep" False %}
 
                     {% for cs in pg.compounds.all %}
+
+                        {% addToDict mm_lookup "compounds" cs %}
+
                         {% for ss in cs.synonyms.all %}
 
                             {% addToDict mm_lookup "compounds__synonyms" ss %}

--- a/DataRepo/tests/test_views.py
+++ b/DataRepo/tests/test_views.py
@@ -779,7 +779,8 @@ class ViewTests(TestCase):
             ("msrun__sample__animal__feeding_status", "Feeding Status"),
             ("formula", "Formula"),
             ("msrun__sample__animal__genotype", "Genotype"),
-            ("compounds__synonyms__name", "Measured Compound"),
+            ("compounds__synonyms__name", "Measured Compound (Any Synonym)"),
+            ("compounds__name", "Measured Compound (Primary Synonym)"),
             ("name", "Peak Group"),
             ("peak_group_set__filename", "Peak Group Set Filename"),
             ("msrun__sample__name", "Sample"),
@@ -828,13 +829,13 @@ class ViewTests(TestCase):
         ]
         self.assertEqual(res, pfl)
 
-    def test_cv_getModels(self):
+    def test_cv_getModelInstances(self):
         """
-        Test getModels
+        Test getModelInstances
         """
         basv_metadata = BaseAdvancedSearchView()
         fmt = "pgtemplate"
-        res = basv_metadata.getModels(fmt)
+        res = basv_metadata.getModelInstances(fmt)
         ml = [
             "PeakGroupSet",
             "CompoundSynonym",
@@ -843,7 +844,8 @@ class ViewTests(TestCase):
             "Sample",
             "Tissue",
             "Animal",
-            "Compound",
+            "TracerCompound",
+            "MeasuredCompound",
             "Study",
         ]
         self.assertEqual(res, ml)

--- a/DataRepo/views.py
+++ b/DataRepo/views.py
@@ -531,12 +531,10 @@ def createNewBasicQuery(basv_metadata, mdl, fld, cmp, val, fmt):
 
     qry = basv_metadata.getRootGroup(fmt)
 
-    models = basv_metadata.getModels(fmt)
-
-    if mdl not in models:
-        raise Http404(
-            "Invalid model [" + mdl + "].  Must be one of [" + ",".join(models) + "]."
-        )
+    try:
+        mdl = basv_metadata.getModelInstance(fmt, mdl)
+    except KeyError as ke:
+        raise Http404(ke)
 
     sfields = basv_metadata.getSearchFields(fmt, mdl)
 


### PR DESCRIPTION
## Summary Change Description

Changes the models datamember in each BaseSearchView class to model_instances, treating the old model keys as model instance names and added the actual model to the inner dict.

I changed the Compound model (instance) in the peakgroups format to TracerCompound and then added MeasuredCompound as a proof that it works.

## Affected Issue Numbers

- Resolves ##296

## Code Review Notes

The models in the new model_instances datamember are not actually used.  They are mainly just labels.  The only thing they're used for in the conversion of a basic search to an advanced search.

I added a backup method of obtaining the right model instance.  If a link is created for example, to "Compound", the initial lookup won't find it, but it will fall back to the model contained in each instance.  If there's only one, it returns the model instance name.  Otherwise, it gives a useful error.

I also added a raised exception for when the refilter doesn't work due to a M:M table not existing in the mm_lookup dict from the template, as the error it was throwing before was cryptic (about NoneType not having a `lower()` method).

## Checklist

- [x] All issue requirements satisfied (or no linked issues)
- [x] [Linting passes](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#linting).
- [x] [Migrations created & committed *(or no model changes)*](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#migration-process)
- [ ] [Tests implemented *(or no code changes)*](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#test-implementation)
- [x] [All tests pass](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#quality-control)
