### PR TITLE
Fixed search validation error

### DIFF
--- a/DataRepo/forms.py
+++ b/DataRepo/forms.py
@@ -50,8 +50,6 @@ class BaseAdvSearchForm(forms.Form):
 
     ncmp = forms.ChoiceField(required=True, widget=forms.Select())
 
-    # TODO: Currently, I am only providing this one field type.  Eventually, I will work out a way to dynamically
-    # update this based on the model's field type
     # Note: the placeholder attribute solves issue #135
     val = forms.CharField(widget=forms.TextInput(attrs={"placeholder": "search term"}))
 

--- a/DataRepo/templates/DataRepo/search/query.html
+++ b/DataRepo/templates/DataRepo/search/query.html
@@ -55,7 +55,7 @@
             initializeRootSearchQuery(allforms)
 
             var myform = document.getElementById("hierarchical-search-form")
-            myform.addEventListener("submit", function (event) {
+            myform.addEventListener("submit", function () {
                 saveSearchQueryHierarchy(document.querySelector('.hierarchical-search'))
                 myform.submit();
             })

--- a/DataRepo/templates/DataRepo/search/query.html
+++ b/DataRepo/templates/DataRepo/search/query.html
@@ -55,7 +55,7 @@
             initializeRootSearchQuery(allforms)
 
             var myform = document.getElementById("hierarchical-search-form")
-            myform.addEventListener("submit", function () {
+            myform.addEventListener("submit", function (event) {
                 saveSearchQueryHierarchy(document.querySelector('.hierarchical-search'))
                 myform.submit();
             })
@@ -104,7 +104,7 @@
                 {{ managing_form.errors.val }}
                 {{ managing_form.management_form }}
             {% endwith %}
-            <label id="formerror" class="text-danger temporal-text"></label>
+            <label id="formerror" class="text-danger temporal-text">{{ error }}</label>
         </form>
         <a id="browselink" href="{% url 'search_advanced' %}?mode=browse" class="tiny">Browse All</a>
     </div>

--- a/DataRepo/templates/DataRepo/search/query.html
+++ b/DataRepo/templates/DataRepo/search/query.html
@@ -55,7 +55,7 @@
             initializeRootSearchQuery(allforms)
 
             var myform = document.getElementById("hierarchical-search-form")
-            document.getElementById("advanced-search-submit").addEventListener("click", function () {
+            myform.addEventListener("submit", function () {
                 saveSearchQueryHierarchy(document.querySelector('.hierarchical-search'))
                 myform.submit();
             })

--- a/DataRepo/views.py
+++ b/DataRepo/views.py
@@ -348,6 +348,7 @@ class AdvancedSearchView(MultiFormsView):
                 ncmp_choices=self.basv_metadata.getComparisonChoices(),
                 fld_types=self.basv_metadata.getFieldTypes(),
                 refilter=False,
+                error="All fields are required",  # Unless hacked, this is the only thing that can go wrong
             )
         )
 


### PR DESCRIPTION
## Summary Change Description

Restored the form validation error about required fields.

## Affected Issue Numbers

- Resolves no issue, but related to #132

## Code Review Notes

The refactor of nested_forms.js to hierarchical_formsets.js awhile back inadvertently removed the required field error last seen [here](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/ec691f3ede85496625225f8bad3d026594c8d714/static/js/nested_forms.js#L101).

This is a simpler quick fix.  I couldn't re-do it the other way because of the code that changes the search term field type, but there's only 1 type of form validation error (other than those that would result from hacking the form submission).

- Removed an outdated todo comment from form.py
- Removed a few console debug prints.
- Filled in a missing argument in a recursive call to `saveSearchQueryHierarchyHelper` (which only [formerly] affected a debug print)
- Added a `curfmt` argument to `saveSearchQueryHierarchyHelper` so that an empty `val` in the selected format could be caught
- Added a required fields error in both the javascript and the form_invalid method so that it could be shown (when there's a missing value) in the search.html template

## Checklist

- [x] All issue requirements satisfied (or no linked issues)
- [x] [Linting passes](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#linting).
- [x] [Migrations created & committed *(or no model changes)*](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#migration-process)
- [ ] [Tests implemented *(or no code changes)*](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#test-implementation)
- [x] [All tests pass](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#quality-control)
