### PR TITLE
bootstrap table numeric sort fix

### DIFF
--- a/DataRepo/templates/DataRepo/animal_detail.html
+++ b/DataRepo/templates/DataRepo/animal_detail.html
@@ -85,26 +85,26 @@
         data-export-types="['csv', 'txt', 'excel']">
         <thead>
             <tr>
-                <th data-field="Animal" data-filter-control="input" data-sortable="true">Animal</th>
-                <th data-field="Study" data-filter-control="input" data-sortable="true">Studies</th>
-                <th data-field="Genotype" data-filter-control="select" data-sortable="true">Genotype</th>
-                <th data-field="Body-Weight" data-visible="false">Body Weight (g)</th>
-                <th data-field="Age" data-filter-control="input" data-sortable="true" data-visible="false">Age (weeks)</th>
-                <th data-field="Sex" data-filter-control="select" data-sortable="true" data-visible="false">Sex</th>
-                <th data-field="Diet" data-filter-control="input" data-sortable="true" data-visible="false">Diet</th>
-                <th data-field="Feeding-Status" data-filter-control="select" data-sortable="true" data-visible="false">Feeding Status</th>
-                <th data-field="Treatment" data-filter-control="input" data-sortable="true">Treatment</th>
-                <th data-field="Tracer" data-filter-control="input" data-sortable="true">Tracer</th>
-                <th data-field="Labeled-Atom" data-filter-control="select" data-sortable="true" data-visible="false">Labeled Element</th>
-                <th data-field="Labeled-Count" data-filter-control="input" data-sortable="true" data-visible="false">Labeled Count</th>
-                <th data-field="Tracer-Infusion-Rate" data-filter-control="input" data-sortable="true" data-visible="false">Infusion Rate (ul/min/g)</th>
-                <th data-field="Tracer-Infusion-Concentration" data-filter-control="input" data-sortable="true" data-visible="false">Infusion Concentration (mM)</th>
-                <th data-field="Tissue" data-filter-control="input" data-sortable="true">Tissue</th>
-                <th data-field="Sample" data-filter-control="input" data-sortable="true">Sample</th>
-                <th data-field="Sample-Owner" data-filter-control="select" data-sortable="true">Sample Owner</th>
-                <th data-field="Sample-Date" data-filter-control="input" data-sortable="true">Sample Date</th>
-                <th data-field="Collect-Time-Minutes" data-filter-control="input" data-sortable="true" data-visible="false">Sample Collect Time (m)</th>
-                <th data-field="MSRun-Detail">MSRun Detail</th>
+                <th data-filter-control="input" data-sorter="alphanum" data-sortable="true" data-field="Animal">Animal</th>
+                <th data-filter-control="input" data-sorter="alphanum" data-sortable="true" data-field="Study">Studies</th>
+                <th data-filter-control="select" data-sorter="alphanum" data-sortable="true" data-field="Genotype">Genotype</th>
+                <th data-visible="false" data-sorter="numericOnly" data-field="Body-Weight">Body Weight (g)</th>
+                <th data-filter-control="input" data-sorter="numericOnly" data-sortable="true" data-visible="false" data-field="Age">Age (weeks)</th>
+                <th data-filter-control="select" data-sorter="alphanum" data-sortable="true" data-visible="false" data-field="Sex">Sex</th>
+                <th data-filter-control="input" data-sorter="alphanum" data-sortable="true" data-visible="false" data-field="Diet">Diet</th>
+                <th data-filter-control="select" data-sorter="alphanum" data-sortable="true" data-visible="false" data-field="Feeding-Status">Feeding Status</th>
+                <th data-filter-control="input" data-sorter="alphanum" data-sortable="true" data-field="Treatment">Treatment</th>
+                <th data-filter-control="input" data-sorter="alphanum" data-sortable="true" data-field="Tracer">Tracer</th>
+                <th data-filter-control="select" data-sorter="alphanum" data-sortable="true" data-visible="false" data-field="Labeled-Atom">Labeled Element</th>
+                <th data-filter-control="input" data-sorter="numericOnly" data-sortable="true" data-visible="false" data-field="Labeled-Count">Labeled Count</th>
+                <th data-filter-control="input" data-sorter="numericOnly" data-sortable="true" data-visible="false" data-field="Tracer-Infusion-Rate">Infusion Rate (ul/min/g)</th>
+                <th data-filter-control="input" data-sorter="numericOnly" data-sortable="true" data-visible="false" data-field="Tracer-Infusion-Concentration">Infusion Concentration (mM)</th>
+                <th data-filter-control="input" data-sorter="alphanum" data-sortable="true" data-field="Tissue">Tissue</th>
+                <th data-filter-control="input" data-sorter="alphanum" data-sortable="true" data-field="Sample">Sample</th>
+                <th data-filter-control="select" data-sorter="alphanum" data-sortable="true" data-field="Sample-Owner">Sample Owner</th>
+                <th data-filter-control="input" data-sorter="alphanum" data-sortable="true" data-field="Sample-Date">Sample Date</th>
+                <th data-filter-control="input" data-sorter="numericOnly" data-sortable="true" data-visible="false" data-field="Collect-Time-Minutes">Sample Collect Time (m)</th>
+                <th data-sorter="alphanum" data-field="MSRun-Detail">MSRun Detail</th>
             </tr>
         </thead>
         <tbody>

--- a/DataRepo/templates/DataRepo/animal_detail.html
+++ b/DataRepo/templates/DataRepo/animal_detail.html
@@ -85,26 +85,26 @@
         data-export-types="['csv', 'txt', 'excel']">
         <thead>
             <tr>
-                <th data-filter-control="input" data-sorter="alphanum" data-sortable="true" data-field="Animal">Animal</th>
-                <th data-filter-control="input" data-sorter="alphanum" data-sortable="true" data-field="Study">Studies</th>
-                <th data-filter-control="select" data-sorter="alphanum" data-sortable="true" data-field="Genotype">Genotype</th>
-                <th data-visible="false" data-sorter="numericOnly" data-field="Body-Weight">Body Weight (g)</th>
-                <th data-filter-control="input" data-sorter="numericOnly" data-sortable="true" data-visible="false" data-field="Age">Age (weeks)</th>
-                <th data-filter-control="select" data-sorter="alphanum" data-sortable="true" data-visible="false" data-field="Sex">Sex</th>
-                <th data-filter-control="input" data-sorter="alphanum" data-sortable="true" data-visible="false" data-field="Diet">Diet</th>
-                <th data-filter-control="select" data-sorter="alphanum" data-sortable="true" data-visible="false" data-field="Feeding-Status">Feeding Status</th>
-                <th data-filter-control="input" data-sorter="alphanum" data-sortable="true" data-field="Treatment">Treatment</th>
-                <th data-filter-control="input" data-sorter="alphanum" data-sortable="true" data-field="Tracer">Tracer</th>
-                <th data-filter-control="select" data-sorter="alphanum" data-sortable="true" data-visible="false" data-field="Labeled-Atom">Labeled Element</th>
-                <th data-filter-control="input" data-sorter="numericOnly" data-sortable="true" data-visible="false" data-field="Labeled-Count">Labeled Count</th>
-                <th data-filter-control="input" data-sorter="numericOnly" data-sortable="true" data-visible="false" data-field="Tracer-Infusion-Rate">Infusion Rate (ul/min/g)</th>
-                <th data-filter-control="input" data-sorter="numericOnly" data-sortable="true" data-visible="false" data-field="Tracer-Infusion-Concentration">Infusion Concentration (mM)</th>
-                <th data-filter-control="input" data-sorter="alphanum" data-sortable="true" data-field="Tissue">Tissue</th>
-                <th data-filter-control="input" data-sorter="alphanum" data-sortable="true" data-field="Sample">Sample</th>
-                <th data-filter-control="select" data-sorter="alphanum" data-sortable="true" data-field="Sample-Owner">Sample Owner</th>
-                <th data-filter-control="input" data-sorter="alphanum" data-sortable="true" data-field="Sample-Date">Sample Date</th>
-                <th data-filter-control="input" data-sorter="numericOnly" data-sortable="true" data-visible="false" data-field="Collect-Time-Minutes">Sample Collect Time (m)</th>
-                <th data-sorter="alphanum" data-field="MSRun-Detail">MSRun Detail</th>
+                <th data-filter-control="input" data-sortable="true" data-field="Animal">Animal</th>
+                <th data-filter-control="input" data-sortable="true" data-field="Study">Studies</th>
+                <th data-filter-control="select" data-sortable="true" data-field="Genotype">Genotype</th>
+                <th data-visible="false" data-field="Body-Weight">Body Weight (g)</th>
+                <th data-filter-control="input" data-sortable="true" data-visible="false" data-field="Age">Age (weeks)</th>
+                <th data-filter-control="select" data-sortable="true" data-visible="false" data-field="Sex">Sex</th>
+                <th data-filter-control="input" data-sortable="true" data-visible="false" data-field="Diet">Diet</th>
+                <th data-filter-control="select" data-sortable="true" data-visible="false" data-field="Feeding-Status">Feeding Status</th>
+                <th data-filter-control="input" data-sortable="true" data-field="Treatment">Treatment</th>
+                <th data-filter-control="input" data-sortable="true" data-field="Tracer">Tracer</th>
+                <th data-filter-control="select" data-sortable="true" data-visible="false" data-field="Labeled-Atom">Labeled Element</th>
+                <th data-filter-control="input" data-sortable="true" data-visible="false" data-field="Labeled-Count">Labeled Count</th>
+                <th data-filter-control="input" data-sortable="true" data-visible="false" data-field="Tracer-Infusion-Rate">Infusion Rate (ul/min/g)</th>
+                <th data-filter-control="input" data-sortable="true" data-visible="false" data-field="Tracer-Infusion-Concentration">Infusion Concentration (mM)</th>
+                <th data-filter-control="input" data-sortable="true" data-field="Tissue">Tissue</th>
+                <th data-filter-control="input" data-sortable="true" data-field="Sample">Sample</th>
+                <th data-filter-control="select" data-sortable="true" data-field="Sample-Owner">Sample Owner</th>
+                <th data-filter-control="input" data-sortable="true" data-field="Sample-Date">Sample Date</th>
+                <th data-filter-control="input" data-sortable="true" data-visible="false" data-field="Collect-Time-Minutes">Sample Collect Time (m)</th>
+                <th data-field="MSRun-Detail">MSRun Detail</th>
             </tr>
         </thead>
         <tbody>

--- a/DataRepo/templates/DataRepo/animal_list.html
+++ b/DataRepo/templates/DataRepo/animal_list.html
@@ -27,24 +27,24 @@
         data-export-types="['csv', 'txt', 'excel']">
         <thead>
             <tr>
-                <th data-field="Animal" data-filter-control="input" data-sortable="true">Animal</th>
-                <th data-field="Studies" data-filter-control="input" data-sortable="true">Studies</th>
-                <th data-field="Genotype" data-filter-control="select" data-sortable="true">Genotype</th>
-                <th data-field="Tracer" data-filter-control="input" data-sortable="true">Tracer</th>
-                <th data-field="Treatment" data-filter-control="input" data-sortable="true">Treatment</th>
-                <th data-field="Labeled_Atom" data-filter-control="select" data-sortable="true">Labeled Atom</th>
-                <th data-field="Labeled_Count" data-filter-control="input" data-sortable="true">Labeled Count</th>
-                <th data-field="Infusion_Rate" data-filter-control="input" data-sortable="true">Infusion Rate (ul/min/g)</th>
-                <th data-field="Infusion_Concentration" data-filter-control="input" data-sortable="true">Infusion Concentration (mM)</th>
-                <th data-field="Body_Weight" data-filter-control="input" data-sortable="true" data-visible="false">Body Weight (g)</th>
-                <th data-field="Age" data-filter-control="input" data-sortable="true" data-visible="false">Age (weeks)</th>
-                <th data-field="Sex" data-filter-control="select" data-sortable="true" data-visible="false">Sex</th>
-                <th data-field="Diet" data-filter-control="input" data-sortable="true" data-visible="false">Diet</th>
-                <th data-field="Feeding_Status" data-filter-control="input" data-sortable="true">Feeding Status</th>
-                <th data-field="Sample-Owners" data-filter-control="select" data-sortable="true">Sample Owners</th>
-                <th data-field="Total-Tissue" data-filter-control="input" data-sortable="true">Total Tissues</th>
-                <th data-field="Total-Sample" data-filter-control="input" data-sortable="true">Total Samples</th>
-                <th data-field="Total-MSRun" data-filter-control="input" data-sortable="true">Total MSRuns</th>
+                <th data-filter-control="input" data-sortable="true" data-field="Animal">Animal</th>
+                <th data-filter-control="input" data-sortable="true" data-field="Studies">Studies</th>
+                <th data-filter-control="select" data-sortable="true" data-field="Genotype">Genotype</th>
+                <th data-filter-control="input" data-sortable="true" data-field="Tracer">Tracer</th>
+                <th data-filter-control="input" data-sortable="true" data-field="Treatment">Treatment</th>
+                <th data-filter-control="select" data-sortable="true" data-field="Labeled_Atom">Labeled Atom</th>
+                <th data-filter-control="input" data-sortable="true" data-field="Labeled_Count">Labeled Count</th>
+                <th data-filter-control="input" data-sortable="true" data-field="Infusion_Rate">Infusion Rate (ul/min/g)</th>
+                <th data-filter-control="input" data-sortable="true" data-field="Infusion_Concentration">Infusion Concentration (mM)</th>
+                <th data-filter-control="input" data-sortable="true" data-visible="false" data-field="Body_Weight">Body Weight (g)</th>
+                <th data-filter-control="input" data-sortable="true" data-visible="false" data-field="Age">Age (weeks)</th>
+                <th data-filter-control="select" data-sortable="true" data-visible="false" data-field="Sex">Sex</th>
+                <th data-filter-control="input" data-sortable="true" data-visible="false" data-field="Diet">Diet</th>
+                <th data-filter-control="input" data-sortable="true" data-field="Feeding_Status">Feeding Status</th>
+                <th data-filter-control="select" data-sortable="true" data-field="Sample-Owners">Sample Owners</th>
+                <th data-filter-control="input" data-sortable="true" data-field="Total-Tissue">Total Tissues</th>
+                <th data-filter-control="input" data-sortable="true" data-field="Total-Sample">Total Samples</th>
+                <th data-filter-control="input" data-sortable="true" data-field="Total-MSRun">Total MSRuns</th>
             </tr>
         </thead>
         <tbody>

