### PR TITLE
Basic search links fixed in study detail

### DIFF
--- a/DataRepo/templates/DataRepo/study_detail.html
+++ b/DataRepo/templates/DataRepo/study_detail.html
@@ -42,9 +42,9 @@
 </div>
 <div>
     <br>
-    <h5><a href="{% url 'search_basic' 'Study' 'id' 'exact' study.id 'peakgroups' %}">View Peak Group Data</a></h5>
-    <h5><a href="{% url 'search_basic' 'Study' 'id' 'exact' study.id 'peakdata' %}">View Peak Data</a></h5>
-    <h5><a href="{% url 'search_basic' 'Study' 'id' 'exact' study.id 'fcirc' %}">View Fcirc Data</a></h5>
+    <h5><a href="{% url 'search_basic' 'Study' 'id' 'iexact' study.id 'peakgroups' %}">View Peak Group Data</a></h5>
+    <h5><a href="{% url 'search_basic' 'Study' 'id' 'iexact' study.id 'peakdata' %}">View Peak Data</a></h5>
+    <h5><a href="{% url 'search_basic' 'Study' 'id' 'iexact' study.id 'fcirc' %}">View Fcirc Data</a></h5>
 </div>
 <br>
 <div>


### PR DESCRIPTION
## Summary Change Description

'exact' is not fully supported.  Changing it to the supported 'iexact'.

## Affected Issue Numbers

- Partially Resolves #339

## Code Review Notes

Making this change on github because it's simple and my clone is in the middle of an edit.  The bug is in 2 other detail templates, so I will submit them individually.  I won't close #339 until I have implemented an error when an invalid ncmp value is supplied.

## Checklist

- [ ] All issue requirements satisfied (or no linked issues)
- [x] [Linting passes](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#linting).
- [x] [Migrations created & committed *(or no model changes)*](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#migration-process)
- [x] [Tests implemented *(or no code changes)*](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#test-implementation)
- [x] [All tests pass](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#quality-control)
