### PR TITLE
Add load_study_set command

### DIFF
--- a/DataRepo/management/commands/load_study_set.py
+++ b/DataRepo/management/commands/load_study_set.py
@@ -8,7 +8,7 @@ class Command(BaseCommand):
 
     # Show this when the user types help
     help = (
-        "Loads a set of study using the load_study command. Input is a file of "
+        "Loads a set of studies using the load_study command. Input is a file of "
         "filenames listing load_study YAML config files, one per line."
         "Example usage: manage.py load_study_set list_of_study_config_files.txt"
     )

--- a/DataRepo/management/commands/load_study_set.py
+++ b/DataRepo/management/commands/load_study_set.py
@@ -1,0 +1,40 @@
+import argparse
+import os
+
+from django.core.management import BaseCommand, call_command
+
+
+class Command(BaseCommand):
+
+    # Show this when the user types help
+    help = (
+        "Loads a set of study using the load_study command. Input is a file of "
+        "filenames listing load_study YAML config files, one per line."
+        "Example usage: manage.py load_study_set list_of_study_config_files.txt"
+    )
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "study_set_list",
+            type=argparse.FileType("r"),
+            help=("File of load_study config filenames, one per line"),
+        )
+
+    def handle(self, *args, **options):
+
+        studies_loaded = list()
+        study_set_dir = os.path.dirname(
+            os.path.realpath(options["study_set_list"].name)
+        )
+        with options["study_set_list"] as study_set:
+            for study in study_set:
+                study_path = os.path.join(study_set_dir, study.strip())
+                self.stdout.write(
+                    self.style.MIGRATE_HEADING(f"Loading study using {study_path}")
+                )
+                call_command("load_study", study_path)
+                studies_loaded.append(study_path)
+
+        self.stdout.write(
+            self.style.SUCCESS(f"Completed loading of {len(studies_loaded)} studies")
+        )


### PR DESCRIPTION
<!-- markdownlint-disable-next-line first-line-heading -->
## Summary Change Description

Add a command to read a file of file names and use those as
`study_params` for the `load_study` command.

## Affected Issue Numbers

- Resolves #327

## Code Review Notes

This PR is missing tests, though I did test it using the data in https://github.com/PrincetonUniversity/tracebase-rabinowitz-data. I would include a test when we organize example and test data (#172 and #325).

## Checklist

- [x] All issue requirements satisfied (or no linked issues)
- [x] [Linting passes](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#linting).
- [x] [Migrations created & committed *(or no model changes)*](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#migration-process)
- [ ] [Tests implemented *(or no code changes)*](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#test-implementation)
- [x] [All tests pass](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#quality-control)