--- a/DataRepo/templates/DataRepo/compound_detail.html
+++ b/DataRepo/templates/DataRepo/compound_detail.html
@@ -56,24 +56,24 @@
         data-export-types="['csv', 'txt', 'excel']">
         <thead>
             <tr>
-                <th data-filter-control="input" data-sortable="true" data-sorter="alphanum" data-field="Animal">Animal</th>
-                <th data-filter-control="input" data-sortable="true" data-sorter="alphanum" data-field="Studies">Studies</th>
-                <th data-filter-control="select" data-sortable="true" data-sorter="alphanum" data-field="Genotype">Genotype</th>
-                <th data-filter-control="input" data-sortable="true" data-sorter="alphanum" data-field="Tracer">Tracer</th>
-                <th data-filter-control="input" data-sortable="true" data-sorter="alphanum" data-field="Treatment">Treatment</th>
-                <th data-filter-control="select" data-sortable="true" data-sorter="alphanum" data-field="Labeled_Atom">Labeled Atom</th>
-                <th data-filter-control="input" data-sortable="true" data-sorter="numericOnly" data-field="Labeled_Count">Labeled Count</th>
-                <th data-filter-control="input" data-sortable="true" data-sorter="numericOnly" data-field="Infusion_Rate">Infusion Rate (ul/min/g)</th>
-                <th data-filter-control="input" data-sortable="true" data-sorter="numericOnly" data-field="Infusion_Concentration">Infusion Concentration (mM)</th>
-                <th data-filter-control="input" data-sortable="true" data-sorter="numericOnly" data-visible="false" data-field="Body_Weight">Body Weight (g)</th>
-                <th data-filter-control="input" data-sortable="true" data-sorter="numericOnly" data-visible="false" data-field="Age">Age (weeks)</th>
-                <th data-filter-control="select" data-sortable="true" data-sorter="alphanum" data-visible="false" data-field="Sex">Sex</th>
-                <th data-filter-control="input" data-sortable="true" data-sorter="alphanum" data-visible="false" data-field="Diet">Diet</th>
-                <th data-filter-control="input" data-sortable="true" data-sorter="alphanum" data-field="Feeding_Status">Feeding Status</th>
-                <th data-filter-control="select" data-sortable="true" data-sorter="alphanum" data-field="Sample-Owners">Sample Owners</th>
-                <th data-filter-control="input" data-sortable="true" data-sorter="numericOnly" data-field="Total-Tissue">Total Tissues</th>
-                <th data-filter-control="input" data-sortable="true" data-sorter="numericOnly" data-field="Total-Sample">Total Samples</th>
-                <th data-filter-control="input" data-sortable="true" data-sorter="numericOnly" data-field="Total-MSRun">Total MSRuns</th>
+                <th data-filter-control="input" data-sortable="true" data-field="Animal">Animal</th>
+                <th data-filter-control="input" data-sortable="true" data-field="Studies">Studies</th>
+                <th data-filter-control="select" data-sortable="true" data-field="Genotype">Genotype</th>
+                <th data-filter-control="input" data-sortable="true" data-field="Tracer">Tracer</th>
+                <th data-filter-control="input" data-sortable="true" data-field="Treatment">Treatment</th>
+                <th data-filter-control="select" data-sortable="true" data-field="Labeled_Atom">Labeled Atom</th>
+                <th data-filter-control="input" data-sortable="true" data-field="Labeled_Count">Labeled Count</th>
+                <th data-filter-control="input" data-sortable="true" data-field="Infusion_Rate">Infusion Rate (ul/min/g)</th>
+                <th data-filter-control="input" data-sortable="true" data-field="Infusion_Concentration">Infusion Concentration (mM)</th>
+                <th data-filter-control="input" data-sortable="true" data-visible="false" data-field="Body_Weight">Body Weight (g)</th>
+                <th data-filter-control="input" data-sortable="true" data-visible="false" data-field="Age">Age (weeks)</th>
+                <th data-filter-control="select" data-sortable="true" data-visible="false" data-field="Sex">Sex</th>
+                <th data-filter-control="input" data-sortable="true" data-visible="false" data-field="Diet">Diet</th>
+                <th data-filter-control="input" data-sortable="true" data-field="Feeding_Status">Feeding Status</th>
+                <th data-filter-control="select" data-sortable="true" data-field="Sample-Owners">Sample Owners</th>
+                <th data-filter-control="input" data-sortable="true" data-field="Total-Tissue">Total Tissues</th>
+                <th data-filter-control="input" data-sortable="true" data-field="Total-Sample">Total Samples</th>
+                <th data-filter-control="input" data-sortable="true" data-field="Total-MSRun">Total MSRuns</th>
             </tr>
         </thead>
         <tbody>

--- a/DataRepo/templates/DataRepo/compound_detail.html
+++ b/DataRepo/templates/DataRepo/compound_detail.html
@@ -56,24 +56,24 @@
         data-export-types="['csv', 'txt', 'excel']">
         <thead>
             <tr>
-                <th data-field="Animal" data-filter-control="input" data-sortable="true">Animal</th>
-                <th data-field="Studies" data-filter-control="input" data-sortable="true">Studies</th>
-                <th data-field="Genotype" data-filter-control="select" data-sortable="true">Genotype</th>
-                <th data-field="Tracer" data-filter-control="input" data-sortable="true">Tracer</th>
-                <th data-field="Treatment" data-filter-control="input" data-sortable="true">Treatment</th>
-                <th data-field="Labeled_Atom" data-filter-control="select" data-sortable="true">Labeled Atom</th>
-                <th data-field="Labeled_Count" data-filter-control="input" data-sortable="true">Labeled Count</th>
-                <th data-field="Infusion_Rate" data-filter-control="input" data-sortable="true">Infusion Rate (ul/min/g)</th>
-                <th data-field="Infusion_Concentration" data-filter-control="input" data-sortable="true">Infusion Concentration (mM)</th>
-                <th data-field="Body_Weight" data-filter-control="input" data-sortable="true" data-visible="false">Body Weight (g)</th>
-                <th data-field="Age" data-filter-control="input" data-sortable="true" data-visible="false">Age (weeks)</th>
-                <th data-field="Sex" data-filter-control="select" data-sortable="true" data-visible="false">Sex</th>
-                <th data-field="Diet" data-filter-control="input" data-sortable="true" data-visible="false">Diet</th>
-                <th data-field="Feeding_Status" data-filter-control="input" data-sortable="true">Feeding Status</th>
-                <th data-field="Sample-Owners" data-filter-control="select" data-sortable="true">Sample Owners</th>
-                <th data-field="Total-Tissue" data-filter-control="input" data-sortable="true">Total Tissues</th>
-                <th data-field="Total-Sample" data-filter-control="input" data-sortable="true">Total Samples</th>
-                <th data-field="Total-MSRun" data-filter-control="input" data-sortable="true">Total MSRuns</th>
+                <th data-filter-control="input" data-sortable="true" data-sorter="alphanum" data-field="Animal">Animal</th>
+                <th data-filter-control="input" data-sortable="true" data-sorter="alphanum" data-field="Studies">Studies</th>
+                <th data-filter-control="select" data-sortable="true" data-sorter="alphanum" data-field="Genotype">Genotype</th>
+                <th data-filter-control="input" data-sortable="true" data-sorter="alphanum" data-field="Tracer">Tracer</th>
+                <th data-filter-control="input" data-sortable="true" data-sorter="alphanum" data-field="Treatment">Treatment</th>
+                <th data-filter-control="select" data-sortable="true" data-sorter="alphanum" data-field="Labeled_Atom">Labeled Atom</th>
+                <th data-filter-control="input" data-sortable="true" data-sorter="numericOnly" data-field="Labeled_Count">Labeled Count</th>
+                <th data-filter-control="input" data-sortable="true" data-sorter="numericOnly" data-field="Infusion_Rate">Infusion Rate (ul/min/g)</th>
+                <th data-filter-control="input" data-sortable="true" data-sorter="numericOnly" data-field="Infusion_Concentration">Infusion Concentration (mM)</th>
+                <th data-filter-control="input" data-sortable="true" data-sorter="numericOnly" data-visible="false" data-field="Body_Weight">Body Weight (g)</th>
+                <th data-filter-control="input" data-sortable="true" data-sorter="numericOnly" data-visible="false" data-field="Age">Age (weeks)</th>
+                <th data-filter-control="select" data-sortable="true" data-sorter="alphanum" data-visible="false" data-field="Sex">Sex</th>
+                <th data-filter-control="input" data-sortable="true" data-sorter="alphanum" data-visible="false" data-field="Diet">Diet</th>
+                <th data-filter-control="input" data-sortable="true" data-sorter="alphanum" data-field="Feeding_Status">Feeding Status</th>
+                <th data-filter-control="select" data-sortable="true" data-sorter="alphanum" data-field="Sample-Owners">Sample Owners</th>
+                <th data-filter-control="input" data-sortable="true" data-sorter="numericOnly" data-field="Total-Tissue">Total Tissues</th>
+                <th data-filter-control="input" data-sortable="true" data-sorter="numericOnly" data-field="Total-Sample">Total Samples</th>
+                <th data-filter-control="input" data-sortable="true" data-sorter="numericOnly" data-field="Total-MSRun">Total MSRuns</th>
             </tr>
         </thead>
         <tbody>

--- a/DataRepo/templates/DataRepo/compound_list.html
+++ b/DataRepo/templates/DataRepo/compound_list.html
@@ -24,12 +24,12 @@
         data-export-types="['csv', 'txt', 'excel']">
         <thead>
             <tr>
-                <th data-filter-control="input" data-sortable="true" data-sorter="alphanum" data-field="Compound">Compound</th>
-                <th data-filter-control="input" data-sortable="true" data-sorter="alphanum" data-field="Formula">Formula</th>
-                <th data-filter-control="input" data-sortable="true" data-sorter="alphanum" data-field="HMDB-ID">HMDB ID</th>
-                <th data-filter-control="input" data-sortable="true" data-sorter="alphanum" data-field="Synonyms">Synonyms</th>
-                <th data-filter-control="select" data-sortable="true" data-sorter="alphanum" data-field="Is-Tracer">Is Tracer</th>
-                <th data-filter-control="input" data-sortable="true" data-sorter="numericOnly" data-field="Total-Animal-Groupby-Tracer">Total Animal By Tracer</th>
+                <th data-filter-control="input" data-sortable="true" data-field="Compound">Compound</th>
+                <th data-filter-control="input" data-sortable="true" data-field="Formula">Formula</th>
+                <th data-filter-control="input" data-sortable="true" data-field="HMDB-ID">HMDB ID</th>
+                <th data-filter-control="input" data-sortable="true" data-field="Synonyms">Synonyms</th>
+                <th data-filter-control="select" data-sortable="true" data-field="Is-Tracer">Is Tracer</th>
+                <th data-filter-control="input" data-sortable="true" data-field="Total-Animal-Groupby-Tracer">Total Animal By Tracer</th>
             </tr>
         </thead>
         <tbody>

--- a/DataRepo/templates/DataRepo/compound_list.html
+++ b/DataRepo/templates/DataRepo/compound_list.html
@@ -24,12 +24,12 @@
         data-export-types="['csv', 'txt', 'excel']">
         <thead>
             <tr>
