### PR TITLE
Server-side Advanced Search Results Sorting

### DIFF
--- a/DataRepo/forms.py
+++ b/DataRepo/forms.py
@@ -175,16 +175,22 @@ class AdvSearchPageForm(forms.Form):
     )  # Used to distinguish pager form submissions from advanced search submissions
 
     def clean(self):
-        """This override of super.clean is so we can reconstruct the search inputs upon form_invalid in views.py"""
+        """
+        This override of super.clean is so we can reconstruct the search inputs upon form_invalid in views.py
+        """
         self.saved_data = self.cleaned_data
         return self.cleaned_data
 
-    def new(self, page_id, rows_id, orderby_id, orderdir_id, rows_attrs={}):
+    def update(self, page_id, rows_id, orderby_id, orderdir_id, rows_attrs={}):
         # Allow IDs for the inputs to be set for javascript to find the inputs and change them
         page = self.fields.get("page")
         rows = self.fields.get("rows")
         order_by = self.fields.get("order_by")
         order_direction = self.fields.get("order_direction")
+
+        #
+        # Make sure any future hard-coded settings are not silently over-ridden
+        #
 
         # page input
         if (

--- a/DataRepo/forms.py
+++ b/DataRepo/forms.py
@@ -165,16 +165,8 @@ class AdvSearchPageForm(forms.Form):
         choices=ROWS_PER_PAGE_CHOICES,
         # TODO: Can probably get the caret in the button image using:
         #   https://stackoverflow.com/questions/45424162/listing-a-choicefield-in-django-as-button
-        widget=forms.Select(
-            attrs={
-                "id": "pager-rows-elem",
-                "class": "btn btn-primary dropdown-toggle",
-                "type": "button",
-                "data-bs-toggle": "dropdown",
-            }
-        ),
-    )
-    page = forms.CharField(widget=forms.HiddenInput(attrs={"id": "pager-page-elem"}))
+        widget=forms.Select())
+    page = forms.CharField(widget=forms.HiddenInput())
     order_by = forms.CharField(widget=forms.HiddenInput())
     order_direction = forms.CharField(widget=forms.HiddenInput())
     adv_search_page_form = forms.CharField(
@@ -186,11 +178,14 @@ class AdvSearchPageForm(forms.Form):
         self.saved_data = self.cleaned_data
         return self.cleaned_data
 
-    def new(self, page_id, rows_id, rows_attrs={}):
+    def new(self, page_id, rows_id, orderby_id, orderdir_id, rows_attrs={}):
+        # Allow IDs for the inputs to be set for javascript to find the inputs and change them
         page = self.fields.get("page")
         rows = self.fields.get("rows")
+        order_by = self.fields.get("order_by")
+        order_direction = self.fields.get("order_direction")
 
-        # Allow IDs for the page and rows inputs to be set for javascript to find the inputs and change them
+        # page input
         if (
             page.widget.attrs
             and "id" in page.widget.attrs
@@ -200,6 +195,8 @@ class AdvSearchPageForm(forms.Form):
                 "ERROR: AdvSearchPageForm class already has an ID set for the page input"
             )
         page.widget.attrs["id"] = page_id
+
+        # rows input
         if (
             rows.widget.attrs
             and "id" in rows.widget.attrs
@@ -209,6 +206,28 @@ class AdvSearchPageForm(forms.Form):
                 "ERROR: AdvSearchPageForm class already has an ID set for the page input"
             )
         rows.widget.attrs["id"] = rows_id
+
+        # order_by input
+        if (
+            order_by.widget.attrs
+            and "id" in order_by.widget.attrs
+            and order_by.widget.attrs["id"] != orderby_id
+        ):
+            raise Exception(
+                "ERROR: AdvSearchPageForm class already has an ID set for the page input"
+            )
+        order_by.widget.attrs["id"] = orderby_id
+
+        # order_direction input
+        if (
+            order_direction.widget.attrs
+            and "id" in order_direction.widget.attrs
+            and order_direction.widget.attrs["id"] != orderdir_id
+        ):
+            raise Exception(
+                "ERROR: AdvSearchPageForm class already has an ID set for the page input"
+            )
+        order_direction.widget.attrs["id"] = orderdir_id
 
         # Allow setting of additional attributes for appearance of the rows select list. Others are assumed to be
         # hidden and page control is assumed to be accomplished using submit buttons that run javascript
@@ -222,6 +241,17 @@ class AdvSearchPageForm(forms.Form):
                     "ERROR: AdvSearchPageForm class already has a [{key}] set for the rows input"
                 )
             rows.widget.attrs[key] = val
+
+    def is_valid(self):
+        # This triggers the setting of self.cleaned_data
+        super().is_valid()
+        data = self.cleaned_data
+        fields = self.base_fields.keys()
+        # Make sure all fields besides the order fields are present
+        for field in fields:
+            if field != "order_by" and field != "order_direction" and field not in data:
+                return False
+        return True
 
 
 class DataSubmissionValidationForm(forms.Form):

--- a/DataRepo/forms.py
+++ b/DataRepo/forms.py
@@ -165,7 +165,8 @@ class AdvSearchPageForm(forms.Form):
         choices=ROWS_PER_PAGE_CHOICES,
         # TODO: Can probably get the caret in the button image using:
         #   https://stackoverflow.com/questions/45424162/listing-a-choicefield-in-django-as-button
-        widget=forms.Select())
+        widget=forms.Select(),
+    )
     page = forms.CharField(widget=forms.HiddenInput())
     order_by = forms.CharField(widget=forms.HiddenInput())
     order_direction = forms.CharField(widget=forms.HiddenInput())

--- a/DataRepo/multiforms.py
+++ b/DataRepo/multiforms.py
@@ -9,20 +9,7 @@ from django.views.generic.edit import ProcessFormView
 #   https://stackoverflow.com/questions/15497693/django-can-class-based-views-accept-two-forms-at-a-time
 #   https://gist.github.com/jamesbrobb/748c47f46b9bd224b07f
 
-# TODO: Re-reading the above stack post after having learned a bunch about various components of form processing, I
-# have realized a few things that I could clean up in here.  First of all, the original code requires that the submit
-# button be named "action" and its "value" must match a form_name that is used as keys in the form_classes dict.
-# However, that form processing only works if the submit button is what submits the form.  E.g. if a user hits enter in
-# another form field, it won't work correctly.  The reason my changes work is because first, I haven't configured the
-# pre-existing code correctly, so it never gets into the various form processing methods and gets to my mixed form
-# check.  I am checking data member values for a "mixed" form.  A "mixed" form is 3 different form classes (all with
-# the same form fields) that are all wrapped in one form tag.  Now, I have added another form type (AdvSearchPageForm)
-# and it needs to be called as an individual form.  Code I added to views to use an additional paging form
-# (AdvSearchPageForm) uses a strategy similar to the original intent of this code.  It identifies a form by one of its
-# input names.  I need to refactor a number of things to make multiforms work correctly and handle my mixed form case
-# AND the page form.  Note the submit button form identification strategy won't work for the mixed forms since they all
-# have the same named fields and don't always use a button to submit, but if I add a hidden field and set its value to
-# identify the form, that would work.
+# TODO: Issue #370 refactor multiforms.py and views.AdvSearchView
 
 
 class MultiFormMixin(ContextMixin):

--- a/DataRepo/pager.py
+++ b/DataRepo/pager.py
@@ -12,6 +12,7 @@ class Pager:
         rows_per_page_field,
         order_by_field,
         order_dir_field,
+        form_name,  # Relies on multiforms
         num_buttons=5,
         other_fields=[],
         # Default form values
@@ -21,7 +22,6 @@ class Pager:
         rows_input_id="pager-rows-elem",
         orderby_input_id="pager-orderby-elem",
         orderdir_input_id="pager-orderdir-elem",
