### PR TITLE
Caching tests

### DIFF
--- a/DataRepo/hier_cached_model.py
+++ b/DataRepo/hier_cached_model.py
@@ -5,10 +5,10 @@ from django.conf import settings
 from django.core.cache import cache
 from django.db.models import Model
 
-use_cache = True
+caching_retrievals = True
 caching_updates = True
-func_name_lists: Dict[str, List] = {}
 throw_cache_errors = False
+func_name_lists: Dict[str, List] = {}
 
 
 def cached_function(f):
@@ -23,12 +23,8 @@ def cached_function(f):
         whether the use the cache or call the original function and save its output in the cache before returning the
         result
         """
-        is_cache_good = False
-        # Infer cache validity via the validity of the associated root record's representative cached value
-        is_cache_hier_good = self.caches_exist()
-        if is_cache_hier_good:
-            result, is_cache_good = get_cache(self, f.__name__)
-        if (not is_cache_hier_good) or not is_cache_good:
+        result, is_cache_good = get_cache(self, f.__name__)
+        if not is_cache_good:
             result = f(self, *args, **kwargs)
             set_cache(self, f.__name__, result)
         return result
@@ -40,7 +36,6 @@ def cached_function(f):
         func_name_lists[class_name] = [f.__name__]
     if settings.DEBUG:
         print(f"Added cached_function decorator to function {f.__qualname__}")
-
     return get_result
 
 
@@ -48,7 +43,7 @@ def get_cache(rec, cache_func_name):
     """
     Returns a cached value and a boolean as to whether the cached value was good or not (e.g. not cached)
     """
-    if not use_cache:
+    if not caching_retrievals:
         return None, False
     try:
         good_cache = True
@@ -56,6 +51,7 @@ def get_cache(rec, cache_func_name):
         cachekey = get_cache_key(rec, cache_func_name)
         result = cache.get(cachekey, uncached)
         if result is uncached:
+            result = None
             good_cache = False
         if settings.DEBUG:
             print(f"Getting cache {cachekey}")
@@ -73,7 +69,7 @@ def set_cache(rec, cache_func_name, value):
     """
     Caches a given value
     """
-    if not use_cache or not caching_updates:
+    if not caching_updates:
         return False
     try:
         cachekey = get_cache_key(rec, cache_func_name)
@@ -81,12 +77,17 @@ def set_cache(rec, cache_func_name, value):
         if settings.DEBUG:
             print(f"Setting cache {cachekey} to {value}")
         root_rec, first_method_name = rec.get_representative_root_rec_and_method()
+        # If this isn't the representative, tell the root record that caches exist under it somewhere
         if (
             root_rec.__class__.__name__ != rec.__class__.__name__
             or cache_func_name != first_method_name
         ):
-            # Tell the root record that caches exist under it somewhere
-            rec.set_caches_exist()
+            # Set a single cached value in the parent to act as a representative
+            rep_result, is_rep_cache_good = get_cache(root_rec, first_method_name)
+            rep_cachekey = get_cache_key(root_rec, first_method_name)
+            if not is_rep_cache_good:
+                rep_result = getattr(root_rec, first_method_name)
+                cache.set(rep_cachekey, rep_result, timeout=None, version=1)
     except Exception as e:
         # Allow tracebase to still work, just without caching
         print(e)
@@ -101,6 +102,10 @@ def get_cache_key(rec, cache_func_name):
     Generates a cache key given a record and the cached_property method name
     """
     return ".".join([rec.__class__.__name__, str(rec.pk), cache_func_name])
+
+
+def delete_all_caches():
+    cache.clear()
 
 
 def get_cached_method_names():
@@ -131,16 +136,16 @@ def disable_caching_retrievals():
     """
     Prevents storage and deletion of cached values.  Currently only used for loading scripts.
     """
-    global use_cache
-    use_cache = False
+    global caching_retrievals
+    caching_retrievals = False
 
 
 def enable_caching_retrievals():
     """
     Reenables storage and deletion of cached values.  Currently only used for loading scripts.
     """
-    global use_cache
-    use_cache = True
+    global caching_retrievals
+    caching_retrievals = True
 
 
 def disable_caching_errors():
@@ -178,11 +183,7 @@ class HierCachedModel(Model):
         If caching updates are enabled, trigger the deletion of every cached value under the linked Animal record
         """
         if caching_updates:
-            if self.parent_related_key_name is not None:
-                parent_instance = getattr(self, self.parent_related_key_name)
-                parent_instance.delete_cache()
-            else:
-                self.delete_cache()
+            self.delete_related_caches()
         super().save(*args, **kwargs)  # Call the "real" save() method.
 
     def delete(self, *args, **kwargs):
@@ -190,29 +191,26 @@ class HierCachedModel(Model):
         If caching updates are enabled, trigger the deletion of every cached value under the linked Animal record
         """
         if caching_updates:
-            if self.parent_related_key_name is not None:
-                parent_instance = getattr(self, self.parent_related_key_name)
-                parent_instance.delete_cache()
-            else:
-                self.delete_cache()
+            self.delete_related_caches()
         super().delete(*args, **kwargs)  # Call the "real" delete() method.
 