-                <th data-field="Compound" data-filter-control="input" data-sortable="true">Compound</th>
-                <th data-field="Formula" data-filter-control="input" data-sortable="true">Formula</th>
-                <th data-field="HMDB-ID" data-filter-control="input" data-sortable="true">HMDB ID</th>
-                <th data-field="Synonyms" data-filter-control="input" data-sortable="true">Synonyms</th>
-                <th data-field="Is-Tracer" data-filter-control="select" data-sortable="true">Is Tracer</th>
-                <th data-field="Total-Animal-Groupby-Tracer" data-filter-control="input" data-sortable="true">Total Animal By Tracer</th>
+                <th data-filter-control="input" data-sortable="true" data-sorter="alphanum" data-field="Compound">Compound</th>
+                <th data-filter-control="input" data-sortable="true" data-sorter="alphanum" data-field="Formula">Formula</th>
+                <th data-filter-control="input" data-sortable="true" data-sorter="alphanum" data-field="HMDB-ID">HMDB ID</th>
+                <th data-filter-control="input" data-sortable="true" data-sorter="alphanum" data-field="Synonyms">Synonyms</th>
+                <th data-filter-control="select" data-sortable="true" data-sorter="alphanum" data-field="Is-Tracer">Is Tracer</th>
+                <th data-filter-control="input" data-sortable="true" data-sorter="numericOnly" data-field="Total-Animal-Groupby-Tracer">Total Animal By Tracer</th>
             </tr>
         </thead>
         <tbody>

--- a/DataRepo/templates/DataRepo/sample_list.html
+++ b/DataRepo/templates/DataRepo/sample_list.html
@@ -26,28 +26,28 @@
         data-export-types="['csv', 'txt', 'excel']">
         <thead>
             <tr>
-                <th data-field="Sample" data-filter-control="input" data-sortable="true">sample</th>
-                <th data-field="Animal" data-filter-control="input" data-sortable="true">Animal</th>
-                <th data-field="Tissue" data-filter-control="input" data-sortable="true">Tissue</th>
-                <th data-field="Studies" data-filter-control="input" data-sortable="true">Studies</th>
-                <th data-field="Genotype" data-filter-control="select" data-sortable="true">Genotype</th>
-                <th data-field="Tracer" data-filter-control="input" data-sortable="true">Tracer</th>
-                <th data-field="Treatment" data-filter-control="input" data-sortable="true">Treatment</th>
-                <th data-field="Labeled_Atom" data-filter-control="select" data-sortable="true" data-visible="false">Labeled Atom</th>
-                <th data-field="Labeled_Count" data-filter-control="input" data-sortable="true" data-visible="false">Labeled Count</th>
-                <th data-field="Infusion_Rate" data-filter-control="input" data-sortable="true" data-visible="false">Infusion Rate (ul/min/g)</th>
-                <th data-field="Infusion_Concentration" data-filter-control="input" data-sortable="true" data-visible="false">Infusion Concentration (mM)</th>
-                <th data-field="Body_Weight" data-filter-control="input" data-sortable="true" data-visible="false">Body Weight</th>
-                <th data-field="Age" data-filter-control="input" data-sortable="true" data-visible="false">Age (weeks)</th>
-                <th data-field="Sex" data-filter-control="select" data-sortable="true" data-visible="false">Sex</th>
-                <th data-field="Diet" data-filter-control="input" data-sortable="true" data-visible="false">Diet</th>
-                <th data-field="Feeding_Status" data-filter-control="input" data-sortable="true">Feeding Status</th>
-                <th data-field="Sample-Owner" data-filter-control="select" data-sortable="true">Sample Owner</th>
-                <th data-field="Sample-Date" data-filter-control="input" data-sortable="true">Sample Date</th>
-                <th data-field="Collect-Time-Minutes" data-filter-control="input" data-sortable="true">Sample Collect Time(m)</th>
-                <th data-field="MSRun-Owner" data-filter-control="select" data-sortable="true">MSRun Owner</th>
-                <th data-field="MSRun-Date" data-filter-control="input" data-sortable="true"> MSRun Date</th>
-                <th data-field="MSRun-Detail" data-filter-control="input" data-sortable="true">MSRun Detail</th>
+                <th data-filter-control="input" data-sorter="alphanum" data-sortable="true" data-field="Sample">sample</th>
+                <th data-filter-control="input" data-sorter="alphanum" data-sortable="true" data-field="Animal">Animal</th>
+                <th data-filter-control="input" data-sorter="alphanum" data-sortable="true" data-field="Tissue">Tissue</th>
+                <th data-filter-control="input" data-sorter="alphanum" data-sortable="true" data-field="Studies">Studies</th>
+                <th data-filter-control="select" data-sorter="alphanum" data-sortable="true" data-field="Genotype">Genotype</th>
+                <th data-filter-control="input" data-sorter="alphanum" data-sortable="true" data-field="Tracer">Tracer</th>
+                <th data-filter-control="input" data-sorter="alphanum" data-sortable="true" data-field="Treatment">Treatment</th>
+                <th data-filter-control="select" data-sorter="alphanum" data-sortable="true" data-visible="false" data-field="Labeled_Atom">Labeled Atom</th>
+                <th data-filter-control="input" data-sorter="numericOnly" data-sortable="true" data-visible="false" data-field="Labeled_Count">Labeled Count</th>
+                <th data-filter-control="input" data-sorter="numericOnly" data-sortable="true" data-visible="false" data-field="Infusion_Rate">Infusion Rate (ul/min/g)</th>
+                <th data-filter-control="input" data-sorter="numericOnly" data-sortable="true" data-visible="false" data-field="Infusion_Concentration">Infusion Concentration (mM)</th>
+                <th data-filter-control="input" data-sorter="numericOnly" data-sortable="true" data-visible="false" data-field="Body_Weight">Body Weight</th>
+                <th data-filter-control="input" data-sorter="numericOnly" data-sortable="true" data-visible="false" data-field="Age">Age (weeks)</th>
+                <th data-filter-control="select" data-sorter="alphanum" data-sortable="true" data-visible="false" data-field="Sex">Sex</th>
+                <th data-filter-control="input" data-sorter="alphanum" data-sortable="true" data-visible="false" data-field="Diet">Diet</th>
+                <th data-filter-control="input" data-sorter="alphanum" data-sortable="true" data-field="Feeding_Status">Feeding Status</th>
+                <th data-filter-control="select" data-sorter="alphanum" data-sortable="true" data-field="Sample-Owner">Sample Owner</th>
+                <th data-filter-control="input" data-sorter="alphanum" data-sortable="true" data-field="Sample-Date">Sample Date</th>
+                <th data-filter-control="input" data-sorter="numericOnly" data-sortable="true" data-field="Collect-Time-Minutes">Sample Collect Time(m)</th>
+                <th data-filter-control="select" data-sorter="alphanum" data-sortable="true" data-field="MSRun-Owner">MSRun Owner</th>
+                <th data-filter-control="input" data-sorter="alphanum" data-sortable="true" data-field="MSRun-Date"> MSRun Date</th>
+                <th data-filter-control="input" data-sorter="alphanum" data-sortable="true" data-field="MSRun-Detail">MSRun Detail</th>
             </tr>
         </thead>
         <tbody>

--- a/DataRepo/templates/DataRepo/sample_list.html
+++ b/DataRepo/templates/DataRepo/sample_list.html
@@ -26,28 +26,28 @@
         data-export-types="['csv', 'txt', 'excel']">
         <thead>
             <tr>
-                <th data-filter-control="input" data-sorter="alphanum" data-sortable="true" data-field="Sample">sample</th>
-                <th data-filter-control="input" data-sorter="alphanum" data-sortable="true" data-field="Animal">Animal</th>
-                <th data-filter-control="input" data-sorter="alphanum" data-sortable="true" data-field="Tissue">Tissue</th>
-                <th data-filter-control="input" data-sorter="alphanum" data-sortable="true" data-field="Studies">Studies</th>
-                <th data-filter-control="select" data-sorter="alphanum" data-sortable="true" data-field="Genotype">Genotype</th>
-                <th data-filter-control="input" data-sorter="alphanum" data-sortable="true" data-field="Tracer">Tracer</th>
-                <th data-filter-control="input" data-sorter="alphanum" data-sortable="true" data-field="Treatment">Treatment</th>
-                <th data-filter-control="select" data-sorter="alphanum" data-sortable="true" data-visible="false" data-field="Labeled_Atom">Labeled Atom</th>
-                <th data-filter-control="input" data-sorter="numericOnly" data-sortable="true" data-visible="false" data-field="Labeled_Count">Labeled Count</th>
-                <th data-filter-control="input" data-sorter="numericOnly" data-sortable="true" data-visible="false" data-field="Infusion_Rate">Infusion Rate (ul/min/g)</th>
-                <th data-filter-control="input" data-sorter="numericOnly" data-sortable="true" data-visible="false" data-field="Infusion_Concentration">Infusion Concentration (mM)</th>
-                <th data-filter-control="input" data-sorter="numericOnly" data-sortable="true" data-visible="false" data-field="Body_Weight">Body Weight</th>
-                <th data-filter-control="input" data-sorter="numericOnly" data-sortable="true" data-visible="false" data-field="Age">Age (weeks)</th>
-                <th data-filter-control="select" data-sorter="alphanum" data-sortable="true" data-visible="false" data-field="Sex">Sex</th>
-                <th data-filter-control="input" data-sorter="alphanum" data-sortable="true" data-visible="false" data-field="Diet">Diet</th>
-                <th data-filter-control="input" data-sorter="alphanum" data-sortable="true" data-field="Feeding_Status">Feeding Status</th>
-                <th data-filter-control="select" data-sorter="alphanum" data-sortable="true" data-field="Sample-Owner">Sample Owner</th>
-                <th data-filter-control="input" data-sorter="alphanum" data-sortable="true" data-field="Sample-Date">Sample Date</th>
-                <th data-filter-control="input" data-sorter="numericOnly" data-sortable="true" data-field="Collect-Time-Minutes">Sample Collect Time(m)</th>
-                <th data-filter-control="select" data-sorter="alphanum" data-sortable="true" data-field="MSRun-Owner">MSRun Owner</th>
-                <th data-filter-control="input" data-sorter="alphanum" data-sortable="true" data-field="MSRun-Date"> MSRun Date</th>
-                <th data-filter-control="input" data-sorter="alphanum" data-sortable="true" data-field="MSRun-Detail">MSRun Detail</th>
+                <th data-filter-control="input" data-sortable="true" data-field="Sample">sample</th>
+                <th data-filter-control="input" data-sortable="true" data-field="Animal">Animal</th>
+                <th data-filter-control="input" data-sortable="true" data-field="Tissue">Tissue</th>
+                <th data-filter-control="input" data-sortable="true" data-field="Studies">Studies</th>
+                <th data-filter-control="select" data-sortable="true" data-field="Genotype">Genotype</th>
+                <th data-filter-control="input" data-sortable="true" data-field="Tracer">Tracer</th>
+                <th data-filter-control="input" data-sortable="true" data-field="Treatment">Treatment</th>
+                <th data-filter-control="select" data-sortable="true" data-visible="false" data-field="Labeled_Atom">Labeled Atom</th>
+                <th data-filter-control="input" data-sortable="true" data-visible="false" data-field="Labeled_Count">Labeled Count</th>
+                <th data-filter-control="input" data-sortable="true" data-visible="false" data-field="Infusion_Rate">Infusion Rate (ul/min/g)</th>
+                <th data-filter-control="input" data-sortable="true" data-visible="false" data-field="Infusion_Concentration">Infusion Concentration (mM)</th>
+                <th data-filter-control="input" data-sortable="true" data-visible="false" data-field="Body_Weight">Body Weight</th>
+                <th data-filter-control="input" data-sortable="true" data-visible="false" data-field="Age">Age (weeks)</th>
+                <th data-filter-control="select" data-sortable="true" data-visible="false" data-field="Sex">Sex</th>
+                <th data-filter-control="input" data-sortable="true" data-visible="false" data-field="Diet">Diet</th>
+                <th data-filter-control="input" data-sortable="true" data-field="Feeding_Status">Feeding Status</th>
+                <th data-filter-control="select" data-sortable="true" data-field="Sample-Owner">Sample Owner</th>
+                <th data-filter-control="input" data-sortable="true" data-field="Sample-Date">Sample Date</th>
+                <th data-filter-control="input" data-sortable="true" data-field="Collect-Time-Minutes">Sample Collect Time(m)</th>
+                <th data-filter-control="select" data-sortable="true" data-field="MSRun-Owner">MSRun Owner</th>
+                <th data-filter-control="input" data-sortable="true" data-field="MSRun-Date"> MSRun Date</th>
+                <th data-filter-control="input" data-sortable="true" data-field="MSRun-Detail">MSRun Detail</th>
             </tr>
         </thead>
         <tbody>