-        form_name="paging",  # Relies on multiforms
         form_id="custom-paging",
         rows_attrs={
             "class": "btn btn-primary dropdown-toggle",
@@ -39,7 +39,7 @@ class Pager:
         self.orderdir_input_id = orderdir_input_id
         self.rows_attrs = rows_attrs
         self.page_form = self.page_form_class()
-        self.page_form.new(
+        self.page_form.update(
             self.page_input_id,
             self.rows_input_id,
             self.orderby_input_id,
@@ -62,7 +62,7 @@ class Pager:
             if self.min_rows_per_page is None or num < self.min_rows_per_page:
                 self.min_rows_per_page = num
 
-    def new(
+    def update(
         self,
         tot=None,
         page=1,
@@ -73,6 +73,11 @@ class Pager:
         order_dir=None,
         other_field_dict=None,
     ):
+        """
+        This method is used to update the pager object for each new current page being sent to the pagination template
+        """
+
+        # Make sure rows, start, and end are set
         if rows is None:
             rows = self.default_rows
         if start is None:
@@ -85,6 +90,8 @@ class Pager:
                 self.end = tot
         else:
             self.end = end
+
+        # Set the member variables
         self.page = page
         self.rows = rows
         self.tot = tot
@@ -116,7 +123,7 @@ class Pager:
                 init_dict[fld] = other_field_dict[fld]
         kwargs = {"initial": init_dict}
         self.page_form = self.page_form_class(**kwargs)
-        self.page_form.new(
+        self.page_form.update(
             self.page_input_id,
             self.rows_input_id,
             self.orderby_input_id,

--- a/DataRepo/pager.py
+++ b/DataRepo/pager.py
@@ -14,11 +14,9 @@ class Pager:
         order_dir_field,
         num_buttons=5,
         other_fields=[],
-
         # Default form values
         default_rows=10,
-
-        #Default form element attributes
+        # Default form element attributes
         page_input_id="pager-page-elem",
         rows_input_id="pager-rows-elem",
         orderby_input_id="pager-orderby-elem",
@@ -41,7 +39,13 @@ class Pager:
         self.orderdir_input_id = orderdir_input_id
         self.rows_attrs = rows_attrs
         self.page_form = self.page_form_class()
-        self.page_form.new(self.page_input_id, self.rows_input_id, self.orderby_input_id, self.orderdir_input_id, self.rows_attrs)
+        self.page_form.new(
+            self.page_input_id,
+            self.rows_input_id,
+            self.orderby_input_id,
+            self.orderdir_input_id,
+            self.rows_attrs,
+        )
         self.rows_per_page_choices = rows_per_page_choices
         self.page_field = page_field
         self.rows_per_page_field = rows_per_page_field
@@ -112,7 +116,13 @@ class Pager:
                 init_dict[fld] = other_field_dict[fld]
         kwargs = {"initial": init_dict}
         self.page_form = self.page_form_class(**kwargs)
-        self.page_form.new(self.page_input_id, self.rows_input_id, self.orderby_input_id, self.orderdir_input_id, self.rows_attrs)
+        self.page_form.new(
+            self.page_input_id,
+            self.rows_input_id,
+            self.orderby_input_id,
+            self.orderdir_input_id,
+            self.rows_attrs,
+        )
 
         # Set up the paging controls
         if tot is not None:

--- a/DataRepo/pager.py
+++ b/DataRepo/pager.py
@@ -14,9 +14,15 @@ class Pager:
         order_dir_field,
         num_buttons=5,
         other_fields=[],
+
+        # Default form values
         default_rows=10,
+
+        #Default form element attributes
         page_input_id="pager-page-elem",
         rows_input_id="pager-rows-elem",
+        orderby_input_id="pager-orderby-elem",
+        orderdir_input_id="pager-orderdir-elem",
         form_name="paging",  # Relies on multiforms
         form_id="custom-paging",
         rows_attrs={
@@ -31,9 +37,11 @@ class Pager:
         self.page_form_class = page_form_class
         self.page_input_id = page_input_id
         self.rows_input_id = rows_input_id
+        self.orderby_input_id = orderby_input_id
+        self.orderdir_input_id = orderdir_input_id
         self.rows_attrs = rows_attrs
         self.page_form = self.page_form_class()
-        self.page_form.new(self.page_input_id, self.rows_input_id, self.rows_attrs)
+        self.page_form.new(self.page_input_id, self.rows_input_id, self.orderby_input_id, self.orderdir_input_id, self.rows_attrs)
         self.rows_per_page_choices = rows_per_page_choices
         self.page_field = page_field
         self.rows_per_page_field = rows_per_page_field
@@ -57,8 +65,8 @@ class Pager:
         rows=None,
         start=None,
         end=None,
-        order_by="placeholder",
-        order_dir="placeholder",
+        order_by=None,
+        order_dir=None,
         other_field_dict=None,
     ):
         if rows is None:
@@ -104,7 +112,7 @@ class Pager:
                 init_dict[fld] = other_field_dict[fld]
         kwargs = {"initial": init_dict}
         self.page_form = self.page_form_class(**kwargs)
-        self.page_form.new(self.page_input_id, self.rows_input_id, self.rows_attrs)
+        self.page_form.new(self.page_input_id, self.rows_input_id, self.orderby_input_id, self.orderdir_input_id, self.rows_attrs)
 
         # Set up the paging controls
         if tot is not None:

--- a/DataRepo/templates/DataRepo/search/results/display.html
+++ b/DataRepo/templates/DataRepo/search/results/display.html
@@ -16,10 +16,22 @@
         function set_template_cookie(name, val) {
             set_cookie(selfmt + "." + name, val);
         }
+
+        function updateAllColumnSwitchingCookies() {
+            var hidarray = $("#advsrchres").bootstrapTable('getHiddenColumns')
+            for (const item of hidarray) {
+                set_template_cookie(item["field"] + "-data-visible", false)
+            }
+            var visarray = $("#advsrchres").bootstrapTable('getVisibleColumns')
+            for (const item of visarray) {
+                set_template_cookie(item["field"] + "-data-visible", true)
+            }
+        }
     </script>
 {% endblock %}
 
 {% block content %}
+
     <div>
         {% define True as valid_search %}
         {% define default_format as selfmt %}
@@ -48,6 +60,9 @@
             <hr>
 
             {% if valid_search %}
+                <div style="margin-left: 16px; float: right;">
+                    <button class="btn btn-primary mb-2" id="reset" title="Reset Page Settings" onclick="restoreDefaults()"><i class="fa">Reset</i></button>
+                </div>
                 <div style="float: right;">
                     <form action="/DataRepo/search_advanced_tsv/" id="advanced-search-download-form" method="POST">
                         {% csrf_token %}

--- a/DataRepo/templates/DataRepo/search/results/display.html
+++ b/DataRepo/templates/DataRepo/search/results/display.html
@@ -2,6 +2,10 @@
 
 {% block head_extras %}
     <script>
+        // This is the selected format saved in javascript form for the purpose of cookie naming so that there are no
+        // collisions between formats for user settings.  The selected format is determined via template tags below
+        // using the qry object, the format URL parameter and the default_format context variable.  It's validated using
+        // forms.keys.
         var selfmt = ""
 
         // Set a Cookie
@@ -14,7 +18,11 @@
         }
 
         function set_template_cookie(name, val) {
-            set_cookie(selfmt + "." + name, val);
+            if (typeof selfmt !== "undefined" && selfmt && selfmt !== "") {
+                set_cookie(selfmt + "." + name, val);
+            } else {
+                console.error("selfmt is undefined.  Unable to set cookie for the current format.")
+            }
         }
 
         function updateAllColumnSwitchingCookies() {

--- a/DataRepo/templates/DataRepo/search/results/display.html
+++ b/DataRepo/templates/DataRepo/search/results/display.html
@@ -2,9 +2,19 @@
 
 {% block head_extras %}
     <script>
+        var selfmt = ""
+
         // Set a Cookie
         function set_cookie(name, val) {
             document.cookie = name + "=" + val + "; path=/";
+        }
+
+        function setSelectedFormat(selfmt) {
+            globalThis.selfmt = selfmt
+        }
+
+        function set_template_cookie(name, val) {
+            set_cookie(selfmt + "." + name, val);
         }
     </script>
 {% endblock %}
@@ -67,6 +77,9 @@
             {% endif %}
             {# 'else' is just the search forms #}
         {% endif %}
+
+        <!-- This is just used for setting cookies without needing to have the set_template_cookie method in every format template -->
+        <script>setSelectedFormat("{{ selfmt }}")</script>
     </div>
 
 {% endblock %}

--- a/DataRepo/templates/DataRepo/search/results/fcirc.html
+++ b/DataRepo/templates/DataRepo/search/results/fcirc.html
@@ -4,8 +4,19 @@
     <script>
         // Inspired by: https://stackoverflow.com/questions/12455699/show-hide-table-column-with-colspan-using-jquery
 
-        // Correct the row count to account for M:M related tables
         document.addEventListener("DOMContentLoaded", function(){
+            // https://bootstrap-table.com/docs/api/events/
+            // https://bootstrap-table.com/docs/api/events/#oncolumnswitch
+            $("#advsrchres").bootstrapTable({
+                onAll: function() {
+                    updateColumnSwitching()
+                    updateRowSwitching()
+                    updateColumnSortControls()
+                    updateAllColumnSwitchingCookies()
+                }
+                // I did have an onColumnSwitch here to set cookies, but it doesn't handle the "Toggle All" control, so I added a call to updateAllColumnSwitchingCookies in onAll
+            })
+
             $("#showaverage").on("click", function(e) {
                 var acbv = $(this).is(":checked")
                 var icbv = $("#showintact").is(":checked")
@@ -56,20 +67,6 @@
                 }
 
                 updateColumnSwitching()
-            })
-
-            // https://bootstrap-table.com/docs/api/events/
-            // https://bootstrap-table.com/docs/api/events/#oncolumnswitch
-            $("#advsrchres").bootstrapTable({
-                onAll: function() {
-                    updateColumnSwitching()
-                    updateRowSwitching()
-                },
-                onColumnSwitch: function(field, checked) {
-                    set_template_cookie(field + '-data-visible', checked)
-                    // This is to update the server-side sort controls after a column switch
-                    setupColumnSort()
-                }
             })
 
             $("#showra").on("click", function(e) {

--- a/DataRepo/templates/DataRepo/search/results/fcirc.html
+++ b/DataRepo/templates/DataRepo/search/results/fcirc.html
@@ -67,6 +67,8 @@
                 },
                 onColumnSwitch: function(field, checked) {
                     set_template_cookie(field + '-data-visible', checked)
+                    // This is to update the server-side sort controls after a column switch
+                    setupColumnSort()
                 }
             })
 

--- a/DataRepo/templates/DataRepo/search/results/fcirc.html
+++ b/DataRepo/templates/DataRepo/search/results/fcirc.html
@@ -361,28 +361,72 @@
                 <th colspan="2" class="intact nonorm">Mouse<br>Normalized<br>(nM/m)</th>
             </tr>
             <tr>
-                <th data-valign="top" data-visible="{% get_template_cookie selfmt 'Animal-data-visible' 'true' %}" data-field="Animal">Animal</th>
-                <th data-valign="top" data-visible="{% get_template_cookie selfmt 'Studies-data-visible' 'true' %}" data-field="Studies">Studies</th>
-                <th data-valign="top" data-visible="{% get_template_cookie selfmt 'Genotype-data-visible' 'true' %}" data-field="Genotype">Genotype</th>
-                <th data-valign="top" data-visible="{% get_template_cookie selfmt 'Body_Weight-data-visible' 'false' %}" data-field="Body_Weight">Body<br>Weight<br>(g)</th>
-                <th data-valign="top" data-visible="{% get_template_cookie selfmt 'Age-data-visible' 'false' %}" data-field="Age">Age<br>(weeks)</th>
-                <th data-valign="top" data-visible="{% get_template_cookie selfmt 'Sex-data-visible' 'false' %}" data-field="Sex">Sex</th>
-                <th data-valign="top" data-visible="{% get_template_cookie selfmt 'Diet-data-visible' 'false' %}" data-field="Diet">Diet</th>
-                <th data-valign="top" data-visible="{% get_template_cookie selfmt 'Feeding_Status-data-visible' 'true' %}" data-field="Feeding_Status">Feeding<br>Status</th>
-                <th data-valign="top" data-visible="{% get_template_cookie selfmt 'Treatment-data-visible' 'true' %}" data-field="Treatment">Treatment</th>
-                <th data-valign="top" data-visible="{% get_template_cookie selfmt 'Tracer_Compound-data-visible' 'true' %}" data-field="Tracer_Compound">Tracer<br>Compound</th>
-                <th data-valign="top" data-visible="{% get_template_cookie selfmt 'Labeled_Element-data-visible' 'false' %}" data-field="Labeled_Element">Labeled<br>Element</th>
-                <th data-valign="top" data-visible="{% get_template_cookie selfmt 'Tracer_Infusion_Rate-data-visible' 'true' %}" data-field="Tracer_Infusion_Rate">Tracer<br>Infusion<br>Rate<br>(ul/m/g)</th>
-                <th data-valign="top" data-visible="{% get_template_cookie selfmt 'Tracer_Infusion_Concentration-data-visible' 'true' %}" data-field="Tracer_Infusion_Concentration">Tracer Infusion<br>Concentration<br>(mM)</th>
-                <th data-valign="top" data-visible="{% get_template_cookie selfmt 'Time_Collected-data-visible' 'true' %}" data-field="Time_Collected">Time<br>Collected<br>(m)</th>
-                <th data-valign="top" data-visible="true" data-switchable="false" data-field="Average_Weight_Normalized_Ra" data-title-tooltip="Average_Weight_Normalized_Ra" class="average weight ra">Ra</th>
-                <th data-valign="top" data-visible="true" data-switchable="false" data-field="Average_Weight_Normalized_Rd" data-title-tooltip="Average_Weight_Normalized_Rd" class="average weight rd">Rd</th>
-                <th data-valign="top" data-visible="true" data-switchable="false" data-field="Average_Mouse_Normalized_Ra" data-title-tooltip="Average_Mouse_Normalized_Ra" class="average nonorm ra">Ra</th>
-                <th data-valign="top" data-visible="true" data-switchable="false" data-field="Average_Mouse_Normalized_Rd" data-title-tooltip="Average_Mouse_Normalized_Rd" class="average nonorm rd">Rd</th>
-                <th data-valign="top" data-visible="true" data-switchable="false" data-field="Intact_Weight_Normalized_Ra" data-title-tooltip="Intact_Weight_Normalized_Ra" class="intact weight ra">Ra</th>
-                <th data-valign="top" data-visible="true" data-switchable="false" data-field="Intact_Weight_Normalized_Rd" data-title-tooltip="Intact_Weight_Normalized_Rd" class="intact weight rd">Rd</th>
-                <th data-valign="top" data-visible="true" data-switchable="false" data-field="Intact_Mouse_Normalized_Ra" data-title-tooltip="Intact_Mouse_Normalized_Ra" class="intact nonorm ra">Ra</th>
-                <th data-valign="top" data-visible="true" data-switchable="false" data-field="Intact_Mouse_Normalized_Rd" data-title-tooltip="Intact_Mouse_Normalized_Rd" class="intact nonorm rd">Rd</th>
+                <th data-valign="top" data-visible="{% get_template_cookie selfmt 'Animal-data-visible' 'true' %}" data-field="Animal">
+                    Animal<div onclick="sortColumn(this)" class="sortable" id="msrun__sample__animal__name"></div>
+                </th>
+                <th data-valign="top" data-visible="{% get_template_cookie selfmt 'Studies-data-visible' 'true' %}" data-field="Studies">
+                    Studies
+                </th>
+                <th data-valign="top" data-visible="{% get_template_cookie selfmt 'Genotype-data-visible' 'true' %}" data-field="Genotype">
+                    <div onclick="sortColumn(this)" class="sortable" id="msrun__sample__animal__genotype" >Genotype</div>
+                </th>
+                <th data-valign="top" data-visible="{% get_template_cookie selfmt 'Body_Weight-data-visible' 'false' %}" data-field="Body_Weight">
+                    <div onclick="sortColumn(this)" class="sortable" id="msrun__sample__animal__body_weight" >Body<br>Weight<br>(g)</div>
+                </th>
+                <th data-valign="top" data-visible="{% get_template_cookie selfmt 'Age-data-visible' 'false' %}" data-field="Age">
+                    <div onclick="sortColumn(this)" class="sortable" id="msrun__sample__animal__age" >Age<br>(weeks)</div>
+                </th>
+                <th data-valign="top" data-visible="{% get_template_cookie selfmt 'Sex-data-visible' 'false' %}" data-field="Sex">
+                    <div onclick="sortColumn(this)" class="sortable" id="msrun__sample__animal__sex" >Sex</div>
+                </th>
+                <th data-valign="top" data-visible="{% get_template_cookie selfmt 'Diet-data-visible' 'false' %}" data-field="Diet">
+                    <div onclick="sortColumn(this)" class="sortable" id="msrun__sample__animal__diet" >Diet</div>
+                </th>
+                <th data-valign="top" data-visible="{% get_template_cookie selfmt 'Feeding_Status-data-visible' 'true' %}" data-field="Feeding_Status">
+                    <div onclick="sortColumn(this)" class="sortable" id="msrun__sample__animal__feeding_status" >Feeding<br>Status</div>
+                </th>
+                <th data-valign="top" data-visible="{% get_template_cookie selfmt 'Treatment-data-visible' 'true' %}" data-field="Treatment">
+                    <div onclick="sortColumn(this)" class="sortable" id="msrun__sample__animal__treatment__name" >Treatment</div>
+                </th>
+                <th data-valign="top" data-visible="{% get_template_cookie selfmt 'Tracer_Compound-data-visible' 'true' %}" data-field="Tracer_Compound">
+                    <div onclick="sortColumn(this)" class="sortable" id="msrun__sample__animal__tracer_compound__name" >Tracer<br>Compound</div>
+                </th>
+                <th data-valign="top" data-visible="{% get_template_cookie selfmt 'Labeled_Element-data-visible' 'false' %}" data-field="Labeled_Element">
+                    <div onclick="sortColumn(this)" class="sortable" id="msrun__sample__animal__tracer_labeled_atom" >Labeled<br>Element</div>
+                </th>
+                <th data-valign="top" data-visible="{% get_template_cookie selfmt 'Tracer_Infusion_Rate-data-visible' 'true' %}" data-field="Tracer_Infusion_Rate">
+                    <div onclick="sortColumn(this)" class="sortable" id="msrun__sample__animal__tracer_infusion_rate" >Tracer<br>Infusion<br>Rate<br>(ul/m/g)</div>
+                </th>
+                <th data-valign="top" data-visible="{% get_template_cookie selfmt 'Tracer_Infusion_Concentration-data-visible' 'true' %}" data-field="Tracer_Infusion_Concentration">
+                    <div onclick="sortColumn(this)" class="sortable" id="msrun__sample__animal__tracer_infusion_concentration" >Tracer Infusion<br>Concentration<br>(mM)</div>
+                </th>
+                <th data-valign="top" data-visible="{% get_template_cookie selfmt 'Time_Collected-data-visible' 'true' %}" data-field="Time_Collected">
+                    <div onclick="sortColumn(this)" class="sortable" id="msrun__sample__time_collected" >Time<br>Collected<br>(m)</div>
+                </th>
+                <th data-valign="top" data-visible="true" data-switchable="false" data-field="Average_Weight_Normalized_Ra" data-title-tooltip="Average_Weight_Normalized_Ra" class="average weight ra">
+                    Ra
+                </th>
+                <th data-valign="top" data-visible="true" data-switchable="false" data-field="Average_Weight_Normalized_Rd" data-title-tooltip="Average_Weight_Normalized_Rd" class="average weight rd">
+                    Rd
+                </th>
+                <th data-valign="top" data-visible="true" data-switchable="false" data-field="Average_Mouse_Normalized_Ra" data-title-tooltip="Average_Mouse_Normalized_Ra" class="average nonorm ra">
+                    Ra
+                </th>
+                <th data-valign="top" data-visible="true" data-switchable="false" data-field="Average_Mouse_Normalized_Rd" data-title-tooltip="Average_Mouse_Normalized_Rd" class="average nonorm rd">
+                    Rd
+                </th>
+                <th data-valign="top" data-visible="true" data-switchable="false" data-field="Intact_Weight_Normalized_Ra" data-title-tooltip="Intact_Weight_Normalized_Ra" class="intact weight ra">
+                    Ra
+                </th>
+                <th data-valign="top" data-visible="true" data-switchable="false" data-field="Intact_Weight_Normalized_Rd" data-title-tooltip="Intact_Weight_Normalized_Rd" class="intact weight rd">
+                    Rd
+                </th>
+                <th data-valign="top" data-visible="true" data-switchable="false" data-field="Intact_Mouse_Normalized_Ra" data-title-tooltip="Intact_Mouse_Normalized_Ra" class="intact nonorm ra">
+                    Ra
+                </th>
+                <th data-valign="top" data-visible="true" data-switchable="false" data-field="Intact_Mouse_Normalized_Rd" data-title-tooltip="Intact_Mouse_Normalized_Rd" class="intact nonorm rd">
+                    Rd
+                </th>
             </tr>
         </thead>
 

--- a/DataRepo/templates/DataRepo/search/results/fcirc.html
+++ b/DataRepo/templates/DataRepo/search/results/fcirc.html
@@ -362,10 +362,10 @@
             </tr>
             <tr>
                 <th data-valign="top" data-visible="{% get_template_cookie selfmt 'Animal-data-visible' 'true' %}" data-field="Animal">
-                    Animal<div onclick="sortColumn(this)" class="sortable" id="msrun__sample__animal__name"></div>
+                    <div onclick="sortColumn(this)" class="sortable" id="msrun__sample__animal__name">Animal</div>
                 </th>
                 <th data-valign="top" data-visible="{% get_template_cookie selfmt 'Studies-data-visible' 'true' %}" data-field="Studies">
-                    Studies
+                    <div onclick="sortColumn(this)" class="sortable" id="msrun__sample__animal__studies__name">Studies</div>
                 </th>
                 <th data-valign="top" data-visible="{% get_template_cookie selfmt 'Genotype-data-visible' 'true' %}" data-field="Genotype">
                     <div onclick="sortColumn(this)" class="sortable" id="msrun__sample__animal__genotype" >Genotype</div>

--- a/DataRepo/templates/DataRepo/search/results/fcirc.html
+++ b/DataRepo/templates/DataRepo/search/results/fcirc.html
@@ -236,10 +236,6 @@
                 }
             })
         }
-
-        function set_template_cookie(name, val) {
-            set_cookie("{{ selfmt }}" + "." + name, val);
-        }
     </script>
 {% endblock %}
 {% block content %}

--- a/DataRepo/templates/DataRepo/search/results/peakdata.html
+++ b/DataRepo/templates/DataRepo/search/results/peakdata.html
@@ -34,6 +34,14 @@
                 $("#advsrchres .datadata").attr("span", datadata_cnt)
                 $("#advsrchres .metadata").attr("span", metadata_cnt)
             }
+
+            $("#advsrchres").bootstrapTable({
+                onColumnSwitch: function(field, checked) {
+                    alert("Resetting column sort controls for " + field + ":" + checked)
+                    set_template_cookie(field + '-data-visible', checked)
+                    setupColumnSort()
+                }
+            })
         })
 
         function set_template_cookie(name, val) {
@@ -66,33 +74,83 @@
 
         <thead>
             <tr>
-                <th data-valign="top" class="idgrp" data-visible="{% get_template_cookie selfmt 'Animal-data-visible' 'false' %}" data-field="Animal">Animal</th>
-                <th data-valign="top" class="idgrp" data-visible="{% get_template_cookie selfmt 'Sample-data-visible' 'true' %}" data-field="Sample" data-switchable="false">Sample</th>
-                <th data-valign="top" class="idgrp" data-visible="{% get_template_cookie selfmt 'Tissue-data-visible' 'true' %}" data-field="Tissue">Tissue</th>
-                <th data-valign="top" class="idgrp" data-visible="{% get_template_cookie selfmt 'Peak_Group-data-visible' 'false' %}" data-field="Peak_Group">Peak Group</th>
-                <th data-valign="top" class="idgrp" data-visible="{% get_template_cookie selfmt 'Measured_Compounds-data-visible' 'true' %}" data-field="Measured_Compounds">Measured<br>Compound(s)</th>
-                <th data-valign="top" class="idgrp" data-visible="{% get_template_cookie selfmt 'Measured_Compound_Synonyms-data-visible' 'false' %}" data-field="Measured_Compound_Synonyms">Measured<br>Compound<br>Synonym(s)</th>
-                <th data-valign="top" class="idgrp" data-visible="{% get_template_cookie selfmt 'Labeled_Element_Count-data-visible' 'true' %}" data-field="Labeled_Element_Count">Labeled<br>Element:<br>Count</th>
-                <th data-valign="top" class="idgrp" data-visible="{% get_template_cookie selfmt 'Peak_Group_Set_Filename-data-visible' 'false' %}" data-field="Peak_Group_Set_Filename">Peak Group Set Filename</th>
+                <th data-valign="top" class="idgrp" data-visible="{% get_template_cookie selfmt 'Animal-data-visible' 'false' %}" data-field="Animal">
+                    <div onclick="sortColumn(this)" class="sortable" id="peak_group__msrun__sample__animal__name">Animal</div>
+                </th>
+                <th data-valign="top" class="idgrp" data-visible="{% get_template_cookie selfmt 'Sample-data-visible' 'true' %}" data-field="Sample" data-switchable="false">
+                    <div onclick="sortColumn(this)" class="sortable" id="peak_group__msrun__sample__name">Sample</div>
+                </th>
+                <th data-valign="top" class="idgrp" data-visible="{% get_template_cookie selfmt 'Tissue-data-visible' 'true' %}" data-field="Tissue">
+                    <div onclick="sortColumn(this)" class="sortable" id="peak_group__msrun__sample__tissue__name">Tissue</div>
+                </th>
+                <th data-valign="top" class="idgrp" data-visible="{% get_template_cookie selfmt 'Peak_Group-data-visible' 'false' %}" data-field="Peak_Group">
+                    <div onclick="sortColumn(this)" class="sortable" id="peak_group__name">Peak Group</div>
+                </th>
+                <th data-valign="top" class="idgrp" data-visible="{% get_template_cookie selfmt 'Measured_Compounds-data-visible' 'true' %}" data-field="Measured_Compounds">
+                    Measured<br>Compound(s)
+                </th>
+                <th data-valign="top" class="idgrp" data-visible="{% get_template_cookie selfmt 'Measured_Compound_Synonyms-data-visible' 'false' %}" data-field="Measured_Compound_Synonyms">
+                    Measured<br>Compound<br>Synonym(s)
+                </th>
+                <th data-valign="top" class="idgrp" data-visible="{% get_template_cookie selfmt 'Labeled_Element_Count-data-visible' 'true' %}" data-field="Labeled_Element_Count">
+                    <div onclick="sortColumn(this)" class="sortable" id="labeled_element">Labeled<br>Element:<br></div><div onclick="sortColumn(this)" class="sortable" id="labeled_count">Count</div>
+                </th>
+                <th data-valign="top" class="idgrp" data-visible="{% get_template_cookie selfmt 'Peak_Group_Set_Filename-data-visible' 'false' %}" data-field="Peak_Group_Set_Filename">
+                    <div onclick="sortColumn(this)" class="sortable" id="peak_group__peak_group_set__filename">Peak Group Set Filename</div>
+                </th>
 
-                <th data-valign="top" class="datagrp" data-visible="{% get_template_cookie selfmt 'Raw_Abundance-data-visible' 'false' %}" data-field="Raw_Abundance">Raw<br>Abundance</th>
-                <th data-valign="top" class="datagrp" data-visible="{% get_template_cookie selfmt 'Corrected_Abundance-data-visible' 'true' %}" data-field="Corrected_Abundance">Corrected<br>Abundance</th>
-                <th data-valign="top" class="datagrp" data-visible="{% get_template_cookie selfmt 'Fraction-data-visible' 'true' %}" data-field="Fraction" data-switchable="false">Fraction</th>
-                <th data-valign="top" class="datagrp" data-visible="{% get_template_cookie selfmt 'Median_MZ-data-visible' 'false' %}" data-field="Median_MZ">Median<br>M/Z</th>
-                <th data-valign="top" class="datagrp" data-visible="{% get_template_cookie selfmt 'Median_RT-data-visible' 'false' %}" data-field="Median_RT">Median<br>RT</th>
+                <th data-valign="top" class="datagrp" data-visible="{% get_template_cookie selfmt 'Raw_Abundance-data-visible' 'false' %}" data-field="Raw_Abundance">
+                    <div onclick="sortColumn(this)" class="sortable" id="raw_abundance">Raw<br>Abundance</div>
+                </th>
+                <th data-valign="top" class="datagrp" data-visible="{% get_template_cookie selfmt 'Corrected_Abundance-data-visible' 'true' %}" data-field="Corrected_Abundance">
+                    <div onclick="sortColumn(this)" class="sortable" id="corrected_abundance">Corrected<br>Abundance</div>
+                </th>
+                <th data-valign="top" class="datagrp" data-visible="{% get_template_cookie selfmt 'Fraction-data-visible' 'true' %}" data-field="Fraction" data-switchable="false">
+                    Fraction
+                </th>
+                <th data-valign="top" class="datagrp" data-visible="{% get_template_cookie selfmt 'Median_MZ-data-visible' 'false' %}" data-field="Median_MZ">
+                    <div onclick="sortColumn(this)" class="sortable" id="med_mz">Median<br>M/Z</div>
+                </th>
+                <th data-valign="top" class="datagrp" data-visible="{% get_template_cookie selfmt 'Median_RT-data-visible' 'false' %}" data-field="Median_RT">
+                    <div onclick="sortColumn(this)" class="sortable" id="med_rt">Median<br>RT</div>
+                </th>
 
-                <th data-valign="top" class="metagrp" data-visible="{% get_template_cookie selfmt 'Formula-data-visible' 'false' %}" data-field="Formula">Formula</th>
-                <th data-valign="top" class="metagrp" data-visible="{% get_template_cookie selfmt 'Genotype-data-visible' 'true' %}" data-field="Genotype">Genotype</th>
-                <th data-valign="top" class="metagrp" data-visible="{% get_template_cookie selfmt 'Sex-data-visible' 'false' %}" data-field="Sex">Sex</th>
-                <th data-valign="top" class="metagrp" data-visible="{% get_template_cookie selfmt 'Age-data-visible' 'false' %}" data-field="Age">Age<br>(weeks)</th>
-                <th data-valign="top" class="metagrp" data-visible="{% get_template_cookie selfmt 'Body_Weight-data-visible' 'false' %}" data-field="Body_Weight">Body<br>Weight<br>(g)</th>
-                <th data-valign="top" class="metagrp" data-visible="{% get_template_cookie selfmt 'Feeding_Status-data-visible' 'true' %}" data-field="Feeding_Status">Feeding<br>Status</th>
-                <th data-valign="top" class="metagrp" data-visible="{% get_template_cookie selfmt 'Treatment-data-visible' 'true' %}" data-field="Treatment">Treatment</th>
-                <th data-valign="top" class="metagrp" data-visible="{% get_template_cookie selfmt 'Diet-data-visible' 'false' %}" data-field="Diet">Diet</th>
-                <th data-valign="top" class="metagrp" data-visible="{% get_template_cookie selfmt 'Tracer_Compound-data-visible' 'true' %}" data-field="Tracer_Compound" data-switchable="false">Tracer<br>Compound</th>
-                <th data-valign="top" class="metagrp" data-visible="{% get_template_cookie selfmt 'Tracer_Infusion_Rate-data-visible' 'false' %}" data-field="Tracer_Infusion_Rate">Tracer<br>Infusion<br>Rate<br>(ul/min/g)</th>
-                <th data-valign="top" class="metagrp" data-visible="{% get_template_cookie selfmt 'Tracer_Infusion_Concentration-data-visible' 'false' %}" data-field="Tracer_Infusion_Concentration">Tracer<br>Infusion<br>Concentration<br>(mM)</th>
-                <th data-valign="top" class="metagrp" data-visible="{% get_template_cookie selfmt 'Study-data-visible' 'true' %}" data-field="Study">Studies</th>
+                <th data-valign="top" class="metagrp" data-visible="{% get_template_cookie selfmt 'Formula-data-visible' 'false' %}" data-field="Formula">
+                    <div onclick="sortColumn(this)" class="sortable" id="peak_group__formula">Formula</div>
+                </th>
+                <th data-valign="top" class="metagrp" data-visible="{% get_template_cookie selfmt 'Genotype-data-visible' 'true' %}" data-field="Genotype">
+                    <div onclick="sortColumn(this)" class="sortable" id="peak_group__msrun__sample__animal__genotype">Genotype</div>
+                </th>
+                <th data-valign="top" class="metagrp" data-visible="{% get_template_cookie selfmt 'Sex-data-visible' 'false' %}" data-field="Sex">
+                    <div onclick="sortColumn(this)" class="sortable" id="peak_group__msrun__sample__animal__sex">Sex</div>
+                </th>
+                <th data-valign="top" class="metagrp" data-visible="{% get_template_cookie selfmt 'Age-data-visible' 'false' %}" data-field="Age">
+                    <div onclick="sortColumn(this)" class="sortable" id="peak_group__msrun__sample__animal__age">Age<br>(weeks)</div>
+                </th>
+                <th data-valign="top" class="metagrp" data-visible="{% get_template_cookie selfmt 'Body_Weight-data-visible' 'false' %}" data-field="Body_Weight">
+                    <div onclick="sortColumn(this)" class="sortable" id="peak_group__msrun__sample__animal__body_weight">Body<br>Weight<br>(g)</div>
+                </th>
+                <th data-valign="top" class="metagrp" data-visible="{% get_template_cookie selfmt 'Feeding_Status-data-visible' 'true' %}" data-field="Feeding_Status">
+                    <div onclick="sortColumn(this)" class="sortable" id="peak_group__msrun__sample__animal__feeding_status">Feeding<br>Status</div>
+                </th>
+                <th data-valign="top" class="metagrp" data-visible="{% get_template_cookie selfmt 'Treatment-data-visible' 'true' %}" data-field="Treatment">
+                    <div onclick="sortColumn(this)" class="sortable" id="peak_group__msrun__treatment__name">Treatment</div>
+                </th>
+                <th data-valign="top" class="metagrp" data-visible="{% get_template_cookie selfmt 'Diet-data-visible' 'false' %}" data-field="Diet">
+                    <div onclick="sortColumn(this)" class="sortable" id="peak_group__msrun__sample__animal__diet">Diet</div>
+                </th>
+                <th data-valign="top" class="metagrp" data-visible="{% get_template_cookie selfmt 'Tracer_Compound-data-visible' 'true' %}" data-field="Tracer_Compound" data-switchable="false">
+                    <div onclick="sortColumn(this)" class="sortable" id="peak_group__msrun__sample__animal__tracer_compound__name">Tracer<br>Compound</div>
+                </th>
+                <th data-valign="top" class="metagrp" data-visible="{% get_template_cookie selfmt 'Tracer_Infusion_Rate-data-visible' 'false' %}" data-field="Tracer_Infusion_Rate">
+                    <div onclick="sortColumn(this)" class="sortable" id="peak_group__msrun__sample__animal__tracer_infusion_rate">Tracer<br>Infusion<br>Rate<br>(ul/min/g)</div>
+                </th>
+                <th data-valign="top" class="metagrp" data-visible="{% get_template_cookie selfmt 'Tracer_Infusion_Concentration-data-visible' 'false' %}" data-field="Tracer_Infusion_Concentration">
+                    <div onclick="sortColumn(this)" class="sortable" id="peak_group__msrun__sample__animal__tracer_infusion_concentration">Tracer<br>Infusion<br>Concentration<br>(mM)</div>
+                </th>
+                <th data-valign="top" class="metagrp" data-visible="{% get_template_cookie selfmt 'Study-data-visible' 'true' %}" data-field="Study">
+                    Studies
+                </th>
             </tr>
         </thead>
 
@@ -220,6 +278,11 @@
                         <p title="{{ pd.peak_group.msrun.sample.animal.age }} (d-hh:mm:ss)">{{ pd.peak_group.msrun.sample.animal.age|durationToWeeks|decimalPlaces:2 }}</p>
                     </td>
 
+                    <!-- Body Weight (g) -->
+                    <td>
+                        {{ pd.peak_group.msrun.sample.animal.body_weight }}
+                    </td>
+
                     <!-- Feeding Status -->
                     <td>
                         {{ pd.peak_group.msrun.sample.animal.feeding_status }}
@@ -227,17 +290,18 @@
 
                     <!-- Treatment -->
                     <td>
-                        {{ pd.peak_group.msrun.treatment.name }}
+                        {% if pd.peak_group.msrun.treatment.name is None %}
+                            <!-- Put displayed link text first for sorting -->
+                            <div style="display:none;">None</div>
+                            <p title="Animal has no treatment.">None</p>
+                        {% else %}
+                            {{ pd.peak_group.msrun.treatment.name }}
+                        {% endif %}
                     </td>
 
                     <!-- Diet -->
                     <td>
                         {{ pd.peak_group.msrun.sample.animal.diet }}
-                    </td>
-
-                    <!-- Body Weight (g) -->
-                    <td>
-                        {{ pd.peak_group.msrun.sample.animal.body_weight }}
                     </td>
 
                     <!-- Tracer Compound -->

--- a/DataRepo/templates/DataRepo/search/results/peakdata.html
+++ b/DataRepo/templates/DataRepo/search/results/peakdata.html
@@ -9,12 +9,10 @@
             $("#advsrchres").bootstrapTable({
                 onAll: function() {
                     updateColumnGroups()
-                },
-                onColumnSwitch: function(field, checked) {
-                    set_template_cookie(field + '-data-visible', checked)
-                    // This is to update the server-side sort controls after a column switch
-                    setupColumnSort()
+                    updateColumnSortControls()
+                    updateAllColumnSwitchingCookies()
                 }
+                // I did have an onColumnSwitch here to set cookies, but it doesn't handle the "Toggle All" control, so I added a call to updateAllColumnSwitchingCookies in onAll
             })
 
             function updateColumnGroups() {

--- a/DataRepo/templates/DataRepo/search/results/peakdata.html
+++ b/DataRepo/templates/DataRepo/search/results/peakdata.html
@@ -43,10 +43,6 @@
                 }
             })
         })
