### PR TITLE
fld selections are now remembered between searches

### DIFF
--- a/DataRepo/compositeviews.py
+++ b/DataRepo/compositeviews.py
@@ -1448,6 +1448,32 @@ class BaseAdvancedSearchView:
         """
         return self.modeldata[format].getSearchFieldChoices()
 
+    def getSearchFieldChoicesDict(self):
+        """
+        Creates a format-keyed dict of the fld choices tuples.  Used to populate the fld select list to
+        address issue #229 in the same way ncmp_choices is populated and pared down by javascript.
+        """
+        fld_choices = {}
+        for fmtid in self.modeldata.keys():
+            fld_choices[fmtid] = self.modeldata[fmtid].getSearchFieldChoices()
+        return fld_choices
+
+    def getAllSearchFieldChoices(self):
+        """
+        Creates a flat tuple of every field in every model of every derived class.  Used to initially populate the fld
+        select list that is updated by javascript based on the selected format.  This initial population in the form
+        class is important for form validation.  Otherwise, nothing but the selected format will validate, causing
+        issues like the one described in #229.
+        """
+        all_fld_choices = ()
+        seen = []
+        for fmtid in self.modeldata.keys():
+            for opt in self.getSearchFieldChoices(fmtid):
+                if opt[0] not in seen:
+                    seen.append(opt[0])
+                    all_fld_choices = all_fld_choices + ((opt[0], opt[1]),)
+        return all_fld_choices
+
     def getComparisonChoices(self):
         """
         Calls getComparisonChoices of the default output format class.
@@ -1476,7 +1502,6 @@ class BaseAdvancedSearchView:
         """
         Returns a dict of search output format class IDs to their user-facing names.
         """
-
         namedict = {}
         for fmtid in self.modeldata.keys():
             namedict[fmtid] = str(self.modeldata[fmtid].name)
@@ -1487,7 +1512,6 @@ class BaseAdvancedSearchView:
         Returns a dict of fmt -> path__field -> {type -> field_type (number, string, enumeration), choices -> list of
         tuples}.
         """
-
         typedict = {}
         for fmtid in self.modeldata.keys():
             typedict[fmtid] = self.modeldata[fmtid].getFieldTypes()

--- a/DataRepo/compositeviews.py
+++ b/DataRepo/compositeviews.py
@@ -1468,10 +1468,10 @@ class BaseAdvancedSearchView:
         all_fld_choices = ()
         seen = []
         for fmtid in self.modeldata.keys():
-            for opt in self.getSearchFieldChoices(fmtid):
-                if opt[0] not in seen:
-                    seen.append(opt[0])
-                    all_fld_choices = all_fld_choices + ((opt[0], opt[1]),)
+            for (fld_val, fld_name) in self.getSearchFieldChoices(fmtid):
+                if fld_val not in seen:
+                    seen.append(fld_val)
+                    all_fld_choices = all_fld_choices + ((fld_val, fld_name),)
         return all_fld_choices
 
     def getComparisonChoices(self):

--- a/DataRepo/forms.py
+++ b/DataRepo/forms.py
@@ -4,6 +4,7 @@ from django import forms
 from django.forms import formset_factory
 
 from DataRepo.compositeviews import (
+    BaseAdvancedSearchView,
     BaseSearchView,
     FluxCircSearchView,
     PeakDataSearchView,
@@ -36,8 +37,15 @@ class BaseAdvSearchForm(forms.Form):
     Advanced search form base class that will be used inside a formset.
     """
 
-    # This is the class used to populate posprefix and fld = set in derived class
+    # This is the class used to populate posprefix value and the fld choices. composite_view_class is set in the
+    # derived class (not here.  Here, it's just declared for mypy).
     composite_view_class: BaseSearchView
+
+    # This class is used to initialize the fld select list choices to a flat tuple encompassing every format
+    # The format-specific list of fields is pared down by javascript using the composite_view_class above
+    # The initial list needs to be comprehensive for form validation so that unselected formats retain their user-
+    # selections after a search is peformed.  See issue #229.
+    advsrch_view_class = BaseAdvancedSearchView()
 
     # See important note above about the pos & posprefix fields above
     posprefix: Optional[str] = None