--- a/DataRepo/templates/DataRepo/search/results/fcirc.html
+++ b/DataRepo/templates/DataRepo/search/results/fcirc.html
@@ -1,5 +1,6 @@
 {% load customtags %}
 {% block head_extras %}
+    <script src="https://cdn.jsdelivr.net/gh/wenzhixin/bootstrap-table-examples@master/utils/natural-sorting/dist/natural-sorting.js"></script>
     <script>
         // Inspired by: https://stackoverflow.com/questions/12455699/show-hide-table-column-with-colspan-using-jquery
 
@@ -294,7 +295,7 @@
                 <th data-valign="top" data-sortable="true" data-sorter="alphanum" data-visible="true" data-field="Studies">Studies</th>
                 <th data-valign="top" data-sortable="true" data-sorter="alphanum" data-visible="true" data-field="Genotype">Genotype</th>
                 <th data-valign="top" data-sortable="true" data-sorter="numericOnly" data-visible="false" data-field="Body_Weight">Body<br>Weight<br>(g)</th>
-                <th data-valign="top" data-sortable="true" data-sorter="numericOnly" data-visible="false" data-field="Age">Age<br>(weeks)</th>
+                <th data-valign="top" data-sortable="true" data-sorter="alphanum" data-visible="false" data-field="Age">Age<br>(weeks)</th>
                 <th data-valign="top" data-sortable="true" data-sorter="alphanum" data-visible="false" data-field="Sex">Sex</th>
                 <th data-valign="top" data-sortable="true" data-sorter="alphanum" data-visible="false" data-field="Diet">Diet</th>
                 <th data-valign="top" data-sortable="true" data-sorter="alphanum" data-visible="true" data-field="Feeding_Status">Feeding<br>Status</th>
@@ -303,7 +304,7 @@
                 <th data-valign="top" data-sortable="true" data-sorter="alphanum" data-visible="false" data-field="Labeled_Element">Labeled<br>Element</th>
                 <th data-valign="top" data-sortable="true" data-sorter="numericOnly" data-visible="true" data-field="Tracer_Infusion_Rate">Tracer<br>Infusion<br>Rate<br>(ul/m/g)</th>
                 <th data-valign="top" data-sortable="true" data-sorter="numericOnly" data-visible="true" data-field="Tracer_Infusion_Concentration">Tracer Infusion<br>Concentration<br>(mM)</th>
-                <th data-valign="top" data-sortable="true" data-sorter="numericOnly" data-visible="true" data-field="Time_Collected">Time<br>Collected<br>(m)</th>
+                <th data-valign="top" data-sortable="true" data-sorter="alphanum" data-visible="true" data-field="Time_Collected">Time<br>Collected<br>(m)</th>
                 <th data-valign="top" data-sortable="true" data-sorter="numericOnly" data-visible="true" data-switchable="false" data-field="Average_Weight_Normalized_Ra" data-title-tooltip="Average_Weight_Normalized_Ra" class="average weight ra">Ra</th>
                 <th data-valign="top" data-sortable="true" data-sorter="numericOnly" data-visible="true" data-switchable="false" data-field="Average_Weight_Normalized_Rd" data-title-tooltip="Average_Weight_Normalized_Rd" class="average weight rd">Rd</th>
                 <th data-valign="top" data-sortable="true" data-sorter="numericOnly" data-visible="true" data-switchable="false" data-field="Average_Mouse_Normalized_Ra" data-title-tooltip="Average_Mouse_Normalized_Ra" class="average nonorm ra">Ra</th>
@@ -428,7 +429,7 @@
                             {% if pg.rate_appearance_average_per_gram is None %}
                                 None
                             {% else %}
-                                <p title="{{ pg.rate_appearance_average_per_gram }}">{{ pg.rate_appearance_average_per_gram|floatformat:2 }}</p>
+                                <p title="{{ pg.rate_appearance_average_per_gram|floatformat:10 }}">{{ pg.rate_appearance_average_per_gram|floatformat:2 }}</p>
                             {% endif %}
                         </td>
 
@@ -437,7 +438,7 @@
                             {% if pg.rate_disappearance_average_per_gram is None %}
                                 None
                             {% else %}
-                                <p title="{{ pg.rate_disappearance_average_per_gram }}">{{ pg.rate_disappearance_average_per_gram|floatformat:2 }}</p>
+                                <p title="{{ pg.rate_disappearance_average_per_gram|floatformat:10 }}">{{ pg.rate_disappearance_average_per_gram|floatformat:2 }}</p>
                             {% endif %}
                         </td>
 
@@ -446,7 +447,7 @@
                             {% if pg.rate_appearance_average_per_animal is None %}
                                 None
                             {% else %}
-                                <p title="{{ pg.rate_appearance_average_per_animal }}">{{ pg.rate_appearance_average_per_animal|floatformat:2 }}</p>
+                                <p title="{{ pg.rate_appearance_average_per_animal|floatformat:10 }}">{{ pg.rate_appearance_average_per_animal|floatformat:2 }}</p>
                             {% endif %}
                         </td>
 
@@ -455,7 +456,7 @@
                             {% if pg.rate_disappearance_average_per_animal is None %}
                                 None
                             {% else %}
-                                <p title="{{ pg.rate_disappearance_average_per_animal }}">{{ pg.rate_disappearance_average_per_animal|floatformat:2 }}</p>
+                                <p title="{{ pg.rate_disappearance_average_per_animal|floatformat:10 }}">{{ pg.rate_disappearance_average_per_animal|floatformat:2 }}</p>
                             {% endif %}
                         </td>
 
@@ -464,7 +465,7 @@
                             {% if pg.rate_appearance_intact_per_gram is None %}
                                 None
                             {% else %}
-                                <p title="{{ pg.rate_appearance_intact_per_gram }}">{{ pg.rate_appearance_intact_per_gram|floatformat:2 }}</p>
+                                <p title="{{ pg.rate_appearance_intact_per_gram|floatformat:10 }}">{{ pg.rate_appearance_intact_per_gram|floatformat:2 }}</p>
                             {% endif %}
                         </td>
 
@@ -473,7 +474,7 @@
                             {% if pg.rate_disappearance_intact_per_gram is None %}
                                 None
                             {% else %}
-                                <p title="{{ pg.rate_disappearance_intact_per_gram }}">{{ pg.rate_disappearance_intact_per_gram|floatformat:2 }}</p>
+                                <p title="{{ pg.rate_disappearance_intact_per_gram|floatformat:10 }}">{{ pg.rate_disappearance_intact_per_gram|floatformat:2 }}</p>
                             {% endif %}
                         </td>
 
@@ -482,7 +483,7 @@
                             {% if pg.rate_appearance_intact_per_animal is None %}
                                 None
                             {% else %}
-                                <p title="{{ pg.rate_appearance_intact_per_animal }}">{{ pg.rate_appearance_intact_per_animal|floatformat:2 }}</p>
+                                <p title="{{ pg.rate_appearance_intact_per_animal|floatformat:10 }}">{{ pg.rate_appearance_intact_per_animal|floatformat:2 }}</p>
                             {% endif %}
                         </td>
 
@@ -491,7 +492,7 @@
                             {% if pg.rate_disappearance_intact_per_animal is None %}
                                 None
                             {% else %}
-                                <p title="{{ pg.rate_disappearance_intact_per_animal }}">{{ pg.rate_disappearance_intact_per_animal|floatformat:2 }}</p>
+                                <p title="{{ pg.rate_disappearance_intact_per_animal|floatformat:10 }}">{{ pg.rate_disappearance_intact_per_animal|floatformat:2 }}</p>
                             {% endif %}
                         </td>
                     </tr>

--- a/DataRepo/templates/DataRepo/search/results/fcirc.html
+++ b/DataRepo/templates/DataRepo/search/results/fcirc.html
@@ -290,28 +290,28 @@
                 <th colspan="2" data-valign="top" data-sortable="false" data-switchable="true" data-field="Mouse_Normalized2" class="intact nonorm">Mouse<br>Normalized<br>(nM/m)</th>
             </tr>
             <tr>
-                <th data-valign="top" data-sortable="true" data-visible="true" data-field="Animal">Animal</th>
-                <th data-valign="top" data-sortable="true" data-visible="true" data-field="Studies">Studies</th>
-                <th data-valign="top" data-sortable="true" data-visible="true" data-field="Genotype">Genotype</th>
-                <th data-valign="top" data-sortable="true" data-visible="false" data-field="Body_Weight">Body<br>Weight<br>(g)</th>
-                <th data-valign="top" data-sortable="true" data-visible="false" data-field="Age">Age<br>(weeks)</th>
-                <th data-valign="top" data-sortable="true" data-visible="false" data-field="Sex">Sex</th>
-                <th data-valign="top" data-sortable="true" data-visible="false" data-field="Diet">Diet</th>
-                <th data-valign="top" data-sortable="true" data-visible="true" data-field="Feeding_Status">Feeding<br>Status</th>
-                <th data-valign="top" data-sortable="true" data-visible="true" data-field="Treatment">Treatment</th>
-                <th data-valign="top" data-sortable="true" data-visible="true" data-field="Tracer_Compound">Tracer<br>Compound</th>
-                <th data-valign="top" data-sortable="true" data-visible="false" data-field="Labeled_Element">Labeled<br>Element</th>
-                <th data-valign="top" data-sortable="true" data-visible="true" data-field="Tracer_Infusion_Rate">Tracer<br>Infusion<br>Rate<br>(ul/m/g)</th>
-                <th data-valign="top" data-sortable="true" data-visible="true" data-field="Tracer_Infusion_Concentration">Tracer Infusion<br>Concentration<br>(mM)</th>
-                <th data-valign="top" data-sortable="true" data-visible="true" data-field="Time_Collected">Time<br>Collected<br>(m)</th>
-                <th data-valign="top" data-sortable="true" data-visible="true" data-switchable="false" data-field="Average_Weight_Normalized_Ra" data-title-tooltip="Average_Weight_Normalized_Ra" class="average weight ra">Ra</th>
-                <th data-valign="top" data-sortable="true" data-visible="true" data-switchable="false" data-field="Average_Weight_Normalized_Rd" data-title-tooltip="Average_Weight_Normalized_Rd" class="average weight rd">Rd</th>
-                <th data-valign="top" data-sortable="true" data-visible="true" data-switchable="false" data-field="Average_Mouse_Normalized_Ra" data-title-tooltip="Average_Mouse_Normalized_Ra" class="average nonorm ra">Ra</th>
-                <th data-valign="top" data-sortable="true" data-visible="true" data-switchable="false" data-field="Average_Mouse_Normalized_Rd" data-title-tooltip="Average_Mouse_Normalized_Rd" class="average nonorm rd">Rd</th>
-                <th data-valign="top" data-sortable="true" data-visible="true" data-switchable="false" data-field="Intact_Weight_Normalized_Ra" data-title-tooltip="Intact_Weight_Normalized_Ra" class="intact weight ra">Ra</th>
-                <th data-valign="top" data-sortable="true" data-visible="true" data-switchable="false" data-field="Intact_Weight_Normalized_Rd" data-title-tooltip="Intact_Weight_Normalized_Rd" class="intact weight rd">Rd</th>
-                <th data-valign="top" data-sortable="true" data-visible="true" data-switchable="false" data-field="Intact_Mouse_Normalized_Ra" data-title-tooltip="Intact_Mouse_Normalized_Ra" class="intact nonorm ra">Ra</th>
-                <th data-valign="top" data-sortable="true" data-visible="true" data-switchable="false" data-field="Intact_Mouse_Normalized_Rd" data-title-tooltip="Intact_Mouse_Normalized_Rd" class="intact nonorm rd">Rd</th>
+                <th data-valign="top" data-sortable="true" data-sorter="alphanum" data-visible="true" data-field="Animal">Animal</th>
+                <th data-valign="top" data-sortable="true" data-sorter="alphanum" data-visible="true" data-field="Studies">Studies</th>
+                <th data-valign="top" data-sortable="true" data-sorter="alphanum" data-visible="true" data-field="Genotype">Genotype</th>
+                <th data-valign="top" data-sortable="true" data-sorter="numericOnly" data-visible="false" data-field="Body_Weight">Body<br>Weight<br>(g)</th>
+                <th data-valign="top" data-sortable="true" data-sorter="numericOnly" data-visible="false" data-field="Age">Age<br>(weeks)</th>
+                <th data-valign="top" data-sortable="true" data-sorter="alphanum" data-visible="false" data-field="Sex">Sex</th>
+                <th data-valign="top" data-sortable="true" data-sorter="alphanum" data-visible="false" data-field="Diet">Diet</th>
+                <th data-valign="top" data-sortable="true" data-sorter="alphanum" data-visible="true" data-field="Feeding_Status">Feeding<br>Status</th>
+                <th data-valign="top" data-sortable="true" data-sorter="alphanum" data-visible="true" data-field="Treatment">Treatment</th>
+                <th data-valign="top" data-sortable="true" data-sorter="alphanum" data-visible="true" data-field="Tracer_Compound">Tracer<br>Compound</th>
+                <th data-valign="top" data-sortable="true" data-sorter="alphanum" data-visible="false" data-field="Labeled_Element">Labeled<br>Element</th>
+                <th data-valign="top" data-sortable="true" data-sorter="numericOnly" data-visible="true" data-field="Tracer_Infusion_Rate">Tracer<br>Infusion<br>Rate<br>(ul/m/g)</th>
+                <th data-valign="top" data-sortable="true" data-sorter="numericOnly" data-visible="true" data-field="Tracer_Infusion_Concentration">Tracer Infusion<br>Concentration<br>(mM)</th>
+                <th data-valign="top" data-sortable="true" data-sorter="numericOnly" data-visible="true" data-field="Time_Collected">Time<br>Collected<br>(m)</th>
+                <th data-valign="top" data-sortable="true" data-sorter="numericOnly" data-visible="true" data-switchable="false" data-field="Average_Weight_Normalized_Ra" data-title-tooltip="Average_Weight_Normalized_Ra" class="average weight ra">Ra</th>
+                <th data-valign="top" data-sortable="true" data-sorter="numericOnly" data-visible="true" data-switchable="false" data-field="Average_Weight_Normalized_Rd" data-title-tooltip="Average_Weight_Normalized_Rd" class="average weight rd">Rd</th>
+                <th data-valign="top" data-sortable="true" data-sorter="numericOnly" data-visible="true" data-switchable="false" data-field="Average_Mouse_Normalized_Ra" data-title-tooltip="Average_Mouse_Normalized_Ra" class="average nonorm ra">Ra</th>
+                <th data-valign="top" data-sortable="true" data-sorter="numericOnly" data-visible="true" data-switchable="false" data-field="Average_Mouse_Normalized_Rd" data-title-tooltip="Average_Mouse_Normalized_Rd" class="average nonorm rd">Rd</th>
+                <th data-valign="top" data-sortable="true" data-sorter="numericOnly" data-visible="true" data-switchable="false" data-field="Intact_Weight_Normalized_Ra" data-title-tooltip="Intact_Weight_Normalized_Ra" class="intact weight ra">Ra</th>
+                <th data-valign="top" data-sortable="true" data-sorter="numericOnly" data-visible="true" data-switchable="false" data-field="Intact_Weight_Normalized_Rd" data-title-tooltip="Intact_Weight_Normalized_Rd" class="intact weight rd">Rd</th>
+                <th data-valign="top" data-sortable="true" data-sorter="numericOnly" data-visible="true" data-switchable="false" data-field="Intact_Mouse_Normalized_Ra" data-title-tooltip="Intact_Mouse_Normalized_Ra" class="intact nonorm ra">Ra</th>
+                <th data-valign="top" data-sortable="true" data-sorter="numericOnly" data-visible="true" data-switchable="false" data-field="Intact_Mouse_Normalized_Rd" data-title-tooltip="Intact_Mouse_Normalized_Rd" class="intact nonorm rd">Rd</th>
             </tr>
         </thead>
 