-
-        function set_template_cookie(name, val) {
-            set_cookie("{{ selfmt }}" + "." + name, val);
-        }
     </script>
     <script src="https://cdn.jsdelivr.net/gh/wenzhixin/bootstrap-table-examples@master/utils/natural-sorting/dist/natural-sorting.js"></script>
 

--- a/DataRepo/templates/DataRepo/search/results/peakdata.html
+++ b/DataRepo/templates/DataRepo/search/results/peakdata.html
@@ -12,6 +12,8 @@
                 },
                 onColumnSwitch: function(field, checked) {
                     set_template_cookie(field + '-data-visible', checked)
+                    // This is to update the server-side sort controls after a column switch
+                    setupColumnSort()
                 }
             })
 
@@ -34,14 +36,6 @@
                 $("#advsrchres .datadata").attr("span", datadata_cnt)
                 $("#advsrchres .metadata").attr("span", metadata_cnt)
             }
-
-            $("#advsrchres").bootstrapTable({
-                onColumnSwitch: function(field, checked) {
-                    alert("Resetting column sort controls for " + field + ":" + checked)
-                    set_template_cookie(field + '-data-visible', checked)
-                    setupColumnSort()
-                }
-            })
         })
     </script>
     <script src="https://cdn.jsdelivr.net/gh/wenzhixin/bootstrap-table-examples@master/utils/natural-sorting/dist/natural-sorting.js"></script>