@@ -76,7 +84,7 @@ class BaseAdvSearchForm(forms.Form):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.posprefix = self.composite_view_class.id
-        self.fields["fld"].choices = self.composite_view_class.getSearchFieldChoices()
+        self.fields["fld"].choices = self.advsrch_view_class.getAllSearchFieldChoices()
         self.fields[
             "ncmp"
         ].choices = self.composite_view_class.getAllComparisonChoices()

--- a/DataRepo/templates/DataRepo/search/query.html
+++ b/DataRepo/templates/DataRepo/search/query.html
@@ -21,6 +21,7 @@
     {{ root_group|json_script:"root_group" }} <!-- unpopulated qry object -->
     {{ ncmp_choices|json_script:"ncmp_choices" }} <!-- dynamic ncmp select list population -->
     {{ fld_types|json_script:"fld_types" }} <!-- dynamic ncmp select list population -->
+    {{ fld_choices|json_script:"fld_choices" }} <!-- dynamic fld select list population -->
 
     {% if qry %}
         <!-- qry has a value when search results are being loaded.  It is used to reconstruct the search form, so the user
@@ -38,11 +39,13 @@
             {% if qry %}
                 init(JSON.parse(document.getElementById('initGroup').textContent),
                     JSON.parse(document.getElementById('ncmp_choices').textContent),
-                    JSON.parse(document.getElementById('fld_types').textContent))
+                    JSON.parse(document.getElementById('fld_types').textContent),
+                    JSON.parse(document.getElementById('fld_choices').textContent))
             {% else %}
                 init(JSON.parse(document.getElementById('root_group').textContent),
                     JSON.parse(document.getElementById('ncmp_choices').textContent),
-                    JSON.parse(document.getElementById('fld_types').textContent))
+                    JSON.parse(document.getElementById('fld_types').textContent),
+                    JSON.parse(document.getElementById('fld_choices').textContent))
                 {% if format and mode and mode == "browse" and not qry %}
                     {% if format not in forms.keys %}
                         rootGroup.selectedtemplate = "{{ default_format }}"

--- a/DataRepo/tests/test_compositeviews.py
+++ b/DataRepo/tests/test_compositeviews.py
@@ -6,6 +6,8 @@ from DataRepo.models import PeakGroup
 
 
 class CompositeViewTests(TestCase):
+    maxDiff = None
+
     @classmethod
     def setUpTestData(cls):
         call_command("loaddata", "tissues.yaml")
@@ -166,3 +168,183 @@ class CompositeViewTests(TestCase):
         condition = "icontains"
         term = "cde"
         bsv.valueMatches(recval, condition, term)
