### PR TITLE
add new methods, views, and templates for testing output of derived p…

### DIFF
--- a/DataRepo/templates/DataRepo/animal_detail.html
+++ b/DataRepo/templates/DataRepo/animal_detail.html
@@ -66,6 +66,14 @@
 </div>
 <br>
 <div>
+    <br>
+    <h4>Test the output from Pandas DataFrames:</h4>
+    <h5><a href="{% url 'derived_peakgroup' %}?obj_type=animal&obj_id={{ animal.id }}&page=1">View Peak Group Data</a></h5>
+    <h5><a href="{% url 'derived_peakdata' %}?obj_type=animal&obj_id={{ animal.id }}&page=1">View Peak Data</a></h5>
+    <h5><a href="{% url 'derived_fcirc' %}?obj_type=animal&obj_id={{ animal.id }}">View Fcirc Data</a></h5>
+</div>
+<br>
+<div>
     <h5>Sample Data for the Animal:</h5>
     {% if df %}
     <table class="table table-sm table-hover table-bordered table-striped table-responsive" w-auto mw-100

--- a/DataRepo/templates/DataRepo/data_output/derived_fcirc.html
+++ b/DataRepo/templates/DataRepo/data_output/derived_fcirc.html
@@ -1,0 +1,291 @@
+{% extends "base2.html" %}
+{% load customtags %}
+
+{% block title %}Fcirc data{% endblock %}
+
+<br>
+{% block content %}
+<h4>Fcirc Data for {{ obj_type }}: {{ obj_name }}</h4>
+<h4>Total rows: {{ total_rows }}</h4>
+<br>
+<!--p>Time before rendering the output table: {% now "Y-m-d H:i:s" %}</p-->
+<div>
+<h4>Data retrieval from database to Pandas DataFrame</h4>
+<h5>Starting time: {{ get_data_start_time }}</h5>
+<h5>Ending time: {{ get_data_end_time }}</h5>
+</div>
+
+    <div style="float: right; margin-right: 1rem;" class="buttons-toolbar"></div>
+    <div style="float: right; margin-right: 1rem;">
+        <small>
+            <table class="table table-highlighted-legend table-hover table-bordered">
+                <tr>
+                    <td><strong>Calculation Method</strong></td>
+                    <td><input type="checkbox" id="showaverage" checked/> Average</td>
+                    <td><input type="checkbox" id="showintact" checked/> Intact</td>
+                </tr>
+                <tr>
+                    <td><strong>Normalization Method</strong></td>
+                    <td><input type="checkbox" id="showweight" checked/> Per gram body-weight</td>
+                    <td><input type="checkbox" id="shownonorm" checked/> Per animal</td>
+                </tr>
+                <tr>
+                    <td><strong>Calculation Type</strong></td>
+                    <td><input type="checkbox" id="showrd" checked/> Rd (disappearance rate)</td>
+                    <td><input type="checkbox" id="showra" checked/> Ra (appearance rate)</td>
+                </tr>
+                <!--tr>
+                    <td><strong>Serum Samples (rows)</strong></td>
+                    <td><input type="checkbox" id="shownotlast" checked/> Previous</td>
+                    <td class="bg-highlighted"><input type="checkbox" id="showlast" checked/> Last</td>
+                </tr-->
+            </table>
+        </small>
+    </div>
+  
+    <table class="table table-highlighted table-hover table-bordered"
+        id="derived_fcirc"
+        data-toggle="table"
+        data-buttons-class="primary"
+        data-buttons-align="left"
+        data-filter-control="true"
+        data-search="true"
+        data-search-align="left"
+        data-show-search-clear-button="true"
+        data-show-fullscreen="true"
+        data-show-multi-sort="true"
+        data-show-columns="true"
+        data-show-columns-toggle-all="true"
+        data-show-export="true"
+        data-export-types="['csv', 'txt', 'excel']">
+
+        <thead>
+            <tr>
+                <th colspan="14" rowspan="2"></th>
+                <th colspan="4" class="average">Average</th>
+                <th colspan="4" class="intact">Intact</th>
+            </tr>
+            <tr>
+                <th colspan="2" data-valign="top" data-sortable="false" data-switchable="true" data-field="Weight_Normalized" class="average weight">Weight<br>Normalized<br>(nM/m/g)</th>
+                <th colspan="2" data-valign="top" data-sortable="false" data-switchable="true" data-field="Mouse_Normalized" class="average nonorm">Mouse<br>Normalized<br>(nM/m)</th>
+                <th colspan="2" data-valign="top" data-sortable="false" data-switchable="true" data-field="Weight_Normalized2" class="intact weight">Weight<br>Normalized<br>(nM/m/g)</th>
+                <th colspan="2" data-valign="top" data-sortable="false" data-switchable="true" data-field="Mouse_Normalized2" class="intact nonorm">Mouse<br>Normalized<br>(nM/m)</th>
+            </tr>
+            <tr>
+                <th data-valign="top" data-sortable="true" data-sorter="alphanum" data-visible="true" data-field="Animal">Animal</th>
+                <th data-valign="top" data-sortable="true" data-sorter="alphanum" data-visible="true" data-field="Studies">Studies</th>
+                <th data-valign="top" data-sortable="true" data-sorter="alphanum" data-visible="true" data-field="Genotype">Genotype</th>
+                <th data-valign="top" data-sortable="true" data-sorter="numericOnly" data-visible="false" data-field="Body_Weight">Body<br>Weight<br>(g)</th>
+                <th data-valign="top" data-sortable="true" data-sorter="alphanum" data-visible="false" data-field="Age">Age<br>(weeks)</th>
+                <th data-valign="top" data-sortable="true" data-sorter="alphanum" data-visible="false" data-field="Sex">Sex</th>
+                <th data-valign="top" data-sortable="true" data-sorter="alphanum" data-visible="false" data-field="Diet">Diet</th>
+                <th data-valign="top" data-sortable="true" data-sorter="alphanum" data-visible="true" data-field="Feeding_Status">Feeding<br>Status</th>
+                <th data-valign="top" data-sortable="true" data-sorter="alphanum" data-visible="true" data-field="Treatment">Treatment</th>
+                <th data-valign="top" data-sortable="true" data-sorter="alphanum" data-visible="true" data-field="Tracer_Compound">Tracer<br>Compound</th>
+                <th data-valign="top" data-sortable="true" data-sorter="alphanum" data-visible="false" data-field="Labeled_Element">Labeled<br>Element</th>
+                <th data-valign="top" data-sortable="true" data-sorter="numericOnly" data-visible="true" data-field="Tracer_Infusion_Rate">Tracer<br>Infusion<br>Rate<br>(ul/m/g)</th>
+                <th data-valign="top" data-sortable="true" data-sorter="numericOnly" data-visible="true" data-field="Tracer_Infusion_Concentration">Tracer Infusion<br>Concentration<br>(mM)</th>
+                <!--add columns for serum sample here-->
+                <th data-valign="top" data-sortable="true" data-sorter="alphanum" data-visible="true" data-field="Serum_Sample">Serum<br>Sample</th>
+                <th data-valign="top" data-sortable="true" data-sorter="numericOnly" data-visible="true" data-field="MSRUN_ID">MSRun Detail</th>
+                <th data-valign="top" data-sortable="true" data-sorter="numericOnly" data-visible="true" data-field="Fraction">Fraction</th>
+                <th data-valign="top" data-sortable="true" data-sorter="numericOnly" data-visible="true" data-field="Enrichment_Fraction">Enrichment<br>Fraction</th>
+
+                <th data-valign="top" data-sortable="true" data-sorter="alphanum" data-visible="true" data-field="Time_Collected">Time<br>Collected<br>(m)</th>
+                <th data-valign="top" data-sortable="true" data-sorter="numericOnly" data-visible="true" data-switchable="false" data-field="Average_Weight_Normalized_Ra" data-title-tooltip="Average_Weight_Normalized_Ra" class="average weight ra">Ra</th>
+                <th data-valign="top" data-sortable="true" data-sorter="numericOnly" data-visible="true" data-switchable="false" data-field="Average_Weight_Normalized_Rd" data-title-tooltip="Average_Weight_Normalized_Rd" class="average weight rd">Rd</th>
+                <th data-valign="top" data-sortable="true" data-sorter="numericOnly" data-visible="true" data-switchable="false" data-field="Average_Mouse_Normalized_Ra" data-title-tooltip="Average_Mouse_Normalized_Ra" class="average nonorm ra">Ra</th>
+                <th data-valign="top" data-sortable="true" data-sorter="numericOnly" data-visible="true" data-switchable="false" data-field="Average_Mouse_Normalized_Rd" data-title-tooltip="Average_Mouse_Normalized_Rd" class="average nonorm rd">Rd</th>
+                <th data-valign="top" data-sortable="true" data-sorter="numericOnly" data-visible="true" data-switchable="false" data-field="Intact_Weight_Normalized_Ra" data-title-tooltip="Intact_Weight_Normalized_Ra" class="intact weight ra">Ra</th>
+                <th data-valign="top" data-sortable="true" data-sorter="numericOnly" data-visible="true" data-switchable="false" data-field="Intact_Weight_Normalized_Rd" data-title-tooltip="Intact_Weight_Normalized_Rd" class="intact weight rd">Rd</th>
+                <th data-valign="top" data-sortable="true" data-sorter="numericOnly" data-visible="true" data-switchable="false" data-field="Intact_Mouse_Normalized_Ra" data-title-tooltip="Intact_Mouse_Normalized_Ra" class="intact nonorm ra">Ra</th>
+                <th data-valign="top" data-sortable="true" data-sorter="numericOnly" data-visible="true" data-switchable="false" data-field="Intact_Mouse_Normalized_Rd" data-title-tooltip="Intact_Mouse_Normalized_Rd" class="intact nonorm rd">Rd</th>
+            </tr>
+        </thead>
+
+        <tbody>
+            {% for i in df %}
+                <!-- Animal -->
+                <td>
+                <!-- Put displayed link text first for sorting -->
+                <div style="display:none;">{{ i.animal }}</div>
+                    <a href="{% url 'animal_detail' i.animal_id %}">
+                            {{ i.animal }}
+                    </a>
+                </td>
+                <!-- Studies -->
+                <td>{{ i.study_id_name_list |obj_hyperlink:"study" }}</td>
+
+                <!-- Genotype -->
+                <td>{{ i.genotype }}</td>
+
+                <!-- Body Weight (g) -->
+                <td class="text-end">
+                    {{ i.body_weight }}
+                </td>
+
+                <!-- Age (weeks) -->
+                <td class="text-end">
+                    {{ i.age |duration_iso_to_weeks }}
+                </td>
+
+                <!-- Sex -->
+                <td>{{ i.sex }}</td>
+
+                <!-- Diet -->
+                <td>{{ i.diet }}</td>
+
+                <!-- Feeding Status -->
+                <td>{{ i.feeding_status }}</td>
+
+                <!-- Treatment -->
+                <!--handle None value for treatement-->
+                <td>
+                {% if pd.treatment %}
+                    <a href="{% url 'protocol_detail' i.treatment_id %}">{{ i.treatment }}</a>
+                {% else %}
+                    None
+                {% endif %}
+                </td>
+
+                <!-- Tracer Compound -->
+                <td>
+                    {% if pd.tracer_compound_id %}
+                        <a href="{% url 'compound_detail' i.tracer_compound_id %}">{{ i.tracer }}</a>
+                    {% else %}
+                        None
+                    {% endif %}
+                </td>
+                <!-- Labeled Element -->
+                <td>{{ i.tracer_labeled_atom }}</td>
+
+                <!-- Tracer Infusion Rate (ul/min/g) -->
+                <td class="text-end">
+                    {{ i.tracer_infusion_rate }}
+                </td>
+
+                <!-- Tracer Infusion Concentration (mM) -->
+                <td class="text-end">
+                    {{ i.tracer_infusion_concentration }}
+                </td>
+
+                <!--add serum sample columns here -->
+                <td> {% if i.sample_id %}
+                    <a href="{% url 'sample_detail' i.sample_id %}">{{ i.serum_sample }}</a></td>
+                    {% else %}
+                        None
+                    {% endif %}
+                <td>
+                    {% if i.msrun_id %}
+                        <a href="{% url 'msrun_detail' i.msrun_id %}">MSRun Detail</a>
+                    {% else %}
+                        None
+                    {% endif %}
+                </td>
+                <!-- Fraction -->
+                <td class="text-end">
+                    {% if i.fraction %}
+                    <p title="{{ i.fraction|floatformat:15 }}">{{ i.fraction|floatformat:4 }}</p>
+                    {% else %}
+                        None
+                    {% endif %}
+                </td>
+                <!-- Enrichment Fraction -->
+                <td class="text-end">
+                    {% if i.pg_enrichment_fraction %}
+                    <p title="{{ i.pg_enrichment_fraction|floatformat:15 }}">{{ i.pg_enrichment_fraction|floatformat:4 }}</p>
+                    {% else %}
+                        None
+                    {% endif %}
+                </td>
+
+                <!-- Time Collected (m) -->
+                <td>{{ i.sample_time_collected |duration_iso_to_mins }}</td>
+                
+                <!-- Average Ra (nM/m/g) -->
+                <td class="text-end average weight ra">
+                    {% if i.Ra_avg_g is None %}
+                        None
+                    {% else %}
+                        <p title="{{ i.Ra_avg_g |floatformat:10 }}">{{ i.Ra_avg_g |floatformat:2 }}</p>
+                    {% endif %}
+                </td>
+
+                <td class="text-end average weight ra">
+                    {% if i.Rd_avg_g is None %}
+                        None
+                    {% else %}
+                        <p title="{{ i.Rd_avg_g |floatformat:10 }}">{{ i.Rd_avg_g |floatformat:2 }}</p>
+                    {% endif %}
+                </td>
+
+                <!-- Average Ra (nM/m) -->
+                <td class="text-end average nonorm ra">
+                    {% if i.Ra_avg is None %}
+                        None
+                    {% else %}
+                        <p title="{{ i.Ra_avg|floatformat:10 }}">{{ i.Ra_avg|floatformat:2 }}</p>
+                    {% endif %}
+                </td>
+
+                <!-- Average Rd (nM/m) -->
+                <td class="text-end average nonorm rd">
+                    {% if i.Rd_avg is None %}
+                        None
+                    {% else %}
+                        <p title="{{ i.Rd_avg|floatformat:10 }}">{{ i.Rd_avg|floatformat:2 }}</p>
+                {% endif %}
+                </td>
+
+                <!-- Intact Ra (nM/m/g) -->
+                <td class="text-end intact weight ra">
+                    {% if i.Ra_intact_g is None %}
+                        None
+                    {% else %}
+                        <p title="{{ i.Ra_intact_g|floatformat:10 }}">{{ i.Ra_intact_g|floatformat:2 }}</p>
+                    {% endif %}
+                </td>
+
+                <!-- Intact Rd (nM/m/g) -->
+                <td class="text-end intact weight rd">
+                    {% if i.Rd_intact_g is None %}
+                        None
+                    {% else %}
+                        <p title="{{ i.Rd_intact_g|floatformat:10 }}">{{ i.Rd_intact_g|floatformat:2 }}</p>
+                    {% endif %}
+                </td>
+
+                <!-- Intact Ra (nM/m) -->
+                <td class="text-end intact nonorm ra">
+                    {% if i.Ra_intact is None %}
+                        None
+                    {% else %}
+                        <p title="{{ i.Ra_intact|floatformat:10 }}">{{ i.Ra_intact|floatformat:2 }}</p>
+                    {% endif %}
+                </td>
+
+                <!-- Intact Rd (nM/m) -->
+                <td class="text-end intact nonorm rd">
+                    {% if i.Rd_intact is None %}
+                        None
+                    {% else %}
+                        <p title="{{ i.Rd_intact|floatformat:10 }}">{{ i.Rd_intact|floatformat:2 }}</p>
+                    {% endif %}
+                </td>
+                </tr>
+            {% endfor %}
+        </tbody>
+    </table>
+{% endblock %}
+
+{% block js_extras %}
+    <script>
+        var $table = $('#derived_fcirc')
+
+        $.extend($.fn.bootstrapTable.columnDefaults, {
+            valign: "top"
+        });
+
+        $('#derived_fcirc').bootstrapTable()
+    </script>
+{% endblock %}