--- a/DataRepo/templates/DataRepo/search/results/peakdata.html
+++ b/DataRepo/templates/DataRepo/search/results/peakdata.html
@@ -87,10 +87,10 @@
                     <div onclick="sortColumn(this)" class="sortable" id="peak_group__name">Peak Group</div>
                 </th>
                 <th data-valign="top" class="idgrp" data-visible="{% get_template_cookie selfmt 'Measured_Compounds-data-visible' 'true' %}" data-field="Measured_Compounds">
-                    Measured<br>Compound(s)
+                    <div onclick="sortColumn(this)" class="sortable" id="peak_group__compounds__name">Measured<br>Compound(s)</div>
                 </th>
                 <th data-valign="top" class="idgrp" data-visible="{% get_template_cookie selfmt 'Measured_Compound_Synonyms-data-visible' 'false' %}" data-field="Measured_Compound_Synonyms">
-                    Measured<br>Compound<br>Synonym(s)
+                    <div onclick="sortColumn(this)" class="sortable" id="peak_group__compounds__synonyms__name">Measured<br>Compound<br>Synonym(s)</div>
                 </th>
                 <th data-valign="top" class="idgrp" data-visible="{% get_template_cookie selfmt 'Labeled_Element_Count-data-visible' 'true' %}" data-field="Labeled_Element_Count">
                     <div onclick="sortColumn(this)" class="sortable" id="labeled_element">Labeled<br>Element:<br></div><div onclick="sortColumn(this)" class="sortable" id="labeled_count">Count</div>