+
+    def test_getSearchFieldChoicesDict(self):
+        basv = BaseAdvancedSearchView()
+        sfcd = basv.getSearchFieldChoicesDict()
+        sfcd_expected = {
+            "fctemplate": (
+                ("msrun__sample__animal__name", "Animal"),
+                ("msrun__sample__animal__body_weight", "Body Weight (g)"),
+                ("msrun__sample__animal__diet", "Diet"),
+                ("msrun__sample__animal__feeding_status", "Feeding Status"),
+                ("msrun__sample__animal__genotype", "Genotype"),
+                ("msrun__sample__animal__sex", "Sex"),
+                ("msrun__sample__animal__studies__name", "Study"),
+                (
+                    "msrun__sample__time_collected",
+                    "Time Collected (hh:mm:ss since infusion)",
+                ),
+                ("msrun__sample__animal__tracer_compound__name", "Tracer Compound"),
+                (
+                    "msrun__sample__animal__tracer_infusion_concentration",
+                    "Tracer Infusion Concentration (mM)",
+                ),
+                (
+                    "msrun__sample__animal__tracer_infusion_rate",
+                    "Tracer Infusion Rate (ul/min/g)",
+                ),
+                (
+                    "msrun__sample__animal__tracer_labeled_atom",
+                    "Tracer Labeled Element",
+                ),
+                ("msrun__sample__animal__treatment__name", "Treatment"),
+            ),
+            "pdtemplate": (
+                ("peak_group__msrun__sample__animal__name", "Animal"),
+                ("peak_group__msrun__sample__animal__body_weight", "Body Weight (g)"),
+                ("corrected_abundance", "Corrected Abundance"),
+                ("peak_group__msrun__sample__animal__diet", "Diet"),
+                ("peak_group__msrun__sample__animal__feeding_status", "Feeding Status"),
+                ("peak_group__formula", "Formula"),
+                ("peak_group__msrun__sample__animal__genotype", "Genotype"),
+                ("labeled_count", "Labeled Count"),
+                ("labeled_element", "Labeled Element"),
+                (
+                    "peak_group__compounds__synonyms__name",
+                    "Measured Compound (Any Synonym)",
+                ),
+                ("peak_group__compounds__name", "Measured Compound (Primary Synonym)"),
+                ("med_mz", "Median M/Z"),
+                ("med_rt", "Median RT"),
+                ("peak_group__name", "Peak Group"),
+                ("peak_group__peak_group_set__filename", "Peak Group Set Filename"),
+                ("raw_abundance", "Raw Abundance"),
+                ("peak_group__msrun__sample__name", "Sample"),
+                ("peak_group__msrun__sample__animal__sex", "Sex"),
+                ("peak_group__msrun__sample__animal__studies__name", "Study"),
+                ("peak_group__msrun__sample__tissue__name", "Tissue"),
+                (
+                    "peak_group__msrun__sample__animal__tracer_compound__name",
+                    "Tracer Compound (Primary Synonym)",
+                ),
+                (
+                    "peak_group__msrun__sample__animal__tracer_infusion_concentration",
+                    "Tracer Infusion Concentration (mM)",
+                ),
+                (
+                    "peak_group__msrun__sample__animal__tracer_infusion_rate",
+                    "Tracer Infusion Rate (ul/min/g)",
+                ),
+                ("peak_group__msrun__sample__animal__treatment__name", "Treatment"),
+            ),
+            "pgtemplate": (
+                ("msrun__sample__animal__name", "Animal"),
+                ("msrun__sample__animal__body_weight", "Body Weight (g)"),
+                ("msrun__sample__animal__diet", "Diet"),
+                ("msrun__sample__animal__feeding_status", "Feeding Status"),
+                ("formula", "Formula"),
+                ("msrun__sample__animal__genotype", "Genotype"),
+                ("compounds__synonyms__name", "Measured Compound (Any Synonym)"),
+                ("compounds__name", "Measured Compound (Primary Synonym)"),
+                ("name", "Peak Group"),
+                ("peak_group_set__filename", "Peak Group Set Filename"),
+                ("msrun__sample__name", "Sample"),
+                ("msrun__sample__animal__sex", "Sex"),
+                ("msrun__sample__animal__studies__name", "Study"),
+                ("msrun__sample__tissue__name", "Tissue"),
+                (
+                    "msrun__sample__animal__tracer_compound__name",
+                    "Tracer Compound (Primary Synonym)",
+                ),
+                (
+                    "msrun__sample__animal__tracer_infusion_concentration",
+                    "Tracer Infusion Concentration (mM)",
+                ),
+                (
+                    "msrun__sample__animal__tracer_infusion_rate",
+                    "Tracer Infusion Rate (ul/min/g)",
+                ),
+                (
+                    "msrun__sample__animal__tracer_labeled_atom",
+                    "Tracer Labeled Element",
+                ),
+                ("msrun__sample__animal__treatment__name", "Treatment"),
+            ),
+        }
+        self.assertDictEqual(sfcd, sfcd_expected)
+
+    def test_getAllSearchFieldChoices(self):
+        basv = BaseAdvancedSearchView()
+        sfct = basv.getAllSearchFieldChoices()
+        sfct_expected = (
+            ("msrun__sample__animal__name", "Animal"),
+            ("msrun__sample__animal__body_weight", "Body Weight (g)"),
+            ("msrun__sample__animal__diet", "Diet"),
+            ("msrun__sample__animal__feeding_status", "Feeding Status"),
+            ("formula", "Formula"),
+            ("msrun__sample__animal__genotype", "Genotype"),
+            ("compounds__synonyms__name", "Measured Compound (Any Synonym)"),
+            ("compounds__name", "Measured Compound (Primary Synonym)"),
+            ("name", "Peak Group"),
+            ("peak_group_set__filename", "Peak Group Set Filename"),
+            ("msrun__sample__name", "Sample"),
+            ("msrun__sample__animal__sex", "Sex"),
+            ("msrun__sample__animal__studies__name", "Study"),
+            ("msrun__sample__tissue__name", "Tissue"),
+            (
+                "msrun__sample__animal__tracer_compound__name",
+                "Tracer Compound (Primary Synonym)",
+            ),
+            (
+                "msrun__sample__animal__tracer_infusion_concentration",
+                "Tracer Infusion Concentration (mM)",
+            ),
+            (
+                "msrun__sample__animal__tracer_infusion_rate",
+                "Tracer Infusion Rate (ul/min/g)",
+            ),
+            ("msrun__sample__animal__tracer_labeled_atom", "Tracer Labeled Element"),
+            ("msrun__sample__animal__treatment__name", "Treatment"),
+            ("peak_group__msrun__sample__animal__name", "Animal"),
+            ("peak_group__msrun__sample__animal__body_weight", "Body Weight (g)"),
+            ("corrected_abundance", "Corrected Abundance"),
+            ("peak_group__msrun__sample__animal__diet", "Diet"),
+            ("peak_group__msrun__sample__animal__feeding_status", "Feeding Status"),
+            ("peak_group__formula", "Formula"),
+            ("peak_group__msrun__sample__animal__genotype", "Genotype"),
+            ("labeled_count", "Labeled Count"),
+            ("labeled_element", "Labeled Element"),
+            (
+                "peak_group__compounds__synonyms__name",
+                "Measured Compound (Any Synonym)",
+            ),
+            ("peak_group__compounds__name", "Measured Compound (Primary Synonym)"),
+            ("med_mz", "Median M/Z"),
+            ("med_rt", "Median RT"),
+            ("peak_group__name", "Peak Group"),
+            ("peak_group__peak_group_set__filename", "Peak Group Set Filename"),
+            ("raw_abundance", "Raw Abundance"),
+            ("peak_group__msrun__sample__name", "Sample"),
+            ("peak_group__msrun__sample__animal__sex", "Sex"),
+            ("peak_group__msrun__sample__animal__studies__name", "Study"),
+            ("peak_group__msrun__sample__tissue__name", "Tissue"),
+            (
+                "peak_group__msrun__sample__animal__tracer_compound__name",
+                "Tracer Compound (Primary Synonym)",
+            ),
+            (
+                "peak_group__msrun__sample__animal__tracer_infusion_concentration",
+                "Tracer Infusion Concentration (mM)",
+            ),
+            (
+                "peak_group__msrun__sample__animal__tracer_infusion_rate",
+                "Tracer Infusion Rate (ul/min/g)",
+            ),
+            ("peak_group__msrun__sample__animal__treatment__name", "Treatment"),
+            (
+                "msrun__sample__time_collected",
+                "Time Collected (hh:mm:ss since infusion)",
+            ),
+        )
+        self.assertTupleEqual(sfct, sfct_expected)