--- a/DataRepo/templates/DataRepo/data_output/derived_fcirc.html
+++ b/DataRepo/templates/DataRepo/data_output/derived_fcirc.html
@@ -141,7 +141,7 @@
                 <!-- Treatment -->
                 <!--handle None value for treatement-->
                 <td>
-                {% if pd.treatment %}
+                {% if i.treatment %}
                     <a href="{% url 'protocol_detail' i.treatment_id %}">{{ i.treatment }}</a>
                 {% else %}
                     None
@@ -150,7 +150,7 @@
 
                 <!-- Tracer Compound -->
                 <td>
-                    {% if pd.tracer_compound_id %}
+                    {% if i.tracer_compound_id %}
                         <a href="{% url 'compound_detail' i.tracer_compound_id %}">{{ i.tracer }}</a>
                     {% else %}
                         None

--- a/DataRepo/templates/DataRepo/data_output/derived_peakdata.html
+++ b/DataRepo/templates/DataRepo/data_output/derived_peakdata.html
@@ -1,0 +1,40 @@
+{% extends "base2.html" %}
+{% load customtags %}
+
+{% block title %}Derived Peakdata{% endblock %}
+
+<br>
+{% block content %}
+<h4>Peakdata for {{ obj_type }}: {{ obj_name }}</h4>
+<br>
+<!--p>Time before rendering the output table: {% now "Y-m-d H:i:s" %}</p-->
+<div>
+<h4>Data retrieval from database to Pandas DataFrame</h4>
+<h5>Starting time: {{ get_data_start_time }}</h5>
+<h5>Ending time: {{ get_data_end_time }}</h5>
+</div>
+
+{% if total_rows %}
+    {% if total_rows < 5000 %}
+        <h5>Total rows: {{ total_rows }} (
+            <a class="link-button" href="{% url 'derived_peakdata' %}?obj_type={{ obj_type }}&obj_id={{ obj_id }}">View All Rows in One Page</a>
+            &nbsp;
+            <a class="link-button" href="{% url 'derived_data_to_csv' %}?category=peakgroup&obj_type={{ obj_type }}&obj_id={{ obj_id }}">Download All Rows to csv File</a>)</h5> 
+    {% else %}
+        <h5>Total rows: {{ total_rows }} (
+         <a class="link-button" href="{% url 'derived_data_to_csv' %}?category=peakgroup&obj_type={{ obj_type }}&obj_id={{ obj_id }}">Download All Rows to csv File)</a></h5>
+    {% endif %}
+{% endif %}
+<br>
+
+
+{% if is_paginated %}
+<h4>View Data by Page:</h4>
+    {% if page_obj %}
+        {% include "DataRepo/data_output/peakdata_tab_multipages.html" %}
+    {% endif %}
+{% else %}
+    {% include "DataRepo/data_output/peakdata_tab_onepage.html" %}
+{% endif %}
+
+{% endblock %}