@@ -149,7 +149,7 @@
                     <div onclick="sortColumn(this)" class="sortable" id="peak_group__msrun__sample__animal__tracer_infusion_concentration">Tracer<br>Infusion<br>Concentration<br>(mM)</div>
                 </th>
                 <th data-valign="top" class="metagrp" data-visible="{% get_template_cookie selfmt 'Study-data-visible' 'true' %}" data-field="Study">
-                    Studies
+                    <div onclick="sortColumn(this)" class="sortable" id="peak_group__msrun__sample__animal__studies__name">Studies</div>
                 </th>
             </tr>
         </thead>

--- a/DataRepo/templates/DataRepo/search/results/peakgroups.html
+++ b/DataRepo/templates/DataRepo/search/results/peakgroups.html
@@ -10,11 +10,10 @@
                 onAll: function() {
                     updateColumnGroups()
                 },
-                onSort: function(name, order) {
-                    alert("PLACEHOLDER: Sorting " + name + " in " + order + " order")
-                },
                 onColumnSwitch: function(field, checked) {
                     set_template_cookie(field + '-data-visible', checked)
+                    // This is to update the server-side sort controls after a column switch
+                    setupColumnSort()
                 }
             })
 

--- a/DataRepo/templates/DataRepo/search/results/peakgroups.html
+++ b/DataRepo/templates/DataRepo/search/results/peakgroups.html
@@ -9,12 +9,10 @@
             $("#advsrchres").bootstrapTable({
                 onAll: function() {
                     updateColumnGroups()
-                },
-                onColumnSwitch: function(field, checked) {
-                    set_template_cookie(field + '-data-visible', checked)
-                    // This is to update the server-side sort controls after a column switch
-                    setupColumnSort()
+                    updateColumnSortControls()
+                    updateAllColumnSwitchingCookies()
                 }
+                // I did have an onColumnSwitch here to set cookies, but it doesn't handle the "Toggle All" control, so I added a call to updateAllColumnSwitchingCookies in onAll
             })
 
             function updateColumnGroups() {

--- a/DataRepo/templates/DataRepo/search/results/peakgroups.html
+++ b/DataRepo/templates/DataRepo/search/results/peakgroups.html
@@ -38,10 +38,6 @@
                 $("#advsrchres .metadata").attr("span", metadata_cnt)
             }
         })
