### PR TITLE
Copy comments on sample table

### DIFF
--- a/DataRepo/templates/upload.html
+++ b/DataRepo/templates/upload.html
@@ -9,7 +9,7 @@
         <ol>
             <h5 id="create-a-sample-sheet"><li>Create a Sample Sheet</li></h5>
             <ol>
-                <li><a href="https://docs.google.com/spreadsheets/d/1To3495KxJkAtnAD9KVdzc162zKbNiYuPEVyPseQPjMQ/copy">Copy</a> the TraceBase Animal and Sample Table Template.
+                <li><a href="https://docs.google.com/spreadsheets/d/1To3495KxJkAtnAD9KVdzc162zKbNiYuPEVyPseQPjMQ/copy?copyComments=true">Copy</a> the TraceBase Animal and Sample Table Template.
                 </li>
                 <li>Fill in the <em>Animals</em> sheet <a class="badge text-light bg-secondary" data-bs-toggle="collapse" data-bs-target="#fill-animals">more</a>
                     <div id="fill-animals" class="collapse">


### PR DESCRIPTION
<!-- markdownlint-disable-next-line first-line-heading -->
## Summary Change Description

Copying the Animal and Sample Template without adding `?copyComments=true` didn't copy the comments in the headers which are very helpful explanatory notes.

## Affected Issue Numbers

## Code Review Notes

The link was tested by @hepcat72, @mneinast, and @lparsons. We want this in for the demo at noon, so merging without review and pushing to tracebase-dev. @jcmatese and @fkang-pu let me know if you see any problems with that.

## Checklist

- [x] All issue requirements satisfied (or no linked issues)
- [ ] [Linting passes](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#linting).
- [x] [Migrations created & committed *(or no model changes)*](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#migration-process)
- [x] [Tests implemented *(or no code changes)*](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#test-implementation)
- [ ] [All tests pass](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#quality-control)