--- a/DataRepo/templates/DataRepo/data_output/derived_peakdata.html
+++ b/DataRepo/templates/DataRepo/data_output/derived_peakdata.html
@@ -19,10 +19,10 @@
         <h5>Total rows: {{ total_rows }} (
             <a class="link-button" href="{% url 'derived_peakdata' %}?obj_type={{ obj_type }}&obj_id={{ obj_id }}">View All Rows in One Page</a>
             &nbsp;
-            <a class="link-button" href="{% url 'derived_data_to_csv' %}?category=peakgroup&obj_type={{ obj_type }}&obj_id={{ obj_id }}">Download All Rows to csv File</a>)</h5> 
+            <a class="link-button" href="{% url 'derived_data_to_file_by_streaming' %}?category=peakgroup&obj_type={{ obj_type }}&obj_id={{ obj_id }}">Download All Rows to File</a>)</h5> 
     {% else %}
         <h5>Total rows: {{ total_rows }} (
-         <a class="link-button" href="{% url 'derived_data_to_csv' %}?category=peakgroup&obj_type={{ obj_type }}&obj_id={{ obj_id }}">Download All Rows to csv File)</a></h5>
+         <a class="link-button" href="{% url 'derived_data_to_file_by_streaming' %}?category=peakgroup&obj_type={{ obj_type }}&obj_id={{ obj_id }}">Download All Rows to File)</a></h5>
     {% endif %}
 {% endif %}
 <br>

--- a/DataRepo/templates/DataRepo/data_output/derived_peakgroup.html
+++ b/DataRepo/templates/DataRepo/data_output/derived_peakgroup.html
@@ -1,0 +1,40 @@
+{% extends "base2.html" %}
+{% load customtags %}
+
+{% block title %}Derived Data for Peakgroups{% endblock %}
+
+<br>
+{% block content %}
+<h4>Peakdata for {{ obj_type }}: {{ obj_name }}</h4>
+<br>
+<!--p>Time before rendering the output table: {% now "Y-m-d H:i:s" %}</p-->
+<div>
+<h4>Data retrieval from database to Pandas DataFrame</h4>
+<h5>Starting time: {{ get_data_start_time }}</h5>
+<h5>Ending time: {{ get_data_end_time }}</h5>
+</div>
+
+{% if total_rows %}
+    {% if total_rows < 5000 %}
+        <h5>Total rows: {{ total_rows }} (
+            <a class="link-button" href="{% url 'derived_peakgroup' %}?obj_type={{ obj_type }}&obj_id={{ obj_id }}">View All Rows in One Page</a>
+            &nbsp;
+            <a class="link-button" href="{% url 'derived_data_to_csv' %}?category=peakgroup&obj_type={{ obj_type }}&obj_id={{ obj_id }}">Download All Rows to csv File</a>)</h5> 
+    {% else %}
+        <h5>Total rows: {{ total_rows }} (
+         <a class="link-button" href="{% url 'derived_data_to_csv' %}?category=peakgroup&obj_type={{ obj_type }}&obj_id={{ obj_id }}">Download All Rows to csv File)</a></h5>
+    {% endif %}
+{% endif %}
+<br>
+
+
+{% if is_paginated %}
+<h4>View Data by Page:</h4>
+    {% if page_obj %}
+        {% include "DataRepo/data_output/peakgroup_tab_multipages.html" %}
+    {% endif %}
+{% else %}
+    {% include "DataRepo/data_output/peakgroup_tab_onepage.html" %}
+{% endif %}
+
+{% endblock %}

--- a/DataRepo/templates/DataRepo/data_output/derived_peakgroup.html
+++ b/DataRepo/templates/DataRepo/data_output/derived_peakgroup.html
@@ -19,10 +19,10 @@
         <h5>Total rows: {{ total_rows }} (
             <a class="link-button" href="{% url 'derived_peakgroup' %}?obj_type={{ obj_type }}&obj_id={{ obj_id }}">View All Rows in One Page</a>
             &nbsp;
-            <a class="link-button" href="{% url 'derived_data_to_csv' %}?category=peakgroup&obj_type={{ obj_type }}&obj_id={{ obj_id }}">Download All Rows to csv File</a>)</h5> 
+            <a class="link-button" href="{% url 'derived_data_to_file_by_streaming' %}?category=peakgroup&obj_type={{ obj_type }}&obj_id={{ obj_id }}">Download All Rows to File</a>)</h5> 
     {% else %}
         <h5>Total rows: {{ total_rows }} (
-         <a class="link-button" href="{% url 'derived_data_to_csv' %}?category=peakgroup&obj_type={{ obj_type }}&obj_id={{ obj_id }}">Download All Rows to csv File)</a></h5>
+         <a class="link-button" href="{% url 'derived_data_to_file_by_streaming' %}?category=peakgroup&obj_type={{ obj_type }}&obj_id={{ obj_id }}">Download All Rows to File)</a></h5>
     {% endif %}
 {% endif %}
 <br>

--- a/DataRepo/templates/DataRepo/data_output/peakdata_tab_multipages.html
+++ b/DataRepo/templates/DataRepo/data_output/peakdata_tab_multipages.html
@@ -1,0 +1,184 @@
+{% load customtags %}
+<br>
+{% block content %}
+<table class="table table-hover table-striped table-bordered"
+id="derived_peakdata"
+data-toggle="table"
+data-buttons-class="primary"
+data-buttons-align="left"
+data-filter-control="false"
+data-search="false"
+data-show-search-clear-button="false"
+data-show-multi-sort="true"
+data-show-columns="true"
+data-show-columns-toggle-all="true"
+data-show-fullscreen="false"
+>
+
+
+<colgroup span="8" class="identdata"></colgroup>
+<colgroup span="5" class="datadata"></colgroup>
+<colgroup span="12" class="metadata"></colgroup>
+
+<thead>
+    <tr>
+        <th data-valign="top" data-sortable="true" class="idgrp" data-visible="false" data-sorter="alphanum" data-field="Animal">Animal</th>
+        <th data-valign="top" data-sortable="true" class="idgrp" data-visible="true" data-sorter="alphanum" data-field="Sample" data-switchable="false">Sample</th>
+        <th data-valign="top" data-sortable="true" class="idgrp" data-visible="true" data-sorter="alphanum" data-field="Tissue">Tissue</th>
+        <th data-valign="top" data-sortable="true" class="idgrp" data-visible="false" data-sorter="alphanum" data-field="Peak_Group">Peak Group</th>
+        <th data-valign="top" data-sortable="true" class="idgrp" data-visible="true" data-sorter="alphanum" data-field="Measured_Compounds">Measured<br>Compound(s)</th>
+        <th data-valign="top" data-sortable="true" class="idgrp" data-visible="false" data-sorter="alphanum" data-field="Measured_Compound_Synonyms">Measured<br>Compound<br>Synonym(s)</th>
+        <th data-valign="top" data-sortable="true" class="idgrp" data-visible="true" data-sorter="alphanum" data-field="Labeled_Element_Count">Labeled<br>Element:<br>Count</th>
+        <th data-valign="top" data-sortable="true" class="idgrp" data-visible="false" data-sorter="alphanum" data-field="Peak_Group_Set_Filename">Peak Group Set Filename</th>
+
+        <th data-valign="top" data-sortable="true" class="datagrp" data-visible="false" data-sorter="numericOnly" data-field="Raw_Abundance">Raw<br>Abundance</th>
+        <th data-valign="top" data-sortable="true" class="datagrp" data-visible="true" data-sorter="numericOnly" data-field="Corrected_Abundance">Corrected<br>Abundance</th>
+        <th data-valign="top" data-sortable="true" class="datagrp" data-visible="true" data-sorter="numericOnly" data-field="Fraction" data-switchable="false">Fraction</th>
+        <th data-valign="top" data-sortable="true" class="datagrp" data-visible="false" data-sorter="numericOnly" data-field="Median_MZ">Median<br>M/Z</th>
+        <th data-valign="top" data-sortable="true" class="datagrp" data-visible="false" data-sorter="numericOnly" data-field="Median_RT">Median<br>RT</th>
+
+        <th data-valign="top" data-sortable="true" class="metagrp" data-visible="false" data-sorter="alphanum" data-field="Formula">Formula</th>
+        <th data-valign="top" data-sortable="true" class="metagrp" data-visible="true" data-sorter="alphanum" data-field="Genotype">Genotype</th>
+        <th data-valign="top" data-sortable="true" class="metagrp" data-visible="false" data-sorter="alphanum" data-field="Sex">Sex</th>
+        <th data-valign="top" data-sortable="true" class="metagrp" data-visible="false" data-sorter="alphanum" data-field="Age">Age<br>(weeks)</th>
+        <th data-valign="top" data-sortable="true" class="metagrp" data-visible="false" data-sorter="numericOnly" data-field="Body_Weight">Body<br>Weight<br>(g)</th>
+        <th data-valign="top" data-sortable="true" class="metagrp" data-visible="true" data-sorter="alphanum" data-field="Feeding_Status">Feeding<br>Status</th>
+        <th data-valign="top" data-sortable="true" class="metagrp" data-visible="true" data-sorter="alphanum" data-field="Treatment">Treatment</th>
+        <th data-valign="top" data-sortable="true" class="metagrp" data-visible="false" data-sorter="alphanum" data-field="Diet">Diet</th>
+        <th data-valign="top" data-sortable="true" class="metagrp" data-visible="true" data-sorter="alphanum" data-field="Tracer_Compound" data-switchable="false">Tracer<br>Compound</th>
+        <th data-valign="top" data-sortable="true" class="metagrp" data-visible="false" data-sorter="numericOnly" data-field="Tracer_Infusion_Rate">Tracer<br>Infusion<br>Rate<br>(ul/min/g)</th>
+        <th data-valign="top" data-sortable="true" class="metagrp" data-visible="false" data-sorter="numericOnly" data-field="Tracer_Infusion_Concentration">Tracer<br>Infusion<br>Concentration<br>(mM)</th>
+        <th data-valign="top" data-sortable="true" class="metagrp" data-visible="true" data-sorter="alphanum" data-field="Studies">Studies</th>
+    </tr>
+</thead>
+
+{% if is_paginated %}
+<tbody>
+    {% for pd in page_obj %}
+        <tr>
+            <td><a href="{% url 'animal_detail' pd.animal_id %}">{{ pd.animal }}</a></td>
+            <td><a href="{% url 'sample_detail' pd.sample_id %}">{{ pd.sample }}</a></td>
+            <td><a href="{% url 'tissue_detail' pd.tissue_id %}">{{ pd.tissue }}</a></td>
+            <!-- Peak Group -->
+            <td>
+                <!-- Put displayed link text first for sorting -->
+                <div style="display:none;">{{ pd.peakgroup_name }}</div>
+                <a href="{% url 'peakgroup_detail' pd.peakgroup_id %}">
+                    {{ pd.peakgroup_name }}
+                </a>
+            </td>
+            <!-- Measured Compound(s) -->
+            <td>{{ pd.pg_id_name_list |obj_hyperlink:"pg_compound"}}</td>
+            <!-- Measured Compound Synonym(s) -->
+            <td>{{ pd.pg_id_synonyms_list |obj_hyperlink:"pg_comp_synonym"}}</td>
+             <!-- Labeled Element:Count -->
+            <td>{{ pd.labeled_element }} : {{ pd.labeled_count }}</td>
+            <!-- Peak Group Set Filename -->
+            <td><a href="{% url 'peakgroupset_detail' pd.peakgroupset_id %}">{{ pd.accucor_filename }}</a></td>
+            
+            <!-- Raw Abundance -->
+            <td class="text-end">
+                <p title="{{ pd.raw_abundance|floatformat:10 }}">{{ pd.raw_abundance|floatformat:1 }}</p>
+            </td>
+            
+            <!-- Corrected Abundance -->
+             <td class="text-end">
+                <p title="{{ pd.corrected_abundance|floatformat:10 }}">{{ pd.corrected_abundance|floatformat:1 }}</p>
+            </td>
+
+            <!-- Fraction -->
+            <td class="text-end">
+                <p title="{{ pd.fraction|floatformat:15 }}">{{ pd.fraction|floatformat:4 }}</p>
+            </td>
+
+            <!-- Median M/Z -->
+            <td class="text-end">
+                <p title="{{ pd.med_mz|floatformat:10 }}">{{ pd.med_mz|floatformat:1 }}</p>
+            </td>
+
+            <!-- Median RT -->
+            <td class="text-end">
+                <p title="{{ pd.med_rt|floatformat:10 }}">{{ pd.med_rt|floatformat:1 }}</p>
+            </td>
+
+            <!-- Formula -->
+            <td>
+                {{ pd.peakgroup_formula }}
+            </td>
+
+            <!-- Genotype -->
+            <td>
+                {{ pd.genotype }}
+            </td>
+
+            <!-- Sex -->
+            <td>
+                {{ pd.sex }}
+            </td>
+
+            <!-- Age (weeks) -->
+            <td class="text-end">
+                {{ pd.age |duration_iso_to_weeks }}
+            </td>
+
+            <!-- Feeding Status -->
+            <td>
+                {{ pd.feeding_status }}
+            </td>
+
+            <!-- Treatment -->
+            <!--handle None value for treatement-->
+            <td>
+                {% if pd.treatment %}
+                    <a href="{% url 'protocol_detail' pd.treatment_id %}">{{ pd.treatment }}</a>
+                {% else %}
+                    None
+                {% endif %}
+            </td>
+
+            <!-- Diet -->
+            <td>
+                {{ pd.diet }}
+            </td>
+
+            <!-- Body Weight (g) -->
+            <td>
+                {{ pd.body_weight }}
+            </td>
+
+            <!-- Tracer Compound -->
+            <td>
+                {% if pd.tracer_compound_id %}
+                    <a href="{% url 'compound_detail' pd.tracer_compound_id %}">{{ pd.tracer }}</a>
+                {% else %}
+                    None
+                {% endif %}
+            </td>
+
+            <!-- Tracer Infusion Rate (ul/min/g) -->
+            <td class="text-end">
+                {{ pd.tracer_infusion_rate }}
+            </td>
+
+            <!-- Tracer Infusion Concentration (mM) -->
+            <td class="text-end">
+                {{ pd.tracer_infusion_concentration }}
+            </td>
+            <td>{{ pd.study_id_name_list |obj_hyperlink:"study" }}</td>
+        {% endfor %}
+</tbody>
+{% endif %}
+</table>
+{% endblock %}
+
+{% block js_extras %}
+    <script>
+        var $table = $('#derived_peakdata')
+
+        $.extend($.fn.bootstrapTable.columnDefaults, {
+            valign: "top"
+        });
+
+        $('#derived_peakdata').bootstrapTable()
+    </script>
+{% endblock %}