-
-        function set_template_cookie(name, val) {
-            set_cookie("{{ selfmt }}" + "." + name, val);
-        }
     </script>
     <script src="https://cdn.jsdelivr.net/gh/wenzhixin/bootstrap-table-examples@master/utils/natural-sorting/dist/natural-sorting.js"></script>
 

--- a/DataRepo/templates/DataRepo/search/results/peakgroups.html
+++ b/DataRepo/templates/DataRepo/search/results/peakgroups.html
@@ -69,32 +69,80 @@
 
         <thead>
             <tr>
-                <th data-valign="top" data-visible="{% get_template_cookie selfmt 'Animal-data-visible' 'false' %}" data-field="Animal" class="idgrp">Animal</th>
-                <th data-valign="top" data-visible="{% get_template_cookie selfmt 'Sample-data-visible' 'true' %}" data-field="Sample" class="idgrp" data-switchable="false">Sample</th>
-                <th data-valign="top" data-visible="{% get_template_cookie selfmt 'Tissue-data-visible' 'true' %}" data-field="Tissue" class="idgrp">Tissue</th>
-                <th data-valign="top" data-visible="{% get_template_cookie selfmt 'Peak_Group-data-visible' 'false' %}" data-field="Peak_Group" class="idgrp">Peak Group</th>
-                <th data-valign="top" data-visible="{% get_template_cookie selfmt 'Compound_Name-data-visible' 'true' %}" data-field="Compound_Name" class="idgrp">Measured<br>Compound</th>
-                <th data-valign="top" data-visible="{% get_template_cookie selfmt 'Compound_Synonym-data-visible' 'false' %}" data-field="Compound_Synonym" class="idgrp">Measured<br>Compound<br>Synonym(s)</th>
-                <th data-valign="top" data-visible="{% get_template_cookie selfmt 'Labeled_Element-data-visible' 'true' %}" data-field="Labeled_Element" class="idgrp">Labeled<br>Element</th>
-                <th data-valign="top" data-visible="{% get_template_cookie selfmt 'Peak_Group_Set_Filename-data-visible' 'false' %}" data-field="Peak_Group_Set_Filename" class="idgrp">Peak Group Set Filename</th>
+                <th data-valign="top" data-visible="{% get_template_cookie selfmt 'Animal-data-visible' 'false' %}" data-field="Animal" class="idgrp">
+                    <div onclick="sortColumn(this)" class="sortable" id="msrun__sample__animal__name">Animal</div>
+                </th>
+                <th data-valign="top" data-visible="{% get_template_cookie selfmt 'Sample-data-visible' 'true' %}" data-field="Sample" class="idgrp" data-switchable="false">
+                    <div onclick="sortColumn(this)" class="sortable" id="msrun__sample__name">Sample</div>
+                </th>
+                <th data-valign="top" data-visible="{% get_template_cookie selfmt 'Tissue-data-visible' 'true' %}" data-field="Tissue" class="idgrp">
+                    <div onclick="sortColumn(this)" class="sortable" id="msrun__sample__tissue__name">Tissue</div>
+                </th>
+                <th data-valign="top" data-visible="{% get_template_cookie selfmt 'Peak_Group-data-visible' 'false' %}" data-field="Peak_Group" class="idgrp">
+                    <div onclick="sortColumn(this)" class="sortable" id="name">Peak Group</div>
+                </th>
+                <th data-valign="top" data-visible="{% get_template_cookie selfmt 'Compound_Name-data-visible' 'true' %}" data-field="Compound_Name" class="idgrp">
+                    <div onclick="sortColumn(this)" class="sortable" id="compounds__name">Measured<br>Compound</div>
+                </th>
+                <th data-valign="top" data-visible="{% get_template_cookie selfmt 'Compound_Synonym-data-visible' 'false' %}" data-field="Compound_Synonym" class="idgrp">
+                    <div onclick="sortColumn(this)" class="sortable" id="compounds__synonyms__name">Measured<br>Compound<br>Synonym(s)</div>
+                </th>
+                <th data-valign="top" data-visible="{% get_template_cookie selfmt 'Labeled_Element-data-visible' 'true' %}" data-field="Labeled_Element" class="idgrp">
+                    <div onclick="sortColumn(this)" class="sortable" id="msrun__sample__animal__tracer_labeled_atom">Labeled<br>Element</div>
+                </th>
+                <th data-valign="top" data-visible="{% get_template_cookie selfmt 'Peak_Group_Set_Filename-data-visible' 'false' %}" data-field="Peak_Group_Set_Filename" class="idgrp">
+                    <div onclick="sortColumn(this)" class="sortable" id="peak_group_set__filename">Peak Group Set Filename</div>
+                </th>
 
-                <th data-valign="top" data-visible="{% get_template_cookie selfmt 'Total_Abundance-data-visible' 'true' %}" data-field="Total_Abundance" class="datagrp" data-switchable="false">Total<br>Abundance</th>
-                <th data-valign="top" data-visible="{% get_template_cookie selfmt 'Enrichment_Fraction-data-visible' 'true' %}" data-field="Enrichment_Fraction" class="datagrp">Enrichment<br>Fraction</th>
-                <th data-valign="top" data-visible="{% get_template_cookie selfmt 'Enrichment_Abundance-data-visible' 'true' %}" data-field="Enrichment_Abundance" class="datagrp">Enrichment<br>Abundance</th>
-                <th data-valign="top" data-visible="{% get_template_cookie selfmt 'Normalized_Labeling-data-visible' 'true' %}" data-field="Normalized_Labeling" class="datagrp">Normalized<br>Labeling</th>
+                <th data-valign="top" data-visible="{% get_template_cookie selfmt 'Total_Abundance-data-visible' 'true' %}" data-field="Total_Abundance" class="datagrp" data-switchable="false">
+                    Total<br>Abundance
+                </th>
+                <th data-valign="top" data-visible="{% get_template_cookie selfmt 'Enrichment_Fraction-data-visible' 'true' %}" data-field="Enrichment_Fraction" class="datagrp">
+                    Enrichment<br>Fraction
+                </th>
+                <th data-valign="top" data-visible="{% get_template_cookie selfmt 'Enrichment_Abundance-data-visible' 'true' %}" data-field="Enrichment_Abundance" class="datagrp">
+                    Enrichment<br>Abundance
+                </th>
+                <th data-valign="top" data-visible="{% get_template_cookie selfmt 'Normalized_Labeling-data-visible' 'true' %}" data-field="Normalized_Labeling" class="datagrp">
+                    Normalized<br>Labeling
+                </th>
 
