### PR TITLE
Basic search links fixed in compound detail

### DIFF
--- a/DataRepo/templates/DataRepo/compound_detail.html
+++ b/DataRepo/templates/DataRepo/compound_detail.html
@@ -33,8 +33,8 @@
 <div>
     <br>
     {% if measured %}
-        <h5><a href="{% url 'search_basic' 'MeasuredCompound' 'id' 'exact' compound.id 'peakgroups' %}">View Peak Groups of this measured compound</a></h5>
-        <h5><a href="{% url 'search_basic' 'MeasuredCompound' 'id' 'exact' compound.id 'peakdata' %}">View Peak Data of this measured compound</a></h5>
+        <h5><a href="{% url 'search_basic' 'MeasuredCompound' 'id' 'iexact' compound.id 'peakgroups' %}">View Peak Groups of this measured compound</a></h5>
+        <h5><a href="{% url 'search_basic' 'MeasuredCompound' 'id' 'iexact' compound.id 'peakdata' %}">View Peak Data of this measured compound</a></h5>
     {% else %}
         No measurements of this compound have yet been loaded.
     {% endif %}


### PR DESCRIPTION
## Summary Change Description

Replaced exact with iexact

## Affected Issue Numbers

- Partially Resolves #339

## Code Review Notes

Making this change on github because it's simple and my clone is in the middle of an edit.  The bug is in 2 other detail templates, so I will submit them individually.  I won't close #339 until I have implemented an error when an invalid ncmp value is supplied.

## Checklist

- [ ] All issue requirements satisfied (or no linked issues)
- [x] [Linting passes](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#linting).
- [x] [Migrations created & committed *(or no model changes)*](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#migration-process)
- [x] [Tests implemented *(or no code changes)*](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#test-implementation)
- [x] [All tests pass](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#quality-control)