--- a/DataRepo/tests/test_compositeviews.py
+++ b/DataRepo/tests/test_compositeviews.py
@@ -169,143 +169,8 @@ class CompositeViewTests(TestCase):
         term = "cde"
         bsv.valueMatches(recval, condition, term)
 
-    def test_getSearchFieldChoicesDict(self):
-        basv = BaseAdvancedSearchView()
-        sfcd = basv.getSearchFieldChoicesDict()
-        sfcd_expected = {
-            "fctemplate": (
-                ("msrun__sample__animal__name", "Animal"),
-                ("msrun__sample__animal__body_weight", "Body Weight (g)"),
-                ("msrun__sample__animal__diet", "Diet"),
-                ("msrun__sample__animal__feeding_status", "Feeding Status"),
-                ("msrun__sample__animal__genotype", "Genotype"),
-                ("msrun__sample__animal__sex", "Sex"),
-                ("msrun__sample__animal__studies__name", "Study"),
-                (
-                    "msrun__sample__time_collected",
-                    "Time Collected (hh:mm:ss since infusion)",
-                ),
-                ("msrun__sample__animal__tracer_compound__name", "Tracer Compound"),
-                (
-                    "msrun__sample__animal__tracer_infusion_concentration",
-                    "Tracer Infusion Concentration (mM)",
-                ),
-                (
-                    "msrun__sample__animal__tracer_infusion_rate",
-                    "Tracer Infusion Rate (ul/min/g)",
-                ),
-                (
-                    "msrun__sample__animal__tracer_labeled_atom",
-                    "Tracer Labeled Element",
-                ),
-                ("msrun__sample__animal__treatment__name", "Treatment"),
-            ),
-            "pdtemplate": (
-                ("peak_group__msrun__sample__animal__name", "Animal"),
-                ("peak_group__msrun__sample__animal__body_weight", "Body Weight (g)"),
-                ("corrected_abundance", "Corrected Abundance"),
-                ("peak_group__msrun__sample__animal__diet", "Diet"),
-                ("peak_group__msrun__sample__animal__feeding_status", "Feeding Status"),
-                ("peak_group__formula", "Formula"),
-                ("peak_group__msrun__sample__animal__genotype", "Genotype"),
-                ("labeled_count", "Labeled Count"),
-                ("labeled_element", "Labeled Element"),
-                (
-                    "peak_group__compounds__synonyms__name",
-                    "Measured Compound (Any Synonym)",
-                ),
-                ("peak_group__compounds__name", "Measured Compound (Primary Synonym)"),
-                ("med_mz", "Median M/Z"),
-                ("med_rt", "Median RT"),
-                ("peak_group__name", "Peak Group"),
-                ("peak_group__peak_group_set__filename", "Peak Group Set Filename"),
-                ("raw_abundance", "Raw Abundance"),
-                ("peak_group__msrun__sample__name", "Sample"),
-                ("peak_group__msrun__sample__animal__sex", "Sex"),
-                ("peak_group__msrun__sample__animal__studies__name", "Study"),
-                ("peak_group__msrun__sample__tissue__name", "Tissue"),
-                (
-                    "peak_group__msrun__sample__animal__tracer_compound__name",
-                    "Tracer Compound (Primary Synonym)",
-                ),
-                (
-                    "peak_group__msrun__sample__animal__tracer_infusion_concentration",
-                    "Tracer Infusion Concentration (mM)",
-                ),
-                (
-                    "peak_group__msrun__sample__animal__tracer_infusion_rate",
-                    "Tracer Infusion Rate (ul/min/g)",
-                ),
-                ("peak_group__msrun__sample__animal__treatment__name", "Treatment"),
-            ),
-            "pgtemplate": (
-                ("msrun__sample__animal__name", "Animal"),
-                ("msrun__sample__animal__body_weight", "Body Weight (g)"),
-                ("msrun__sample__animal__diet", "Diet"),
-                ("msrun__sample__animal__feeding_status", "Feeding Status"),
-                ("formula", "Formula"),
-                ("msrun__sample__animal__genotype", "Genotype"),
-                ("compounds__synonyms__name", "Measured Compound (Any Synonym)"),
-                ("compounds__name", "Measured Compound (Primary Synonym)"),
-                ("name", "Peak Group"),
-                ("peak_group_set__filename", "Peak Group Set Filename"),
-                ("msrun__sample__name", "Sample"),
-                ("msrun__sample__animal__sex", "Sex"),
-                ("msrun__sample__animal__studies__name", "Study"),
-                ("msrun__sample__tissue__name", "Tissue"),
-                (
-                    "msrun__sample__animal__tracer_compound__name",
-                    "Tracer Compound (Primary Synonym)",
-                ),
-                (
-                    "msrun__sample__animal__tracer_infusion_concentration",
-                    "Tracer Infusion Concentration (mM)",
-                ),
-                (
-                    "msrun__sample__animal__tracer_infusion_rate",
-                    "Tracer Infusion Rate (ul/min/g)",
-                ),
-                (
-                    "msrun__sample__animal__tracer_labeled_atom",
-                    "Tracer Labeled Element",
-                ),
-                ("msrun__sample__animal__treatment__name", "Treatment"),
-            ),
-        }
-        self.assertDictEqual(sfcd, sfcd_expected)
-
-    def test_getAllSearchFieldChoices(self):
-        basv = BaseAdvancedSearchView()
-        sfct = basv.getAllSearchFieldChoices()
-        sfct_expected = (
-            ("msrun__sample__animal__name", "Animal"),
-            ("msrun__sample__animal__body_weight", "Body Weight (g)"),
-            ("msrun__sample__animal__diet", "Diet"),
-            ("msrun__sample__animal__feeding_status", "Feeding Status"),
-            ("formula", "Formula"),
-            ("msrun__sample__animal__genotype", "Genotype"),
-            ("compounds__synonyms__name", "Measured Compound (Any Synonym)"),
-            ("compounds__name", "Measured Compound (Primary Synonym)"),
-            ("name", "Peak Group"),
-            ("peak_group_set__filename", "Peak Group Set Filename"),
-            ("msrun__sample__name", "Sample"),
-            ("msrun__sample__animal__sex", "Sex"),
-            ("msrun__sample__animal__studies__name", "Study"),
-            ("msrun__sample__tissue__name", "Tissue"),
-            (
-                "msrun__sample__animal__tracer_compound__name",
-                "Tracer Compound (Primary Synonym)",
-            ),
-            (
-                "msrun__sample__animal__tracer_infusion_concentration",
-                "Tracer Infusion Concentration (mM)",
-            ),
-            (
-                "msrun__sample__animal__tracer_infusion_rate",
-                "Tracer Infusion Rate (ul/min/g)",
-            ),
-            ("msrun__sample__animal__tracer_labeled_atom", "Tracer Labeled Element"),
-            ("msrun__sample__animal__treatment__name", "Treatment"),
+    def getPdtemplateChoicesTuple(self):
+        return (
             ("peak_group__msrun__sample__animal__name", "Animal"),
             ("peak_group__msrun__sample__animal__body_weight", "Body Weight (g)"),
             ("corrected_abundance", "Corrected Abundance"),
@@ -342,6 +207,82 @@ class CompositeViewTests(TestCase):
                 "Tracer Infusion Rate (ul/min/g)",
             ),
             ("peak_group__msrun__sample__animal__treatment__name", "Treatment"),
+        )
+
+    def getPgtemplateChoicesTuple(self):
+        return (
+            ("msrun__sample__animal__name", "Animal"),
+            ("msrun__sample__animal__body_weight", "Body Weight (g)"),
+            ("msrun__sample__animal__diet", "Diet"),
+            ("msrun__sample__animal__feeding_status", "Feeding Status"),
+            ("formula", "Formula"),
+            ("msrun__sample__animal__genotype", "Genotype"),
+            ("compounds__synonyms__name", "Measured Compound (Any Synonym)"),
+            ("compounds__name", "Measured Compound (Primary Synonym)"),
+            ("name", "Peak Group"),
+            ("peak_group_set__filename", "Peak Group Set Filename"),
+            ("msrun__sample__name", "Sample"),
+            ("msrun__sample__animal__sex", "Sex"),
+            ("msrun__sample__animal__studies__name", "Study"),
+            ("msrun__sample__tissue__name", "Tissue"),
+            (
+                "msrun__sample__animal__tracer_compound__name",
+                "Tracer Compound (Primary Synonym)",
+            ),
+            (
+                "msrun__sample__animal__tracer_infusion_concentration",
+                "Tracer Infusion Concentration (mM)",
+            ),
+            (
+                "msrun__sample__animal__tracer_infusion_rate",
+                "Tracer Infusion Rate (ul/min/g)",
+            ),
+            ("msrun__sample__animal__tracer_labeled_atom", "Tracer Labeled Element"),
+            ("msrun__sample__animal__treatment__name", "Treatment"),
+        )
+
+    def test_getSearchFieldChoicesDict(self):
+        basv = BaseAdvancedSearchView()
+        sfcd = basv.getSearchFieldChoicesDict()
+        sfcd_expected = {
+            "fctemplate": (
+                ("msrun__sample__animal__name", "Animal"),
+                ("msrun__sample__animal__body_weight", "Body Weight (g)"),
+                ("msrun__sample__animal__diet", "Diet"),
+                ("msrun__sample__animal__feeding_status", "Feeding Status"),
+                ("msrun__sample__animal__genotype", "Genotype"),
+                ("msrun__sample__animal__sex", "Sex"),
+                ("msrun__sample__animal__studies__name", "Study"),
+                (
+                    "msrun__sample__time_collected",
+                    "Time Collected (hh:mm:ss since infusion)",
+                ),
+                ("msrun__sample__animal__tracer_compound__name", "Tracer Compound"),
+                (
+                    "msrun__sample__animal__tracer_infusion_concentration",
+                    "Tracer Infusion Concentration (mM)",
+                ),
+                (
+                    "msrun__sample__animal__tracer_infusion_rate",
+                    "Tracer Infusion Rate (ul/min/g)",
+                ),
+                (
+                    "msrun__sample__animal__tracer_labeled_atom",
+                    "Tracer Labeled Element",
+                ),
+                ("msrun__sample__animal__treatment__name", "Treatment"),
+            ),
+            "pdtemplate": self.getPdtemplateChoicesTuple(),
+            "pgtemplate": self.getPgtemplateChoicesTuple(),
+        }
+        self.assertDictEqual(sfcd, sfcd_expected)
+
+    def test_getAllSearchFieldChoices(self):
+        basv = BaseAdvancedSearchView()
+        sfct = basv.getAllSearchFieldChoices()
+        sfct_expected = self.getPgtemplateChoicesTuple()
+        sfct_expected += self.getPdtemplateChoicesTuple()
+        sfct_expected += (
             (
                 "msrun__sample__time_collected",
                 "Time Collected (hh:mm:ss since infusion)",

--- a/DataRepo/tests/test_views.py
+++ b/DataRepo/tests/test_views.py
@@ -34,6 +34,8 @@ from DataRepo.views import (
 
 
 class ViewTests(TestCase):
+    maxDiff = None
+
     @classmethod
     def setUpTestData(cls):
         call_command("loaddata", "tissues.yaml")
@@ -438,7 +440,7 @@ class ViewTests(TestCase):
                                 "pos": "",
                                 "ncmp": "iexact",
                                 "static": "",
-                                "fld": "",
+                                "fld": "labeled_element",
                                 "val": "",
                             }
                         ],

--- a/DataRepo/views.py
+++ b/DataRepo/views.py
@@ -278,6 +278,7 @@ def search_basic(request, mdl, fld, cmp, val, fmt):
             "default_format": basv_metadata.default_format,
             "ncmp_choices": basv_metadata.getComparisonChoices(),
             "fld_types": basv_metadata.getFieldTypes(),
+            "fld_choices": basv_metadata.getSearchFieldChoicesDict(),
         },
     )
 