--- a/DataRepo/templates/DataRepo/search/results/peakdata.html
+++ b/DataRepo/templates/DataRepo/search/results/peakdata.html
@@ -10,6 +10,7 @@
             rec_cnt_elem.innerHTML = rec_cnt
         })
     </script>
+    <script src="https://cdn.jsdelivr.net/gh/wenzhixin/bootstrap-table-examples@master/utils/natural-sorting/dist/natural-sorting.js"></script>
 
 {% endblock %}
 {% block content %}
@@ -45,7 +46,7 @@
                 <th data-valign="top" data-sortable="true" data-sorter="alphanum" data-field="Animal">Animal</th>
                 <th data-valign="top" data-sortable="true" data-sorter="alphanum" data-field="Genotype">Genotype</th>
                 <th data-valign="top" data-sortable="true" data-sorter="numericOnly" data-field="Body_Weight">Body<br>Weight<br>(g)</th>
-                <th data-valign="top" data-sortable="true" data-sorter="numericOnly" data-field="Age">Age<br>(weeks)</th>
+                <th data-valign="top" data-sortable="true" data-sorter="alphanum" data-field="Age">Age<br>(weeks)</th>
                 <th data-valign="top" data-sortable="true" data-sorter="alphanum" data-field="Sex">Sex</th>
                 <th data-valign="top" data-sortable="true" data-sorter="alphanum" data-field="Diet">Diet</th>
                 <th data-valign="top" data-sortable="true" data-sorter="alphanum" data-field="Feeding_Status">Feeding<br>Status</th>
@@ -115,27 +116,27 @@
 
                             <!-- Raw Abundance -->
                             <td class="text-end">
-                                <p title="{{ pd.raw_abundance }}">{{ pd.raw_abundance|floatformat:1 }}</p>
+                                <p title="{{ pd.raw_abundance|floatformat:10 }}">{{ pd.raw_abundance|floatformat:1 }}</p>
                             </td>
 
                             <!-- Corrected Abundance -->
                             <td class="text-end">
-                                <p title="{{ pd.corrected_abundance }}">{{ pd.corrected_abundance|floatformat:1 }}</p>
+                                <p title="{{ pd.corrected_abundance|floatformat:10 }}">{{ pd.corrected_abundance|floatformat:1 }}</p>
                             </td>
 
                             <!-- Fraction -->
                             <td class="text-end">
-                                <p title="{{ pd.fraction }}">{{ pd.fraction|floatformat:4 }}</p>
+                                <p title="{{ pd.fraction|floatformat:15 }}">{{ pd.fraction|floatformat:4 }}</p>
                             </td>
 
                             <!-- Median M/Z -->
                             <td class="text-end">
-                                <p title="{{ pd.med_mz }}">{{ pd.med_mz|floatformat:1 }}</p>
+                                <p title="{{ pd.med_mz|floatformat:10 }}">{{ pd.med_mz|floatformat:1 }}</p>
                             </td>
 
                             <!-- Median RT -->
                             <td class="text-end">
-                                <p title="{{ pd.med_rt }}">{{ pd.med_rt|floatformat:1 }}</p>
+                                <p title="{{ pd.med_rt|floatformat:10 }}">{{ pd.med_rt|floatformat:1 }}</p>
                             </td>
 
                             <!-- Peak Group Set Filename -->

--- a/DataRepo/templates/DataRepo/search/results/peakdata.html
+++ b/DataRepo/templates/DataRepo/search/results/peakdata.html
@@ -31,29 +31,29 @@
         data-show-export="false">
         <thead>
             <tr>
-                <th data-valign="top" data-sortable="true" data-field="Sample">Sample</th>
-                <th data-valign="top" data-sortable="true" data-field="Tissue">Tissue</th>
-                <th data-valign="top" data-sortable="true" data-field="Peak_Group">Peak Group</th>
-                <th data-valign="top" data-sortable="true" data-field="Formula">Formula</th>
-                <th data-valign="top" data-sortable="true" data-field="Labeled_Element_Count">Labeled<br>Element:<br>Count</th>
-                <th data-valign="top" data-sortable="true" data-field="Raw_Abundance">Raw<br>Abundance</th>
-                <th data-valign="top" data-sortable="true" data-field="Corrected_Abundance">Corrected<br>Abundance</th>
-                <th data-valign="top" data-sortable="true" data-field="Fraction">Fraction</th>
-                <th data-valign="top" data-sortable="true" data-field="Median_MZ">Median<br>M/Z</th>
-                <th data-valign="top" data-sortable="true" data-field="Median_RT">Median<br>RT</th>
-                <th data-valign="top" data-sortable="true" data-field="Peak_Group_Set_Filename">Peak Group Set Filename</th>
-                <th data-valign="top" data-sortable="true" data-field="Animal">Animal</th>
-                <th data-valign="top" data-sortable="true" data-field="Genotype">Genotype</th>
-                <th data-valign="top" data-sortable="true" data-field="Body_Weight">Body<br>Weight<br>(g)</th>
-                <th data-valign="top" data-sortable="true" data-field="Age">Age<br>(weeks)</th>
-                <th data-valign="top" data-sortable="true" data-field="Sex">Sex</th>
-                <th data-valign="top" data-sortable="true" data-field="Diet">Diet</th>
-                <th data-valign="top" data-sortable="true" data-field="Feeding_Status">Feeding<br>Status</th>
-                <th data-valign="top" data-sortable="true" data-field="Treatment">Treatment</th>
-                <th data-valign="top" data-sortable="true" data-field="Tracer_Compound">Tracer<br>Compound</th>
-                <th data-valign="top" data-sortable="true" data-field="Tracer_Infusion_Rate">Tracer<br>Infusion<br>Rate<br>(ul/min/g)</th>
-                <th data-valign="top" data-sortable="true" data-field="Tracer_Infusion_Concentration">Tracer<br>Infusion<br>Concentration<br>(mM)</th>
-                <th data-valign="top" data-sortable="true" data-field="Study">Study</th>
+                <th data-valign="top" data-sortable="true" data-sorter="alphanum" data-field="Sample">Sample</th>
+                <th data-valign="top" data-sortable="true" data-sorter="alphanum" data-field="Tissue">Tissue</th>
+                <th data-valign="top" data-sortable="true" data-sorter="alphanum" data-field="Peak_Group">Peak Group</th>
+                <th data-valign="top" data-sortable="true" data-sorter="alphanum" data-field="Formula">Formula</th>
+                <th data-valign="top" data-sortable="true" data-sorter="alphanum" data-field="Labeled_Element_Count">Labeled<br>Element:<br>Count</th>
+                <th data-valign="top" data-sortable="true" data-sorter="numericOnly" data-field="Raw_Abundance">Raw<br>Abundance</th>
+                <th data-valign="top" data-sortable="true" data-sorter="numericOnly" data-field="Corrected_Abundance">Corrected<br>Abundance</th>
+                <th data-valign="top" data-sortable="true" data-sorter="numericOnly" data-field="Fraction">Fraction</th>
+                <th data-valign="top" data-sortable="true" data-sorter="numericOnly" data-field="Median_MZ">Median<br>M/Z</th>
+                <th data-valign="top" data-sortable="true" data-sorter="numericOnly" data-field="Median_RT">Median<br>RT</th>
+                <th data-valign="top" data-sortable="true" data-sorter="alphanum" data-field="Peak_Group_Set_Filename">Peak Group Set Filename</th>
+                <th data-valign="top" data-sortable="true" data-sorter="alphanum" data-field="Animal">Animal</th>
+                <th data-valign="top" data-sortable="true" data-sorter="alphanum" data-field="Genotype">Genotype</th>
+                <th data-valign="top" data-sortable="true" data-sorter="numericOnly" data-field="Body_Weight">Body<br>Weight<br>(g)</th>
+                <th data-valign="top" data-sortable="true" data-sorter="numericOnly" data-field="Age">Age<br>(weeks)</th>
+                <th data-valign="top" data-sortable="true" data-sorter="alphanum" data-field="Sex">Sex</th>
+                <th data-valign="top" data-sortable="true" data-sorter="alphanum" data-field="Diet">Diet</th>
+                <th data-valign="top" data-sortable="true" data-sorter="alphanum" data-field="Feeding_Status">Feeding<br>Status</th>
+                <th data-valign="top" data-sortable="true" data-sorter="alphanum" data-field="Treatment">Treatment</th>
+                <th data-valign="top" data-sortable="true" data-sorter="alphanum" data-field="Tracer_Compound">Tracer<br>Compound</th>
+                <th data-valign="top" data-sortable="true" data-sorter="numericOnly" data-field="Tracer_Infusion_Rate">Tracer<br>Infusion<br>Rate<br>(ul/min/g)</th>
+                <th data-valign="top" data-sortable="true" data-sorter="numericOnly" data-field="Tracer_Infusion_Concentration">Tracer<br>Infusion<br>Concentration<br>(mM)</th>
+                <th data-valign="top" data-sortable="true" data-sorter="alphanum" data-field="Study">Study</th>
             </tr>
         </thead>
 

--- a/DataRepo/templates/DataRepo/search/results/peakgroups.html
+++ b/DataRepo/templates/DataRepo/search/results/peakgroups.html
@@ -10,6 +10,7 @@
             rec_cnt_elem.innerHTML = real_cnt
         })
     </script>
+    <script src="https://cdn.jsdelivr.net/gh/wenzhixin/bootstrap-table-examples@master/utils/natural-sorting/dist/natural-sorting.js"></script>
 
 {% endblock %}
 {% block content %}
