### PR TITLE
Made the Advanced Search templates work with a barebones context

### DIFF
--- a/DataRepo/templates/DataRepo/search/query.html
+++ b/DataRepo/templates/DataRepo/search/query.html
@@ -5,120 +5,133 @@
 {% block head_extras %}
     {{ block.super }}
 
-    <!-- The hierarchical_formsets items were inspired by both:
+    {% if mode != "view" %}
 
-        - https://github.com/elo80ka/django-dynamic-formset/
-        - https://stackoverflow.com/questions/50736373/html-unlimited-hierarchy-input-to-form
+        <!-- The hierarchical_formsets items were inspired by both:
 
-        The 2 were incompatible, so the result is a re-implementation of the stack one to add to the first one in pure javascript.
+            - https://github.com/elo80ka/django-dynamic-formset/
+            - https://stackoverflow.com/questions/50736373/html-unlimited-hierarchy-input-to-form
 
-    -->
+            The 2 were incompatible, so the result is a re-implementation of the stack one to add to the first one in pure javascript.
 
-    <link href="{% static 'css/extras.css' %}" rel="stylesheet">
-    <link href="{% static 'css/hierarchical_formsets.css' %}" rel="stylesheet">
-    <script src="{% static 'js/hierarchical_formsets.js' %}"></script>
+        -->
 
-    {{ root_group|json_script:"root_group" }} <!-- unpopulated qry object -->
-    {{ ncmp_choices|json_script:"ncmp_choices" }} <!-- dynamic ncmp select list population -->
-    {{ fld_types|json_script:"fld_types" }} <!-- dynamic ncmp select list population -->
-    {{ fld_choices|json_script:"fld_choices" }} <!-- dynamic fld select list population -->
+        <link href="{% static 'css/extras.css' %}" rel="stylesheet">
+        <link href="{% static 'css/hierarchical_formsets.css' %}" rel="stylesheet">
+        <script src="{% static 'js/hierarchical_formsets.js' %}"></script>
 
-    {% if qry %}
-        <!-- qry has a value when search results are being loaded.  It is used to reconstruct the search form, so the user
-            can tweak their search.  This tag (json_script) turns the qry dict into a json-ized HTML object that is
-            consumed by javascript below, which is injests via JSON.parse. -->
+        {{ root_group|json_script:"root_group" }} <!-- unpopulated qry object -->
+        {{ ncmp_choices|json_script:"ncmp_choices" }} <!-- dynamic ncmp select list population -->
+        {{ fld_types|json_script:"fld_types" }} <!-- dynamic ncmp select list population -->
+        {{ fld_choices|json_script:"fld_choices" }} <!-- dynamic fld select list population -->
 
-        {{ qry|json_script:"initGroup" }} <!-- previous/executed qry object -->
+        {% if qry %}
+            <!-- qry has a value when search results are being loaded.  It is used to reconstruct the search form, so the user
+                can tweak their search.  This tag (json_script) turns the qry dict into a json-ized HTML object that is
+                consumed by javascript below, which is injests via JSON.parse. -->
 
-    {% endif %}
+            {{ qry|json_script:"initGroup" }} <!-- previous/executed qry object -->
 