--- a/DataRepo/templates/DataRepo/data_output/peakdata_tab_multipages.html
+++ b/DataRepo/templates/DataRepo/data_output/peakdata_tab_multipages.html
@@ -121,6 +121,11 @@ data-show-fullscreen="false"
                 {{ pd.age |duration_iso_to_weeks }}
             </td>
 
+            <!-- Body Weight -->
+            <td>
+                {{ pd.body_weight }}
+            </td>
+
             <!-- Feeding Status -->
             <td>
                 {{ pd.feeding_status }}

--- a/DataRepo/templates/DataRepo/data_output/peakdata_tab_onepage.html
+++ b/DataRepo/templates/DataRepo/data_output/peakdata_tab_onepage.html
@@ -123,6 +123,11 @@ data-export-types="['csv', 'txt', 'excel']">
                 {{ pd.age |duration_iso_to_weeks }}
             </td>
 
+            <!-- Body Weight -->
+            <td>
+                {{ pd.body_weight }}
+            </td>
+
             <!-- Feeding Status -->
             <td>
                 {{ pd.feeding_status }}

--- a/DataRepo/templates/DataRepo/data_output/peakdata_tab_onepage.html
+++ b/DataRepo/templates/DataRepo/data_output/peakdata_tab_onepage.html
@@ -1,0 +1,188 @@
+{% load customtags %}
+<h5><a class="link-button" href="{% url 'derived_peakdata' %}?obj_type={{ obj_type }}&obj_id={{ obj_id }}&page=1">View Data by Page</a></h5>
+<br>
+{% block content %}
+<table class="table table-hover table-striped table-bordered"
+id="derived_peakdata"
+data-toggle="table"
+data-buttons-class="primary"
+data-buttons-align="left"
+data-filter-control="false"
+data-search="false"
+data-show-search-clear-button="false"
+data-show-multi-sort="true"
+data-show-columns="true"
+data-show-columns-toggle-all="true"
+data-show-fullscreen="false"
+data-show-export="true"
+data-export-types="['csv', 'txt', 'excel']">
+
+
+<colgroup span="8" class="identdata"></colgroup>
+<colgroup span="5" class="datadata"></colgroup>
+<colgroup span="12" class="metadata"></colgroup>
+
+<thead>
+    <tr>
+        <th data-valign="top" data-sortable="true" class="idgrp" data-visible="false" data-sorter="alphanum" data-field="Animal">Animal</th>
+        <th data-valign="top" data-sortable="true" class="idgrp" data-visible="true" data-sorter="alphanum" data-field="Sample" data-switchable="false">Sample</th>
+        <th data-valign="top" data-sortable="true" class="idgrp" data-visible="true" data-sorter="alphanum" data-field="Tissue">Tissue</th>
+        <th data-valign="top" data-sortable="true" class="idgrp" data-visible="false" data-sorter="alphanum" data-field="Peak_Group">Peak Group</th>
+        <th data-valign="top" data-sortable="true" class="idgrp" data-visible="true" data-sorter="alphanum" data-field="Measured_Compounds">Measured<br>Compound(s)</th>
+        <th data-valign="top" data-sortable="true" class="idgrp" data-visible="false" data-sorter="alphanum" data-field="Measured_Compound_Synonyms">Measured<br>Compound<br>Synonym(s)</th>
+        <th data-valign="top" data-sortable="true" class="idgrp" data-visible="true" data-sorter="alphanum" data-field="Labeled_Element_Count">Labeled<br>Element:<br>Count</th>
+        <th data-valign="top" data-sortable="true" class="idgrp" data-visible="false" data-sorter="alphanum" data-field="Peak_Group_Set_Filename">Peak Group Set Filename</th>
+
+        <th data-valign="top" data-sortable="true" class="datagrp" data-visible="false" data-sorter="numericOnly" data-field="Raw_Abundance">Raw<br>Abundance</th>
+        <th data-valign="top" data-sortable="true" class="datagrp" data-visible="true" data-sorter="numericOnly" data-field="Corrected_Abundance">Corrected<br>Abundance</th>
+        <th data-valign="top" data-sortable="true" class="datagrp" data-visible="true" data-sorter="numericOnly" data-field="Fraction" data-switchable="false">Fraction</th>
+        <th data-valign="top" data-sortable="true" class="datagrp" data-visible="false" data-sorter="numericOnly" data-field="Median_MZ">Median<br>M/Z</th>
+        <th data-valign="top" data-sortable="true" class="datagrp" data-visible="false" data-sorter="numericOnly" data-field="Median_RT">Median<br>RT</th>
+
+        <th data-valign="top" data-sortable="true" class="metagrp" data-visible="false" data-sorter="alphanum" data-field="Formula">Formula</th>
+        <th data-valign="top" data-sortable="true" class="metagrp" data-visible="true" data-sorter="alphanum" data-field="Genotype">Genotype</th>
+        <th data-valign="top" data-sortable="true" class="metagrp" data-visible="false" data-sorter="alphanum" data-field="Sex">Sex</th>
+        <th data-valign="top" data-sortable="true" class="metagrp" data-visible="false" data-sorter="alphanum" data-field="Age">Age<br>(weeks)</th>
+        <th data-valign="top" data-sortable="true" class="metagrp" data-visible="false" data-sorter="numericOnly" data-field="Body_Weight">Body<br>Weight<br>(g)</th>
+        <th data-valign="top" data-sortable="true" class="metagrp" data-visible="true" data-sorter="alphanum" data-field="Feeding_Status">Feeding<br>Status</th>
+        <th data-valign="top" data-sortable="true" class="metagrp" data-visible="true" data-sorter="alphanum" data-field="Treatment">Treatment</th>
+        <th data-valign="top" data-sortable="true" class="metagrp" data-visible="false" data-sorter="alphanum" data-field="Diet">Diet</th>
+        <th data-valign="top" data-sortable="true" class="metagrp" data-visible="true" data-sorter="alphanum" data-field="Tracer_Compound" data-switchable="false">Tracer<br>Compound</th>
+        <th data-valign="top" data-sortable="true" class="metagrp" data-visible="false" data-sorter="numericOnly" data-field="Tracer_Infusion_Rate">Tracer<br>Infusion<br>Rate<br>(ul/min/g)</th>
+        <th data-valign="top" data-sortable="true" class="metagrp" data-visible="false" data-sorter="numericOnly" data-field="Tracer_Infusion_Concentration">Tracer<br>Infusion<br>Concentration<br>(mM)</th>
+        <th data-valign="top" data-sortable="true" class="metagrp" data-visible="true" data-sorter="alphanum" data-field="Studies">Studies</th>
+    </tr>
+</thead>
+
+
+<tbody>
+    {% for pd in page_obj %}
+        <tr>
+            <td><a href="{% url 'animal_detail' pd.animal_id %}">{{ pd.animal }}</a></td>
+            <td><a href="{% url 'sample_detail' pd.sample_id %}">{{ pd.sample }}</a></td>
+            <td><a href="{% url 'tissue_detail' pd.tissue_id %}">{{ pd.tissue }}</a></td>
+            <!-- Peak Group -->
+            <td>
+                <!-- Put displayed link text first for sorting -->
+                <div style="display:none;">{{ pd.peakgroup_name }}</div>
+                <a href="{% url 'peakgroup_detail' pd.peakgroup_id %}">
+                    {{ pd.peakgroup_name }}
+                </a>
+            </td>
+            <!-- Measured Compound(s) -->
+            <td>{{ pd.pg_id_name_list |obj_hyperlink:"pg_compound"}}</td>
+            <!-- Measured Compound Synonym(s) -->
+            <td>{{ pd.pg_id_synonyms_list |obj_hyperlink:"pg_comp_synonym"}}</td>
+             <!-- Labeled Element:Count -->
+            <td>{{ pd.labeled_element }} : {{ pd.labeled_count }}</td>
+            <!-- Peak Group Set Filename -->
+            <td><a href="{% url 'peakgroupset_detail' pd.peakgroupset_id %}">{{ pd.accucor_filename }}</a></td>
+            
+            <!-- Raw Abundance -->
+            <td class="text-end">
+                <p title="{{ pd.raw_abundance|floatformat:10 }}">{{ pd.raw_abundance|floatformat:1 }}</p>
+            </td>
+            
+            <!-- Corrected Abundance -->
+             <td class="text-end">
+                <p title="{{ pd.corrected_abundance|floatformat:10 }}">{{ pd.corrected_abundance|floatformat:1 }}</p>
+            </td>
+
+            <!-- Fraction -->
+            <td class="text-end">
+                <p title="{{ pd.fraction|floatformat:15 }}">{{ pd.fraction|floatformat:4 }}</p>
+            </td>
+
+            <!-- Median M/Z -->
+            <td class="text-end">
+                <p title="{{ pd.med_mz|floatformat:10 }}">{{ pd.med_mz|floatformat:1 }}</p>
+            </td>
+
+            <!-- Median RT -->
+            <td class="text-end">
+                <p title="{{ pd.med_rt|floatformat:10 }}">{{ pd.med_rt|floatformat:1 }}</p>
+            </td>
+
+            <!-- Formula -->
+            <td>
+                {{ pd.peakgroup_formula }}
+            </td>
+
+            <!-- Genotype -->
+            <td>
+                {{ pd.genotype }}
+            </td>
+
+            <!-- Sex -->
+            <td>
+                {{ pd.sex }}
+            </td>
+
+            <!-- Age (weeks) -->
+            <td class="text-end">
+                {{ pd.age |duration_iso_to_weeks }}
+            </td>
+
+            <!-- Feeding Status -->
+            <td>
+                {{ pd.feeding_status }}
+            </td>
+
+            <!-- Treatment -->
+            <!--handle None value for treatement-->
+            <td>
+                {% if pd.treatment %}
+                    <a href="{% url 'protocol_detail' pd.treatment_id %}">{{ pd.treatment }}</a>
+                {% else %}
+                    None
+                {% endif %}
+            </td>
+
+            <!-- Diet -->
+            <td>
+                {{ pd.diet }}
+            </td>
+
+            <!-- Body Weight (g) -->
+            <td>
+                {{ pd.body_weight }}
+            </td>
+
+            <!-- Tracer Compound -->
+            <td>
+                {% if pd.tracer_compound_id %}
+                    <a href="{% url 'compound_detail' pd.tracer_compound_id %}">{{ pd.tracer }}</a>
+                {% else %}
+                    None
+                {% endif %}
+            </td>
+
+            <!-- Tracer Infusion Rate (ul/min/g) -->
+            <td class="text-end">
+                {{ pd.tracer_infusion_rate }}
+            </td>
+
+            <!-- Tracer Infusion Concentration (mM) -->
+            <td class="text-end">
+                {{ pd.tracer_infusion_concentration }}
+            </td>
+            <td>{{ pd.study_id_name_list |obj_hyperlink:"study" }}</td>
+        {% endfor %}
+</tbody>
+
+</table>
+
+
+{% endblock %}
+
+{% block js_extras %}
+    <script>
+        var $table = $('#derived_peakdata')
+
+        $.extend($.fn.bootstrapTable.columnDefaults, {
+            valign: "top"
+        });
+
+        $('#derived_peakdata').bootstrapTable()
+    </script>
+{% endblock %}