@@ -45,7 +46,7 @@
                 <th data-valign="top" data-sortable="true" data-sorter="alphanum" data-field="Animal">Animal</th>
                 <th data-valign="top" data-sortable="true" data-sorter="alphanum" data-field="Genotype">Genotype</th>
                 <th data-valign="top" data-sortable="true" data-sorter="numericOnly" data-field="Body_Weight">Body<br>Weight<br>(g)</th>
-                <th data-valign="top" data-sortable="true" data-sorter="numericOnly" data-field="Age">Age<br>(weeks)</th>
+                <th data-valign="top" data-sortable="true" data-sorter="alphanum" data-field="Age">Age<br>(weeks)</th>
                 <th data-valign="top" data-sortable="true" data-sorter="alphanum" data-field="Sex">Sex</th>
                 <th data-valign="top" data-sortable="true" data-sorter="alphanum" data-field="Diet">Diet</th>
                 <th data-valign="top" data-sortable="true" data-sorter="alphanum" data-field="Feeding_Status">Feeding<br>Status</th>
@@ -154,17 +155,17 @@
 
                             <!-- Total Abundance -->
                             <td class="text-end">
-                                <p title="{{ pg.total_abundance }}">{{ pg.total_abundance|floatformat:1 }}</p>
+                                <p title="{{ pg.total_abundance|floatformat:10 }}">{{ pg.total_abundance|floatformat:1 }}</p>
                             </td>
 
                             <!-- Enrichment Fraction -->
                             <td class="text-end">
-                                <p title="{{ pg.enrichment_fraction }}">{{ pg.enrichment_fraction|floatformat:4 }}</p>
+                                <p title="{{ pg.enrichment_fraction|floatformat:15 }}">{{ pg.enrichment_fraction|floatformat:4 }}</p>
                             </td>
 
                             <!-- Enrichment Abundance -->
                             <td class="text-end">
-                                <p title="{{ pg.enrichment_abundance }}">{{ pg.enrichment_abundance|floatformat:4 }}</p>
+                                <p title="{{ pg.enrichment_abundance|floatformat:10 }}">{{ pg.enrichment_abundance|floatformat:4 }}</p>
                             </td>
 
                             <!-- Normalized Labeling -->
@@ -172,7 +173,7 @@
                                 {% if pg.normalized_labeling is None %}
                                     <p title="Associated serum sample not found.">None</p>
                                 {% else %}
-                                    <p title="{{ pg.normalized_labeling }}">{{ pg.normalized_labeling|floatformat:4 }}</p>
+                                    <p title="{{ pg.normalized_labeling|floatformat:15 }}">{{ pg.normalized_labeling|floatformat:4 }}</p>
                                 {% endif %}
                             </td>
 

--- a/DataRepo/templates/DataRepo/search/results/peakgroups.html
+++ b/DataRepo/templates/DataRepo/search/results/peakgroups.html
@@ -31,29 +31,29 @@
         data-show-export="false">
         <thead>
             <tr>
-                <th data-valign="top" data-sortable="true" data-field="Sample">Sample</th>
-                <th data-valign="top" data-sortable="true" data-field="Tissue">Tissue</th>
-                <th data-valign="top" data-sortable="true" data-field="Peak_Group">Peak Group</th>
-                <th data-valign="top" data-sortable="true" data-field="Compound_Synonym">Measured<br>Compound(s)</th>
-                <th data-valign="top" data-sortable="true" data-field="Formula">Formula</th>
-                <th data-valign="top" data-sortable="true" data-field="Labeled_Element">Labeled<br>Element</th>
-                <th data-valign="top" data-sortable="true" data-field="Total_Abundance">Total<br>Abundance</th>
-                <th data-valign="top" data-sortable="true" data-field="Enrichment_Fraction">Enrichment<br>Fraction</th>
-                <th data-valign="top" data-sortable="true" data-field="Enrichment_Abundance">Enrichment<br>Abundance</th>
-                <th data-valign="top" data-sortable="true" data-field="Normalized_Labeling">Normalized<br>Labeling</th>
-                <th data-valign="top" data-sortable="true" data-field="Peak_Group_Set_Filename">Peak Group Set Filename</th>
-                <th data-valign="top" data-sortable="true" data-field="Animal">Animal</th>
-                <th data-valign="top" data-sortable="true" data-field="Genotype">Genotype</th>
-                <th data-valign="top" data-sortable="true" data-field="Body_Weight">Body<br>Weight<br>(g)</th>
-                <th data-valign="top" data-sortable="true" data-field="Age">Age<br>(weeks)</th>
-                <th data-valign="top" data-sortable="true" data-field="Sex">Sex</th>
-                <th data-valign="top" data-sortable="true" data-field="Diet">Diet</th>
-                <th data-valign="top" data-sortable="true" data-field="Feeding_Status">Feeding<br>Status</th>
-                <th data-valign="top" data-sortable="true" data-field="Treatment">Treatment</th>
-                <th data-valign="top" data-sortable="true" data-field="Tracer_Compound">Tracer<br>Compound</th>
-                <th data-valign="top" data-sortable="true" data-field="Tracer_Infusion_Rate">Tracer<br>Infusion<br>Rate<br>(ul/min/g)</th>
-                <th data-valign="top" data-sortable="true" data-field="Tracer_Infusion_Concentration">Tracer<br>Infusion<br>Concentration<br>(mM)</th>
-                <th data-valign="top" data-sortable="true" data-field="Study">Study</th>
+                <th data-valign="top" data-sortable="true" data-sorter="alphanum" data-field="Sample">Sample</th>
+                <th data-valign="top" data-sortable="true" data-sorter="alphanum" data-field="Tissue">Tissue</th>
+                <th data-valign="top" data-sortable="true" data-sorter="alphanum" data-field="Peak_Group">Peak Group</th>
+                <th data-valign="top" data-sortable="true" data-sorter="alphanum" data-field="Compound_Synonym">Measured<br>Compound(s)</th>
+                <th data-valign="top" data-sortable="true" data-sorter="alphanum" data-field="Formula">Formula</th>
+                <th data-valign="top" data-sortable="true" data-sorter="alphanum" data-field="Labeled_Element">Labeled<br>Element</th>
+                <th data-valign="top" data-sortable="true" data-sorter="numericOnly" data-field="Total_Abundance">Total<br>Abundance</th>
+                <th data-valign="top" data-sortable="true" data-sorter="numericOnly" data-field="Enrichment_Fraction">Enrichment<br>Fraction</th>
+                <th data-valign="top" data-sortable="true" data-sorter="numericOnly" data-field="Enrichment_Abundance">Enrichment<br>Abundance</th>
+                <th data-valign="top" data-sortable="true" data-sorter="numericOnly" data-field="Normalized_Labeling">Normalized<br>Labeling</th>
+                <th data-valign="top" data-sortable="true" data-sorter="alphanum" data-field="Peak_Group_Set_Filename">Peak Group Set Filename</th>
+                <th data-valign="top" data-sortable="true" data-sorter="alphanum" data-field="Animal">Animal</th>
+                <th data-valign="top" data-sortable="true" data-sorter="alphanum" data-field="Genotype">Genotype</th>
+                <th data-valign="top" data-sortable="true" data-sorter="numericOnly" data-field="Body_Weight">Body<br>Weight<br>(g)</th>
+                <th data-valign="top" data-sortable="true" data-sorter="numericOnly" data-field="Age">Age<br>(weeks)</th>
+                <th data-valign="top" data-sortable="true" data-sorter="alphanum" data-field="Sex">Sex</th>
+                <th data-valign="top" data-sortable="true" data-sorter="alphanum" data-field="Diet">Diet</th>
+                <th data-valign="top" data-sortable="true" data-sorter="alphanum" data-field="Feeding_Status">Feeding<br>Status</th>
+                <th data-valign="top" data-sortable="true" data-sorter="alphanum" data-field="Treatment">Treatment</th>
+                <th data-valign="top" data-sortable="true" data-sorter="alphanum" data-field="Tracer_Compound">Tracer<br>Compound</th>
+                <th data-valign="top" data-sortable="true" data-sorter="numericOnly" data-field="Tracer_Infusion_Rate">Tracer<br>Infusion<br>Rate<br>(ul/min/g)</th>
+                <th data-valign="top" data-sortable="true" data-sorter="numericOnly" data-field="Tracer_Infusion_Concentration">Tracer<br>Infusion<br>Concentration<br>(mM)</th>
+                <th data-valign="top" data-sortable="true" data-sorter="alphanum" data-field="Study">Study</th>
             </tr>
         </thead>
 

--- a/DataRepo/templates/DataRepo/study_detail.html
+++ b/DataRepo/templates/DataRepo/study_detail.html
@@ -67,27 +67,27 @@
         data-export-types="['csv', 'txt', 'excel']">
         <thead>
             <tr>
-                <th data-filter-control="input" data-sortable="true" data-sorter="alphanum" data-field="Study">Study</th>
-                <th data-filter-control="input" data-sortable="true" data-sorter="alphanum" data-visible="false" data-field="Study-Description">Description</th>
-                <th data-filter-control="input" data-sortable="true" data-sorter="alphanum" data-field="Animal">Animal</th>
-                <th data-filter-control="select" data-sortable="true" data-sorter="alphanum" data-field="Genotype">Genotype</th>
-                <th data-visible="false" data-sorter="numericOnly" data-field="Body-Weight">Body Weight (g)</th>
-                <th data-filter-control="input" data-sortable="true" data-sorter="numericOnly" data-visible="false" data-field="Age">Age (weeks)</th>
-                <th data-filter-control="select" data-sortable="true" data-sorter="alphanum" data-visible="false" data-field="Sex">Sex</th>
-                <th data-filter-control="input" data-sortable="true" data-sorter="alphanum" data-visible="false" data-field="Diet">Diet</th>
-                <th data-filter-control="select" data-sortable="true" data-sorter="alphanum" data-field="Feeding-Status">Feeding Status</th>
-                <th data-filter-control="input" data-sortable="true" data-sorter="alphanum" data-field="Treatment">Treatment</th>
-                <th data-filter-control="input" data-sortable="true" data-sorter="alphanum" data-field="Tracer">Tracer</th>
-                <th data-filter-control="select" data-sortable="true" data-sorter="alphanum" data-field="Labeled-Atom">Labeled Element</th>
-                <th data-filter-control="input" data-sortable="true" data-sorter="numericOnly" data-visible="false" data-field="Labeled-Count">Labeled Count</th>
-                <th data-filter-control="input" data-sortable="true" data-sorter="numericOnly" data-visible="false" data-field="Tracer-Infusion-Rate">Infusion Rate (ul/min/g)</th>
-                <th data-filter-control="input" data-sortable="true" data-sorter="numericOnly" data-visible="false" data-field="Tracer-Infusion-Concentration">Infusion Concentration (mM)</th>
-                <th data-filter-control="input" data-sortable="true" data-sorter="alphanum" data-field="Tissue">Tissue</th>
-                <th data-filter-control="input" data-sortable="true" data-sorter="alphanum" data-field="Sample">Sample</th>
-                <th data-filter-control="select" data-sortable="true" data-sorter="alphanum" data-field="Sample-Owner">Sample Owner</th>
-                <th data-filter-control="input" data-sortable="true" data-sorter="alphanum" data-field="Sample-Date">Sample Date</th>
-                <th data-filter-control="input" data-sortable="true" data-sorter="numericOnly" data-visible="false"  data-field="Collect-Time-Minutes">Sample Collect Time(m)</th>
-                <th data-filter-control="input" data-sortable="true" data-sorter="alphanum" data-visible="false"  data-field="MSRun-Detail">MSRun Detail</th>
+                <th data-filter-control="input" data-sortable="true" data-field="Study">Study</th>
+                <th data-filter-control="input" data-sortable="true" data-visible="false" data-field="Study-Description">Description</th>
+                <th data-filter-control="input" data-sortable="true" data-field="Animal">Animal</th>
+                <th data-filter-control="select" data-sortable="true" data-field="Genotype">Genotype</th>
+                <th data-visible="false" data-field="Body-Weight">Body Weight (g)</th>
+                <th data-filter-control="input" data-sortable="true" data-visible="false" data-field="Age">Age (weeks)</th>
+                <th data-filter-control="select" data-sortable="true" data-visible="false" data-field="Sex">Sex</th>
+                <th data-filter-control="input" data-sortable="true" data-visible="false" data-field="Diet">Diet</th>
+                <th data-filter-control="select" data-sortable="true" data-field="Feeding-Status">Feeding Status</th>
+                <th data-filter-control="input" data-sortable="true" data-field="Treatment">Treatment</th>
+                <th data-filter-control="input" data-sortable="true" data-field="Tracer">Tracer</th>
+                <th data-filter-control="select" data-sortable="true" data-field="Labeled-Atom">Labeled Element</th>
+                <th data-filter-control="input" data-sortable="true" data-visible="false" data-field="Labeled-Count">Labeled Count</th>
+                <th data-filter-control="input" data-sortable="true" data-visible="false" data-field="Tracer-Infusion-Rate">Infusion Rate (ul/min/g)</th>
+                <th data-filter-control="input" data-sortable="true" data-visible="false" data-field="Tracer-Infusion-Concentration">Infusion Concentration (mM)</th>
+                <th data-filter-control="input" data-sortable="true" data-field="Tissue">Tissue</th>
+                <th data-filter-control="input" data-sortable="true" data-field="Sample">Sample</th>
+                <th data-filter-control="select" data-sortable="true" data-field="Sample-Owner">Sample Owner</th>
+                <th data-filter-control="input" data-sortable="true" data-field="Sample-Date">Sample Date</th>
+                <th data-filter-control="input" data-sortable="true" data-visible="false"  data-field="Collect-Time-Minutes">Sample Collect Time(m)</th>
+                <th data-filter-control="input" data-sortable="true" data-visible="false"  data-field="MSRun-Detail">MSRun Detail</th>
             </tr>
         </thead>
         <tbody>