-    def delete_cache(self):
+    def delete_related_caches(self):
         """
-        Cascading cache deletion (originally triggered through an Animal record down to PeakData
+        If caching updates are enabled, trigger the deletion of every cached value under the linked Animal record
+        """
+        if caching_updates:
+            self.get_root_record().delete_descendant_caches()
+
+    def delete_descendant_caches(self):
+        """
+        Cascading cache deletion from self, downward. Call from a root record to delete all belonging to the same root
+        parent
         """
         if not caching_updates:
             return
         delete_keys = []
         # For every cached property, delete the cache value
-        # COMMENTED CODE is here until I've had a chance to at least manually test it.  I've been working on
-        # profiling...
-        # for member_key in self.__class__.__dict__.keys():
         for cached_function in self.get_my_cached_method_names():
-            #     self.__class__.__dict__[member_key].__class__.__name__
-            #     == "cached_property"
-            # ):
-            # cache_key = get_cache_key(self, member_key)
             cache_key = get_cache_key(self, cached_function)
             if settings.DEBUG:
                 print(f"Deleting cache {cache_key}")
@@ -222,21 +220,20 @@ class HierCachedModel(Model):
         # For every child model for which we have a related name
         for child_rel_name in self.child_related_key_names:
             child_instance = getattr(self, child_rel_name)
-            # For every child record, call its delete_cache()
+            # For every child record, call its delete_descendant_caches()
             for rec in child_instance.all():
-                rec.delete_cache()
+                rec.delete_descendant_caches()
 
-    def get_my_cached_method_names(self):
+    @classmethod
+    def get_my_cached_method_names(cls):
         """
         Convenience method to retrieve all the cached functions of the calling model.
         """
-        if self.__class__.__name__ in func_name_lists:
-            return func_name_lists[self.__class__.__name__]
+        if cls.__name__ in func_name_lists:
+            return func_name_lists[cls.__name__]
         else:
             if settings.DEBUG:
-                print(
-                    f"Class [{self.__class__.__name__}] does not have any cached functions."
-                )
+                print(f"Class [{cls.__name__}] does not have any cached functions.")
             return []
 
     def caches_exist(self):
@@ -256,8 +253,8 @@ class HierCachedModel(Model):
         cached values exist under it.  There is no way to infer a false value because if you did so by deleting the
         cache of the representative record, that doesn't delete the caches under it - and then if another cached value
         under it sets it back to true, that vestigial (presumably) invalid value would persist, so the only way to set
-        the value to false is to delete an entire hierarchy of cached values.  delete_cache is called when a record's
-        save or delete method is called (i.e. when something in the database changes).
+        the value to false is to delete an entire hierarchy of cached values.  delete_descendant_caches is called when
+        a record's save or delete method is called (i.e. when something in the database changes).
         """
         root_rec, first_method_name = self.get_representative_root_rec_and_method()
         # Set a single cached value in the parent to act as a representative
@@ -294,88 +291,6 @@ class HierCachedModel(Model):
             return parent_instance.get_root_record()
         else:
             return self
-
-    def build_all_new_caches(self, mdl_names=["all"]):
-        """
-        This method will build cached values that are either not currently cached or belong to a root model record whose
-        representative cached value has been deleted (or is expired).
-        """
-        if not caching_updates:
-            raise Exception(
-                "caching_updates are currently disabled.  Call enable_caching_updates() and try again."
-            )
-
-        root_model_obj = self.get_root_record()
-        fn_lists = {}
-
-        if len(mdl_names) == 1 and mdl_names[0] == "all":
-            fn_lists = func_name_lists
-        else:
-            mdl_errs = []
-            for mdl_name in mdl_names:
-                if mdl_name != "all":
-                    if mdl_name not in func_name_lists.keys():
-                        mdl_errs.append(mdl_name)
-                    else:
-                        fn_lists[mdl_name] = func_name_lists[mdl_name]
-
-            if len(mdl_errs) > 0:
-                raise KeyError(
-                    f"Models [{', '.join(mdl_errs)}] is not a model with tracked cached_functions.  Available "
-                    f"models are: [{', '.join(func_name_lists.keys())}]."
-                )
-            elif len(mdl_errs) == 0:
-                raise Exception(
-                    f"Invalid empty mdl_names argument.  Supply either ['all'] or a subset of the available "
-                    f"models: [{', '.join(func_name_lists.keys())}]."
-                )
-
-        cur_model_obj = root_model_obj
-        status = True
-
-        for child_rel_name in cur_model_obj.child_related_key_names:
-            cur_model_class = cur_model_obj.__class__
-            # For every record in this model
-            for rec in cur_model_class.objects.all():
-                if settings.DEBUG:
-                    print(f"Rebuilding caches for {cur_model_class}.{rec.id}")
-                if not rec.build_new_caches():
-                    status = False
-            cur_model_obj = getattr(cur_model_obj, child_rel_name)
-
-        return status
-
-    def build_new_caches(self):
-        """
-        This method will build cached values that are either not currently cached or belong to a root model record whose
-        representative cached value has been deleted (or is expired).
-        """
-        if not caching_updates:
-            raise Exception(
-                "caching_updates are currently disabled.  Call enable_caching_updates() and try again."
-            )
-
-        cls = self.__class__
-        class_name = cls.__name__
-
-        for cfunc_name in func_name_lists[class_name]:
-            # Ensure everything is cached
-            for rec in cls.objects.all():
-                try:
-                    getattr(rec, cfunc_name)
-                except Exception as e:
-                    print(e)
-                    return False
-
-        return True
-
-    def rebuild_all_caches(self):
-        if not caching_updates:
-            raise Exception(
-                "caching_updates are currently disabled.  Call enable_caching_updates() and try again."
-            )
-        cache.clear()
-        return self.build_all_new_caches(["all"])
 
     class Meta:
         abstract = True

--- a/DataRepo/models.py
+++ b/DataRepo/models.py
@@ -1439,6 +1439,9 @@ class PeakData(models.Model, TracerLabeledClass):
     For example, this could describe the data for M+2 in glucose from mouse 345 brain tissue.
     """
 