--- a/DataRepo/templates/DataRepo/data_output/peakgroup_tab_multipages.html
+++ b/DataRepo/templates/DataRepo/data_output/peakgroup_tab_multipages.html
@@ -1,0 +1,182 @@
+{% load customtags %}
+
+{% block content %}
+<table class="table table-hover table-striped table-bordered"
+id="derived_peakgroup"
+data-toggle="table"
+data-buttons-class="primary"
+data-buttons-align="left"
+data-filter-control="false"
+data-search="false"
+data-show-search-clear-button="false"
+data-show-multi-sort="true"
+data-show-columns="true"
+data-show-columns-toggle-all="true"
+data-show-fullscreen="false"
+>
+
+
+<colgroup span="8" class="identdata"></colgroup>
+<colgroup span="5" class="datadata"></colgroup>
+<colgroup span="12" class="metadata"></colgroup>
+
+<thead>
+    <tr>
+        <th data-valign="top" data-sortable="true" class="idgrp" data-visible="false" data-sorter="alphanum" data-field="Animal">Animal</th>
+        <th data-valign="top" data-sortable="true" class="idgrp" data-visible="true" data-sorter="alphanum" data-field="Sample" data-switchable="false">Sample</th>
+        <th data-valign="top" data-sortable="true" class="idgrp" data-visible="true" data-sorter="alphanum" data-field="Tissue">Tissue</th>
+        <th data-valign="top" data-sortable="true" class="idgrp" data-visible="false" data-sorter="alphanum" data-field="Peak_Group">Peak Group</th>
+        <th data-valign="top" data-sortable="true" class="idgrp" data-visible="true" data-sorter="alphanum" data-field="Measured_Compounds">Measured<br>Compound(s)</th>
+        <th data-valign="top" data-sortable="true" class="idgrp" data-visible="false" data-sorter="alphanum" data-field="Measured_Compound_Synonyms">Measured<br>Compound<br>Synonym(s)</th>
+        <th data-valign="top" data-sortable="true" class="idgrp" data-visible="true" data-sorter="alphanum" data-field="Labeled_Element_Count">Labeled<br>Element</th>
+        <th data-valign="top" data-sortable="true" class="idgrp" data-visible="false" data-sorter="alphanum" data-field="Peak_Group_Set_Filename">Peak Group Set Filename</th>
+
+        <th data-valign="top" data-sortable="true" data-visible="true" data-sorter="numericOnly" data-field="Total_Abundance" class="datagrp" data-switchable="false">Total<br>Abundance</th>
+        <th data-valign="top" data-sortable="true" data-visible="true" data-sorter="numericOnly" data-field="Enrichment_Fraction" class="datagrp">Enrichment<br>Fraction</th>
+        <th data-valign="top" data-sortable="true" data-visible="true" data-sorter="numericOnly" data-field="Enrichment_Abundance" class="datagrp">Enrichment<br>Abundance</th>
+        <th data-valign="top" data-sortable="true" data-visible="true" data-sorter="numericOnly" data-field="Normalized_Labeling" class="datagrp">Normalized<br>Labeling</th>
+
+
+        <th data-valign="top" data-sortable="true" class="metagrp" data-visible="false" data-sorter="alphanum" data-field="Formula">Formula</th>
+        <th data-valign="top" data-sortable="true" class="metagrp" data-visible="true" data-sorter="alphanum" data-field="Genotype">Genotype</th>
+        <th data-valign="top" data-sortable="true" class="metagrp" data-visible="false" data-sorter="alphanum" data-field="Sex">Sex</th>
+        <th data-valign="top" data-sortable="true" class="metagrp" data-visible="false" data-sorter="alphanum" data-field="Age">Age<br>(weeks)</th>
+        <th data-valign="top" data-sortable="true" class="metagrp" data-visible="false" data-sorter="numericOnly" data-field="Body_Weight">Body<br>Weight<br>(g)</th>
+        <th data-valign="top" data-sortable="true" class="metagrp" data-visible="true" data-sorter="alphanum" data-field="Feeding_Status">Feeding<br>Status</th>
+        <th data-valign="top" data-sortable="true" class="metagrp" data-visible="true" data-sorter="alphanum" data-field="Treatment">Treatment</th>
+        <th data-valign="top" data-sortable="true" class="metagrp" data-visible="false" data-sorter="alphanum" data-field="Diet">Diet</th>
+        <th data-valign="top" data-sortable="true" class="metagrp" data-visible="true" data-sorter="alphanum" data-field="Tracer_Compound" data-switchable="false">Tracer<br>Compound</th>
+        <th data-valign="top" data-sortable="true" class="metagrp" data-visible="false" data-sorter="numericOnly" data-field="Tracer_Infusion_Rate">Tracer<br>Infusion<br>Rate<br>(ul/min/g)</th>
+        <th data-valign="top" data-sortable="true" class="metagrp" data-visible="false" data-sorter="numericOnly" data-field="Tracer_Infusion_Concentration">Tracer<br>Infusion<br>Concentration<br>(mM)</th>
+        <th data-valign="top" data-sortable="true" class="metagrp" data-visible="true" data-sorter="alphanum" data-field="Studies">Studies</th>
+    </tr>
+</thead>
+
+{% if is_paginated %}
+<tbody>
+    {% for pg in page_obj %}
+        <tr>
+            <td><a href="{% url 'animal_detail' pg.animal_id %}">{{ pg.animal }}</a></td>
+            <td><a href="{% url 'sample_detail' pg.sample_id %}">{{ pg.sample }}</a></td>
+            <td><a href="{% url 'tissue_detail' pg.tissue_id %}">{{ pg.tissue }}</a></td>
+            <!-- Peak Group -->
+            <td>
+                <!-- Put displayed link text first for sorting -->
+                <div style="display:none;">{{ pg.peakgroup_name }}</div>
+                <a href="{% url 'peakgroup_detail' pg.peakgroup_id %}">
+                    {{ pg.peakgroup_name }}
+                </a>
+            </td>
+            <!-- Measured Compound(s) -->
+            <td>{{ pg.pg_id_name_list |obj_hyperlink:"pg_compound"}}</td>
+            <!-- Measured Compound Synonym(s) -->
+            <td>{{ pg.pg_id_synonyms_list |obj_hyperlink:"pg_comp_synonym"}}</td>
+             <!-- Labeled Element -->
+            <td>{{ pg.labeled_element }}</td>
+            <!-- Peak Group Set Filename -->
+            <td><a href="{% url 'peakgroupset_detail' pg.peakgroupset_id %}">{{ pg.accucor_filename }}</a></td>
+            
+            <!-- Total Abundance -->
+            <td class="text-end">
+                <p title="{{ pg.pg_total_abundance|floatformat:10 }}">{{ pg.pg_total_abundance|floatformat:1 }}</p>
+            </td>
+            
+            <!-- Enrichment Fraction -->
+             <td class="text-end">
+                <p title="{{ pg.pg_enrichment_fraction|floatformat:15 }}">{{ pg.pg_enrichment_fraction|floatformat:4}}</p>
+            </td>
+
+            <!-- Enrichment Abundance -->
+            <td class="text-end">
+                <p title="{{ pg.pg_enrichment_abundance|floatformat:10 }}">{{ pg.pg_enrichment_abundance|floatformat:4 }}</p>
+            </td>
+
+            <!-- Normalized Labeling -->
+            <td class="text-end">
+                <p title="{{ pg.pg_normalized_labeling|floatformat:15 }}">{{ pg.pg_normalized_labeling|floatformat:4 }}</p>
+            </td>
+
+            <!-- Formula -->
+            <td>
+                {{ pg.peakgroup_formula }}
+            </td>
+
+            <!-- Genotype -->
+            <td>
+                {{ pg.genotype }}
+            </td>
+
+            <!-- Sex -->
+            <td>
+                {{ pg.sex }}
+            </td>
+
+            <!-- Age (weeks) -->
+            <td class="text-end">
+                {{ pg.age |duration_iso_to_weeks }}
+            </td>
+
+            <!-- Feeding Status -->
+            <td>
+                {{ pg_comp_synonym.feeding_status }}
+            </td>
+
+            <!-- Treatment -->
+            <!--handle None value for treatement-->
+            <td>
+                {% if pg.treatment %}
+                    <a href="{% url 'protocol_detail' pg.treatment_id %}">{{ pg.treatment }}</a>
+                {% else %}
+                    None
+                {% endif %}
+            </td>
+
+            <!-- Diet -->
+            <td>
+                {{ pg.diet }}
+            </td>
+
+            <!-- Body Weight (g) -->
+            <td>
+                {{ pg.body_weight }}
+            </td>
+
+            <!-- Tracer Compound -->
+            <td>
+                {% if pd.tracer_compound_id %}
+                    <a href="{% url 'compound_detail' pd.tracer_compound_id %}">{{ pd.tracer }}</a>
+                {% else %}
+                    None
+                {% endif %}
+            </td>
+
+            <!-- Tracer Infusion Rate (ul/min/g) -->
+            <td class="text-end">
+                {{ pg.tracer_infusion_rate }}
+            </td>
+
+            <!-- Tracer Infusion Concentration (mM) -->
+            <td class="text-end">
+                {{ pg.tracer_infusion_concentration }}
+            </td>
+            <td>{{ pg.study_id_name_list |obj_hyperlink:"study" }}</td>
+        {% endfor %}
+</tbody>
+{% endif %}
+</table>
+
+
+{% endblock %}
+
+{% block js_extras %}
+<script>
+    var $table = $('#derived_peakgroup')
+
+    $.extend($.fn.bootstrapTable.columnDefaults, {
+        valign: "top"
+    });
+
+    $('#derived_peakgroup').bootstrapTable()
+</script>
+{% endblock %}
+      