--- a/DataRepo/templates/DataRepo/study_detail.html
+++ b/DataRepo/templates/DataRepo/study_detail.html
@@ -67,27 +67,27 @@
         data-export-types="['csv', 'txt', 'excel']">
         <thead>
             <tr>
-                <th data-field="Study" data-filter-control="input" data-sortable="true">Study</th>
-                <th data-field="Study-Description" data-filter-control="input" data-sortable="true" data-visible="false">Description</th>
-                <th data-field="Animal" data-filter-control="input" data-sortable="true">Animal</th>
-                <th data-field="Genotype" data-filter-control="select" data-sortable="true">Genotype</th>
-                <th data-field="Body-Weight" data-visible="false">Body Weight (g)</th>
-                <th data-field="Age" data-filter-control="input" data-sortable="true" data-visible="false">Age (weeks)</th>
-                <th data-field="Sex" data-filter-control="select" data-sortable="true" data-visible="false">Sex</th>
-                <th data-field="Diet" data-filter-control="input" data-sortable="true" data-visible="false">Diet</th>
-                <th data-field="Feeding-Status" data-filter-control="select" data-sortable="true">Feeding Status</th>
-                <th data-field="Treatment" data-filter-control="input" data-sortable="true">Treatment</th>
-                <th data-field="Tracer" data-filter-control="input" data-sortable="true">Tracer</th>
-                <th data-field="Labeled-Atom" data-filter-control="select" data-sortable="true">Labeled Element</th>
-                <th data-field="Labeled-Count" data-filter-control="input" data-sortable="true" data-visible="false">Labeled Count</th>
-                <th data-field="Tracer-Infusion-Rate" data-filter-control="input" data-sortable="true" data-visible="false">Infusion Rate (ul/min/g)</th>
-                <th data-field="Tracer-Infusion-Concentration" data-filter-control="input" data-sortable="true" data-visible="false">Infusion Concentration (mM)</th>
-                <th data-field="Tissue" data-filter-control="input" data-sortable="true">Tissue</th>
-                <th data-field="Sample" data-filter-control="input" data-sortable="true">Sample</th>
-                <th data-field="Sample-Owner" data-filter-control="select" data-sortable="true">Sample Owner</th>
-                <th data-field="Sample-Date" data-filter-control="input" data-sortable="true">Sample Date</th>
-                <th data-field="Collect-Time-Minutes" data-filter-control="input" data-sortable="true" data-visible="false">Sample Collect Time(m)</th>
-                <th data-field="MSRun-Detail" data-filter-control="input" data-sortable="true" data-visible="false">MSRun Detail</th>
+                <th data-filter-control="input" data-sortable="true" data-sorter="alphanum" data-field="Study">Study</th>
+                <th data-filter-control="input" data-sortable="true" data-sorter="alphanum" data-visible="false" data-field="Study-Description">Description</th>
+                <th data-filter-control="input" data-sortable="true" data-sorter="alphanum" data-field="Animal">Animal</th>
+                <th data-filter-control="select" data-sortable="true" data-sorter="alphanum" data-field="Genotype">Genotype</th>
+                <th data-visible="false" data-sorter="numericOnly" data-field="Body-Weight">Body Weight (g)</th>
+                <th data-filter-control="input" data-sortable="true" data-sorter="numericOnly" data-visible="false" data-field="Age">Age (weeks)</th>
+                <th data-filter-control="select" data-sortable="true" data-sorter="alphanum" data-visible="false" data-field="Sex">Sex</th>
+                <th data-filter-control="input" data-sortable="true" data-sorter="alphanum" data-visible="false" data-field="Diet">Diet</th>
+                <th data-filter-control="select" data-sortable="true" data-sorter="alphanum" data-field="Feeding-Status">Feeding Status</th>
+                <th data-filter-control="input" data-sortable="true" data-sorter="alphanum" data-field="Treatment">Treatment</th>
+                <th data-filter-control="input" data-sortable="true" data-sorter="alphanum" data-field="Tracer">Tracer</th>
+                <th data-filter-control="select" data-sortable="true" data-sorter="alphanum" data-field="Labeled-Atom">Labeled Element</th>
+                <th data-filter-control="input" data-sortable="true" data-sorter="numericOnly" data-visible="false" data-field="Labeled-Count">Labeled Count</th>
+                <th data-filter-control="input" data-sortable="true" data-sorter="numericOnly" data-visible="false" data-field="Tracer-Infusion-Rate">Infusion Rate (ul/min/g)</th>
+                <th data-filter-control="input" data-sortable="true" data-sorter="numericOnly" data-visible="false" data-field="Tracer-Infusion-Concentration">Infusion Concentration (mM)</th>
+                <th data-filter-control="input" data-sortable="true" data-sorter="alphanum" data-field="Tissue">Tissue</th>
+                <th data-filter-control="input" data-sortable="true" data-sorter="alphanum" data-field="Sample">Sample</th>
+                <th data-filter-control="select" data-sortable="true" data-sorter="alphanum" data-field="Sample-Owner">Sample Owner</th>
+                <th data-filter-control="input" data-sortable="true" data-sorter="alphanum" data-field="Sample-Date">Sample Date</th>
+                <th data-filter-control="input" data-sortable="true" data-sorter="numericOnly" data-visible="false"  data-field="Collect-Time-Minutes">Sample Collect Time(m)</th>
+                <th data-filter-control="input" data-sortable="true" data-sorter="alphanum" data-visible="false"  data-field="MSRun-Detail">MSRun Detail</th>
             </tr>
         </thead>
         <tbody>

--- a/DataRepo/templates/DataRepo/study_list.html
+++ b/DataRepo/templates/DataRepo/study_list.html
@@ -26,16 +26,16 @@
         data-export-types="['csv', 'txt', 'excel']">
         <thead>
             <tr>
-                <th data-sorter="alphanum" data-filter-control="input" data-sortable="true" data-field="Study">Study</th>
-                <th data-sorter="alphanum" data-filter-control="input" data-sortable="true" data-field="Study-Description">Description</th>
-                <th data-sorter="alphanum" data-filter-control="select" data-sortable="true" data-field="Genotypes">Genotypes</th>
-                <th data-sorter="alphanum" data-filter-control="input" data-sortable="true" data-field="Tracers">Tracers</th>
-                <th data-sorter="alphanum" data-filter-control="input" data-sortable="true" data-field="Treatments">Treatments</th>
-                <th data-sorter="alphanum" data-filter-control="select" data-sortable="true" data-field="Sample-Owners">Sample Owners</th>
-                <th data-sorter="numericOnly" data-filter-control="input" data-sortable="true" data-field="Total-Animal">Total Animals</th>
-                <th data-sorter="numericOnly" data-filter-control="input" data-sortable="true" data-field="Total-Tissue">Total Tissues</th>
-                <th data-sorter="numericOnly" data-filter-control="input" data-sortable="true" data-field="Total-Sample">Total Samples</th>
-                <th data-sorter="numericOnly" data-filter-control="input" data-sortable="true" data-field="Total-MSRun">Total MSRuns</th>
+                <th data-filter-control="input" data-sortable="true" data-field="Study">Study</th>
+                <th data-filter-control="input" data-sortable="true" data-field="Study-Description">Description</th>
+                <th data-filter-control="select" data-sortable="true" data-field="Genotypes">Genotypes</th>
+                <th data-filter-control="input" data-sortable="true" data-field="Tracers">Tracers</th>
+                <th data-filter-control="input" data-sortable="true" data-field="Treatments">Treatments</th>
+                <th data-filter-control="select" data-sortable="true" data-field="Sample-Owners">Sample Owners</th>
+                <th data-filter-control="input" data-sortable="true" data-field="Total-Animal">Total Animals</th>
+                <th data-filter-control="input" data-sortable="true" data-field="Total-Tissue">Total Tissues</th>
+                <th data-filter-control="input" data-sortable="true" data-field="Total-Sample">Total Samples</th>
+                <th data-filter-control="input" data-sortable="true" data-field="Total-MSRun">Total MSRuns</th>
             </tr>
         </thead>
         <tbody>

--- a/DataRepo/templates/DataRepo/study_list.html
+++ b/DataRepo/templates/DataRepo/study_list.html
@@ -26,16 +26,16 @@
         data-export-types="['csv', 'txt', 'excel']">
         <thead>
             <tr>
-                <th data-field="Study" data-filter-control="input" data-sortable="true">Study</th>
-                <th data-field="Study-Description" data-filter-control="input" data-sortable="true">Description</th>
-                <th data-field="Genotypes" data-filter-control="select" data-sortable="true">Genotypes</th>
-                <th data-field="Tracers" data-filter-control="input" data-sortable="true">Tracers</th>
-                <th data-field="Treatments" data-filter-control="input" data-sortable="true">Treatments</th>
-                <th data-field="Sample-Owners" data-filter-control="select" data-sortable="true">Sample Owners</th>
-                <th data-field="Total-Animal" data-filter-control="input" data-sortable="true">Total Animals</th>
-                <th data-field="Total-Tissue" data-filter-control="input" data-sortable="true">Total Tissues</th>
-                <th data-field="Total-Sample" data-filter-control="input" data-sortable="true">Total Samples</th>
-                <th data-field="Total-MSRun" data-filter-control="input" data-sortable="true">Total MSRuns</th>
+                <th data-sorter="alphanum" data-filter-control="input" data-sortable="true" data-field="Study">Study</th>
+                <th data-sorter="alphanum" data-filter-control="input" data-sortable="true" data-field="Study-Description">Description</th>
+                <th data-sorter="alphanum" data-filter-control="select" data-sortable="true" data-field="Genotypes">Genotypes</th>
+                <th data-sorter="alphanum" data-filter-control="input" data-sortable="true" data-field="Tracers">Tracers</th>
+                <th data-sorter="alphanum" data-filter-control="input" data-sortable="true" data-field="Treatments">Treatments</th>
+                <th data-sorter="alphanum" data-filter-control="select" data-sortable="true" data-field="Sample-Owners">Sample Owners</th>
+                <th data-sorter="numericOnly" data-filter-control="input" data-sortable="true" data-field="Total-Animal">Total Animals</th>
+                <th data-sorter="numericOnly" data-filter-control="input" data-sortable="true" data-field="Total-Tissue">Total Tissues</th>
+                <th data-sorter="numericOnly" data-filter-control="input" data-sortable="true" data-field="Total-Sample">Total Samples</th>
+                <th data-sorter="numericOnly" data-filter-control="input" data-sortable="true" data-field="Total-MSRun">Total MSRuns</th>
             </tr>
         </thead>
         <tbody>

--- a/DataRepo/templates/DataRepo/study_summary.html
+++ b/DataRepo/templates/DataRepo/study_summary.html
@@ -24,27 +24,27 @@
     data-export-types="['csv', 'txt', 'excel']">
     <thead>
         <tr>
