### PR TITLE
Sort lists in sample check error message

### DIFF
--- a/DataRepo/utils.py
+++ b/DataRepo/utils.py
@@ -594,8 +594,8 @@ class AccuCorDataLoader:
                     )
 
             # Make sure that the sheets have the same number of sample columns
-            original_only = list(set(original_samples) - set(corrected_samples))
-            corrected_only = list(set(corrected_samples) - set(original_samples))
+            original_only = sorted(set(original_samples) - set(corrected_samples))
+            corrected_only = sorted(set(corrected_samples) - set(original_samples))
             err_msg = (
                 "Samples in the original and corrected sheets differ."
                 f"\nOriginal contains {len(orig_iter)} samples | Corrected contains {len(corr_iter)} samples"


### PR DESCRIPTION
<!-- markdownlint-disable-next-line first-line-heading -->
## Summary Change Description
 
Minor change to sort the output in the error message when sample lists don't between original and corrected sheets in an AccuCor file.

## Affected Issue Numbers

- Addresses @hepcat72 's comment: https://github.com/Princeton-LSI-ResearchComputing/tracebase/pull/359#discussion_r799613570

## Code Review Notes

## Checklist

- [x] All issue requirements satisfied (or no linked issues)
- [x] [Linting passes](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#linting).
- [x] [Migrations created & committed *(or no model changes)*](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#migration-process)
- [ ] [Tests implemented *(or no code changes)*](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#test-implementation)
- [x] [All tests pass](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#quality-control)