--- a/DataRepo/templates/DataRepo/data_output/peakgroup_tab_multipages.html
+++ b/DataRepo/templates/DataRepo/data_output/peakgroup_tab_multipages.html
@@ -116,9 +116,14 @@ data-show-fullscreen="false"
                 {{ pg.age |duration_iso_to_weeks }}
             </td>
 
+            <!-- Body Weight -->
+            <td>
+                {{ pg.body_weight }}
+            </td>
+
             <!-- Feeding Status -->
             <td>
-                {{ pg_comp_synonym.feeding_status }}
+                {{ pg.feeding_status }}
             </td>
 
             <!-- Treatment -->
@@ -136,15 +141,10 @@ data-show-fullscreen="false"
                 {{ pg.diet }}
             </td>
 
-            <!-- Body Weight (g) -->
-            <td>
-                {{ pg.body_weight }}
-            </td>
-
             <!-- Tracer Compound -->
             <td>
-                {% if pd.tracer_compound_id %}
-                    <a href="{% url 'compound_detail' pd.tracer_compound_id %}">{{ pd.tracer }}</a>
+                {% if pg.tracer_compound_id %}
+                    <a href="{% url 'compound_detail' pg.tracer_compound_id %}">{{ pg.tracer }}</a>
                 {% else %}
                     None
                 {% endif %}

--- a/DataRepo/templates/DataRepo/data_output/peakgroup_tab_onepage.html
+++ b/DataRepo/templates/DataRepo/data_output/peakgroup_tab_onepage.html
@@ -118,9 +118,14 @@ data-export-types="['csv', 'txt', 'excel']">
                 {{ pg.age |duration_iso_to_weeks }}
             </td>
 
+            <!-- Body Weight -->
+            <td>
+                {{ pg.body_weight }}
+            </td>
+
             <!-- Feeding Status -->
             <td>
-                {{ pg_comp_synonym.feeding_status }}
+                {{ pg.feeding_status }}
             </td>
 
             <!-- Treatment -->
@@ -138,15 +143,10 @@ data-export-types="['csv', 'txt', 'excel']">
                 {{ pg.diet }}
             </td>
 
-            <!-- Body Weight (g) -->
-            <td>
-                {{ pg.body_weight }}
-            </td>
-
             <!-- Tracer Compound -->
             <td>
-                {% if pd.tracer_compound_id %}
-                    <a href="{% url 'compound_detail' pd.tracer_compound_id %}">{{ pd.tracer }}</a>
+                {% if pg.tracer_compound_id %}
+                    <a href="{% url 'compound_detail' pg.tracer_compound_id %}">{{ pg.tracer }}</a>
                 {% else %}
                     None
                 {% endif %}

