### PR TITLE
Eliminated the need to define the validation database environment var…

### DIFF
--- a/.github/workflows/tracebase-tests.yml
+++ b/.github/workflows/tracebase-tests.yml
@@ -41,6 +41,7 @@ jobs:
       DATABASE_PORT: 5432
       DEBUG: true
       CACHES: TEST_CACHES
+      VALIDATION_ENABLED: true
       VALIDATION_DATABASE_NAME: tracebase_validation
       VALIDATION_DATABASE_USER: postgres
       VALIDATION_DATABASE_PASSWORD: postgres

--- a/TraceBase/settings.py
+++ b/TraceBase/settings.py
@@ -100,14 +100,19 @@ DATABASES = {
     }
 }
 
-VALIDATION_ENABLED = env.bool("VALIDATION_ENABLED", default=True)
-vdb_def_name = "tracebase_validation"
+VALIDATION_ENABLED = env.bool("VALIDATION_ENABLED")
 # If the validation database is configured in the .env file...
-if VALIDATION_ENABLED and env("VALIDATION_DATABASE_NAME", default=vdb_def_name):
+if VALIDATION_ENABLED:
+    # Only for use in the exception, if it occurs, so that we reference the set name
+    vdb_name = env(
+        "VALIDATION_DATABASE_NAME", default=DATABASES["default"]["NAME"] + "_validation"
+    )
     try:
         DATABASES["validation"] = {
-            "ENGINE": "django.db.backends.postgresql",
-            "NAME": env("VALIDATION_DATABASE_NAME", default=vdb_def_name),
+            "ENGINE": env(
+                "VALIDATION_DATABASE_ENGINE", default=DATABASES["default"]["ENGINE"]
+            ),
+            "NAME": env("VALIDATION_DATABASE_NAME"),
             "USER": env("VALIDATION_DATABASE_USER"),
             "PASSWORD": env("VALIDATION_DATABASE_PASSWORD"),
             "HOST": env("VALIDATION_DATABASE_HOST"),
@@ -115,10 +120,7 @@ if VALIDATION_ENABLED and env("VALIDATION_DATABASE_NAME", default=vdb_def_name):
         }
         VALIDATION_ENABLED = True
     except Exception as e:
-        print(
-            f"Could not configure access to the {env('VALIDATION_DATABASE_NAME', default=vdb_def_name)} database: {e}"
-        )
-        VALIDATION_ENABLED = False
+        raise Exception(f"Could not configure access to the {vdb_name} database: {e}")
 
 # These values are the keys of the DATABASES dict
 TRACEBASE_DB = "default"

--- a/TraceBase/settings.py
+++ b/TraceBase/settings.py
@@ -101,12 +101,13 @@ DATABASES = {
 }
 
 VALIDATION_ENABLED = env.bool("VALIDATION_ENABLED", default=True)
+vdb_def_name = "tracebase_validation"
 # If the validation database is configured in the .env file...
-if VALIDATION_ENABLED and env("VALIDATION_DATABASE_NAME"):
+if VALIDATION_ENABLED and env("VALIDATION_DATABASE_NAME", default=vdb_def_name):
     try:
         DATABASES["validation"] = {
             "ENGINE": "django.db.backends.postgresql",
-            "NAME": env("VALIDATION_DATABASE_NAME"),
+            "NAME": env("VALIDATION_DATABASE_NAME", default=vdb_def_name),
             "USER": env("VALIDATION_DATABASE_USER"),
             "PASSWORD": env("VALIDATION_DATABASE_PASSWORD"),
             "HOST": env("VALIDATION_DATABASE_HOST"),
@@ -115,7 +116,7 @@ if VALIDATION_ENABLED and env("VALIDATION_DATABASE_NAME"):
         VALIDATION_ENABLED = True
     except Exception as e:
         print(
-            f"Could not configure access to the {env('VALIDATION_DATABASE_NAME')} database: {e}"
+            f"Could not configure access to the {env('VALIDATION_DATABASE_NAME', default=vdb_def_name)} database: {e}"
         )
         VALIDATION_ENABLED = False
 


### PR DESCRIPTION
## Summary Change Description

Fixed the ability to run without validation DB environment variables.

## Affected Issue Numbers

- Resolves #385

## Code Review Notes

It's straightforward/self explanatory.  I tested by commenting out the variables in my .env.

## Checklist

- [x] All issue requirements satisfied (or no linked issues)
- [x] [Linting passes](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#linting).
- [x] [Migrations created & committed *(or no model changes)*](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#migration-process)
- [ ] [Tests implemented *(or no code changes)*](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#test-implementation)
- [x] [All tests pass](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#quality-control)