-                <th data-valign="top" data-visible="{% get_template_cookie selfmt 'Formula-data-visible' 'false' %}" data-field="Formula" class="metagrp">Formula</th>
-                <th data-valign="top" data-visible="{% get_template_cookie selfmt 'Genotype-data-visible' 'true' %}" data-field="Genotype" class="metagrp">Genotype</th>
-                <th data-valign="top" data-visible="{% get_template_cookie selfmt 'Sex-data-visible' 'false' %}" data-field="Sex" class="metagrp">Sex</th>
-                <th data-valign="top" data-visible="{% get_template_cookie selfmt 'Feeding_Status-data-visible' 'true' %}" data-field="Feeding_Status" class="metagrp">Feeding<br>Status</th>
-                <th data-valign="top" data-visible="{% get_template_cookie selfmt 'Diet-data-visible' 'false' %}" data-field="Diet" class="metagrp">Diet</th>
-                <th data-valign="top" data-visible="{% get_template_cookie selfmt 'Treatment-data-visible' 'true' %}" data-field="Treatment" class="metagrp">Treatment</th>
-                <th data-valign="top" data-visible="{% get_template_cookie selfmt 'Body_Weight-data-visible' 'false' %}" data-field="Body_Weight" class="metagrp">Body<br>Weight<br>(g)</th>
-                <th data-valign="top" data-visible="{% get_template_cookie selfmt 'Age-data-visible' 'false' %}" data-field="Age" class="metagrp">Age<br>(weeks)</th>
-                <th data-valign="top" data-visible="{% get_template_cookie selfmt 'Tracer_Compound-data-visible' 'true' %}" data-field="Tracer_Compound" class="metagrp" data-switchable="false">Tracer<br>Compound</th>
-                <th data-valign="top" data-visible="{% get_template_cookie selfmt 'Tracer_Infusion_Rate-data-visible' 'false' %}" data-field="Tracer_Infusion_Rate" class="metagrp">Tracer<br>Infusion<br>Rate<br>(ul/min/g)</th>
-                <th data-valign="top" data-visible="{% get_template_cookie selfmt 'Tracer_Infusion_Concentration-data-visible' 'false' %}" data-field="Tracer_Infusion_Concentration" class="metagrp">Tracer<br>Infusion<br>Concentration<br>(mM)</th>
-                <th data-valign="top" data-visible="{% get_template_cookie selfmt 'Study-data-visible' 'true' %}" data-field="Study" class="metagrp">Studies</th>
+                <th data-valign="top" data-visible="{% get_template_cookie selfmt 'Formula-data-visible' 'false' %}" data-field="Formula" class="metagrp">
+                    <div onclick="sortColumn(this)" class="sortable" id="formula">Formula</div>
+                </th>
+                <th data-valign="top" data-visible="{% get_template_cookie selfmt 'Genotype-data-visible' 'true' %}" data-field="Genotype" class="metagrp">
+                    <div onclick="sortColumn(this)" class="sortable" id="msrun__sample__animal__genotype">Genotype</div>
+                </th>
+                <th data-valign="top" data-visible="{% get_template_cookie selfmt 'Sex-data-visible' 'false' %}" data-field="Sex" class="metagrp">
+                    <div onclick="sortColumn(this)" class="sortable" id="msrun__sample__animal__sex">Sex</div>
+                </th>
+                <th data-valign="top" data-visible="{% get_template_cookie selfmt 'Feeding_Status-data-visible' 'true' %}" data-field="Feeding_Status" class="metagrp">
+                    <div onclick="sortColumn(this)" class="sortable" id="msrun__sample__animal__feeding_status">Feeding<br>Status</div>
+                </th>
+                <th data-valign="top" data-visible="{% get_template_cookie selfmt 'Diet-data-visible' 'false' %}" data-field="Diet" class="metagrp">
+                    <div onclick="sortColumn(this)" class="sortable" id="msrun__sample__animal__diet">Diet</div>
+                </th>
+                <th data-valign="top" data-visible="{% get_template_cookie selfmt 'Treatment-data-visible' 'true' %}" data-field="Treatment" class="metagrp">
+                    <div onclick="sortColumn(this)" class="sortable" id="msrun__sample__animal__treatment__name">Treatment</div>
+                </th>
+                <th data-valign="top" data-visible="{% get_template_cookie selfmt 'Body_Weight-data-visible' 'false' %}" data-field="Body_Weight" class="metagrp">
+                    <div onclick="sortColumn(this)" class="sortable" id="msrun__sample__animal__body_weight">Body<br>Weight<br>(g)</div>
+                </th>
+                <th data-valign="top" data-visible="{% get_template_cookie selfmt 'Age-data-visible' 'false' %}" data-field="Age" class="metagrp">
+                    <div onclick="sortColumn(this)" class="sortable" id="msrun__sample__animal__age">Age<br>(weeks)</div>
+                </th>
+                <th data-valign="top" data-visible="{% get_template_cookie selfmt 'Tracer_Compound-data-visible' 'true' %}" data-field="Tracer_Compound" class="metagrp" data-switchable="false">
+                    <div onclick="sortColumn(this)" class="sortable" id="msrun__sample__animal__tracer_compound__name">Tracer<br>Compound</div>
+                </th>
+                <th data-valign="top" data-visible="{% get_template_cookie selfmt 'Tracer_Infusion_Rate-data-visible' 'false' %}" data-field="Tracer_Infusion_Rate" class="metagrp">
+                    <div onclick="sortColumn(this)" class="sortable" id="msrun__sample__animal__tracer_infusion_rate">Tracer<br>Infusion<br>Rate<br>(ul/min/g)</div>
+                </th>
+                <th data-valign="top" data-visible="{% get_template_cookie selfmt 'Tracer_Infusion_Concentration-data-visible' 'false' %}" data-field="Tracer_Infusion_Concentration" class="metagrp">
+                    <div onclick="sortColumn(this)" class="sortable" id="msrun__sample__animal__tracer_infusion_concentration">Tracer<br>Infusion<br>Concentration<br>(mM)</div>
+                </th>
+                <th data-valign="top" data-visible="{% get_template_cookie selfmt 'Study-data-visible' 'true' %}" data-field="Study" class="metagrp">
+                    <div onclick="sortColumn(this)" class="sortable" id="msrun__sample__animal__studies__name">Studies</div>
+                </th>
             </tr>
         </thead>
 

--- a/DataRepo/templates/pagination.html
+++ b/DataRepo/templates/pagination.html
@@ -136,23 +136,19 @@
         }
     </script>
 
-    {% if pager.tot|gt:pager.min_rows_per_page %}
-        <div class="fixed-table-pagination" style="padding-top: 10px;">
-    {% else %}
-        {% comment %} We need at least a hidden form to support server side sorting {% endcomment %}
-        <div class="fixed-table-pagination" style="display:none;">
-    {% endif %}
-            <form action="{{ pager.action }}" id="{{ pager.form_id }}" name="{{ pager.form_name }}" method="POST">
-                {% csrf_token %}
-                {{ pager.page_form.qryjson }}
-                {{ pager.page_form.order_by }}
-                {{ pager.page_form.order_direction }}
-                {{ pager.page_form.page }}
-                {{ pager.page_form.adv_search_page_form }}
-                <div style="float: left;">
-                    Showing {{ pager.start }} to {{ pager.end }} of {{ pager.tot }} rows, {{ pager.page_form.rows }} rows per page
-                </div>
-    {% if pager.tot|gt:pager.rows %}
+    {% comment %} We need at least a hidden form to support server side sorting {% endcomment %}
+    <div class="fixed-table-pagination" style="{% if pager.tot|gt:pager.min_rows_per_page %}padding-top: 10px;{% else %}display:none;{% endif %}">
+        <form action="{{ pager.action }}" id="{{ pager.form_id }}" name="{{ pager.form_name }}" method="POST">
+            {% csrf_token %}
+            {{ pager.page_form.qryjson }}
+            {{ pager.page_form.order_by }}
+            {{ pager.page_form.order_direction }}
+            {{ pager.page_form.page }}
+            {{ pager.page_form.adv_search_page_form }}
+            <div style="float: left;">
+                Showing {{ pager.start }} to {{ pager.end }} of {{ pager.tot }} rows, {{ pager.page_form.rows }} rows per page
+            </div>
+            {% if pager.tot|gt:pager.rows %}
                 <div style="float: right;">
                     <nav aria-label="Page navigation">
                         <ul class="pagination">
@@ -176,7 +172,7 @@
                         </ul>
                     </nav>
                 </div>
-    {% endif %}
+            {% endif %}
         </form>
     </div>
 {% endif %}

--- a/DataRepo/templates/pagination.html
+++ b/DataRepo/templates/pagination.html
@@ -27,22 +27,123 @@
                 rowselem.addEventListener("change", function (event) {
                     set_template_cookie("{{ pager.rows_per_page_field }}", event.target.value)
                     setPage(1)
-                    myform.submit();
+                    submitForm()
                 })
             }
+
+            setupColumnSort()
         })
 
+        function setupColumnSort() {
+            // Add sort controls to every sortable column header (div around th contents with class 'sortable')
+            //$('.sortable').addClass('both');
+
+            // The column ID must match the database field path contained in the pager's order_by member variable, e.g. "peak_group__msrun__sample__animal__name"
+            sorted_column_id = "{{ pager.order_by }}"
+            sorted_dir = {% if pager.order_dir is None %}"undefined"{% else %}"{{ pager.order_dir }}"{% endif %}
+
+            // Check that the sorted column ID is valid
+            sorted_column_elem = document.getElementById(sorted_column_id)
+            if (typeof sorted_column_elem === "undefined" || !sorted_column_elem) {
+                if (sorted_column_id !== "" && sorted_column_id !== "None") {
+                    alert("ERROR: Could not find sortable div element with the ID " + sorted_column_id + ".  Make sure a div element containing the class 'sortable' and the given ID exists in the template.  Abandonning sorted column control settings.")
+                }
+                // Else: No explicit sort exists, all columns should be "both"
+                console.warn("Sort column not set: " + sorted_column_id + " Element:",sorted_column_elem)
+            } else {
+                // We know which column is sorted.  Now let's figure out the direction to know what class to set for the icon controls.
+                // alert("Sorting column: " + sorted_column_id + " " + sorted_dir)
+                console.log("Before applying sort class changes:", sorted_column_elem)
+            }
+
+            console.log("Setting sort controls for sorted element " + sorted_column_id + "...")
+
+            $('.sortable').each(function() {
+                var elem_id = this.id
+                console.log("Setting sort controls for element " + elem_id, this)
+                if (elem_id === sorted_column_id) {
+                    // I think bootstrap table's javascript is adding "both" on page load...
+                    this.classList.remove("both")
+                    console.log("Adding asc or desc")
+                    if (sorted_dir === "undefined" || !sorted_dir || sorted_dir === "asc") {
+                        this.classList.add("asc")
+                    } else if (sorted_dir === "desc") {
+                        this.classList.add("desc")
+                    } else {
+                        alert("Invalid order by direction [" + sorted_dir + "].  Must be None, 'asc', or 'desc'.  Abandonning sorted column control settings.")
+                    }
+                } else {
+                    console.log("Adding both")
+                    this.classList.add('both')
+                }
+            })
+            {% comment %} console.log("After applying sort class changes:", sorted_column_elem) {% endcomment %}
+        }
+
+        function sortColumn(elem) {
+            isBoth = $(elem).hasClass("both")
+            isAsc = $(elem).hasClass("asc")
+            isDesc = $(elem).hasClass("desc")
+
+            sort_col_id = elem.id
+
+            if (isBoth) {
+                alert("Current sort is both")
+                setPage(1)
+                setOrderBy(sort_col_id)
+                setOrderDir("asc")
+            } else if (isAsc) {
+                alert("Current sort is asc")
+                setOrderBy(sort_col_id)
+                setOrderDir("desc")
+            } else if (isDesc){
+                alert("Current sort is desc")
+                setOrderBy(sort_col_id)
+                setOrderDir("asc")
+            } else {
+                // This should not happen
+                alert("ERROR: sortColumn called from an element (ID: " + sort_col_id + ") that is not set up for sorting.  Make sure sortColumn is being called from an element containing the sortable class.")
+                return
+            }
+
+            submitForm()
+        }
+
+        function submitForm() {
+            var myform = document.getElementById("{{ pager.form_id }}")
+            myform.submit();
+        }
+
+        function setOrderBy(field_path) {
+            setPageFormValue("{{ pager.orderby_input_id }}", field_path)
+        }
+
+        function setOrderDir(dir) {
+            setPageFormValue("{{ pager.orderdir_input_id }}", dir)
+        }
+
         function setPage(pagenum){
-            // The "pager-page-elem" ID is set in for django form class
-            var pageelem = document.getElementById("{{ pager.page_input_id }}")
-            if (typeof pageelem !== 'undefined' && pageelem) {
-                pageelem.value = pagenum;
+            setPageFormValue("{{ pager.page_input_id }}", pagenum)
+        }
+
+        function setPageFormValue(elem_id, val) {
+            var input_elem = document.getElementById(elem_id)
+            if (typeof input_elem !== 'undefined' && input_elem) {
+                console.log("Setting " + elem_id + " to " + val)
+                input_elem.value = val;
+                console.log("New value is ", input_elem)
+            } else {
+                alert("Could not find page form input element: " + elem_id + ".  Make sure the input element's ID is set to this value.")
             }
         }
     </script>
 
     {% if pager.tot|gt:pager.min_rows_per_page %}
         <div class="fixed-table-pagination" style="padding-top: 10px;">
+    {% else %}
+        {% comment %} We need at least a hidden form to support server side sorting {% endcomment %}
+        <div class="fixed-table-pagination" style="display:none;">
+    {% endif %}
             <form action="{{ pager.action }}" id="{{ pager.form_id }}" name="{{ pager.form_name }}" method="POST">
                 {% csrf_token %}
                 {{ pager.page_form.qryjson }}
@@ -53,7 +154,6 @@
                 <div style="float: left;">
                     Showing {{ pager.start }} to {{ pager.end }} of {{ pager.tot }} rows, {{ pager.page_form.rows }} rows per page
                 </div>
-    {% endif %}
     {% if pager.tot|gt:pager.rows %}
                 <div style="float: right;">
                     <nav aria-label="Page navigation">
@@ -79,8 +179,6 @@
                     </nav>
                 </div>
     {% endif %}
-    {% if pager.tot|gt:pager.min_rows_per_page %}
-            </form>
-        </div>
-    {% endif %}
+        </form>
+    </div>
 {% endif %}

--- a/DataRepo/templates/pagination.html
+++ b/DataRepo/templates/pagination.html
@@ -31,12 +31,11 @@
                 })
             }
 
