### PR TITLE
Add detail to sample name check error message

### DIFF
--- a/DataRepo/utils.py
+++ b/DataRepo/utils.py
@@ -572,7 +572,6 @@ class AccuCorDataLoader:
 
         # Make sure all sample columns have names
         corr_iter = collections.Counter(corrected_samples)
-        corr_iter_err = ""
         for k, v in corr_iter.items():
             if k.startswith("Unnamed: "):
                 enable_caching_updates()
@@ -581,12 +580,10 @@ class AccuCorDataLoader:
                     + str(len(self.accucor_corrected_df.columns))
                     + " columns."
                 )
-            corr_iter_err += '"' + str(k) + '":"' + str(v) + '",'
 
         if original_samples:
             # Make sure all sample columns have names
             orig_iter = collections.Counter(original_samples)
-            orig_iter_err = ""
             for k, v in orig_iter.items():
                 if k.startswith("Unnamed: "):
                     enable_caching_updates()
@@ -595,12 +592,15 @@ class AccuCorDataLoader:
                         + str(len(self.accucor_original_df.columns))
                         + " columns. Be sure to delete any unused columns."
                     )
-                orig_iter_err += '"' + str(k) + '":' + str(v) + '",'
 
             # Make sure that the sheets have the same number of sample columns
+            original_only = list(set(original_samples) - set(corrected_samples))
+            corrected_only = list(set(corrected_samples) - set(original_samples))
             err_msg = (
-                "Number of samples in the original and corrected sheets differ."
-                f"Original: [{orig_iter_err}] Corrected: [{corr_iter_err}]."
+                "Samples in the original and corrected sheets differ."
+                f"\nOriginal contains {len(orig_iter)} samples | Corrected contains {len(corr_iter)} samples"
+                f"\nSamples in original sheet missing from corrected:\n{original_only}"
+                f"\nSamples in corrected sheet missing from original:\n{corrected_only}"
             )
             assert orig_iter == corr_iter, err_msg
 


### PR DESCRIPTION
<!-- markdownlint-disable-next-line first-line-heading -->
## Summary Change Description

Add detail to the check between sample names in the original vs corrected AccuCor sheets. 

This was code I added while trying to sort out issues in some submitted AccuCor files.

Example output:
```
AssertionError: Samples in the original and corrected sheets differ.
Original contains 80 | Corrected contains 80
Samples in original sheet missing from corrected:
['xz933-t', 'xz934-t', 'xz935-t', 'xz936-t']
Samples in corrected sheet missing from original:
['xz933', 'xz935', 'xz936', 'xz934']
```

## Affected Issue Numbers

None

## Code Review Notes

## Checklist

- [x] All issue requirements satisfied (or no linked issues)
- [x] [Linting passes](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#linting).
- [x] [Migrations created & committed *(or no model changes)*](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#migration-process)
- [ ] [Tests implemented *(or no code changes)*](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#test-implementation)
- [x] [All tests pass](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#quality-control)
