### PR TITLE
Add skip-researcher-check option to load_study

### DIFF
--- a/DataRepo/management/commands/load_study.py
+++ b/DataRepo/management/commands/load_study.py
@@ -83,10 +83,14 @@ class Command(BaseCommand):
                 )
             else:
                 headers_file = None
+            skip_researcher_check = study_params["animals_samples_treatments"].get(
+                "skip_researcher_check", False
+            )
             call_command(
                 "load_animals_and_samples",
                 animal_and_sample_table_filename=animals_samples_table_file,
                 table_headers=headers_file,
+                skip_researcher_check=skip_researcher_check,
             )
 
         if "accucor_data" in study_params:

--- a/DataRepo/schemas/load_study.yaml
+++ b/DataRepo/schemas/load_study.yaml
@@ -14,8 +14,13 @@ properties:
       headers:
         type: string
         description: filename of yaml file defining headers for Excel worksheets
+      skip_researcher_check:
+        type: boolean
+        default: false
+        description: do not check that all reseachers already exist
     required:
       - table
+    additionalProperties: false
   accucor_data:
     type: object
     properties:
@@ -45,29 +50,31 @@ properties:
                 type: string
           required:
             - name
-    msrun_protocol:
-      type: string
-      description: name of ms run protocol
-    date:
-      type: string
-      description: date of ms run
-    researcher:
-      type: string
-      description: name of resercher who performed ms run
-    new_researcher:
-      type: boolean
-      default: False
-      description: flag to indiciate the researcher should be added
-    skip_samples:
-      type: array
-      description: list of sample names to skip when loading
-      items:
+          additionalProperties: false
+      msrun_protocol:
         type: string
-    sample_name_prefix:
-      type: string
-      description: prefix to append to sample names prior to searching
+        description: name of ms run protocol
+      date:
+        type: string
+        description: date of ms run
+      researcher:
+        type: string
+        description: name of resercher who performed ms run
+      new_researcher:
+        type: boolean
+        default: False
+        description: flag to indiciate the researcher should be added
+      skip_samples:
+        type: array
+        description: list of sample names to skip when loading
+        items:
+          type: string
+      sample_name_prefix:
+        type: string
+        description: prefix to append to sample names prior to searching
     required:
       - accucor_files
       - msrun_protocol
       - date
       - researcher
+    additionalProperties: false


### PR DESCRIPTION
<!-- markdownlint-disable-next-line first-line-heading -->
## Summary Change Description

Allow load_study config to specify the `skip-researcher-check` option on
load_animals_and_samples. This simplifies loading of files that contain
multiple researchers.

This issue came up during my attempts to load the fluxomics 2020 study data (#250).

## Affected Issue Numbers

## Code Review Notes

## Checklist

- [x] All issue requirements satisfied (or no linked issues)
- [ ] [Linting passes](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#linting).
- [x] [Migrations created & committed *(or no model changes)*](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#migration-process)
- [ ] [Tests implemented *(or no code changes)*](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#test-implementation)
- [ ] [All tests pass](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#quality-control)