-            setupColumnSort()
+            updateColumnSortControls()
         })
 
-        function setupColumnSort() {
+        function updateColumnSortControls() {
             // Add sort controls to every sortable column header (div around th contents with class 'sortable')
-            //$('.sortable').addClass('both');
 
             // The column ID must match the database field path contained in the pager's order_by member variable, e.g. "peak_group__msrun__sample__animal__name"
             sorted_column_id = "{{ pager.order_by }}"
@@ -49,22 +48,14 @@
                     alert("ERROR: Could not find sortable div element with the ID " + sorted_column_id + ".  Make sure a div element containing the class 'sortable' and the given ID exists in the template.  Abandonning sorted column control settings.")
                 }
                 // Else: No explicit sort exists, all columns should be "both"
-                console.warn("Sort column not set: " + sorted_column_id + " Element:",sorted_column_elem)
-            } else {
-                // We know which column is sorted.  Now let's figure out the direction to know what class to set for the icon controls.
-                // alert("Sorting column: " + sorted_column_id + " " + sorted_dir)
-                console.log("Before applying sort class changes:", sorted_column_elem)
+                console.log("Sort column not set")
             }
-
-            console.log("Setting sort controls for sorted element " + sorted_column_id + "...")
 
             $('.sortable').each(function() {
                 var elem_id = this.id
-                console.log("Setting sort controls for element " + elem_id, this)
                 if (elem_id === sorted_column_id) {
                     // I think bootstrap table's javascript is adding "both" on page load...
                     this.classList.remove("both")
-                    console.log("Adding asc or desc")
                     if (sorted_dir === "undefined" || !sorted_dir || sorted_dir === "asc") {
                         this.classList.add("asc")
                     } else if (sorted_dir === "desc") {
@@ -73,11 +64,9 @@
                         alert("Invalid order by direction [" + sorted_dir + "].  Must be None, 'asc', or 'desc'.  Abandonning sorted column control settings.")
                     }
                 } else {
-                    console.log("Adding both")
                     this.classList.add('both')
                 }
             })
-            {% comment %} console.log("After applying sort class changes:", sorted_column_elem) {% endcomment %}
         }
 
         function sortColumn(elem) {
@@ -88,16 +77,13 @@
             sort_col_id = elem.id
 
             if (isBoth) {
-                alert("Current sort is both")
                 setPage(1)
                 setOrderBy(sort_col_id)
                 setOrderDir("asc")
             } else if (isAsc) {
-                alert("Current sort is asc")
                 setOrderBy(sort_col_id)
                 setOrderDir("desc")
             } else if (isDesc){
-                alert("Current sort is desc")
                 setOrderBy(sort_col_id)
                 setOrderDir("asc")
             } else {
@@ -129,12 +115,24 @@
         function setPageFormValue(elem_id, val) {
             var input_elem = document.getElementById(elem_id)
             if (typeof input_elem !== 'undefined' && input_elem) {
-                console.log("Setting " + elem_id + " to " + val)
                 input_elem.value = val;
-                console.log("New value is ", input_elem)
             } else {
                 alert("Could not find page form input element: " + elem_id + ".  Make sure the input element's ID is set to this value.")
             }
+        }
+
+        function restoreDefaults() {
+            // I wanted to have this inside display.html, but since reloading does a GET and not a POST, the current page needs to be POSTed, so it made sense to put it here for the form POST of the current page
+            var hidarray = $("#advsrchres").bootstrapTable('getHiddenColumns')
+            for (const item of hidarray) {
+                set_template_cookie(item["field"] + "-data-visible", "__default__")
+            }
+            var visarray = $("#advsrchres").bootstrapTable('getVisibleColumns')
+            for (const item of visarray) {
+                set_template_cookie(item["field"] + "-data-visible", "__default__")
+            }
+            var myform = document.getElementById("{{ pager.form_id }}")
+            myform.submit();
         }
     </script>
 

--- a/DataRepo/templatetags/customtags.py
+++ b/DataRepo/templatetags/customtags.py
@@ -200,6 +200,8 @@ def get_template_cookie(context, template_name, cookie_name, cookie_default):
     request = context["request"]
     full_cookie_name = ".".join([template_name, cookie_name])
     result = request.COOKIES.get(full_cookie_name, cookie_default)
+    if result == "__default__":
+        result = cookie_default
     return result
 
 

--- a/DataRepo/views.py
+++ b/DataRepo/views.py
@@ -675,7 +675,9 @@ class AdvancedSearchView(MultiFormsView):
             print(f"SETTING UP BROWSE MODE WITH QRY: {qry}")
         elif (
             "qry" in context
-            and isQryObjValid(context["qry"], self.basv_metadata.getFormatNames().keys())
+            and isQryObjValid(
+                context["qry"], self.basv_metadata.getFormatNames().keys()
+            )
             and isValidQryObjPopulated(context["qry"])
             and ("res" not in context or len(context["res"]) == 0)
         ):
@@ -936,7 +938,9 @@ def performQuery(
                 if order_direction == "desc":
                     order_by = f"-{order_by}"
                 elif order_direction and order_direction != "asc":
-                    raise Exception(f"Invalid order direction: {order_direction}.  Must be 'asc' or 'desc'.")
+                    raise Exception(
+                        f"Invalid order direction: {order_direction}.  Must be 'asc' or 'desc'."
+                    )
             print(f"Ordering by {order_by}")
             res2 = res.order_by(order_by)
         else:
@@ -954,7 +958,7 @@ def performQuery(
     else:
         # Log a warning
         print("WARNING: Invalid selected format:", fmt)
-    
+
     prefetches = basv.getPrefetches(fmt)
     if prefetches is not None:
         res4 = res3.prefetch_related(*prefetches)


### PR DESCRIPTION
## Summary Change Description

I have re-introduced the ability to sort the advanced search results, only now using server-side mechanisms.  I also fixed an issue with the "toggle all" column switch control to be able to remembered from page to page.  With that, I realized that there needed to be a way to reset the column switch selections back to default, so I added a "Reset" button to the controls over the table at the top right.

Unfortunately, with server-side sort, it's no longer possible to sort the calculated field columns, because the `.order_by()` method doesn't support it.

Also fixed the peakdata column header issue.

And I reduced code redundancy by having `getAllBrowseData` call `performQuery`.

## Affected Issue Numbers

- Resolves #336
- Resolves #365

## Code Review Notes

I addressed issues from the previous PR, so you can assess those changes and re-comment in this PR if there's still an issue.

I don't like how the javascript methods are mixed among different templates.  I'd wanted to keep pagination-associated methods' calls (and definitions) in `pagination.html` and cookie-related method calls in `display.html`, but for various reasons, had to put them redundantly in the format templates.  For example, calls to updateAllColumnSwitchingCookies (which I tried to encapsulate in `display.html`) had to be in the format templates because when I tried to add a call using bootstrap table's `onAll` event in `display.html`, it never got called.  I suspect that setting that `onAll` event callback only supports a single function call.  Maybe there's a way to get around that?

I couldn't figure out how to delete cookies using javascript.  The code I found online didn't seem to work.  I'm probably getting the cookie incorrectly, which likely requires explicitly checking its expiry.

All the cookie updates now get triggered using BST's onAll event.  This annoyingly triggers a bunch of repeated updates when only a single column is switched, but there's no provided event by BST to otherwise capture the "Toggle All" event.  It may be possible to us the alternative event trigger strategy mentioned in their doc.  I'd tried using `onPostBody` too, but I think when I'd tried that, I had an unrelated bug, though I didn't try it again after finding and fixing that bug.  Ultimately, I decided it wasn't worth optimizing because it's imperceptibly fast anyway, even with the probably pointless calls (though I'm not entirely certain they are pointless).

## Checklist

- [x] All issue requirements satisfied (or no linked issues)
- [x] [Linting passes](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#linting).
- [x] [Migrations created & committed *(or no model changes)*](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#migration-process)
- [ ] [Tests implemented *(or no code changes)*](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#test-implementation)
- [x] [All tests pass](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#quality-control)