--- a/DataRepo/templates/DataRepo/data_output/peakgroup_tab_onepage.html
+++ b/DataRepo/templates/DataRepo/data_output/peakgroup_tab_onepage.html
@@ -1,0 +1,184 @@
+{% load customtags %}
+<h5><a class="link-button" href="{% url 'derived_peakgroup' %}?obj_type={{ obj_type }}&obj_id={{ obj_id }}&page=1">View Data by Page</a></h5>
+<br>
+{% block content %}
+<table class="table table-hover table-striped table-bordered"
+id="derived_peakgroup"
+data-toggle="table"
+data-buttons-class="primary"
+data-buttons-align="left"
+data-filter-control="false"
+data-search="false"
+data-show-search-clear-button="false"
+data-show-multi-sort="true"
+data-show-columns="true"
+data-show-columns-toggle-all="true"
+data-show-fullscreen="false"
+data-show-export="true"
+data-export-types="['csv', 'txt', 'excel']">
+
+
+<colgroup span="8" class="identdata"></colgroup>
+<colgroup span="5" class="datadata"></colgroup>
+<colgroup span="12" class="metadata"></colgroup>
+
+<thead>
+    <tr>
+        <th data-valign="top" data-sortable="true" class="idgrp" data-visible="false" data-sorter="alphanum" data-field="Animal">Animal</th>
+        <th data-valign="top" data-sortable="true" class="idgrp" data-visible="true" data-sorter="alphanum" data-field="Sample" data-switchable="false">Sample</th>
+        <th data-valign="top" data-sortable="true" class="idgrp" data-visible="true" data-sorter="alphanum" data-field="Tissue">Tissue</th>
+        <th data-valign="top" data-sortable="true" class="idgrp" data-visible="false" data-sorter="alphanum" data-field="Peak_Group">Peak Group</th>
+        <th data-valign="top" data-sortable="true" class="idgrp" data-visible="true" data-sorter="alphanum" data-field="Measured_Compounds">Measured<br>Compound(s)</th>
+        <th data-valign="top" data-sortable="true" class="idgrp" data-visible="false" data-sorter="alphanum" data-field="Measured_Compound_Synonyms">Measured<br>Compound<br>Synonym(s)</th>
+        <th data-valign="top" data-sortable="true" class="idgrp" data-visible="true" data-sorter="alphanum" data-field="Labeled_Element">Labeled<br>Element</th>
+        <th data-valign="top" data-sortable="true" class="idgrp" data-visible="false" data-sorter="alphanum" data-field="Peak_Group_Set_Filename">Peak Group Set Filename</th>
+
+        <th data-valign="top" data-sortable="true" data-visible="true" data-sorter="numericOnly" data-field="Total_Abundance" class="datagrp" data-switchable="false">Total<br>Abundance</th>
+        <th data-valign="top" data-sortable="true" data-visible="true" data-sorter="numericOnly" data-field="Enrichment_Fraction" class="datagrp">Enrichment<br>Fraction</th>
+        <th data-valign="top" data-sortable="true" data-visible="true" data-sorter="numericOnly" data-field="Enrichment_Abundance" class="datagrp">Enrichment<br>Abundance</th>
+        <th data-valign="top" data-sortable="true" data-visible="true" data-sorter="numericOnly" data-field="Normalized_Labeling" class="datagrp">Normalized<br>Labeling</th>
+
+
+        <th data-valign="top" data-sortable="true" class="metagrp" data-visible="false" data-sorter="alphanum" data-field="Formula">Formula</th>
+        <th data-valign="top" data-sortable="true" class="metagrp" data-visible="true" data-sorter="alphanum" data-field="Genotype">Genotype</th>
+        <th data-valign="top" data-sortable="true" class="metagrp" data-visible="false" data-sorter="alphanum" data-field="Sex">Sex</th>
+        <th data-valign="top" data-sortable="true" class="metagrp" data-visible="false" data-sorter="alphanum" data-field="Age">Age<br>(weeks)</th>
+        <th data-valign="top" data-sortable="true" class="metagrp" data-visible="false" data-sorter="numericOnly" data-field="Body_Weight">Body<br>Weight<br>(g)</th>
+        <th data-valign="top" data-sortable="true" class="metagrp" data-visible="true" data-sorter="alphanum" data-field="Feeding_Status">Feeding<br>Status</th>
+        <th data-valign="top" data-sortable="true" class="metagrp" data-visible="true" data-sorter="alphanum" data-field="Treatment">Treatment</th>
+        <th data-valign="top" data-sortable="true" class="metagrp" data-visible="false" data-sorter="alphanum" data-field="Diet">Diet</th>
+        <th data-valign="top" data-sortable="true" class="metagrp" data-visible="true" data-sorter="alphanum" data-field="Tracer_Compound" data-switchable="false">Tracer<br>Compound</th>
+        <th data-valign="top" data-sortable="true" class="metagrp" data-visible="false" data-sorter="numericOnly" data-field="Tracer_Infusion_Rate">Tracer<br>Infusion<br>Rate<br>(ul/min/g)</th>
+        <th data-valign="top" data-sortable="true" class="metagrp" data-visible="false" data-sorter="numericOnly" data-field="Tracer_Infusion_Concentration">Tracer<br>Infusion<br>Concentration<br>(mM)</th>
+        <th data-valign="top" data-sortable="true" class="metagrp" data-visible="true" data-sorter="alphanum" data-field="Studies">Studies</th>
+    </tr>
+</thead>
+
+
+<tbody>
+    {% for pg in page_obj %}
+        <tr>
+            <td><a href="{% url 'animal_detail' pg.animal_id %}">{{ pg.animal }}</a></td>
+            <td><a href="{% url 'sample_detail' pg.sample_id %}">{{ pg.sample }}</a></td>
+            <td><a href="{% url 'tissue_detail' pg.tissue_id %}">{{ pg.tissue }}</a></td>
+            <!-- Peak Group -->
+            <td>
+                <!-- Put displayed link text first for sorting -->
+                <div style="display:none;">{{ pg.peakgroup_name }}</div>
+                <a href="{% url 'peakgroup_detail' pg.peakgroup_id %}">
+                    {{ pg.peakgroup_name }}
+                </a>
+            </td>
+            <!-- Measured Compound(s) -->
+            <td>{{ pg.pg_id_name_list |obj_hyperlink:"pg_compound"}}</td>
+            <!-- Measured Compound Synonym(s) -->
+            <td>{{ pg.pg_id_synonyms_list |obj_hyperlink:"pg_comp_synonym"}}</td>
+             <!-- Labeled Element-->
+            <td>{{ pg.labeled_element }}</td>
+            <!-- Peak Group Set Filename -->
+            <td><a href="{% url 'peakgroupset_detail' pg.peakgroupset_id %}">{{ pg.accucor_filename }}</a></td>
+            
+            <!-- Total Abundance -->
+            <td class="text-end">
+                <p title="{{ pg.pg_total_abundance|floatformat:10 }}">{{ pg.pg_total_abundance|floatformat:1 }}</p>
+            </td>
+            
+            <!-- Enrichment Fraction -->
+             <td class="text-end">
+                <p title="{{ pg.pg_enrichment_fraction|floatformat:15 }}">{{ pg.pg_enrichment_fraction|floatformat:4}}</p>
+            </td>
+
+            <!-- Enrichment Abundance -->
+            <td class="text-end">
+                <p title="{{ pg.pg_enrichment_abundance|floatformat:10 }}">{{ pg.pg_enrichment_abundance|floatformat:4 }}</p>
+            </td>
+
+            <!-- Normalized Labeling -->
+            <td class="text-end">
+                <p title="{{ pg.pg_normalized_labeling|floatformat:15 }}">{{ pg.pg_normalized_labeling|floatformat:4 }}</p>
+            </td>
+
+            <!-- Formula -->
+            <td>
+                {{ pg.peakgroup_formula }}
+            </td>
+
+            <!-- Genotype -->
+            <td>
+                {{ pg.genotype }}
+            </td>
+
+            <!-- Sex -->
+            <td>
+                {{ pg.sex }}
+            </td>
+
+            <!-- Age (weeks) -->
+            <td class="text-end">
+                {{ pg.age |duration_iso_to_weeks }}
+            </td>
+
+            <!-- Feeding Status -->
+            <td>
+                {{ pg_comp_synonym.feeding_status }}
+            </td>
+
+            <!-- Treatment -->
+            <!--handle None value for treatement-->
+            <td>
+                {% if pg.treatment %}
+                    <a href="{% url 'protocol_detail' pg.treatment_id %}">{{ pg.treatment }}</a>
+                {% else %}
+                    None
+                {% endif %}
+            </td>
+
+            <!-- Diet -->
+            <td>
+                {{ pg.diet }}
+            </td>
+
+            <!-- Body Weight (g) -->
+            <td>
+                {{ pg.body_weight }}
+            </td>
+
+            <!-- Tracer Compound -->
+            <td>
+                {% if pd.tracer_compound_id %}
+                    <a href="{% url 'compound_detail' pd.tracer_compound_id %}">{{ pd.tracer }}</a>
+                {% else %}
+                    None
+                {% endif %}
+            </td>
+
+            <!-- Tracer Infusion Rate (ul/min/g) -->
+            <td class="text-end">
+                {{ pg.tracer_infusion_rate }}
+            </td>
+
+            <!-- Tracer Infusion Concentration (mM) -->
+            <td class="text-end">
+                {{ pg.tracer_infusion_concentration }}
+            </td>
+            <td>{{ pg.study_id_name_list |obj_hyperlink:"study" }}</td>
+        {% endfor %}
+</tbody>
+
+</table>
+
+
+{% endblock %}
+
+{% block js_extras %}
+<script>
+    var $table = $('#derived_peakgroup')
+
+    $.extend($.fn.bootstrapTable.columnDefaults, {
+        valign: "top"
+    });
+
+    $('#derived_peakgroup').bootstrapTable()
+</script>
+{% endblock %}
+      

--- a/DataRepo/templates/DataRepo/study_detail.html
+++ b/DataRepo/templates/DataRepo/study_detail.html
@@ -56,6 +56,13 @@
 </div>
 <br>
 <div>
+    <br>
+    <h4>Test downloading data from Pandas DataFrames:</h4>
+    <h5><a href="{% url 'derived_data_to_file_by_streaming' %}?category=peakgroup&obj_type=study&obj_id={{ study.id }}">Download Peak Group Data</a></h5>
+    <h5><a href="{% url 'derived_data_to_file_by_streaming' %}?category=peakdata&obj_type=study&obj_id={{ study.id }}">Download Peak Data</a></h5>
+</div>
+<br>
+<div>
     <h5>Animal and Sample Data for the Study:</h5>
     {% if df %}
     <table class="table table-sm table-hover table-bordered table-striped table-responsive" w-auto mw-100

--- a/DataRepo/templates/DataRepo/study_detail.html
+++ b/DataRepo/templates/DataRepo/study_detail.html
@@ -48,6 +48,14 @@
 </div>
 <br>
 <div>
+    <br>
+    <h4>Test the output from Pandas DataFrames:</h4>
+    <h5><a href="{% url 'derived_peakgroup' %}?obj_type=study&obj_id={{ study.id }}&page=1">View Peak Group Data</a></h5>
+    <h5><a href="{% url 'derived_peakdata' %}?obj_type=study&obj_id={{ study.id }}&page=1">View Peak Data</a></h5>
+    <h5><a href="{% url 'derived_fcirc' %}?obj_type=study&obj_id={{ study.id }}">View Fcirc Data</a></h5>
+</div>
+<br>
+<div>
     <h5>Animal and Sample Data for the Study:</h5>
     {% if df %}
     <table class="table table-sm table-hover table-bordered table-striped table-responsive" w-auto mw-100