+    parent_cache_key_name = "peak_group"
+    child_cache_related_names = []  # Leaf
+
     id = models.AutoField(primary_key=True)
     peak_group = models.ForeignKey(
         PeakGroup, on_delete=models.CASCADE, null=False, related_name="peak_data"

--- a/DataRepo/models.py
+++ b/DataRepo/models.py
@@ -1439,9 +1439,6 @@ class PeakData(models.Model, TracerLabeledClass):
     For example, this could describe the data for M+2 in glucose from mouse 345 brain tissue.
     """
 
-    parent_cache_key_name = "peak_group"
-    child_cache_related_names = []  # Leaf
-
     id = models.AutoField(primary_key=True)
     peak_group = models.ForeignKey(
         PeakGroup, on_delete=models.CASCADE, null=False, related_name="peak_data"

--- a/DataRepo/tests/test_hier_cached_model.py
+++ b/DataRepo/tests/test_hier_cached_model.py
@@ -1,0 +1,599 @@
+from django.conf import settings
+from django.core.management import call_command
+from django.test import TestCase
+
+from DataRepo.hier_cached_model import (
+    HierCachedModel,
+    cached_function,
+    delete_all_caches,
+    disable_caching_retrievals,
+    disable_caching_updates,
+    enable_caching_retrievals,
+    enable_caching_updates,
+    get_cache,
+    get_cache_key,
+    get_cached_method_names,
+    set_cache,
+)
+from DataRepo.management.commands.build_caches import cached_function_call
+from DataRepo.models import Animal, MSRun, PeakGroup, Sample
+
+
+def load_data():
+    load_minimum_data()
+    call_command(
+        "load_accucor_msruns",
+        protocol="Default",
+        accucor_file="DataRepo/example_data/small_dataset/small_obob_maven_6eaas_serum.xlsx",
+        date="2021-06-03",
+        researcher="Michael Neinast",
+        new_researcher=False,
+    )
+
+
+def load_minimum_data():
+    call_command("loaddata", "tissues.yaml")
+    call_command(
+        "load_compounds",
+        compounds="DataRepo/example_data/small_dataset/small_obob_compounds.tsv",
+    )
+    call_command(
+        "load_samples",
+        "DataRepo/example_data/small_dataset/small_obob_sample_table.tsv",
+        sample_table_headers="DataRepo/example_data/sample_table_headers.yaml",
+    )
+    call_command(
+        "load_accucor_msruns",
+        protocol="Default",
+        accucor_file="DataRepo/example_data/small_dataset/small_obob_maven_6eaas_inf.xlsx",
+        date="2021-06-03",
+        researcher="Michael Neinast",
+        new_researcher=True,
+    )
+
+
+class GlobalCacheTests(TestCase):
+    maxDiff = None
+
+    @classmethod
+    def setUpTestData(cls):
+        load_data()
+
+    def test_load_not_cached(self):
+        a = Animal.objects.all().first()
+        f = "final_serum_sample"
+        v, s = get_cache(a, "final_serum_sample")
+        self.assertEqual(
+            v,
+            None,
+            msg="Load commands in setUpTestData should not have cached anything (value is None)",
+        )
+        self.assertFalse(
+            s,
+            msg="Load commands in setUpTestData should not have cached anything (status is false)",
+        )
+
+    def test_get_cache_disabled(self):
+        a = Animal.objects.all().first()
+        f = "final_serum_sample"
+        # Ensure I get the value not using the cache
+        disable_caching_retrievals()
+        v = getattr(a, f)  # same as `v = a.final_serum_sample`
+        delete_all_caches()
+        enable_caching_updates()
+        set_cache(a, "final_serum_sample", v)
+        disable_caching_retrievals()
+        res, sts = get_cache(a, "final_serum_sample")
+        self.assertEqual(
+            res,
+            None,
+            msg="Cached value should be None when caching retrievals are disabled",
+        )
+        self.assertFalse(
+            sts,
+            msg="Cached status should be false when caching retrievals are disabled",
+        )
+
+    def test_get_cache_uncached(self):
+        a = Animal.objects.all().first()
+        f = "final_serum_sample"
+        delete_all_caches()
+        enable_caching_retrievals()
+        res, sts = get_cache(a, f)
+        print(f"Returned cached value: [{str(res.__class__)}]")
+        self.assertEqual(
+            res, None, msg="Cached value should be None when no cached value exists"
+        )
+        self.assertFalse(
+            sts, msg="Cached status should be false when when no cached value exists"
+        )
+
+    def test_get_cache_enabled(self):
+        a = Animal.objects.all().first()
+        f = "final_serum_sample"
+        # Ensure I get the value not using the cache
+        disable_caching_retrievals()
+        v = getattr(a, f)  # same as `v = a.final_serum_sample`
+        delete_all_caches()
+        enable_caching_updates()
+        set_cache(a, "final_serum_sample", v)
+        enable_caching_retrievals()
+        res, sts = get_cache(a, "final_serum_sample")
+        self.assertEqual(
+            res,
+            v,
+            msg="Cached value should be correct when caching retrievals are enabled and the value is cached",
+        )
+        self.assertTrue(
+            sts,
+            msg="Cached status should be true when caching retrievals are enabled and the value is cached",
+        )
+
+    def test_set_cache_disabled(self):
+        a = Animal.objects.all().first()
+        f = "final_serum_sample"
+        # Ensure I get the value not using the cache
+        disable_caching_retrievals()
+        v = getattr(a, f)  # same as `v = a.final_serum_sample`
+        delete_all_caches()
+        disable_caching_updates()
+        sts = set_cache(a, "final_serum_sample", v)
+        self.assertFalse(
+            sts,
+            msg="Cache save status should be false when caching updates are disabled",
+        )
+
+    def test_set_cache_enabled(self):
+        a = Animal.objects.all().first()
+        # Ensure I get the value not using the cache
+        disable_caching_retrievals()
+        # Representative
+        rr, rf = a.get_representative_root_rec_and_method()
+        rv = getattr(rr, rf)  # Representative value
+        # Value in question
+        f = "final_serum_sample_id"  # Field
+        v = getattr(a, f)  # same as `v = a.final_serum_sample`
+
+        delete_all_caches()
+        enable_caching_retrievals()
+        vres, vsts = get_cache(a, f)
+        self.assertFalse(
+            vsts,
+            msg="Initial cache retrieval status must be false for the next assertions to be meaningful",
+        )
+        self.assertEqual(
+            vres,
+            None,
+            msg="Initial cache retrieval value must be None for the next assertions to be meaningful",
+        )
+        rvres, rvsts = get_cache(a, rf)
+        self.assertFalse(
+            rvsts,
+            msg="Initial cache retrieval representative status must be false for the next assertions to be meaningful",
+        )
+        self.assertEqual(
+            rvres,
+            None,
+            msg="Initial cache retrieval representative value must be None for the next assertions to be meaningful",
+        )
+
+        enable_caching_updates()
+        sts = set_cache(a, f, v)
+        gvres, gvsts = get_cache(a, f)
+        self.assertTrue(
+            gvsts,
+            msg="After cache save retrieval status must be true for the next assertions to be meaningful",
+        )
+        self.assertEqual(
+            gvres,
+            v,
+            msg="Cached value should be the same as before it was saved in the cache",
+        )
+        self.assertTrue(
+            sts, msg="Cache save status should be true when caching updates are enabled"
+        )
+
+        grvres, grvsts = get_cache(a, rf)
+        self.assertTrue(
+            grvsts,
+            msg="After cache save representative retrieval status must be true for the next assertion to be meaningful",
+        )
+        self.assertEqual(
+            grvres,
+            rv,
+            msg="Caching a child value should trigger a caching of the root model's representative value, which should be the same as before it was saved in the cache",
+        )
+
+    def test_get_cache_key(self):
+        a = Animal.objects.all().first()
+        f = "final_serum_sample"
+        expected_key = f"Animal.{a.id}.{f}"
+        res = get_cache_key(a, f)
+        self.assertEqual(
+            res, expected_key, msg="Cache key is not in the expected format"
+        )
+
+    def test_get_cached_method_names(self):
+        res = get_cached_method_names()
+        expected_structure = {
+            "Animal": [
+                "final_serum_sample",
+                "final_serum_sample_id",
+                "all_serum_samples_tracer_peak_groups",
+                "final_serum_sample_tracer_peak_group",
+                "intact_tracer_peak_data",
+                "final_serum_tracer_rate_disappearance_intact_per_gram",
+                "final_serum_tracer_rate_appearance_intact_per_gram",
+                "final_serum_tracer_rate_disappearance_intact_per_animal",
+                "final_serum_tracer_rate_appearance_intact_per_animal",
+                "final_serum_tracer_rate_disappearance_average_per_gram",
+                "final_serum_tracer_rate_appearance_average_per_gram",
+                "final_serum_tracer_rate_disappearance_average_per_animal",
+                "final_serum_tracer_rate_appearance_average_per_animal",
+                "final_serum_tracer_rate_appearance_average_atom_turnover",
+            ],
+            "Sample": ["is_serum_sample"],
+            "PeakGroup": [
+                "enrichment_fraction",
+                "enrichment_abundance",
+                "normalized_labeling",
+                "is_tracer_compound_group",
+                "from_serum_sample",
+                "can_compute_tracer_rates",
+                "can_compute_intact_tracer_rates",
+                "can_compute_average_tracer_rates",
+                "rate_disappearance_intact_per_gram",
+                "rate_appearance_intact_per_gram",
+                "rate_disappearance_intact_per_animal",
+                "rate_appearance_intact_per_animal",
+                "rate_disappearance_average_per_gram",
+                "rate_appearance_average_per_gram",
+                "rate_disappearance_average_per_animal",
+                "rate_appearance_average_per_animal",
+                "rate_appearance_average_atom_turnover",
+            ],
+        }
+        self.assertEqual(
+            res,
+            expected_structure,
+            "The methods with @cached_function decorators are not what is expected.",
+        )
+
+
+class HierCachedModelTests(TestCase):
+    maxDiff = None
+
+    @classmethod
+    def setUpTestData(cls):
+        load_data()
+
+    def test_cached_function_decorator(self):
+        delete_all_caches()
+        pg = PeakGroup.objects.all().first()
+        f = "normalized_labeling"
+
+        # Get uncached value
+        disable_caching_retrievals()
+        disable_caching_updates()
+        nl = getattr(pg, f)
+
+        # Trigger caching via decorator
+        enable_caching_retrievals()
+        enable_caching_updates()
+        saved_return = getattr(pg, f)  # same as `saved_return = pg.normalized_labeling`
+        cnl, sts = get_cache(pg, f)
+        self.assertTrue(
+            sts,
+            msg="Ensure what we got back was a cached value so the next assertion is meaningful",
+        )
+        self.assertEqual(
+            saved_return,
+            nl,
+            msg="Ensure decorator cache save returns the correct value",
+        )
+        self.assertEqual(
+            cnl,
+            nl,
+            msg="Ensure decorator works to save and retrieve cache, and that the value is correct",
+        )
+
+    def test_save_override(self):
+        delete_all_caches()
+        smp = Sample.objects.all().first()
+        f = "is_serum_sample"
+
+        enable_caching_retrievals()
+        enable_caching_updates()
+        # Trigger caching via decorator
+        getattr(smp, f)  # same as `smp.is_serum_sample`
+        rep_rec, rep_fnc = smp.get_representative_root_rec_and_method()
+
+        # Ensure cached
+        v, s = get_cache(smp, f)
+        rv, rs = get_cache(rep_rec, rep_fnc)
+        self.assertTrue(
+            s,
+            msg="Ensure what we got back was a cached value for the called function so the next assertions are meaningful",
+        )
+        self.assertTrue(
+            rs,
+            msg="Ensure what we got back was a cached value for the representative function so the next assertions are meaningful",
+        )
+
+        smp.save()
+
+        # Ensure no longer cached
+        nv, ns = get_cache(smp, f)
+        nrv, nrs = get_cache(rep_rec, rep_fnc)
+        self.assertFalse(
+            ns,
+            msg="Ensure the value for the called function in not cached after a save",
+        )
+        self.assertFalse(
+            nrs,
+            msg="Ensure the value for the representative function in not cached after a save",
+        )
+
+    def test_delete_override(self):
+        delete_all_caches()
+        pg = PeakGroup.objects.all().first()
+        f = "enrichment_fraction"
+
+        enable_caching_retrievals()
+        enable_caching_updates()
+        # Trigger caching via decorator
+        getattr(pg, f)
+        rep_rec, rep_fnc = pg.get_representative_root_rec_and_method()
+
+        # Ensure cached
+        v, s = get_cache(pg, f)
+        rv, rs = get_cache(rep_rec, rep_fnc)
+        self.assertTrue(
+            s,
+            msg="Ensure what we got back was a cached value for the called function so the next assertions are meaningful",
+        )
+        self.assertTrue(
+            rs,
+            msg="Ensure what we got back was a cached value for the representative function so the next assertions are meaningful",
+        )
+
+        # delete() calls from animal, sample, and MSRun are restricted
+        pg.delete()
+
+        # Ensure no longer cached
+        nv, ns = get_cache(pg, f)
+        nrv, nrs = get_cache(rep_rec, rep_fnc)
+        self.assertFalse(
+            ns,
+            msg="Ensure the value for the called function in not cached after a delete",
+        )
+        self.assertFalse(
+            nrs,
+            msg=f"Ensure the value for the representative function {rep_rec.__class__.__name__}.{rep_fnc} in not cached after a delete",
+        )
+
+    def test_delete_descendant_caches(self):
+        delete_all_caches()
+        smp = Sample.objects.all().first()
+        f = "is_serum_sample"
+
+        enable_caching_retrievals()
+        enable_caching_updates()
+        # Trigger caching via decorator
+        getattr(smp, f)  # same as `smp.is_serum_sample`
+        rep_rec, rep_fnc = smp.get_representative_root_rec_and_method()
+
+        # Ensure cached
+        v, s = get_cache(smp, f)
+        rv, rs = get_cache(rep_rec, rep_fnc)
+        self.assertTrue(
+            s,
+            msg="Ensure what we got back was a cached value for the called function so the next assertions are meaningful",
+        )
+        self.assertTrue(
+            rs,
+            msg="Ensure what we got back was a cached value for the representative function so the next assertions are meaningful",
+        )
+
+        smp.delete_descendant_caches()
+
+        # Ensure no longer cached
+        nv, ns = get_cache(smp, f)
+        nrv, nrs = get_cache(rep_rec, rep_fnc)
+        self.assertFalse(
+            ns,
+            msg="Ensure the value for the called function in not cached after a delete_descendant_caches",
+        )
+
+        # Ensure root cache is still intact
+        self.assertTrue(
+            nrs,
+            msg=f"Ensure the value for the representative function {rep_rec.__class__.__name__}.{rep_fnc} is still cached after a delete_descendant_caches on a descendant",
+        )
+
+    def test_delete_related_caches(self):
+        delete_all_caches()
+        smp = Sample.objects.all().first()
+        f = "is_serum_sample"
+
+        enable_caching_retrievals()
+        enable_caching_updates()
+        # Trigger caching via decorator
+        getattr(smp, f)  # same as `smp.is_serum_sample`
+        rep_rec, rep_fnc = smp.get_representative_root_rec_and_method()
+
+        # Ensure cached
+        v, s = get_cache(smp, f)
+        rv, rs = get_cache(rep_rec, rep_fnc)
+        self.assertTrue(
+            s,
+            msg="Ensure what we got back was a cached value for the called function so the next assertions are meaningful",
+        )
+        self.assertTrue(
+            rs,
+            msg="Ensure what we got back was a cached value for the representative function so the next assertions are meaningful",
+        )
+
+        smp.delete_related_caches()
+
+        # Ensure no longer cached
+        nv, ns = get_cache(smp, f)
+        nrv, nrs = get_cache(rep_rec, rep_fnc)
+        self.assertFalse(
+            ns,
+            msg="Ensure the value for the called function in not cached after a delete_descendant_caches",
+        )
+
+        # Ensure root cache is still intact
+        self.assertFalse(
+            nrs,
+            msg=f"Ensure the value for the representative function {rep_rec.__class__.__name__}.{rep_fnc} is not cached after a delete_related_caches on a descendant",
+        )
+
+    def test_get_my_cached_method_names(self):
+        pg = PeakGroup.objects.all().first()
+        expected = [
+            "enrichment_fraction",
+            "enrichment_abundance",
+            "normalized_labeling",
+            "is_tracer_compound_group",
+            "from_serum_sample",
+            "can_compute_tracer_rates",
+            "can_compute_intact_tracer_rates",
+            "can_compute_average_tracer_rates",
+            "rate_disappearance_intact_per_gram",
+            "rate_appearance_intact_per_gram",
+            "rate_disappearance_intact_per_animal",
+            "rate_appearance_intact_per_animal",
+            "rate_disappearance_average_per_gram",
+            "rate_appearance_average_per_gram",
+            "rate_disappearance_average_per_animal",
+            "rate_appearance_average_per_animal",
+            "rate_appearance_average_atom_turnover",
+        ]
+        self.assertEqual(
+            pg.get_my_cached_method_names(),
+            expected,
+            msg="Ensure get_my_cached_method_names returns all expected cache_functions.",
+        )
+
+    def test_caches_exist(self):
+        delete_all_caches()
+        # Get 2 samples belonging to the same animal and the second one's first peak group
+        a = Animal.objects.all().first()
+        samples = Sample.objects.filter(animal__id__exact=a.id)
+        s1 = samples[0]
+        s2 = samples[1]
+        s2pg = PeakGroup.objects.filter(msrun__sample__id__exact=s2.id).first()
+        pgf = "enrichment_fraction"
+
+        res1 = s1.caches_exist()
+        self.assertFalse(
+            res1,
+            msg="caches_exist from uncached related object returns false when related record's cache does not yet exist",
+        )
+
+        # Cache sample 2's first peak group's enrichment_fraction value
+        enable_caching_retrievals()
+        enable_caching_updates()
+        getattr(s2pg, pgf)
+
+        # Call caches_exist on the first sample
+        res2 = s1.caches_exist()
+
+        self.assertTrue(
+            res2,
+            msg="caches_exist from uncached related object returns true for related record's cache existing",
+        )
+
+    def test_caches_exist(self):
+        delete_all_caches()
+        a = Animal.objects.all().first()
+        samples = Sample.objects.filter(animal__id__exact=a.id)
+        s1 = samples[0]
+        s2 = samples[1]
+        s2.set_caches_exist()
+        res = s1.caches_exist()
+
+        self.assertTrue(
+            res,
+            msg="set_caches_exist results in caches_exist returning true for related records",
+        )
+
+    def test_get_representative_root_rec_and_method(self):
+        a = Animal.objects.all().first()
+        s = Sample.objects.filter(animal__id__exact=a.id).first()
+        msr = MSRun.objects.filter(sample__id__exact=s.id).first()
+
+        rep_rec, rep_fnc = msr.get_representative_root_rec_and_method()
+        cached_fncs = a.get_my_cached_method_names()
+        first_fnc = cached_fncs[0]
+
+        self.assertEqual(
+            rep_rec.__class__.__name__,
+            "Animal",
+            msg="The representative record from get_representative_root_rec_and_method is from the root model (Animal)",
+        )
+        self.assertEqual(
+            rep_rec.id,
+            a.id,
+            msg="The representative root model record from get_representative_root_rec_and_method is directly related",
+        )
+        self.assertEqual(
+            rep_fnc,
+            first_fnc,
+            msg="The representative root model cached function from get_representative_root_rec_and_method is its first decorated function",
+        )
+
+    def test_get_root_record(self):
+        a = Animal.objects.all().first()
+        s = Sample.objects.filter(animal__id__exact=a.id).first()
+        pg = PeakGroup.objects.filter(msrun__sample__id__exact=s.id).first()
+
+        rep_rec = pg.get_root_record()
+
+        self.assertEqual(
+            rep_rec.__class__.__name__,
+            "Animal",
+            msg="The record returned by get_root_record is from the root model (Animal)",
+        )
+        self.assertEqual(
+            rep_rec.id,
+            a.id,
+            msg="The root model record returned by get_root_record is directly related",
+        )
+
+
+class BuildCachesTests(TestCase):
+    maxDiff = None
+
+    @classmethod
+    def setUpTestData(cls):
+        load_minimum_data()
+
+    def test_cached_function_call(self):
+        c = Animal
+        f = "final_serum_sample_id"
+        a = Animal.objects.all().first()
+        l = Animal.objects.all().last()
+        disable_caching_retrievals()
+        # Get the first and last uncached value
+        uv = getattr(a, f)
+        lv = getattr(l, f)
+
+        enable_caching_retrievals()
+        enable_caching_updates()
+        delete_all_caches()
+
+        # Call cached_function_call to populate all cached values for f
+        cached_function_call(c, f)
+
+        # Try to retrieve those cached values
+        v, s = get_cache(a, f)
+        lv, ls = get_cache(l, f)
+
+        # Ensure the value was cached for both the first and last record
+        self.assertEqual(v, uv)
+        self.assertTrue(s)
+        self.assertEqual(lv, uv)
+        self.assertTrue(ls)

--- a/DataRepo/tests/test_hier_cached_model.py
+++ b/DataRepo/tests/test_hier_cached_model.py
@@ -29,29 +29,29 @@ def load_data():
 
 
 def load_minimum_data():
-        call_command("load_study", "DataRepo/example_data/tissues/loading.yaml")
-        call_command(
-            "load_compounds",
-            compounds="DataRepo/example_data/small_dataset/small_obob_compounds.tsv",
-        )
-        call_command(
-            "load_samples",
-            "DataRepo/example_data/small_dataset/small_obob_sample_table.tsv",
-            sample_table_headers="DataRepo/example_data/sample_table_headers.yaml",
-        )
-        call_command(
-            "load_samples",
-            "DataRepo/example_data/small_dataset/small_obob_sample_table_2ndstudy.tsv",
-            sample_table_headers="DataRepo/example_data/sample_table_headers.yaml",
-        )
-        call_command(
-            "load_accucor_msruns",
-            protocol="Default",
-            accucor_file="DataRepo/example_data/small_dataset/small_obob_maven_6eaas_inf.xlsx",
-            date="2021-06-03",
-            researcher="Michael Neinast",
-            new_researcher=True,
-        )
+    call_command("load_study", "DataRepo/example_data/tissues/loading.yaml")
+    call_command(
+        "load_compounds",
+        compounds="DataRepo/example_data/small_dataset/small_obob_compounds.tsv",
+    )
+    call_command(
+        "load_samples",
+        "DataRepo/example_data/small_dataset/small_obob_sample_table.tsv",
+        sample_table_headers="DataRepo/example_data/sample_table_headers.yaml",
+    )
+    call_command(
+        "load_samples",
+        "DataRepo/example_data/small_dataset/small_obob_sample_table_2ndstudy.tsv",
+        sample_table_headers="DataRepo/example_data/sample_table_headers.yaml",
+    )
+    call_command(
+        "load_accucor_msruns",
+        protocol="Default",
+        accucor_file="DataRepo/example_data/small_dataset/small_obob_maven_6eaas_inf.xlsx",
+        date="2021-06-03",
+        researcher="Michael Neinast",
+        new_researcher=True,
+    )
 
 
 class GlobalCacheTests(TestCase):

--- a/DataRepo/tests/test_hier_cached_model.py
+++ b/DataRepo/tests/test_hier_cached_model.py
@@ -29,24 +29,29 @@ def load_data():
 
 
 def load_minimum_data():
-    call_command("loaddata", "tissues.yaml")
-    call_command(
-        "load_compounds",
-        compounds="DataRepo/example_data/small_dataset/small_obob_compounds.tsv",
-    )
-    call_command(
-        "load_samples",
-        "DataRepo/example_data/small_dataset/small_obob_sample_table.tsv",
-        sample_table_headers="DataRepo/example_data/sample_table_headers.yaml",
-    )
-    call_command(
-        "load_accucor_msruns",
-        protocol="Default",
-        accucor_file="DataRepo/example_data/small_dataset/small_obob_maven_6eaas_inf.xlsx",
-        date="2021-06-03",
-        researcher="Michael Neinast",
-        new_researcher=True,
-    )
+        call_command("load_study", "DataRepo/example_data/tissues/loading.yaml")
+        call_command(
+            "load_compounds",
+            compounds="DataRepo/example_data/small_dataset/small_obob_compounds.tsv",
+        )
+        call_command(
+            "load_samples",
+            "DataRepo/example_data/small_dataset/small_obob_sample_table.tsv",
+            sample_table_headers="DataRepo/example_data/sample_table_headers.yaml",
+        )
+        call_command(
+            "load_samples",
+            "DataRepo/example_data/small_dataset/small_obob_sample_table_2ndstudy.tsv",
+            sample_table_headers="DataRepo/example_data/sample_table_headers.yaml",
+        )
+        call_command(
+            "load_accucor_msruns",
+            protocol="Default",
+            accucor_file="DataRepo/example_data/small_dataset/small_obob_maven_6eaas_inf.xlsx",
+            date="2021-06-03",
+            researcher="Michael Neinast",
+            new_researcher=True,
+        )
 
 
 class GlobalCacheTests(TestCase):

--- a/DataRepo/tests/test_models.py
+++ b/DataRepo/tests/test_models.py
@@ -8,6 +8,7 @@ from django.db import IntegrityError
 from django.db.models.deletion import RestrictedError
 from django.test import TestCase, override_settings, tag
 
+from DataRepo.hier_cached_model import set_cache
 from DataRepo.models import (
     Animal,
     Compound,
@@ -1337,17 +1338,16 @@ class DataLoadingTests(TestCase):
         pg = self.MAIN_SERUM_ANIMAL.final_serum_sample_tracer_peak_group
         self.assertTrue(pg.can_compute_average_tracer_rates)
 
-    # This was setting the value of the cached property.  Now that there is no cached property, and caching for the
-    # tests is using DummyCache, there seems to be no way to make this return false.  Leaving as commented until this
-    # can be fixed.  Please flag this to create an issue in the PR review.
-    # @tag("fcirc")
-    # def test_peakgroup_can_compute_average_tracer_rates_false(self):
-    #     # need to invalidate the computed/cached enrichment_fraction, somehow
-    #     pg = self.MAIN_SERUM_ANIMAL.final_serum_sample_tracer_peak_group
-    #     # simplest way?
-    #     pg.enrichment_fraction = None
-    #     with self.assertWarns(UserWarning):
-    #         self.assertFalse(pg.can_compute_average_tracer_rates)
+    @tag("fcirc")
+    def test_peakgroup_can_compute_average_tracer_rates_false(self):
+        # need to invalidate the computed/cached enrichment_fraction, somehow
+        pg = self.MAIN_SERUM_ANIMAL.final_serum_sample_tracer_peak_group
+        set_cache(pg, "enrichment_fraction", None)
+        # When/if we remove the hier_cached_model strategy and restore the cached_property strategy, we can uncomment:
+        #     # simplest way?
+        #     pg.enrichment_fraction = None
+        with self.assertWarns(UserWarning):
+            self.assertFalse(pg.can_compute_average_tracer_rates)
 
     @tag("synonym_data_loading")
     def test_valid_synonym_accucor_load(self):

--- a/DataRepo/utils.py
+++ b/DataRepo/utils.py
@@ -404,7 +404,7 @@ class SampleTableLoader:
         for animal in animals_to_uncache:
             if settings.DEBUG:
                 print(f"Expiring animal {animal.id}'s cache")
-            animal.delete_cache()
+            animal.delete_related_caches()
         if settings.DEBUG:
             print("Expiring done.")
 
@@ -1023,7 +1023,7 @@ class AccuCorDataLoader:
         for animal in animals_to_uncache:
             if settings.DEBUG:
                 print(f"Expiring animal {animal.id}'s cache")
-            animal.delete_cache()
+            animal.delete_related_caches()
         if settings.DEBUG:
             print("Expiring done.")
 


### PR DESCRIPTION
## Summary Change Description

Added tests to the caching code and fixes a few bugs (that didn't affect regular caching operations).

- Fixed a test in test_models.py
- Removed the cache building methods from HierCachedModel because I couldn't figure out how to do it without importing the derived classes.
- Made get_my_cached_method_names a class method.
- Changed the use_cache variable to caching_retrievals because it was too confusing in the testing.
- Created a delete_all_caches method so that files using this file don't also need to import django.core.cache
- Changed get_result to not consult the root record via caches_exist, because I realized that you cannot infer cache invalidity from the representative - only validity.  Any invalidation is/must be handled via immediate deletion of all affected cached values.

## Affected Issue Numbers

- Partially addresses #336

## Code Review Notes

- I removed efforts to be able to build caches from HierCachedModel because I could not figure out how to do it elegantly.
- Changed delete_cache to a split into 2 different methods: delete_related_caches (which deletes all from the root) and delete_descendant_caches (which deletes from the caller downward)

## Checklist

- [ ] All issue requirements satisfied (or no linked issues)
- [x] [Linting passes](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#linting).
- [x] [Migrations created & committed *(or no model changes)*](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#migration-process)
- [x] [Tests implemented *(or no code changes)*](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#test-implementation)
- [x] [All tests pass](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#quality-control)