-    <script>
-        document.addEventListener("DOMContentLoaded", function(){
+        {% endif %}
 
-            // If a search has been performed, restore the form
-            {% if qry %}
-                init(JSON.parse(document.getElementById('initGroup').textContent),
-                    JSON.parse(document.getElementById('ncmp_choices').textContent),
-                    JSON.parse(document.getElementById('fld_types').textContent),
-                    JSON.parse(document.getElementById('fld_choices').textContent))
-            {% else %}
-                init(JSON.parse(document.getElementById('root_group').textContent),
-                    JSON.parse(document.getElementById('ncmp_choices').textContent),
-                    JSON.parse(document.getElementById('fld_types').textContent),
-                    JSON.parse(document.getElementById('fld_choices').textContent))
-                {% if format and mode and mode == "browse" and not qry %}
-                    {% if format not in forms.keys %}
-                        rootGroup.selectedtemplate = "{{ default_format }}"
-                    {% else %}
-                        rootGroup.selectedtemplate = "{{ format }}"
+        <script>
+            document.addEventListener("DOMContentLoaded", function(){
+
+                // If a search has been performed, restore the form
+                {% if qry %}
+                    init(JSON.parse(document.getElementById('initGroup').textContent),
+                        JSON.parse(document.getElementById('ncmp_choices').textContent),
+                        JSON.parse(document.getElementById('fld_types').textContent),
+                        JSON.parse(document.getElementById('fld_choices').textContent))
+                {% else %}
+                    init(JSON.parse(document.getElementById('root_group').textContent),
+                        JSON.parse(document.getElementById('ncmp_choices').textContent),
+                        JSON.parse(document.getElementById('fld_types').textContent),
+                        JSON.parse(document.getElementById('fld_choices').textContent))
+                    {% if format and mode and mode == "browse" and not qry %}
+                        {% if format not in forms.keys %}
+                            rootGroup.selectedtemplate = "{{ default_format }}"
+                        {% else %}
+                            rootGroup.selectedtemplate = "{{ format }}"
+                        {% endif %}
                     {% endif %}
                 {% endif %}
-            {% endif %}
-            const allforms = document.querySelector('.hierarchical-search')
-            initializeRootSearchQuery(allforms)
+                const allforms = document.querySelector('.hierarchical-search')
+                initializeRootSearchQuery(allforms)
 
-            var myform = document.getElementById("hierarchical-search-form")
-            myform.addEventListener("submit", function () {
-                saveSearchQueryHierarchy(document.querySelector('.hierarchical-search'))
-                myform.submit();
-            })
-
-            {% if res %}
-                var dlform = document.getElementById("advanced-search-download-form")
-                document.getElementById("advanced-download-submit").addEventListener("click", function () {
-                    dlform.submit(function (event) {
-                        // Stop form from submitting normally
-                        event.preventDefault();
-                    })
+                var myform = document.getElementById("hierarchical-search-form")
+                myform.addEventListener("submit", function () {
+                    saveSearchQueryHierarchy(document.querySelector('.hierarchical-search'))
+                    myform.submit();
                 })
-            {% endif %}
 
-        })
-    </script>
+                {% if res %}
+                    var dlform = document.getElementById("advanced-search-download-form")
+                    document.getElementById("advanced-download-submit").addEventListener("click", function () {
+                        dlform.submit(function (event) {
+                            // Stop form from submitting normally
+                            event.preventDefault();
+                        })
+                    })
+                {% endif %}
+
+            })
+        </script>
+
+    {% endif %}
 
 {% endblock %}
 
 {% block content %}
-    <div>
-        <h3>Advanced Search</h3>
+    {% if mode != "view" %}
 
-        {% for template_key in forms.keys %}
-            {% with forms|index:template_key as frm %}
-                <!-- Form template for the given output format from django's forms.py -->
-                {% with frm.empty_form as f %}
-                    <div id="{{ template_key }}" style="display:none;">
-                        {{ f.pos }}
-                        {{ f.static }}
-                        {{ f.fld }}
-                        {{ f.ncmp }}
-                        {{ f.val }}
-                        <label class="text-danger"> {{ f.val.errors }} </label>
-                    </div>
+        <div>
+            <h3>Advanced Search</h3>
+
+            {% for template_key in forms.keys %}
+                {% with forms|index:template_key as frm %}
+                    <!-- Form template for the given output format from django's forms.py -->
+                    {% with frm.empty_form as f %}
+                        <div id="{{ template_key }}" style="display:none;">
+                            {{ f.pos }}
+                            {{ f.static }}
+                            {{ f.fld }}
+                            {{ f.ncmp }}
+                            {{ f.val }}
+                            <label class="text-danger"> {{ f.val.errors }} </label>
+                        </div>
+                    {% endwith %}
                 {% endwith %}
-            {% endwith %}
-        {% endfor %}
+            {% endfor %}
 
-        <form action="/DataRepo/search_advanced/" id="hierarchical-search-form" method="POST">
-            {% csrf_token %}
-            <div class="hierarchical-search"></div>
-            <button type="submit" class="btn btn-primary" id="advanced-search-submit" name="advanced-search-submit">Search</button>
-            <!-- There are multiple form types, but we only need one set of form management inputs. We can get away with this because all the fields are the same. -->
-            {% with forms|index:default_format as managing_form %}
-                {{ managing_form.errors.val }}
-                {{ managing_form.management_form }}
-            {% endwith %}
-            <label id="formerror" class="text-danger temporal-text">{{ error }}</label>
-        </form>
-        <a id="browselink" href="{% url 'search_advanced' %}?mode=browse" class="tiny">Browse All</a>
-    </div>
+            <form action="/DataRepo/search_advanced/" id="hierarchical-search-form" method="POST">
+                {% csrf_token %}
+                <div class="hierarchical-search"></div>
+                <button type="submit" class="btn btn-primary" id="advanced-search-submit" name="advanced-search-submit">Search</button>
+                <!-- There are multiple form types, but we only need one set of form management inputs. We can get away with this because all the fields are the same. -->
+                {% with forms|index:default_format as managing_form %}
+                    {{ managing_form.errors.val }}
+                    {{ managing_form.management_form }}
+                {% endwith %}
+                <label id="formerror" class="text-danger temporal-text">{{ error }}</label>
+            </form>
+            <a id="browselink" href="{% url 'search_advanced' %}?mode=browse" class="tiny">Browse All</a>
+        </div>
 
-    {% if debug %}
-        The following only prints in DEBUG mode, controlled by settings.DEBUG:<br>
-        {% if qry %}
-            Query: {{ qry }}
-        {% else %}
-            Query was empty
+        {% if debug %}
+            The following only prints in DEBUG mode, controlled by settings.DEBUG:<br>
+            {% if qry %}
+                Query: {{ qry }}
+            {% else %}
+                Query was empty
+            {% endif %}
         {% endif %}
+
+    {% else %}
+        <div>
+            <h3>Advanced Search Interface Disabled for This View</h3>
+            No search parameters available/provided.
+        </div>
     {% endif %}
 
     {% include "DataRepo/search/results/display.html" %}

--- a/DataRepo/templates/DataRepo/search/results/display.html
+++ b/DataRepo/templates/DataRepo/search/results/display.html
@@ -41,33 +41,44 @@
 {% block content %}
 
     <div>
-        {% define True as valid_search %}
-        {% define default_format as selfmt %}
-        {% if mode == "search" %}
-            {% if qry %}
-                {% if qry.selectedtemplate in forms.keys %}
-                    {% define forms|index:qry.selectedtemplate as selfrm %}
-                    {% if not valid_search or selfrm.0.val == "" or selfrm.0.val.errors %}
-                        {% define False as valid_search %}
+        {% if mode == "view" %}
+            {% define format as selfmt %}
+            {% if selfmt == "pgtemplate" %}
+                {% define "PeakGroups" as fmt_title %}
+            {% elif selfmt == "pdtemplate" %}
+                {% define "PeakData" as fmt_title %}
+            {% elif selfmt == "fctemplate" %}
+                {% define "FCirc" as fmt_title %}
+            {% endif %}
+        {% else %}
+            {% define True as valid_search %}
+            {% define default_format as selfmt %}
+            {% if mode == "search" %}
+                {% if qry %}
+                    {% if qry.selectedtemplate in forms.keys %}
+                        {% define forms|index:qry.selectedtemplate as selfrm %}
+                        {% if not valid_search or selfrm.0.val == "" or selfrm.0.val.errors %}
+                            {% define False as valid_search %}
+                        {% else %}
+                            {% define qry.selectedtemplate as selfmt %}
+                        {% endif %}
                     {% else %}
-                        {% define qry.selectedtemplate as selfmt %}
+                        {% define False as valid_search %}
                     {% endif %}
+                {% endif %}
+            {% else %}
+                {% if format in forms.keys %}
+                    {% define format as selfmt %}
                 {% else %}
                     {% define False as valid_search %}
                 {% endif %}
-            {% endif %}
-        {% else %}
-            {% if format in forms.keys %}
-                {% define format as selfmt %}
-            {% else %}
-                {% define False as valid_search %}
             {% endif %}
         {% endif %}
 
         {% if res %}
             <hr>
 
-            {% if valid_search %}
+            {% if mode != "view" or valid_search %}
                 <div style="margin-left: 16px; float: right;">
                     <button class="btn btn-primary mb-2" id="reset" title="Reset Page Settings" onclick="restoreDefaults()"><i class="fa">Reset</i></button>
                 </div>
@@ -82,7 +93,11 @@
                 </div>
 
                 <h3 style="margin: 0; display: inline-block;">{{ qry|getFormatName:selfmt }} Results ({{ pager.tot|default:"0" }} Rows)</h3>
+            {% elif mode == "view" %}
+                <h3 style="margin: 0; display: inline-block;">{{ fmt_title }} Static Set View ({{ res.count|default:"0" }} Rows)</h3>
+            {% endif %}
 
+            {% if mode == "view" or valid_search %}
                 {% if selfmt == "pgtemplate" %}
                     {% include "DataRepo/search/results/peakgroups.html" with selfmt=selfmt %}
                 {% elif selfmt == "pdtemplate" %}
@@ -90,11 +105,15 @@
                 {% elif selfmt == "fctemplate" %}
                     {% include "DataRepo/search/results/fcirc.html" with selfmt=selfmt %}
                 {% endif %}
-            {% else %}
+            {% endif %}
+
+            {% if mode != "view" and not valid_search %}
                 <label class="text-danger">Invalid format: {{ selfmt }}</label>
             {% endif %}
+
         {% else %}
-            {% if valid_search and mode == "browse" or qry %}
+
+            {% if mode == "view" or valid_search and mode == "browse" or qry %}
                 <hr>
                 <p>No matching records found.</p>
             {% endif %}

--- a/DataRepo/templates/DataRepo/search/results/fcirc.html
+++ b/DataRepo/templates/DataRepo/search/results/fcirc.html
@@ -11,7 +11,9 @@
                 onAll: function() {
                     updateColumnSwitching()
                     updateRowSwitching()
-                    updateColumnSortControls()
+                    {% if mode != 'view' %}
+                        updateColumnSortControls()
+                    {% endif %}
                     updateAllColumnSwitchingCookies()
                 }
                 // I did have an onColumnSwitch here to set cookies, but it doesn't handle the "Toggle All" control, so I added a call to updateAllColumnSwitchingCookies in onAll
@@ -351,76 +353,132 @@
                 <th colspan="4" class="intact">Intact</th>
             </tr>
             <tr>
-                <th colspan="2" class="average weight">Weight<br>Normalized<br>(nM/m/g)</th>
-                <th colspan="2" class="average nonorm">Mouse<br>Normalized<br>(nM/m)</th>
-                <th colspan="2" class="intact weight">Weight<br>Normalized<br>(nM/m/g)</th>
-                <th colspan="2" class="intact nonorm">Mouse<br>Normalized<br>(nM/m)</th>
+                <th colspan="2" data-sortable="false" class="average weight">Weight<br>Normalized<br>(nM/m/g)</th>
+                <th colspan="2" data-sortable="false" class="average nonorm">Mouse<br>Normalized<br>(nM/m)</th>
+                <th colspan="2" data-sortable="false" class="intact weight">Weight<br>Normalized<br>(nM/m/g)</th>
+                <th colspan="2" data-sortable="false" class="intact nonorm">Mouse<br>Normalized<br>(nM/m)</th>
             </tr>
             <tr>
-                <th data-valign="top" data-visible="{% get_template_cookie selfmt 'Animal-data-visible' 'true' %}" data-field="Animal">
-                    <div onclick="sortColumn(this)" class="sortable" id="msrun__sample__animal__name">Animal</div>
+                <th data-valign="top" data-sortable="{% if mode == 'view' %}true{% else %}false{% endif %}" data-sorter="alphanum" data-visible="{% get_template_cookie selfmt 'Animal-data-visible' 'true' %}" data-field="Animal">
+                    {% with "Animal" as colhead %}
+                        {% if mode == "view" %}{{ colhead }}{% else %}
+                            <div onclick="sortColumn(this)" class="sortable" id="msrun__sample__animal__name">{{ colhead }}</div>
+                        {% endif %}
+                    {% endwith %}
                 </th>
-                <th data-valign="top" data-visible="{% get_template_cookie selfmt 'Studies-data-visible' 'true' %}" data-field="Studies">
-                    <div onclick="sortColumn(this)" class="sortable" id="msrun__sample__animal__studies__name">Studies</div>
+                <th data-valign="top" data-sortable="{% if mode == 'view' %}true{% else %}false{% endif %}" data-sorter="alphanum" data-visible="{% get_template_cookie selfmt 'Studies-data-visible' 'true' %}" data-field="Studies">
+                    {% with "Studies" as colhead %}
+                        {% if mode == "view" %}{{ colhead }}{% else %}
+                            <div onclick="sortColumn(this)" class="sortable" id="msrun__sample__animal__studies__name">{{ colhead }}</div>
+                        {% endif %}
+                    {% endwith %}
                 </th>
-                <th data-valign="top" data-visible="{% get_template_cookie selfmt 'Genotype-data-visible' 'true' %}" data-field="Genotype">
-                    <div onclick="sortColumn(this)" class="sortable" id="msrun__sample__animal__genotype" >Genotype</div>
+                <th data-valign="top" data-sortable="{% if mode == 'view' %}true{% else %}false{% endif %}" data-sorter="alphanum" data-visible="{% get_template_cookie selfmt 'Genotype-data-visible' 'true' %}" data-field="Genotype">
+                    {% with "Genotype" as colhead %}
+                        {% if mode == "view" %}{{ colhead }}{% else %}
+                            <div onclick="sortColumn(this)" class="sortable" id="msrun__sample__animal__genotype">{{ colhead }}</div>
+                        {% endif %}
+                    {% endwith %}
                 </th>
-                <th data-valign="top" data-visible="{% get_template_cookie selfmt 'Body_Weight-data-visible' 'false' %}" data-field="Body_Weight">
-                    <div onclick="sortColumn(this)" class="sortable" id="msrun__sample__animal__body_weight" >Body<br>Weight<br>(g)</div>
+                <th data-valign="top" data-sortable="{% if mode == 'view' %}true{% else %}false{% endif %}" data-sorter="numericOnly" data-visible="{% get_template_cookie selfmt 'Body_Weight-data-visible' 'false' %}" data-field="Body_Weight">
+                    {% with "Body<br>Weight<br>(g)" as colhead %}
+                        {% if mode == "view" %}{{ colhead }}{% else %}
+                            <div onclick="sortColumn(this)" class="sortable" id="msrun__sample__animal__body_weight">{{ colhead }}</div>
+                        {% endif %}
+                    {% endwith %}
                 </th>
-                <th data-valign="top" data-visible="{% get_template_cookie selfmt 'Age-data-visible' 'false' %}" data-field="Age">
-                    <div onclick="sortColumn(this)" class="sortable" id="msrun__sample__animal__age" >Age<br>(weeks)</div>
+                <th data-valign="top" data-sortable="{% if mode == 'view' %}true{% else %}false{% endif %}" data-sorter="alphanum" data-visible="{% get_template_cookie selfmt 'Age-data-visible' 'false' %}" data-field="Age">
+                    {% with "Age<br>(weeks)" as colhead %}
+                        {% if mode == "view" %}{{ colhead }}{% else %}
+                            <div onclick="sortColumn(this)" class="sortable" id="msrun__sample__animal__age">{{ colhead }}</div>
+                        {% endif %}
+                    {% endwith %}
                 </th>
-                <th data-valign="top" data-visible="{% get_template_cookie selfmt 'Sex-data-visible' 'false' %}" data-field="Sex">
-                    <div onclick="sortColumn(this)" class="sortable" id="msrun__sample__animal__sex" >Sex</div>
+                <th data-valign="top" data-sortable="{% if mode == 'view' %}true{% else %}false{% endif %}" data-sorter="alphanum" data-visible="{% get_template_cookie selfmt 'Sex-data-visible' 'false' %}" data-field="Sex">
+                    {% with "Sex" as colhead %}
+                        {% if mode == "view" %}{{ colhead }}{% else %}
+                            <div onclick="sortColumn(this)" class="sortable" id="msrun__sample__animal__sex">{{ colhead }}</div>
+                        {% endif %}
+                    {% endwith %}
                 </th>
-                <th data-valign="top" data-visible="{% get_template_cookie selfmt 'Diet-data-visible' 'false' %}" data-field="Diet">
-                    <div onclick="sortColumn(this)" class="sortable" id="msrun__sample__animal__diet" >Diet</div>
+                <th data-valign="top" data-sortable="{% if mode == 'view' %}true{% else %}false{% endif %}" data-sorter="alphanum" data-visible="{% get_template_cookie selfmt 'Diet-data-visible' 'false' %}" data-field="Diet">
+                    {% with "Diet" as colhead %}
+                        {% if mode == "view" %}{{ colhead }}{% else %}
+                            <div onclick="sortColumn(this)" class="sortable" id="msrun__sample__animal__diet">{{ colhead }}</div>
+                        {% endif %}
+                    {% endwith %}
                 </th>
-                <th data-valign="top" data-visible="{% get_template_cookie selfmt 'Feeding_Status-data-visible' 'true' %}" data-field="Feeding_Status">
-                    <div onclick="sortColumn(this)" class="sortable" id="msrun__sample__animal__feeding_status" >Feeding<br>Status</div>
+                <th data-valign="top" data-sortable="{% if mode == 'view' %}true{% else %}false{% endif %}" data-sorter="alphanum" data-visible="{% get_template_cookie selfmt 'Feeding_Status-data-visible' 'true' %}" data-field="Feeding_Status">
+                    {% with "Feeding<br>Status" as colhead %}
+                        {% if mode == "view" %}{{ colhead }}{% else %}
+                            <div onclick="sortColumn(this)" class="sortable" id="msrun__sample__animal__feeding_status">Feeding<br>Status</div>
+                        {% endif %}
+                    {% endwith %}
                 </th>
-                <th data-valign="top" data-visible="{% get_template_cookie selfmt 'Treatment-data-visible' 'true' %}" data-field="Treatment">
-                    <div onclick="sortColumn(this)" class="sortable" id="msrun__sample__animal__treatment__name" >Treatment</div>
+                <th data-valign="top" data-sortable="{% if mode == 'view' %}true{% else %}false{% endif %}" data-sorter="alphanum" data-visible="{% get_template_cookie selfmt 'Treatment-data-visible' 'true' %}" data-field="Treatment">
+                    {% with "Treatment" as colhead %}
+                        {% if mode == "view" %}{{ colhead }}{% else %}
+                            <div onclick="sortColumn(this)" class="sortable" id="msrun__sample__animal__treatment__name">{{ colhead }}</div>
+                        {% endif %}
+                    {% endwith %}
                 </th>
-                <th data-valign="top" data-visible="{% get_template_cookie selfmt 'Tracer_Compound-data-visible' 'true' %}" data-field="Tracer_Compound">
-                    <div onclick="sortColumn(this)" class="sortable" id="msrun__sample__animal__tracer_compound__name" >Tracer<br>Compound</div>
+                <th data-valign="top" data-sortable="{% if mode == 'view' %}true{% else %}false{% endif %}" data-sorter="alphanum" data-visible="{% get_template_cookie selfmt 'Tracer_Compound-data-visible' 'true' %}" data-field="Tracer_Compound">
+                    {% with "Tracer<br>Compound" as colhead %}
+                        {% if mode == "view" %}{{ colhead }}{% else %}
+                            <div onclick="sortColumn(this)" class="sortable" id="msrun__sample__animal__tracer_compound__name">{{ colhead }}</div>
+                        {% endif %}
+                    {% endwith %}
                 </th>
-                <th data-valign="top" data-visible="{% get_template_cookie selfmt 'Labeled_Element-data-visible' 'false' %}" data-field="Labeled_Element">
-                    <div onclick="sortColumn(this)" class="sortable" id="msrun__sample__animal__tracer_labeled_atom" >Labeled<br>Element</div>
+                <th data-valign="top" data-sortable="{% if mode == 'view' %}true{% else %}false{% endif %}" data-sorter="alphanum" data-visible="{% get_template_cookie selfmt 'Labeled_Element-data-visible' 'false' %}" data-field="Labeled_Element">
+                    {% with "Labeled<br>Element" as colhead %}
+                        {% if mode == "view" %}{{ colhead }}{% else %}
+                            <div onclick="sortColumn(this)" class="sortable" id="msrun__sample__animal__tracer_labeled_atom">{{ colhead }}</div>
+                        {% endif %}
+                    {% endwith %}
                 </th>
-                <th data-valign="top" data-visible="{% get_template_cookie selfmt 'Tracer_Infusion_Rate-data-visible' 'true' %}" data-field="Tracer_Infusion_Rate">
-                    <div onclick="sortColumn(this)" class="sortable" id="msrun__sample__animal__tracer_infusion_rate" >Tracer<br>Infusion<br>Rate<br>(ul/m/g)</div>
+                <th data-valign="top" data-sortable="{% if mode == 'view' %}true{% else %}false{% endif %}" data-sorter="numericOnly" data-visible="{% get_template_cookie selfmt 'Tracer_Infusion_Rate-data-visible' 'true' %}" data-field="Tracer_Infusion_Rate">
+                    {% with "Tracer<br>Infusion<br>Rate<br>(ul/m/g)" as colhead %}
+                        {% if mode == "view" %}{{ colhead }}{% else %}
+                            <div onclick="sortColumn(this)" class="sortable" id="msrun__sample__animal__tracer_infusion_rate">{{ colhead }}</div>
+                        {% endif %}
+                    {% endwith %}
                 </th>
-                <th data-valign="top" data-visible="{% get_template_cookie selfmt 'Tracer_Infusion_Concentration-data-visible' 'true' %}" data-field="Tracer_Infusion_Concentration">
-                    <div onclick="sortColumn(this)" class="sortable" id="msrun__sample__animal__tracer_infusion_concentration" >Tracer Infusion<br>Concentration<br>(mM)</div>
+                <th data-valign="top" data-sortable="{% if mode == 'view' %}true{% else %}false{% endif %}" data-sorter="numericOnly" data-visible="{% get_template_cookie selfmt 'Tracer_Infusion_Concentration-data-visible' 'true' %}" data-field="Tracer_Infusion_Concentration">
+                    {% with "Tracer Infusion<br>Concentration<br>(mM)" as colhead %}
+                        {% if mode == "view" %}{{ colhead }}{% else %}
+                            <div onclick="sortColumn(this)" class="sortable" id="msrun__sample__animal__tracer_infusion_concentration">{{ colhead }}</div>
+                        {% endif %}
+                    {% endwith %}
                 </th>
-                <th data-valign="top" data-visible="{% get_template_cookie selfmt 'Time_Collected-data-visible' 'true' %}" data-field="Time_Collected">
-                    <div onclick="sortColumn(this)" class="sortable" id="msrun__sample__time_collected" >Time<br>Collected<br>(m)</div>
+                <th data-valign="top" data-sortable="{% if mode == 'view' %}true{% else %}false{% endif %}" data-sorter="alphanum" data-visible="{% get_template_cookie selfmt 'Time_Collected-data-visible' 'true' %}" data-field="Time_Collected">
+                    {% with "Time<br>Collected<br>(m)" as colhead %}
+                        {% if mode == "view" %}{{ colhead }}{% else %}
+                            <div onclick="sortColumn(this)" class="sortable" id="msrun__sample__time_collected">{{ colhead }}</div>
+                        {% endif %}
+                    {% endwith %}
                 </th>
-                <th data-valign="top" data-visible="true" data-switchable="false" data-field="Average_Weight_Normalized_Ra" data-title-tooltip="Average_Weight_Normalized_Ra" class="average weight ra">
+                <th data-valign="top" data-sortable="{% if mode == 'view' %}true{% else %}false{% endif %}" data-sorter="numericOnly" data-visible="true" data-switchable="false" data-field="Average_Weight_Normalized_Ra" data-title-tooltip="Average_Weight_Normalized_Ra" class="average weight ra">
                     Ra
                 </th>
-                <th data-valign="top" data-visible="true" data-switchable="false" data-field="Average_Weight_Normalized_Rd" data-title-tooltip="Average_Weight_Normalized_Rd" class="average weight rd">
+                <th data-valign="top" data-sortable="{% if mode == 'view' %}true{% else %}false{% endif %}" data-sorter="numericOnly" data-visible="true" data-switchable="false" data-field="Average_Weight_Normalized_Rd" data-title-tooltip="Average_Weight_Normalized_Rd" class="average weight rd">
                     Rd
                 </th>
-                <th data-valign="top" data-visible="true" data-switchable="false" data-field="Average_Mouse_Normalized_Ra" data-title-tooltip="Average_Mouse_Normalized_Ra" class="average nonorm ra">
+                <th data-valign="top" data-sortable="{% if mode == 'view' %}true{% else %}false{% endif %}" data-sorter="numericOnly" data-visible="true" data-switchable="false" data-field="Average_Mouse_Normalized_Ra" data-title-tooltip="Average_Mouse_Normalized_Ra" class="average nonorm ra">
                     Ra
                 </th>
-                <th data-valign="top" data-visible="true" data-switchable="false" data-field="Average_Mouse_Normalized_Rd" data-title-tooltip="Average_Mouse_Normalized_Rd" class="average nonorm rd">
+                <th data-valign="top" data-sortable="{% if mode == 'view' %}true{% else %}false{% endif %}" data-sorter="numericOnly" data-visible="true" data-switchable="false" data-field="Average_Mouse_Normalized_Rd" data-title-tooltip="Average_Mouse_Normalized_Rd" class="average nonorm rd">
                     Rd
                 </th>
-                <th data-valign="top" data-visible="true" data-switchable="false" data-field="Intact_Weight_Normalized_Ra" data-title-tooltip="Intact_Weight_Normalized_Ra" class="intact weight ra">
+                <th data-valign="top" data-sortable="{% if mode == 'view' %}true{% else %}false{% endif %}" data-sorter="numericOnly" data-visible="true" data-switchable="false" data-field="Intact_Weight_Normalized_Ra" data-title-tooltip="Intact_Weight_Normalized_Ra" class="intact weight ra">
                     Ra
                 </th>
-                <th data-valign="top" data-visible="true" data-switchable="false" data-field="Intact_Weight_Normalized_Rd" data-title-tooltip="Intact_Weight_Normalized_Rd" class="intact weight rd">
+                <th data-valign="top" data-sortable="{% if mode == 'view' %}true{% else %}false{% endif %}" data-sorter="numericOnly" data-visible="true" data-switchable="false" data-field="Intact_Weight_Normalized_Rd" data-title-tooltip="Intact_Weight_Normalized_Rd" class="intact weight rd">
                     Rd
                 </th>
-                <th data-valign="top" data-visible="true" data-switchable="false" data-field="Intact_Mouse_Normalized_Ra" data-title-tooltip="Intact_Mouse_Normalized_Ra" class="intact nonorm ra">
+                <th data-valign="top" data-sortable="{% if mode == 'view' %}true{% else %}false{% endif %}" data-sorter="numericOnly" data-visible="true" data-switchable="false" data-field="Intact_Mouse_Normalized_Ra" data-title-tooltip="Intact_Mouse_Normalized_Ra" class="intact nonorm ra">
                     Ra
                 </th>
-                <th data-valign="top" data-visible="true" data-switchable="false" data-field="Intact_Mouse_Normalized_Rd" data-title-tooltip="Intact_Mouse_Normalized_Rd" class="intact nonorm rd">
+                <th data-valign="top" data-sortable="{% if mode == 'view' %}true{% else %}false{% endif %}" data-sorter="numericOnly" data-visible="true" data-switchable="false" data-field="Intact_Mouse_Normalized_Rd" data-title-tooltip="Intact_Mouse_Normalized_Rd" class="intact nonorm rd">
                     Rd
                 </th>
             </tr>

--- a/DataRepo/templates/DataRepo/search/results/fcirc.html
+++ b/DataRepo/templates/DataRepo/search/results/fcirc.html
@@ -238,7 +238,7 @@
     </script>
 {% endblock %}
 {% block content %}
-    <div style="float: right; margin-right: 1rem;" class="buttons-toolbar"></div>
+    <div style="float: right; {% if mode == 'view' %}margin-right: 1rem;margin-bottom: 1rem;{% else %}margin-right: 1rem;{% endif %}" class="buttons-toolbar"></div>
     <div style="float: right; margin-right: 1rem;">
         <small>
             <table class="table table-highlighted-legend table-hover table-bordered">
@@ -338,11 +338,12 @@
         data-filter-control="false"
         data-search="false"
         data-show-search-clear-button="false"
-        data-show-multi-sort="true"
+        data-show-multi-sort="{% if mode == 'view' %}true{% else %}false{% endif %}"
         data-show-columns="true"
         data-show-columns-toggle-all="true"
         data-show-fullscreen="false"
-        data-show-export="false">
+        data-show-export="false"
+        data-pagination="{% if mode == 'view' %}true{% else %}false{% endif %}">
         <thead>
             <tr>
                 <th colspan="14" rowspan="2"></th>

--- a/DataRepo/templates/DataRepo/search/results/peakdata.html
+++ b/DataRepo/templates/DataRepo/search/results/peakdata.html
@@ -9,7 +9,9 @@
             $("#advsrchres").bootstrapTable({
                 onAll: function() {
                     updateColumnGroups()
-                    updateColumnSortControls()
+                    {% if mode != 'view' %}
+                        updateColumnSortControls()
+                    {% endif %}
                     updateAllColumnSwitchingCookies()
                 }
                 // I did have an onColumnSwitch here to set cookies, but it doesn't handle the "Toggle All" control, so I added a call to updateAllColumnSwitchingCookies in onAll
@@ -64,81 +66,177 @@
         <thead>
             <tr>
                 <th data-valign="top" class="idgrp" data-visible="{% get_template_cookie selfmt 'Animal-data-visible' 'false' %}" data-field="Animal">
-                    <div onclick="sortColumn(this)" class="sortable" id="peak_group__msrun__sample__animal__name">Animal</div>
+                    {% with "Animal" as colhead %}
+                        {% if mode == "view" %}{{ colhead }}{% else %}
+                            <div onclick="sortColumn(this)" class="sortable" id="peak_group__msrun__sample__animal__name">Animal</div>
+                        {% endif %}
+                    {% endwith %}
                 </th>
                 <th data-valign="top" class="idgrp" data-visible="{% get_template_cookie selfmt 'Sample-data-visible' 'true' %}" data-field="Sample" data-switchable="false">
-                    <div onclick="sortColumn(this)" class="sortable" id="peak_group__msrun__sample__name">Sample</div>
+                    {% with "Sample" as colhead %}
+                        {% if mode == "view" %}{{ colhead }}{% else %}
+                            <div onclick="sortColumn(this)" class="sortable" id="peak_group__msrun__sample__name">Sample</div>
+                        {% endif %}
+                    {% endwith %}
                 </th>
                 <th data-valign="top" class="idgrp" data-visible="{% get_template_cookie selfmt 'Tissue-data-visible' 'true' %}" data-field="Tissue">
-                    <div onclick="sortColumn(this)" class="sortable" id="peak_group__msrun__sample__tissue__name">Tissue</div>
+                    {% with "Tissue" as colhead %}
+                        {% if mode == "view" %}{{ colhead }}{% else %}
+                            <div onclick="sortColumn(this)" class="sortable" id="peak_group__msrun__sample__tissue__name">Tissue</div>
+                        {% endif %}
+                    {% endwith %}
                 </th>
                 <th data-valign="top" class="idgrp" data-visible="{% get_template_cookie selfmt 'Peak_Group-data-visible' 'false' %}" data-field="Peak_Group">
-                    <div onclick="sortColumn(this)" class="sortable" id="peak_group__name">Peak Group</div>
+                    {% with "Peak Group" as colhead %}
+                        {% if mode == "view" %}{{ colhead }}{% else %}
+                            <div onclick="sortColumn(this)" class="sortable" id="peak_group__name">Peak Group</div>
+                        {% endif %}
+                    {% endwith %}
                 </th>
                 <th data-valign="top" class="idgrp" data-visible="{% get_template_cookie selfmt 'Measured_Compounds-data-visible' 'true' %}" data-field="Measured_Compounds">
-                    <div onclick="sortColumn(this)" class="sortable" id="peak_group__compounds__name">Measured<br>Compound(s)</div>
+                    {% with "Measured<br>Compound(s)" as colhead %}
+                        {% if mode == "view" %}{{ colhead }}{% else %}
+                            <div onclick="sortColumn(this)" class="sortable" id="peak_group__compounds__name">Measured<br>Compound(s)</div>
+                        {% endif %}
+                    {% endwith %}
                 </th>
                 <th data-valign="top" class="idgrp" data-visible="{% get_template_cookie selfmt 'Measured_Compound_Synonyms-data-visible' 'false' %}" data-field="Measured_Compound_Synonyms">
-                    <div onclick="sortColumn(this)" class="sortable" id="peak_group__compounds__synonyms__name">Measured<br>Compound<br>Synonym(s)</div>
+                    {% with "Measured<br>Compound<br>Synonym(s)" as colhead %}
+                        {% if mode == "view" %}{{ colhead }}{% else %}
+                            <div onclick="sortColumn(this)" class="sortable" id="peak_group__compounds__synonyms__name">Measured<br>Compound<br>Synonym(s)</div>
+                        {% endif %}
+                    {% endwith %}
                 </th>
                 <th data-valign="top" class="idgrp" data-visible="{% get_template_cookie selfmt 'Labeled_Element_Count-data-visible' 'true' %}" data-field="Labeled_Element_Count">
-                    <div onclick="sortColumn(this)" class="sortable" id="labeled_element">Labeled<br>Element:<br></div><div onclick="sortColumn(this)" class="sortable" id="labeled_count">Count</div>
+                    {% with colhead1="Labeled<br>Element:<br>" colhead2="Count" %}
+                        {% if mode == "view" %}{{ colhead1 }}{{ colhead2 }}{% else %}
+                            <div onclick="sortColumn(this)" class="sortable" id="labeled_element">{{ colhead1 }}</div><div onclick="sortColumn(this)" class="sortable" id="labeled_count">{{ colhead2 }}</div>
+                        {% endif %}
+                    {% endwith %}
                 </th>
                 <th data-valign="top" class="idgrp" data-visible="{% get_template_cookie selfmt 'Peak_Group_Set_Filename-data-visible' 'false' %}" data-field="Peak_Group_Set_Filename">
-                    <div onclick="sortColumn(this)" class="sortable" id="peak_group__peak_group_set__filename">Peak Group Set Filename</div>
+                    {% with "Peak Group Set Filename" as colhead %}
+                        {% if mode == "view" %}{{ colhead }}{% else %}
+                            <div onclick="sortColumn(this)" class="sortable" id="peak_group__peak_group_set__filename">Peak Group Set Filename</div>
+                        {% endif %}
+                    {% endwith %}
                 </th>
 
                 <th data-valign="top" class="datagrp" data-visible="{% get_template_cookie selfmt 'Raw_Abundance-data-visible' 'false' %}" data-field="Raw_Abundance">
-                    <div onclick="sortColumn(this)" class="sortable" id="raw_abundance">Raw<br>Abundance</div>
+                    {% with "Raw<br>Abundance" as colhead %}
+                        {% if mode == "view" %}{{ colhead }}{% else %}
+                            <div onclick="sortColumn(this)" class="sortable" id="raw_abundance">Raw<br>Abundance</div>
+                        {% endif %}
+                    {% endwith %}
                 </th>
                 <th data-valign="top" class="datagrp" data-visible="{% get_template_cookie selfmt 'Corrected_Abundance-data-visible' 'true' %}" data-field="Corrected_Abundance">
-                    <div onclick="sortColumn(this)" class="sortable" id="corrected_abundance">Corrected<br>Abundance</div>
+                    {% with "Corrected<br>Abundance" as colhead %}
+                        {% if mode == "view" %}{{ colhead }}{% else %}
+                            <div onclick="sortColumn(this)" class="sortable" id="corrected_abundance">Corrected<br>Abundance</div>
+                        {% endif %}
+                    {% endwith %}
                 </th>
                 <th data-valign="top" class="datagrp" data-visible="{% get_template_cookie selfmt 'Fraction-data-visible' 'true' %}" data-field="Fraction" data-switchable="false">
                     Fraction
                 </th>
                 <th data-valign="top" class="datagrp" data-visible="{% get_template_cookie selfmt 'Median_MZ-data-visible' 'false' %}" data-field="Median_MZ">
-                    <div onclick="sortColumn(this)" class="sortable" id="med_mz">Median<br>M/Z</div>
+                    {% with "Median<br>M/Z" as colhead %}
+                        {% if mode == "view" %}{{ colhead }}{% else %}
+                            <div onclick="sortColumn(this)" class="sortable" id="med_mz">Median<br>M/Z</div>
+                        {% endif %}
+                    {% endwith %}
                 </th>
                 <th data-valign="top" class="datagrp" data-visible="{% get_template_cookie selfmt 'Median_RT-data-visible' 'false' %}" data-field="Median_RT">
-                    <div onclick="sortColumn(this)" class="sortable" id="med_rt">Median<br>RT</div>
+                    {% with "Median<br>RT" as colhead %}
+                        {% if mode == "view" %}{{ colhead }}{% else %}
+                            <div onclick="sortColumn(this)" class="sortable" id="med_rt">Median<br>RT</div>
+                        {% endif %}
+                    {% endwith %}
                 </th>
 
                 <th data-valign="top" class="metagrp" data-visible="{% get_template_cookie selfmt 'Formula-data-visible' 'false' %}" data-field="Formula">
-                    <div onclick="sortColumn(this)" class="sortable" id="peak_group__formula">Formula</div>
+                    {% with "Formula" as colhead %}
+                        {% if mode == "view" %}{{ colhead }}{% else %}
+                            <div onclick="sortColumn(this)" class="sortable" id="peak_group__formula">Formula</div>
+                        {% endif %}
+                    {% endwith %}
                 </th>
                 <th data-valign="top" class="metagrp" data-visible="{% get_template_cookie selfmt 'Genotype-data-visible' 'true' %}" data-field="Genotype">
-                    <div onclick="sortColumn(this)" class="sortable" id="peak_group__msrun__sample__animal__genotype">Genotype</div>
+                    {% with "Genotype" as colhead %}
+                        {% if mode == "view" %}{{ colhead }}{% else %}
+                            <div onclick="sortColumn(this)" class="sortable" id="peak_group__msrun__sample__animal__genotype">Genotype</div>
+                        {% endif %}
+                    {% endwith %}
                 </th>
                 <th data-valign="top" class="metagrp" data-visible="{% get_template_cookie selfmt 'Sex-data-visible' 'false' %}" data-field="Sex">
-                    <div onclick="sortColumn(this)" class="sortable" id="peak_group__msrun__sample__animal__sex">Sex</div>
+                    {% with "Sex" as colhead %}
+                        {% if mode == "view" %}{{ colhead }}{% else %}
+                            <div onclick="sortColumn(this)" class="sortable" id="peak_group__msrun__sample__animal__sex">Sex</div>
+                        {% endif %}
+                    {% endwith %}
                 </th>
                 <th data-valign="top" class="metagrp" data-visible="{% get_template_cookie selfmt 'Age-data-visible' 'false' %}" data-field="Age">
-                    <div onclick="sortColumn(this)" class="sortable" id="peak_group__msrun__sample__animal__age">Age<br>(weeks)</div>
+                    {% with "Age<br>(weeks)" as colhead %}
+                        {% if mode == "view" %}{{ colhead }}{% else %}
+                            <div onclick="sortColumn(this)" class="sortable" id="peak_group__msrun__sample__animal__age">Age<br>(weeks)</div>
+                        {% endif %}
+                    {% endwith %}
                 </th>
                 <th data-valign="top" class="metagrp" data-visible="{% get_template_cookie selfmt 'Body_Weight-data-visible' 'false' %}" data-field="Body_Weight">
-                    <div onclick="sortColumn(this)" class="sortable" id="peak_group__msrun__sample__animal__body_weight">Body<br>Weight<br>(g)</div>
+                    {% with "Body<br>Weight<br>(g)" as colhead %}
+                        {% if mode == "view" %}{{ colhead }}{% else %}
+                            <div onclick="sortColumn(this)" class="sortable" id="peak_group__msrun__sample__animal__body_weight">Body<br>Weight<br>(g)</div>
+                        {% endif %}
+                    {% endwith %}
                 </th>
                 <th data-valign="top" class="metagrp" data-visible="{% get_template_cookie selfmt 'Feeding_Status-data-visible' 'true' %}" data-field="Feeding_Status">
-                    <div onclick="sortColumn(this)" class="sortable" id="peak_group__msrun__sample__animal__feeding_status">Feeding<br>Status</div>
+                    {% with "Feeding<br>Status" as colhead %}
+                        {% if mode == "view" %}{{ colhead }}{% else %}
+                            <div onclick="sortColumn(this)" class="sortable" id="peak_group__msrun__sample__animal__feeding_status">Feeding<br>Status</div>
+                        {% endif %}
+                    {% endwith %}
                 </th>
                 <th data-valign="top" class="metagrp" data-visible="{% get_template_cookie selfmt 'Treatment-data-visible' 'true' %}" data-field="Treatment">
-                    <div onclick="sortColumn(this)" class="sortable" id="peak_group__msrun__treatment__name">Treatment</div>
+                    {% with "Treatment" as colhead %}
+                        {% if mode == "view" %}{{ colhead }}{% else %}
+                            <div onclick="sortColumn(this)" class="sortable" id="peak_group__msrun__treatment__name">Treatment</div>
+                        {% endif %}
+                    {% endwith %}
                 </th>
                 <th data-valign="top" class="metagrp" data-visible="{% get_template_cookie selfmt 'Diet-data-visible' 'false' %}" data-field="Diet">
-                    <div onclick="sortColumn(this)" class="sortable" id="peak_group__msrun__sample__animal__diet">Diet</div>
+                    {% with "Diet" as colhead %}
+                        {% if mode == "view" %}{{ colhead }}{% else %}
+                            <div onclick="sortColumn(this)" class="sortable" id="peak_group__msrun__sample__animal__diet">Diet</div>
+                        {% endif %}
+                    {% endwith %}
                 </th>
                 <th data-valign="top" class="metagrp" data-visible="{% get_template_cookie selfmt 'Tracer_Compound-data-visible' 'true' %}" data-field="Tracer_Compound" data-switchable="false">
-                    <div onclick="sortColumn(this)" class="sortable" id="peak_group__msrun__sample__animal__tracer_compound__name">Tracer<br>Compound</div>
+                    {% with "Tracer<br>Compound" as colhead %}
+                        {% if mode == "view" %}{{ colhead }}{% else %}
+                            <div onclick="sortColumn(this)" class="sortable" id="peak_group__msrun__sample__animal__tracer_compound__name">Tracer<br>Compound</div>
+                        {% endif %}
+                    {% endwith %}
                 </th>
                 <th data-valign="top" class="metagrp" data-visible="{% get_template_cookie selfmt 'Tracer_Infusion_Rate-data-visible' 'false' %}" data-field="Tracer_Infusion_Rate">
-                    <div onclick="sortColumn(this)" class="sortable" id="peak_group__msrun__sample__animal__tracer_infusion_rate">Tracer<br>Infusion<br>Rate<br>(ul/min/g)</div>
+                    {% with "Tracer<br>Infusion<br>Rate<br>(ul/min/g)" as colhead %}
+                        {% if mode == "view" %}{{ colhead }}{% else %}
+                            <div onclick="sortColumn(this)" class="sortable" id="peak_group__msrun__sample__animal__tracer_infusion_rate">Tracer<br>Infusion<br>Rate<br>(ul/min/g)</div>
+                        {% endif %}
+                    {% endwith %}
                 </th>
                 <th data-valign="top" class="metagrp" data-visible="{% get_template_cookie selfmt 'Tracer_Infusion_Concentration-data-visible' 'false' %}" data-field="Tracer_Infusion_Concentration">
-                    <div onclick="sortColumn(this)" class="sortable" id="peak_group__msrun__sample__animal__tracer_infusion_concentration">Tracer<br>Infusion<br>Concentration<br>(mM)</div>
+                    {% with "Tracer<br>Infusion<br>Concentration<br>(mM)" as colhead %}
+                        {% if mode == "view" %}{{ colhead }}{% else %}
+                            <div onclick="sortColumn(this)" class="sortable" id="peak_group__msrun__sample__animal__tracer_infusion_concentration">Tracer<br>Infusion<br>Concentration<br>(mM)</div>
+                        {% endif %}
+                    {% endwith %}
                 </th>
                 <th data-valign="top" class="metagrp" data-visible="{% get_template_cookie selfmt 'Study-data-visible' 'true' %}" data-field="Study">
-                    <div onclick="sortColumn(this)" class="sortable" id="peak_group__msrun__sample__animal__studies__name">Studies</div>
+                    {% with "Studies" as colhead %}
+                        {% if mode == "view" %}{{ colhead }}{% else %}
+                            <div onclick="sortColumn(this)" class="sortable" id="peak_group__msrun__sample__animal__studies__name">Studies</div>
+                        {% endif %}
+                    {% endwith %}
                 </th>
             </tr>
         </thead>

--- a/DataRepo/templates/DataRepo/search/results/peakdata.html
+++ b/DataRepo/templates/DataRepo/search/results/peakdata.html
@@ -40,7 +40,7 @@
 
 {% endblock %}
 {% block content %}
-    <div style="float: right; margin-right: 1rem;" class="buttons-toolbar"></div>
+    <div style="float: right; {% if mode == 'view' %}margin-right: 1rem;margin-bottom: 1rem;{% else %}margin-right: 1rem;{% endif %}" class="buttons-toolbar"></div>
     <table class="table table-hover table-striped table-bordered"
         id="advsrchres"
         data-toggle="table"
@@ -50,11 +50,12 @@
         data-filter-control="false"
         data-search="false"
         data-show-search-clear-button="false"
-        data-show-multi-sort="true"
+        data-show-multi-sort="{% if mode == 'view' %}true{% else %}false{% endif %}"
         data-show-columns="true"
         data-show-columns-toggle-all="true"
         data-show-fullscreen="false"
-        data-show-export="false">
+        data-show-export="false"
+        data-pagination="{% if mode == 'view' %}true{% else %}false{% endif %}">
 
         <colgroup span="8" class="identdata"></colgroup>
         <colgroup span="5" class="datadata"></colgroup>

--- a/DataRepo/templates/DataRepo/search/results/peakgroups.html
+++ b/DataRepo/templates/DataRepo/search/results/peakgroups.html
@@ -40,7 +40,7 @@
 
 {% endblock %}
 {% block content %}
-    <div style="float: right; margin-right: 1rem;" class="buttons-toolbar"></div>
+    <div style="float: right; {% if mode == 'view' %}margin-right: 1rem;margin-bottom: 1rem;{% else %}margin-right: 1rem;{% endif %}" class="buttons-toolbar"></div>
     <table class="table table-hover table-striped table-bordered"
         id="advsrchres"
         data-toggle="table"
@@ -50,11 +50,12 @@
         data-filter-control="false"
         data-search="false"
         data-show-search-clear-button="false"
-        data-show-multi-sort="false"
+        data-show-multi-sort="{% if mode == 'view' %}true{% else %}false{% endif %}"
         data-show-columns="true"
         data-show-columns-toggle-all="true"
         data-show-fullscreen="false"
-        data-show-export="false">
+        data-show-export="false"
+        data-pagination="{% if mode == 'view' %}true{% else %}false{% endif %}">
 
         <colgroup span="8" class="identdata"></colgroup>
         <colgroup span="4" class="datadata"></colgroup>

--- a/DataRepo/templates/DataRepo/search/results/peakgroups.html
+++ b/DataRepo/templates/DataRepo/search/results/peakgroups.html
@@ -9,7 +9,9 @@
             $("#advsrchres").bootstrapTable({
                 onAll: function() {
                     updateColumnGroups()
-                    updateColumnSortControls()
+                    {% if mode != 'view' %}
+                        updateColumnSortControls()
+                    {% endif %}
                     updateAllColumnSwitchingCookies()
                 }
                 // I did have an onColumnSwitch here to set cookies, but it doesn't handle the "Toggle All" control, so I added a call to updateAllColumnSwitchingCookies in onAll
@@ -63,79 +65,159 @@
 
         <thead>
             <tr>
-                <th data-valign="top" data-visible="{% get_template_cookie selfmt 'Animal-data-visible' 'false' %}" data-field="Animal" class="idgrp">
-                    <div onclick="sortColumn(this)" class="sortable" id="msrun__sample__animal__name">Animal</div>
+                <th data-valign="top" data-sortable="{% if mode == 'view' %}true{% else %}false{% endif %}" data-sorter="alphanum" data-visible="{% get_template_cookie selfmt 'Animal-data-visible' 'false' %}" data-field="Animal" class="idgrp">
+                    {% with "Animal" as colhead %}
+                        {% if mode == "view" %}{{ colhead }}{% else %}
+                            <div onclick="sortColumn(this)" class="sortable" id="msrun__sample__animal__name">{{ colhead }}</div>
+                        {% endif %}
+                    {% endwith %}
                 </th>
-                <th data-valign="top" data-visible="{% get_template_cookie selfmt 'Sample-data-visible' 'true' %}" data-field="Sample" class="idgrp" data-switchable="false">
-                    <div onclick="sortColumn(this)" class="sortable" id="msrun__sample__name">Sample</div>
+                <th data-valign="top" data-sortable="{% if mode == 'view' %}true{% else %}false{% endif %}" data-sorter="alphanum" data-visible="{% get_template_cookie selfmt 'Sample-data-visible' 'true' %}" data-field="Sample" class="idgrp" data-switchable="false">
+                    {% with "Sample" as colhead %}
+                        {% if mode == "view" %}{{ colhead }}{% else %}
+                            <div onclick="sortColumn(this)" class="sortable" id="msrun__sample__name">{{ colhead }}</div>
+                        {% endif %}
+                    {% endwith %}
                 </th>
-                <th data-valign="top" data-visible="{% get_template_cookie selfmt 'Tissue-data-visible' 'true' %}" data-field="Tissue" class="idgrp">
-                    <div onclick="sortColumn(this)" class="sortable" id="msrun__sample__tissue__name">Tissue</div>
+                <th data-valign="top" data-sortable="{% if mode == 'view' %}true{% else %}false{% endif %}" data-sorter="alphanum" data-visible="{% get_template_cookie selfmt 'Tissue-data-visible' 'true' %}" data-field="Tissue" class="idgrp">
+                    {% with "Tissue" as colhead %}
+                        {% if mode == "view" %}{{ colhead }}{% else %}
+                            <div onclick="sortColumn(this)" class="sortable" id="msrun__sample__tissue__name">{{ colhead }}</div>
+                        {% endif %}
+                    {% endwith %}
                 </th>
-                <th data-valign="top" data-visible="{% get_template_cookie selfmt 'Peak_Group-data-visible' 'false' %}" data-field="Peak_Group" class="idgrp">
-                    <div onclick="sortColumn(this)" class="sortable" id="name">Peak Group</div>
+                <th data-valign="top" data-sortable="{% if mode == 'view' %}true{% else %}false{% endif %}" data-sorter="alphanum" data-visible="{% get_template_cookie selfmt 'Peak_Group-data-visible' 'false' %}" data-field="Peak_Group" class="idgrp">
+                    {% with "Peak Group" as colhead %}
+                        {% if mode == "view" %}{{ colhead }}{% else %}
+                            <div onclick="sortColumn(this)" class="sortable" id="name">{{ colhead }}</div>
+                        {% endif %}
+                    {% endwith %}
                 </th>
-                <th data-valign="top" data-visible="{% get_template_cookie selfmt 'Compound_Name-data-visible' 'true' %}" data-field="Compound_Name" class="idgrp">
-                    <div onclick="sortColumn(this)" class="sortable" id="compounds__name">Measured<br>Compound</div>
+                <th data-valign="top" data-sortable="{% if mode == 'view' %}true{% else %}false{% endif %}" data-sorter="alphanum" data-visible="{% get_template_cookie selfmt 'Compound_Name-data-visible' 'true' %}" data-field="Compound_Name" class="idgrp">
+                    {% with "Measured<br>Compound" as colhead %}
+                        {% if mode == "view" %}{{ colhead }}{% else %}
+                            <div onclick="sortColumn(this)" class="sortable" id="compounds__name">{{ colhead }}</div>
+                        {% endif %}
+                    {% endwith %}
                 </th>
-                <th data-valign="top" data-visible="{% get_template_cookie selfmt 'Compound_Synonym-data-visible' 'false' %}" data-field="Compound_Synonym" class="idgrp">
-                    <div onclick="sortColumn(this)" class="sortable" id="compounds__synonyms__name">Measured<br>Compound<br>Synonym(s)</div>
+                <th data-valign="top" data-sortable="{% if mode == 'view' %}true{% else %}false{% endif %}" data-sorter="alphanum" data-visible="{% get_template_cookie selfmt 'Compound_Synonym-data-visible' 'false' %}" data-field="Compound_Synonym" class="idgrp">
+                    {% with "Measured<br>Compound<br>Synonym(s)" as colhead %}
+                        {% if mode == "view" %}{{ colhead }}{% else %}
+                            <div onclick="sortColumn(this)" class="sortable" id="compounds__synonyms__name">{{ colhead }}</div>
+                        {% endif %}
+                    {% endwith %}
                 </th>
-                <th data-valign="top" data-visible="{% get_template_cookie selfmt 'Labeled_Element-data-visible' 'true' %}" data-field="Labeled_Element" class="idgrp">
-                    <div onclick="sortColumn(this)" class="sortable" id="msrun__sample__animal__tracer_labeled_atom">Labeled<br>Element</div>
+                <th data-valign="top" data-sortable="{% if mode == 'view' %}true{% else %}false{% endif %}" data-sorter="alphanum" data-visible="{% get_template_cookie selfmt 'Labeled_Element-data-visible' 'true' %}" data-field="Labeled_Element" class="idgrp">
+                    {% with "Labeled<br>Element" as colhead %}
+                        {% if mode == "view" %}{{ colhead }}{% else %}
+                            <div onclick="sortColumn(this)" class="sortable" id="msrun__sample__animal__tracer_labeled_atom">{{ colhead }}</div>
+                        {% endif %}
+                    {% endwith %}
                 </th>
-                <th data-valign="top" data-visible="{% get_template_cookie selfmt 'Peak_Group_Set_Filename-data-visible' 'false' %}" data-field="Peak_Group_Set_Filename" class="idgrp">
-                    <div onclick="sortColumn(this)" class="sortable" id="peak_group_set__filename">Peak Group Set Filename</div>
+                <th data-valign="top" data-sortable="{% if mode == 'view' %}true{% else %}false{% endif %}" data-sorter="alphanum" data-visible="{% get_template_cookie selfmt 'Peak_Group_Set_Filename-data-visible' 'false' %}" data-field="Peak_Group_Set_Filename" class="idgrp">
+                    {% with "Peak Group Set Filename" as colhead %}
+                        {% if mode == "view" %}{{ colhead }}{% else %}
+                            <div onclick="sortColumn(this)" class="sortable" id="peak_group_set__filename">{{ colhead }}</div>
+                        {% endif %}
+                    {% endwith %}
                 </th>
 
-                <th data-valign="top" data-visible="{% get_template_cookie selfmt 'Total_Abundance-data-visible' 'true' %}" data-field="Total_Abundance" class="datagrp" data-switchable="false">
+                <th data-valign="top" data-sortable="{% if mode == 'view' %}true{% else %}false{% endif %}" data-sorter="alphanum" data-visible="{% get_template_cookie selfmt 'Total_Abundance-data-visible' 'true' %}" data-field="Total_Abundance" class="datagrp" data-switchable="false">
                     Total<br>Abundance
                 </th>
-                <th data-valign="top" data-visible="{% get_template_cookie selfmt 'Enrichment_Fraction-data-visible' 'true' %}" data-field="Enrichment_Fraction" class="datagrp">
+                <th data-valign="top" data-sortable="{% if mode == 'view' %}true{% else %}false{% endif %}" data-sorter="alphanum" data-visible="{% get_template_cookie selfmt 'Enrichment_Fraction-data-visible' 'true' %}" data-field="Enrichment_Fraction" class="datagrp">
                     Enrichment<br>Fraction
                 </th>
-                <th data-valign="top" data-visible="{% get_template_cookie selfmt 'Enrichment_Abundance-data-visible' 'true' %}" data-field="Enrichment_Abundance" class="datagrp">
+                <th data-valign="top" data-sortable="{% if mode == 'view' %}true{% else %}false{% endif %}" data-sorter="alphanum" data-visible="{% get_template_cookie selfmt 'Enrichment_Abundance-data-visible' 'true' %}" data-field="Enrichment_Abundance" class="datagrp">
                     Enrichment<br>Abundance
                 </th>
-                <th data-valign="top" data-visible="{% get_template_cookie selfmt 'Normalized_Labeling-data-visible' 'true' %}" data-field="Normalized_Labeling" class="datagrp">
+                <th data-valign="top" data-sortable="{% if mode == 'view' %}true{% else %}false{% endif %}" data-sorter="alphanum" data-visible="{% get_template_cookie selfmt 'Normalized_Labeling-data-visible' 'true' %}" data-field="Normalized_Labeling" class="datagrp">
                     Normalized<br>Labeling
                 </th>
 
-                <th data-valign="top" data-visible="{% get_template_cookie selfmt 'Formula-data-visible' 'false' %}" data-field="Formula" class="metagrp">
-                    <div onclick="sortColumn(this)" class="sortable" id="formula">Formula</div>
+                <th data-valign="top" data-sortable="{% if mode == 'view' %}true{% else %}false{% endif %}" data-sorter="alphanum" data-visible="{% get_template_cookie selfmt 'Formula-data-visible' 'false' %}" data-field="Formula" class="metagrp">
+                    {% with "Formula" as colhead %}
+                        {% if mode == "view" %}{{ colhead }}{% else %}
+                            <div onclick="sortColumn(this)" class="sortable" id="formula">{{ colhead }}</div>
+                        {% endif %}
+                    {% endwith %}
                 </th>
-                <th data-valign="top" data-visible="{% get_template_cookie selfmt 'Genotype-data-visible' 'true' %}" data-field="Genotype" class="metagrp">
-                    <div onclick="sortColumn(this)" class="sortable" id="msrun__sample__animal__genotype">Genotype</div>
+                <th data-valign="top" data-sortable="{% if mode == 'view' %}true{% else %}false{% endif %}" data-sorter="alphanum" data-visible="{% get_template_cookie selfmt 'Genotype-data-visible' 'true' %}" data-field="Genotype" class="metagrp">
+                    {% with "Genotype" as colhead %}
+                        {% if mode == "view" %}{{ colhead }}{% else %}
+                            <div onclick="sortColumn(this)" class="sortable" id="msrun__sample__animal__genotype">{{ colhead }}</div>
+                        {% endif %}
+                    {% endwith %}
                 </th>
-                <th data-valign="top" data-visible="{% get_template_cookie selfmt 'Sex-data-visible' 'false' %}" data-field="Sex" class="metagrp">
-                    <div onclick="sortColumn(this)" class="sortable" id="msrun__sample__animal__sex">Sex</div>
+                <th data-valign="top" data-sortable="{% if mode == 'view' %}true{% else %}false{% endif %}" data-sorter="alphanum" data-visible="{% get_template_cookie selfmt 'Sex-data-visible' 'false' %}" data-field="Sex" class="metagrp">
+                    {% with "Sex" as colhead %}
+                        {% if mode == "view" %}{{ colhead }}{% else %}
+                            <div onclick="sortColumn(this)" class="sortable" id="msrun__sample__animal__sex">{{ colhead }}</div>
+                        {% endif %}
+                    {% endwith %}
                 </th>
-                <th data-valign="top" data-visible="{% get_template_cookie selfmt 'Feeding_Status-data-visible' 'true' %}" data-field="Feeding_Status" class="metagrp">
-                    <div onclick="sortColumn(this)" class="sortable" id="msrun__sample__animal__feeding_status">Feeding<br>Status</div>
+                <th data-valign="top" data-sortable="{% if mode == 'view' %}true{% else %}false{% endif %}" data-sorter="alphanum" data-visible="{% get_template_cookie selfmt 'Feeding_Status-data-visible' 'true' %}" data-field="Feeding_Status" class="metagrp">
+                    {% with "Feeding<br>Status" as colhead %}
+                        {% if mode == "view" %}{{ colhead }}{% else %}
+                            <div onclick="sortColumn(this)" class="sortable" id="msrun__sample__animal__feeding_status">{{ colhead }}</div>
+                        {% endif %}
+                    {% endwith %}
                 </th>
-                <th data-valign="top" data-visible="{% get_template_cookie selfmt 'Diet-data-visible' 'false' %}" data-field="Diet" class="metagrp">
-                    <div onclick="sortColumn(this)" class="sortable" id="msrun__sample__animal__diet">Diet</div>
+                <th data-valign="top" data-sortable="{% if mode == 'view' %}true{% else %}false{% endif %}" data-sorter="alphanum" data-visible="{% get_template_cookie selfmt 'Diet-data-visible' 'false' %}" data-field="Diet" class="metagrp">
+                    {% with "Diet" as colhead %}
+                        {% if mode == "view" %}{{ colhead }}{% else %}
+                            <div onclick="sortColumn(this)" class="sortable" id="msrun__sample__animal__diet">{{ colhead }}</div>
+                        {% endif %}
+                    {% endwith %}
                 </th>
-                <th data-valign="top" data-visible="{% get_template_cookie selfmt 'Treatment-data-visible' 'true' %}" data-field="Treatment" class="metagrp">
-                    <div onclick="sortColumn(this)" class="sortable" id="msrun__sample__animal__treatment__name">Treatment</div>
+                <th data-valign="top" data-sortable="{% if mode == 'view' %}true{% else %}false{% endif %}" data-sorter="alphanum" data-visible="{% get_template_cookie selfmt 'Treatment-data-visible' 'true' %}" data-field="Treatment" class="metagrp">
+                    {% with "Treatment" as colhead %}
+                        {% if mode == "view" %}{{ colhead }}{% else %}
+                            <div onclick="sortColumn(this)" class="sortable" id="msrun__sample__animal__treatment__name">{{ colhead }}</div>
+                        {% endif %}
+                    {% endwith %}
                 </th>
-                <th data-valign="top" data-visible="{% get_template_cookie selfmt 'Body_Weight-data-visible' 'false' %}" data-field="Body_Weight" class="metagrp">
-                    <div onclick="sortColumn(this)" class="sortable" id="msrun__sample__animal__body_weight">Body<br>Weight<br>(g)</div>
+                <th data-valign="top" data-sortable="{% if mode == 'view' %}true{% else %}false{% endif %}" data-sorter="alphanum" data-visible="{% get_template_cookie selfmt 'Body_Weight-data-visible' 'false' %}" data-field="Body_Weight" class="metagrp">
+                    {% with "Body<br>Weight<br>(g)" as colhead %}
+                        {% if mode == "view" %}{{ colhead }}{% else %}
+                            <div onclick="sortColumn(this)" class="sortable" id="msrun__sample__animal__body_weight">{{ colhead }}</div>
+                        {% endif %}
+                    {% endwith %}
                 </th>
-                <th data-valign="top" data-visible="{% get_template_cookie selfmt 'Age-data-visible' 'false' %}" data-field="Age" class="metagrp">
-                    <div onclick="sortColumn(this)" class="sortable" id="msrun__sample__animal__age">Age<br>(weeks)</div>
+                <th data-valign="top" data-sortable="{% if mode == 'view' %}true{% else %}false{% endif %}" data-sorter="alphanum" data-visible="{% get_template_cookie selfmt 'Age-data-visible' 'false' %}" data-field="Age" class="metagrp">
+                    {% with "Age<br>(weeks)" as colhead %}
+                        {% if mode == "view" %}{{ colhead }}{% else %}
+                            <div onclick="sortColumn(this)" class="sortable" id="msrun__sample__animal__age">{{ colhead }}</div>
+                        {% endif %}
+                    {% endwith %}
                 </th>
-                <th data-valign="top" data-visible="{% get_template_cookie selfmt 'Tracer_Compound-data-visible' 'true' %}" data-field="Tracer_Compound" class="metagrp" data-switchable="false">
-                    <div onclick="sortColumn(this)" class="sortable" id="msrun__sample__animal__tracer_compound__name">Tracer<br>Compound</div>
+                <th data-valign="top" data-sortable="{% if mode == 'view' %}true{% else %}false{% endif %}" data-sorter="alphanum" data-visible="{% get_template_cookie selfmt 'Tracer_Compound-data-visible' 'true' %}" data-field="Tracer_Compound" class="metagrp" data-switchable="false">
+                    {% with "Tracer<br>Compound" as colhead %}
+                        {% if mode == "view" %}{{ colhead }}{% else %}
+                            <div onclick="sortColumn(this)" class="sortable" id="msrun__sample__animal__tracer_compound__name">{{ colhead }}</div>
+                        {% endif %}
+                    {% endwith %}
                 </th>
-                <th data-valign="top" data-visible="{% get_template_cookie selfmt 'Tracer_Infusion_Rate-data-visible' 'false' %}" data-field="Tracer_Infusion_Rate" class="metagrp">
-                    <div onclick="sortColumn(this)" class="sortable" id="msrun__sample__animal__tracer_infusion_rate">Tracer<br>Infusion<br>Rate<br>(ul/min/g)</div>
+                <th data-valign="top" data-sortable="{% if mode == 'view' %}true{% else %}false{% endif %}" data-sorter="alphanum" data-visible="{% get_template_cookie selfmt 'Tracer_Infusion_Rate-data-visible' 'false' %}" data-field="Tracer_Infusion_Rate" class="metagrp">
+                    {% with "Tracer<br>Infusion<br>Rate<br>(ul/min/g)" as colhead %}
+                        {% if mode == "view" %}{{ colhead }}{% else %}
+                            <div onclick="sortColumn(this)" class="sortable" id="msrun__sample__animal__tracer_infusion_rate">{{ colhead }}</div>
+                        {% endif %}
+                    {% endwith %}
                 </th>
-                <th data-valign="top" data-visible="{% get_template_cookie selfmt 'Tracer_Infusion_Concentration-data-visible' 'false' %}" data-field="Tracer_Infusion_Concentration" class="metagrp">
-                    <div onclick="sortColumn(this)" class="sortable" id="msrun__sample__animal__tracer_infusion_concentration">Tracer<br>Infusion<br>Concentration<br>(mM)</div>
+                <th data-valign="top" data-sortable="{% if mode == 'view' %}true{% else %}false{% endif %}" data-sorter="alphanum" data-visible="{% get_template_cookie selfmt 'Tracer_Infusion_Concentration-data-visible' 'false' %}" data-field="Tracer_Infusion_Concentration" class="metagrp">
+                    {% with "Tracer<br>Infusion<br>Concentration<br>(mM)" as colhead %}
+                        {% if mode == "view" %}{{ colhead }}{% else %}
+                            <div onclick="sortColumn(this)" class="sortable" id="msrun__sample__animal__tracer_infusion_concentration">{{ colhead }}</div>
+                        {% endif %}
+                    {% endwith %}
                 </th>
-                <th data-valign="top" data-visible="{% get_template_cookie selfmt 'Study-data-visible' 'true' %}" data-field="Study" class="metagrp">
-                    <div onclick="sortColumn(this)" class="sortable" id="msrun__sample__animal__studies__name">Studies</div>
+                <th data-valign="top" data-sortable="{% if mode == 'view' %}true{% else %}false{% endif %}" data-sorter="alphanum" data-visible="{% get_template_cookie selfmt 'Study-data-visible' 'true' %}" data-field="Study" class="metagrp">
+                    {% with "Studies" as colhead %}
+                        {% if mode == "view" %}{{ colhead }}{% else %}
+                            <div onclick="sortColumn(this)" class="sortable" id="msrun__sample__animal__studies__name">{{ colhead }}</div>
+                        {% endif %}
+                    {% endwith %}
                 </th>
             </tr>
         </thead>

--- a/DataRepo/urls.py
+++ b/DataRepo/urls.py
@@ -12,6 +12,12 @@ urlpatterns = [
         views.search_basic,
         name="search_basic",
     ),
+    # Remove this when done
+    path(
+        "test_barebones_advanced_search/",
+        views.test_barebones_advanced_search,
+        name="test_barebones_advanced_search",
+    ),
     path(
         "search_advanced/",
         views.AdvancedSearchView.as_view(),

--- a/DataRepo/views.py
+++ b/DataRepo/views.py
@@ -328,6 +328,26 @@ def search_basic(request, mdl, fld, cmp, val, fmt):
     )
 
 
+def test_barebones_advanced_search(request):
+    """
+    Demonstrates the flexibility added to the advanced search templates
+    """
+
+    format_template = "DataRepo/search/query.html"
+
+    res = PeakGroup.objects.filter(name__contains="glut")
+
+    return render(
+        request,
+        format_template,
+        {
+            "res": res,
+            "format": "pgtemplate",  # pgtemplate = peakgroups, pdtemplate = peakdata, fctemplate = fcirc
+            "mode": "view",  # This is a new mode that means "I'm only providing a queryset"
+        },
+    )
+
+
 # Based on:
 #   https://stackoverflow.com/questions/15497693/django-can-class-based-views-accept-two-forms-at-a-time
 class AdvancedSearchView(MultiFormsView):


### PR DESCRIPTION
## Summary Change Description

This makes it possible to render any of the advanced search output formats by supplying it a queryset and 2 other basic parameters:

- `mode` (with the value `view`)
- `format` with 1 of 3 possible values:
   - `pgtemplate` (for peakgroups)
   - `pdtemplate` for peakdata
   - `fctemplate` for fcirc

## Affected Issue Numbers

- Resolves #371

## Code Review Notes

I included a temporary function in views.py called `test_barebones_advanced_search` to demonstrate how you can call the template.

I basically just added checks on the new mode to decide whether to render things in the template that depend on various context variables being present.

I consider this implementation a first (very simple) step.  I think the next step would be the ability to show an empty search interface above the results (the same way there is one when in "browse" mode).

## Checklist

- [ ] All issue requirements satisfied (or no linked issues)
- [x] [Linting passes](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#linting).
- [x] [Migrations created & committed *(or no model changes)*](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#migration-process)
- [ ] [Tests implemented *(or no code changes)*](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#test-implementation)
- [x] [All tests pass](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#quality-control)