--- a/DataRepo/templates/base2.html
+++ b/DataRepo/templates/base2.html
@@ -1,0 +1,72 @@
+{% load static %}
+<!--use Bootstrap CSS and JS 5.0.2-->
+<!--https://getbootstrap.com/docs/5.0/getting-started/download/-->
+<!--use Bootstrap Table plugin 1.18.3-->
+<!--https://bootstrap-table.com/docs/getting-started/introduction/-->
+<!doctype html>
+<html lang="en-US">
+    <head>
+        <!-- Required meta tags -->
+        <meta charset="utf-8">
+        <meta name="viewport" content="width=device-width, initial-scale=1">
+
+        <!-- Bootstrap CSS -->
+        <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.0.2/dist/css/bootstrap.min.css" rel="stylesheet"
+            integrity="sha384-EVSTQN3/azprG1Anm3QDgpJLIm9Nao0Yz1ztcQTwFspd3yD65VohhpuuCOmLASjC"
+            crossorigin="anonymous">
+
+        <!--Font Awesome-->
+        <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.6.3/css/all.css"
+            integrity="sha384-UHRtZLI+pbxtHCWp1t77Bi1L4ZtiqrqD80Kn4Z8NTSRyMA2Fd33n5dQ8lWUE00s/"
+            crossorigin="anonymous">
+
+        <!-- Bootstrap Table CSS -->
+        <link rel="stylesheet" href="https://unpkg.com/bootstrap-table@1.18.3/dist/bootstrap-table.min.css">
+
+        <!-- Bootstrap Icons -->
+        <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.7.2/font/bootstrap-icons.css">
+
+         <!-- Custom styles for this template -->
+        <link href="{% static 'css/sidebar.css' %}" rel="stylesheet">
+        <link href="{% static 'css/extras.css' %}" rel="stylesheet">
+
+        {% block head_extras %}
+        {% endblock %}
+
+        <title>{% block title %}TraceBase{% endblock %}</title>
+    </head>
+
+    <body>
+
+        {% include 'navbar.html' %}
+
+        <div class="d-flex" id="wrapper">
+            {% include 'sidebar.html' %}
+            <div class="container-fluid" style="width: 90%">
+                {% block content %}
+                {% endblock %}
+
+                {% include 'pagination2.html' %}
+            </div>
+        </div>
+
+        <!-- jQuery JS -->
+        <script src="https://cdn.jsdelivr.net/npm/jquery/dist/jquery.min.js"></script>
+        <script src="https://unpkg.com/tableexport.jquery.plugin/tableExport.min.js"></script>
+
+        <!-- Bootstrap JS -->
+        <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.0.2/dist/js/bootstrap.bundle.min.js"
+            integrity="sha384-MrcW6ZMFYlzcLA8Nl+NtUVF0sA7MsXsP1UyJoMp4YLEuNSfAP+JcXn/tWtIaxVXM"
+            crossorigin="anonymous">
+        </script>
+
+        <!-- Bootstrap Table JS -->
+        <script src="https://unpkg.com/bootstrap-table@1.18.3/dist/bootstrap-table.min.js"></script>
+        <script src="https://unpkg.com/bootstrap-table@1.18.3/dist/extensions/filter-control/bootstrap-table-filter-control.min.js"></script>
+        <script src="https://unpkg.com/bootstrap-table@1.18.3/dist/extensions/export/bootstrap-table-export.min.js"></script>
+
+    </body>
+
+    {% block js_extras %}
+    {% endblock %}
+</html>

--- a/DataRepo/templates/pagination2.html
+++ b/DataRepo/templates/pagination2.html
@@ -1,0 +1,20 @@
+{% load static %}
+{% load customtags %}
+
+<!-- modified code based on: https://www.caktusgroup.com/blog/2018/10/18/filtering-and-pagination-django/-->:
+{% if is_paginated %}
+    <div class="pagination">
+        <span class="page-links">
+        {% if page_obj.has_previous %}
+            <a href="?{% param_replace page=page_obj.previous_page_number %}">previous</a>
+        {% endif %}
+        <span class="page-current">
+            Page {{ page_obj.number }} of {{ page_obj.paginator.num_pages }}.
+        </span>
+        {% if page_obj.has_next %}
+        <a href="?{% param_replace page=page_obj.next_page_number %}">next</a>
+        {% endif %}
+    </span>
+</div>
+    <p>Rows: {{ page_obj.start_index }} - {{ page_obj.end_index }}</p>
+{% endif %}

--- a/DataRepo/templatetags/customtags.py
+++ b/DataRepo/templatetags/customtags.py
@@ -138,6 +138,10 @@ def obj_hyperlink(id_name_list, obj):
         tmplt_name = "compound_detail"
     elif obj == "treatment":
         tmplt_name = "protocol_detail"
+    elif obj == "pg_compound":
+        tmplt_name = "compound_detail"
+    elif obj == "pg_comp_synonym":
+        tmplt_name = "compound_detail"
 
     if id_name_list == [None]:
         return None
@@ -200,3 +204,28 @@ def get_case_insensitive_synonyms(case_qs):
         lcitem = item.lower()
         case_insensitive_dict[lcitem] = item
     return list(case_insensitive_dict.values())
+
+
+@register.simple_tag(takes_context=True)
+def param_replace(context, **kwargs):
+    """
+    code and notes copies from:
+    https://www.caktusgroup.com/blog/2018/10/18/filtering-and-pagination-django/
+    Return encoded URL parameters that are the same as the current
+    request's parameters, only with the specified GET parameters added or changed.
+
+    It also removes any empty parameters to keep things neat,
+    so you can remove a parm by setting it to ``""``.
+
+    For example, if you're on the page ``/things/?with_frosting=true&page=5``,
+    then
+    <a href="/things/?{% param_replace page=3 %}">Page 3</a>
+    would expand to
+    <a href="/things/?with_frosting=true&page=3">Page 3</a>
+    """
+    d = context['request'].GET.copy()
+    for k, v in kwargs.items():
+        d[k] = v
+    for k in [k for k, v in d.items() if not v]:
+        del d[k]
+    return d.urlencode()

--- a/DataRepo/urls.py
+++ b/DataRepo/urls.py
@@ -60,4 +60,8 @@ urlpatterns = [
         name="peakgroup_detail",
     ),
     path("peakdata/", views.PeakDataListView.as_view(), name="peakdata_list"),
+    path("data_output/derived_peakdata/", views.derived_peakdata, name="derived_peakdata"),
+    path("data_output/derived_peakgroup/", views.derived_peakgroup, name="derived_peakgroup"),
+    path("data_output/derived_fcirc/", views.derived_fcirc, name="derived_fcirc"),
+    path("data_output/download/", views.derived_data_to_csv, name="derived_data_to_csv"),
 ]

--- a/DataRepo/urls.py
+++ b/DataRepo/urls.py
@@ -63,5 +63,6 @@ urlpatterns = [
     path("data_output/derived_peakdata/", views.derived_peakdata, name="derived_peakdata"),
     path("data_output/derived_peakgroup/", views.derived_peakgroup, name="derived_peakgroup"),
     path("data_output/derived_fcirc/", views.derived_fcirc, name="derived_fcirc"),
-    path("data_output/download/", views.derived_data_to_csv, name="derived_data_to_csv"),
+    # path("data_output/download/", views.derived_data_to_csv, name="derived_data_to_csv"),
+    path("data_output/download/", views.derived_data_to_file_by_streaming, name="derived_data_to_file_by_streaming"),
 ]


### PR DESCRIPTION
…eak data in dataframes

<!-- markdownlint-disable-next-line first-line-heading -->
## Summary Change Description

Its' **proof-of-concept** code to test the following ideas:

* if the speed of parsing peakdata/peakgroups data can be improved by doing data manipulation in Pandas dataframes.

* if Django's Paginator can be used with output from Pandas dataframes.
  I tries to get data output format similar to that from Django's ListView, which also allows easy data handling in template(s).

* if calculation of Fcirc values can be improved by using Pandas dataframe. also get serum sample for each set of Fcirc.

* if Django's low level cache API can be used for displaying large set of data with Django's pagination.

* A view for handling data download with different data formats.

- **Test results so far (my laptop):**
  data retrieval from database to dataframe:

  Peakdata:
  obob_fasted (4381 rows): 2s
  fluxomics 2020(152,559 rows): 44s to 55s

  Peakgroup data:
  obob_fasted (4381 rows): 2s
  fluxomics 2020(21008 rows): 44s to 49s

  Fcirc data with serum sample:
  obob_fasted (7 rows):  1s
  fluxomics 2020 (89 rows): 5s

## Affected Issue Numbers


## Code Review Notes

- I haven't run SuperLinter yet. No test code either. I only did some manual tests with selected studies/animals so far. Want to get your feedback first to see if I should invest more time on this.

- I used Rob's peakdata/peakgroup/fcirc templates with modifications.

- I tried to create cache key in views for peakdata (or peagroup) output if total peakdata rows >5000 ( Django's low level cache API). With cache key, the first retrieval of large dataset is slow (e.g. fluxomics 2020, ~45s), then scrolling through additional pages took 1-2s.

- Bootstrap-table seems slow when total rows reach ~5000 range.
  So I implemented the following strategy:

  use total_rows =5000 as cutoff value:
  allow two mode display: single page or multi-page with pagination (if total_rows <5000)
  only allow pagination view for a large dataset

- Created a view for downloading data from a dataframe to csv file:

  Downloading data for a study or animal to csv file worked during my tests, though it took ~45s for prompt to show up for "fluxomics 2020" peakdata/peakgroup.  It's not great, but a user can at least get a whole set of  fluxomics 2020 study data downloaded within 2 minutes. Could use Django's StreamingHttpResponse to improve the downloading process.

- The above tests can be run with links from Study details and Animal details webpages. The timestamps for data retrieval and total rows are displayed at the webpage.

- After I updated my local branch with Rob's cachetable and cache features, the retrieval of data from a dataframe seemed to be a bit slower than without those settings (e.g. 44 s vs. 55s for fluxomics 2020 ).

## Checklist

- [ ] All issue requirements satisfied (or no linked issues)
- [ ] [Linting passes](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#linting).
- [ ] [Migrations created & committed *(or no model changes)*](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#migration-process)
- [ ] [Tests implemented *(or no code changes)*](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#test-implementation)
- [ ] [All tests pass](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#quality-control)