@@ -347,6 +348,7 @@ class AdvancedSearchView(MultiFormsView):
                 default_format=self.basv_metadata.default_format,
                 ncmp_choices=self.basv_metadata.getComparisonChoices(),
                 fld_types=self.basv_metadata.getFieldTypes(),
+                fld_choices=self.basv_metadata.getSearchFieldChoicesDict(),
                 refilter=False,
             )
         )
@@ -381,6 +383,7 @@ class AdvancedSearchView(MultiFormsView):
                 default_format=self.basv_metadata.default_format,
                 ncmp_choices=self.basv_metadata.getComparisonChoices(),
                 fld_types=self.basv_metadata.getFieldTypes(),
+                fld_choices=self.basv_metadata.getSearchFieldChoicesDict(),
                 refilter=self.basv_metadata.shouldReFilter(qry),
             )
         )
@@ -398,6 +401,7 @@ class AdvancedSearchView(MultiFormsView):
         context["root_group"] = self.basv_metadata.getRootGroup()
         context["ncmp_choices"] = self.basv_metadata.getComparisonChoices()
         context["fld_types"] = self.basv_metadata.getFieldTypes()
+        context["fld_choices"] = self.basv_metadata.getSearchFieldChoicesDict()
 
         if "qry" not in context or (
             mode == "browse" and not isValidQryObjPopulated(context["qry"])


### PR DESCRIPTION
## Summary Change Description

See the resolved issue for details, but basically now when a user selects fields in any/all formats and executes a search, those selections will all be remembered if the user switches formats again after the search was executed.

## Affected Issue Numbers

- Resolves #229

## Code Review Notes

I added these methods to the BaseAdvSearchView class:

- `getSearchFieldChoicesDict` - saves the fld select lists that should be set by javascript based on the selected output format.  This structure is passed from the view to the template, which is then consumed by javascript to make the dynamic updates.
- `getAllSearchFieldChoices` - saves the flattened fld select list as a single tuple. This is used by the form class to validate the fld select lists for every format.  However, it's checked by the selected format's class, so it needs to have all possible values so that the remembered values can be re-selected.

These changes fixed a previously unknown bug and I updated `test_views.py` to reflect the correction.  It previously populated the fld value in an invalid fashion (empty string).

See the issue for how to reproduce the original problem if you wish to test.

## Checklist

- [x] All issue requirements satisfied (or no linked issues)
- [x] [Linting passes](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#linting).
- [x] [Migrations created & committed *(or no model changes)*](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#migration-process)
- [x] [Tests implemented *(or no code changes)*](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#test-implementation)
- [x] [All tests pass](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#quality-control)
