### PR TITLE
Added feedback link

### DIFF
--- a/DataRepo/templates/navbar.html
+++ b/DataRepo/templates/navbar.html
@@ -40,6 +40,11 @@
             <li class="nav-item">
                 <a class="nav-link" href="{% url 'upload' %}">Upload</a>
             </li>
+            <li class="nav-item dropdown">
+                <a class="nav-link" href="https://docs.google.com/forms/d/e/1FAIpQLSdnYe_gvKdoELXexZ9508xO8o59F1WgXcWBNh-_oxYh9WfHPg/viewform?usp=pp_url&entry.1881422913={{ request.get_full_path }}" target="_blank">
+                    Feedback
+                </a>
+            </li>
         </ul>
 
         <!-- Commenting to leave as a placeholder until this is implemented.
@@ -48,11 +53,11 @@
             <button class="btn btn-outline-success me-2" type="submit">Search</button>
         </form>
         -->
-        <a role="button" class="btn btn-outline-success nobr" href="{% url 'search_advanced' %}">Advanced Search</a>
         <ul class="navbar-nav mr-auto" style="margin-left: 1rem;">
             <li class="nav-item mr-auto">
                 <a class="nav-link" href="{% url 'admin:index' %}">Admin</a>
             </li>
         </ul>
+        <a role="button" class="btn btn-outline-success nobr" href="{% url 'search_advanced' %}">Advanced Search</a>
     </div>
 </nav>


### PR DESCRIPTION
## Summary Change Description

I edited the google form to create a field for the page that the clicked feedback link was on.  I expect this could potentially be useful to put any comments a user submits in the proper context.  Please consider making suggestions to edit that field prompt...

[Google form edit page](https://docs.google.com/forms/d/1DdC6BtOEZZYsrc06yh4Akt6sMkFmHuICrT6ew1qLUMM/edit)
[Google form submission page](https://docs.google.com/forms/d/e/1FAIpQLSdnYe_gvKdoELXexZ9508xO8o59F1WgXcWBNh-_oxYh9WfHPg/viewform?usp=pp_url&entry.1881422913=Tracebase+path+will+be+prefilled+here)

I also slightly reordered the admin & advanced search items.

## Affected Issue Numbers

- Resolves #308

## Code Review Notes

I was annoyed that I couldn't hide the field containing the referred URL in the google form.  If you figure out a way to do that that's straightforward, please create an issue.  I figured it might be OK for a user to edit that value if they know what they're doing.

I also noted that that value may only be useful for the bug form, but then again, it could also indicate a page where they want to see a specific feature implemented...

The pre-filled google form hack is described [here](https://support.google.com/docs/thread/3341555/can-google-forms-use-codes-from-url-to-auto-fill-fields-in-the-form?hl=en).

I generate the URL to supply to it using [this django feature](https://docs.djangoproject.com/en/3.2/ref/request-response/#django.http.HttpRequest.get_full_path).

## Checklist

- [x] All issue requirements satisfied (or no linked issues)
- [x] [Linting passes](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#linting).
- [x] [Migrations created & committed *(or no model changes)*](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#migration-process)
- [x] [Tests implemented *(or no code changes)*](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#test-implementation)
- [x] [All tests pass](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#quality-control)