-            <th data-filter-control="input" data-sorter="alphanum" data-sortable="true" data-field="Study">Study</th>
-            <th data-filter-control="input" data-sorter="alphanum" data-sortable="true" data-visible="false" data-field="Study-Description">Description</th>
-            <th data-filter-control="input" data-sorter="alphanum" data-sortable="true" data-field="Animal">Animal</th>
-            <th data-filter-control="select" data-sorter="alphanum" data-sortable="true" data-field="Genotype">Genotype</th>
-            <th data-visible="false" data-sorter="numericOnly" data-field="Body-Weight">Body Weight (g)</th>
-            <th data-filter-control="input" data-sorter="numericOnly" data-sortable="true" data-visible="false" data-field="Age">Age (weeks)</th>
-            <th data-filter-control="select" data-sorter="alphanum" data-sortable="true" data-visible="false" data-field="Sex">Sex</th>
-            <th data-filter-control="input" data-sorter="alphanum" data-sortable="true" data-visible="false" data-field="Diet">Diet</th>
-            <th data-filter-control="select" data-sorter="alphanum" data-sortable="true" data-field="Feeding-Status">Feeding Status</th>
-            <th data-filter-control="input" data-sorter="alphanum" data-sortable="true" data-field="Treatment">Treatment</th>
-            <th data-filter-control="input" data-sorter="alphanum" data-sortable="true" data-field="Tracer">Tracer</th>
-            <th data-filter-control="select" data-sorter="alphanum" data-sortable="true" data-field="Labeled-Atom">Labeled Element</th>
-            <th data-filter-control="input" data-sorter="numericOnly" data-sortable="true" data-visible="false" data-field="Labeled-Count">Labeled Count</th>
-            <th data-filter-control="input" data-sorter="numericOnly" data-sortable="true" data-visible="false" data-field="Tracer-Infusion-Rate">Infusion Rate (ul/min/g)</th>
-            <th data-filter-control="input" data-sorter="numericOnly" data-sortable="true" data-visible="false" data-field="Tracer-Infusion-Concentration">Infusion Concentration (mM)</th>
-            <th data-filter-control="input" data-sorter="alphanum" data-sortable="true" data-field="Tissue">Tissue</th>
-            <th data-filter-control="input" data-sorter="alphanum" data-sortable="true" data-field="Sample">Sample</th>
-            <th data-filter-control="select" data-sorter="alphanum" data-sortable="true" data-field="Sample-Owner">Sample Owner</th>
-            <th data-filter-control="input" data-sorter="alphanum" data-sortable="true" data-field="Sample-Date">Sample Date</th>
-            <th data-filter-control="input" data-sorter="numericOnly" data-sortable="true" data-visible="false" data-field="Collect-Time-Minites">Sample Collect Time(m)</th>
-            <th data-filter-control="input" data-sorter="alphanum" data-sortable="true" data-visible="false" data-field="MSRun-Detail">MSRun Detail</th>
+            <th data-filter-control="input" data-sortable="true" data-field="Study">Study</th>
+            <th data-filter-control="input" data-sortable="true" data-visible="false" data-field="Study-Description">Description</th>
+            <th data-filter-control="input" data-sortable="true" data-field="Animal">Animal</th>
+            <th data-filter-control="select" data-sortable="true" data-field="Genotype">Genotype</th>
+            <th data-visible="false" data-field="Body-Weight">Body Weight (g)</th>
+            <th data-filter-control="input" data-sortable="true" data-visible="false" data-field="Age">Age (weeks)</th>
+            <th data-filter-control="select" data-sortable="true" data-visible="false" data-field="Sex">Sex</th>
+            <th data-filter-control="input" data-sortable="true" data-visible="false" data-field="Diet">Diet</th>
+            <th data-filter-control="select" data-sortable="true" data-field="Feeding-Status">Feeding Status</th>
+            <th data-filter-control="input" data-sortable="true" data-field="Treatment">Treatment</th>
+            <th data-filter-control="input" data-sortable="true" data-field="Tracer">Tracer</th>
+            <th data-filter-control="select" data-sortable="true" data-field="Labeled-Atom">Labeled Element</th>
+            <th data-filter-control="input" data-sortable="true" data-visible="false" data-field="Labeled-Count">Labeled Count</th>
+            <th data-filter-control="input" data-sortable="true" data-visible="false" data-field="Tracer-Infusion-Rate">Infusion Rate (ul/min/g)</th>
+            <th data-filter-control="input" data-sortable="true" data-visible="false" data-field="Tracer-Infusion-Concentration">Infusion Concentration (mM)</th>
+            <th data-filter-control="input" data-sortable="true" data-field="Tissue">Tissue</th>
+            <th data-filter-control="input" data-sortable="true" data-field="Sample">Sample</th>
+            <th data-filter-control="select" data-sortable="true" data-field="Sample-Owner">Sample Owner</th>
+            <th data-filter-control="input" data-sortable="true" data-field="Sample-Date">Sample Date</th>
+            <th data-filter-control="input" data-sortable="true" data-visible="false" data-field="Collect-Time-Minites">Sample Collect Time(m)</th>
+            <th data-filter-control="input" data-sortable="true" data-visible="false" data-field="MSRun-Detail">MSRun Detail</th>
         </tr>
     </thead>
     <tbody>

--- a/DataRepo/templates/DataRepo/study_summary.html
+++ b/DataRepo/templates/DataRepo/study_summary.html
@@ -24,27 +24,27 @@
     data-export-types="['csv', 'txt', 'excel']">
     <thead>
         <tr>
-            <th data-field="Study" data-filter-control="input" data-sortable="true">Study</th>
-            <th data-field="Study-Description" data-filter-control="input" data-sortable="true" data-visible="false">Description</th>
-            <th data-field="Animal" data-filter-control="input" data-sortable="true">Animal</th>
-            <th data-field="Genotype" data-filter-control="select" data-sortable="true">Genotype</th>
-            <th data-field="Body-Weight" data-visible="false">Body Weight (g)</th>
-            <th data-field="Age" data-filter-control="input" data-sortable="true" data-visible="false">Age (weeks)</th>
-            <th data-field="Sex" data-filter-control="select" data-sortable="true" data-visible="false">Sex</th>
-            <th data-field="Diet" data-filter-control="input" data-sortable="true" data-visible="false">Diet</th>
-            <th data-field="Feeding-Status" data-filter-control="select" data-sortable="true">Feeding Status</th>
-            <th data-field="Treatment" data-filter-control="input" data-sortable="true">Treatment</th>
-            <th data-field="Tracer" data-filter-control="input" data-sortable="true">Tracer</th>
-            <th data-field="Labeled-Atom" data-filter-control="select" data-sortable="true">Labeled Element</th>
-            <th data-field="Labeled-Count" data-filter-control="input" data-sortable="true" data-visible="false">Labeled Count</th>
-            <th data-field="Tracer-Infusion-Rate" data-filter-control="input" data-sortable="true" data-visible="false">Infusion Rate (ul/min/g)</th>
-            <th data-field="Tracer-Infusion-Concentration" data-filter-control="input" data-sortable="true" data-visible="false">Infusion Concentration (mM)</th>
-            <th data-field="Tissue" data-filter-control="input" data-sortable="true">Tissue</th>
-            <th data-field="Sample" data-filter-control="input" data-sortable="true">Sample</th>
-            <th data-field="Sample-Owner" data-filter-control="select" data-sortable="true">Sample Owner</th>
-            <th data-field="Sample-Date" data-filter-control="input" data-sortable="true">Sample Date</th>
-            <th data-field="Collect-Time-Minites" data-filter-control="input" data-sortable="true" data-visible="false">Sample Collect Time(m)</th>
-            <th data-field="MSRun-Detail" data-filter-control="input" data-sortable="true" data-visible="false">MSRun Detail</th>
+            <th data-filter-control="input" data-sorter="alphanum" data-sortable="true" data-field="Study">Study</th>
+            <th data-filter-control="input" data-sorter="alphanum" data-sortable="true" data-visible="false" data-field="Study-Description">Description</th>
+            <th data-filter-control="input" data-sorter="alphanum" data-sortable="true" data-field="Animal">Animal</th>
+            <th data-filter-control="select" data-sorter="alphanum" data-sortable="true" data-field="Genotype">Genotype</th>
+            <th data-visible="false" data-sorter="numericOnly" data-field="Body-Weight">Body Weight (g)</th>
+            <th data-filter-control="input" data-sorter="numericOnly" data-sortable="true" data-visible="false" data-field="Age">Age (weeks)</th>
+            <th data-filter-control="select" data-sorter="alphanum" data-sortable="true" data-visible="false" data-field="Sex">Sex</th>
+            <th data-filter-control="input" data-sorter="alphanum" data-sortable="true" data-visible="false" data-field="Diet">Diet</th>
+            <th data-filter-control="select" data-sorter="alphanum" data-sortable="true" data-field="Feeding-Status">Feeding Status</th>
+            <th data-filter-control="input" data-sorter="alphanum" data-sortable="true" data-field="Treatment">Treatment</th>
+            <th data-filter-control="input" data-sorter="alphanum" data-sortable="true" data-field="Tracer">Tracer</th>
+            <th data-filter-control="select" data-sorter="alphanum" data-sortable="true" data-field="Labeled-Atom">Labeled Element</th>
+            <th data-filter-control="input" data-sorter="numericOnly" data-sortable="true" data-visible="false" data-field="Labeled-Count">Labeled Count</th>
+            <th data-filter-control="input" data-sorter="numericOnly" data-sortable="true" data-visible="false" data-field="Tracer-Infusion-Rate">Infusion Rate (ul/min/g)</th>
+            <th data-filter-control="input" data-sorter="numericOnly" data-sortable="true" data-visible="false" data-field="Tracer-Infusion-Concentration">Infusion Concentration (mM)</th>
+            <th data-filter-control="input" data-sorter="alphanum" data-sortable="true" data-field="Tissue">Tissue</th>
+            <th data-filter-control="input" data-sorter="alphanum" data-sortable="true" data-field="Sample">Sample</th>
+            <th data-filter-control="select" data-sorter="alphanum" data-sortable="true" data-field="Sample-Owner">Sample Owner</th>
+            <th data-filter-control="input" data-sorter="alphanum" data-sortable="true" data-field="Sample-Date">Sample Date</th>
+            <th data-filter-control="input" data-sorter="numericOnly" data-sortable="true" data-visible="false" data-field="Collect-Time-Minites">Sample Collect Time(m)</th>
+            <th data-filter-control="input" data-sorter="alphanum" data-sortable="true" data-visible="false" data-field="MSRun-Detail">MSRun Detail</th>
         </tr>
     </thead>
     <tbody>

--- a/DataRepo/templates/base.html
+++ b/DataRepo/templates/base.html
@@ -61,6 +61,7 @@
         <script src="https://unpkg.com/bootstrap-table@1.18.3/dist/bootstrap-table.min.js"></script>
         <script src="https://unpkg.com/bootstrap-table@1.18.3/dist/extensions/filter-control/bootstrap-table-filter-control.min.js"></script>
         <script src="https://unpkg.com/bootstrap-table@1.18.3/dist/extensions/export/bootstrap-table-export.min.js"></script>
+        <script src="https://unpkg.com/bootstrap-table@1.18.3/dist/extensions/natural-sorting/bootstrap-table-natural-sorting.js"></script>
 
     </body>
 

--- a/DataRepo/templates/base.html
+++ b/DataRepo/templates/base.html
@@ -61,7 +61,6 @@
         <script src="https://unpkg.com/bootstrap-table@1.18.3/dist/bootstrap-table.min.js"></script>
         <script src="https://unpkg.com/bootstrap-table@1.18.3/dist/extensions/filter-control/bootstrap-table-filter-control.min.js"></script>
         <script src="https://unpkg.com/bootstrap-table@1.18.3/dist/extensions/export/bootstrap-table-export.min.js"></script>
-        <script src="https://unpkg.com/bootstrap-table@1.18.3/dist/extensions/natural-sorting/bootstrap-table-natural-sorting.js"></script>
 
     </body>
 


### PR DESCRIPTION
## Summary Change Description

Fixed the numeric sort for the case where bootstrap table's default sort messes up when a tooltip with a variable number of decimal places is present.

## Affected Issue Numbers

- Resolves #305

## Code Review Notes

I set an arbitrary max number of decimal places for the tooltip values (10 for values greater than 1 and 15 for values less than 1).  My original intent of the tooltip was to show the *unmodified* value.  The thought was to be able to search for an exact value and also know what you would get in the download (which still does not modify the value).  These modifications back-fill zeroes when the places are below the threshold and truncate anything longer than the threshold.  I did not check the DB for how many decimal places are possible, but these arbitrary settings are likely overkill.

While working out what was going on, I had temporarily edited the data values everywhere bootstrap table was used, and to make the edit easier, I moved the `data-field` value to the end of the list of attributes.  So:

**You can ignore all the edits for all templates except the 3 advanced searches.**

I included the new javascript source in the 3 advanced search results templates.  Let me know if you'd prefer me to put that in the static directory.

I also observed that not all of our javascript inclusions (including ones outside of this PR) set an integrity or crossorigin value (see `base.html`).  Please create an issue if you think that security measure is necessary.

Note that all the other bootstrap tables (i.e. Fan's tables) appear to numerically sort correctly because they do not have tooltips.  I even think it would sort correctly, based on my testing, if the number of decimal places varied.  It's only when there is a number in the tooltip when there's an issue.

## Checklist

- [x] All issue requirements satisfied (or no linked issues)
- [x] [Linting passes](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#linting).
- [x] [Migrations created & committed *(or no model changes)*](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#migration-process)
- [ ] [Tests implemented *(or no code changes)*](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#test-implementation)
- [x] [All tests pass](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#quality-control)
