### PR TITLE
Split row counts now accurate

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -19,7 +19,9 @@ This document will serve to guide developers on implementing new code.
          - AutoFields (like IDs) should not be displayed (because they can change depending on how the data is loaded from scratch, thus, they should be obfuscated from the user).
          - If `displayed` is False, set a `handoff` key whose value is a unique field (e.g. `name`).  See any `id` field in the copied class's models data.
    - If not already there, add the root model to the DataRepo.models import at the top of the file.
-   - Set each model's manytomany["is"] value as True/False based on whether it is in a many-to-many relationship with the root model.  Any many-to-many relationship on the key path necessitates a many-to-many status for that model instance.  Set each model's manytomany["fulljoin"] value as True/False based on whether the template will have a separate row for every root-model/M:M-model combo.
+   - Set each model's manytomany["is"] value as True/False based on whether it is in a many-to-many relationship with the root model.  Any many-to-many relationship on the key path necessitates a many-to-many status for that model instance.  Set each model's manytomany["split_rows"] value as True/False based on whether the template should display a separate row for every root-model/M:M-model combo.
+      - A default annotation field (`manytomany["root_annot_fld"]`) will be created that is the lower case version of the M:M model name, but if this causes a conflict with existing root model fields, you can:
+         - specify a custom annotation field name by setting `manytomany["root_annot_fld"]`.  E.g. For the MeasureCompound model instance, `manytomany["root_annot_fld"]` is explicitly set to `compound` in the PeakGroupSeachView class.
    - Add the new class to the for loop in BaseAdvancedSearchView.__init__
 
 2. `DataRepo/forms.py`
@@ -30,7 +32,11 @@ This document will serve to guide developers on implementing new code.
 
 3. `DataRepo/templates/results/<format name>.html`
    - Copy `DataRepo/templates/results/peakgroups.html` to a new file with a name that indicates the format and edit as you wish, following these guidelines:
-      - If a field's path includes a many-to-many relationship, e.g. `models.ManyToManyField`, and the resulting table should include a row for every root-model/M:M-model combo, a nested `for` loop will be necessary in the template, e.g. `{% for study in pg.msrun.sample.animal.studies.all %}`.
+      - If a field's path includes a many-to-many relationship, e.g. `models.ManyToManyField`, and the resulting table should include a row for every root-model/M:M-model combo...
+         - See the `manytomany` settings for step 1 above.
+         - See the MeasuredCompound column code in the `peakgroups.html` for an example.  Othwerwise, follow these guidelines:
+            - You should not create a nested `for` loop.  Instead, you can retrieve the M:M related record to be included on the current row of the outer loop by calling the `get_manytomany_rec` template tag.  Based on the `manytomany` config, it will either return all related records as a list or it will return the one related table record (also as a list).
+            - It is encouraged that you implement a `for` loop inside the `<td>` tags that can render the records either as a delimited series or as an individual value so that how the field is displayed can be toggled by the `manytomany` settings.
       - If there are no M:M relationships, the nested `for` loop in the copied template may be removed.
       - Use column headers that match the field's displayname set in step 1 so that they match the field select list.  (A reference to this value may be supplied in the future.)
       - Numeric values should use `<td class="text-end">`
@@ -39,7 +45,11 @@ This document will serve to guide developers on implementing new code.
 
 4. `DataRepo/templates/downloads/<format name>_{colheads,row}.tsv`
    - Copy `DataRepo/templates/downloads/peakgroups_colheads.tsv` and `DataRepo/templates/downloads/peakgroups_row.tsv` to new files with a name that indicates the format (e.g., same name as in step 3 with a different extension) and edit as you wish, following these guidelines:
-      - If a field's path includes a many-to-many relationship, e.g. `models.ManyToManyField`, and the resulting table should include a row for every root-model/M:M-model combo, a nested `for` loop will be necessary in the template, e.g. `{% for study in pg.msrun.sample.animal.studies.all %}`.
+      - If a field's path includes a many-to-many relationship, e.g. `models.ManyToManyField`, and the resulting table should include a row for every root-model/M:M-model combo...
+         - See the `manytomany` settings for step 1 above.
+         - See the MeasuredCompound column code in the `peakgroups.html` for an example.  Othwerwise, follow these guidelines:
+            - You should not create a nested `for` loop.  Instead, you can retrieve the M:M related record to be included on the current row of the outer loop by calling the `get_manytomany_rec` template tag.  Based on the `manytomany` config, it will either return all related records as a list or it will return the one related table record (also as a list).
+            - It is encouraged that you implement a `for` loop inside the `<td>` tags that can render the records either as a delimited series or as an individual value so that how the field is displayed can be toggled by the `manytomany` settings.
       - If there are no M:M relationships, the nested `for` loop in the copied template may be removed.
       - Use column headers that match the field's displayname set in step 1 so that they match the field select list.  (A reference to this value may be supplied in the future.)
 

--- a/DataRepo/compositeviews.py
+++ b/DataRepo/compositeviews.py
@@ -264,10 +264,10 @@ class BaseSearchView:
 
     def getFullJoinAnnotations(self):
         """
-        This retrurns a list of dicts that, when expanded, can be supplied to .annotate().  It is intended to be used
-        to distinguish between otherwise identical root table records that are returned because they link to many
-        records of a related table, so that when looping through those subtable records, you can skip the ones that do
-        not belong to that fully joined record.
+        This returns a list of dicts that, when expanded, can be supplied to .annotate().  It is intended to be used to
+        distinguish between otherwise identical root table records that are returned because they link to many records
+        of a related table, so that when looping through those subtable records, you can skip the ones that do not
+        belong to that fully joined record.
 
         This is necessary because the Django ORM does not suppored many-to-many tables involved in a join.  You always
         get every M:M related record with every root table record even though Django returned the number of root table
@@ -297,7 +297,7 @@ class BaseSearchView:
                         raise Exception(
                             f"Many-to-many model {mdl_inst_nm} with split_rows=True in format {self.id} must have a "
                             "value for [root_annot_fld].  This is the name that will be used to associate a root "
-                            f"table record with its M:M field in a unique combination."
+                            "table record with its M:M field in a unique combination."
                         )
 
                 # Append a dict that creates an annotation when supplied to .annotate()

--- a/DataRepo/compositeviews.py
+++ b/DataRepo/compositeviews.py
@@ -614,8 +614,7 @@ class PeakGroupsSearchView(BaseSearchView):
             "reverse_path": "compound__peak_groups",
             "manytomany": {
                 "is": True,
-                "split_rows": False,  # This is a test for only including study records when they match a search term on
-                # this field: Test with citrate; isocitrate
+                "split_rows": False,
             },
             "fields": {
                 "name": {
@@ -855,10 +854,8 @@ class PeakGroupsSearchView(BaseSearchView):
             "reverse_path": "peak_groups",
             "manytomany": {
                 "is": True,
-                "split_rows": True,  # This is a test for only including study records when they match a search term on
-                # this field: Test with citrate; isocitrate
-                "root_annot_fld": "compound",  # This is a name of the field that will be added to the root table
-                # record and can be used to identify the M:M related record that goes with it in the template
+                "split_rows": False,
+                "root_annot_fld": "compound",
             },
             "fields": {
                 "id": {
@@ -882,8 +879,8 @@ class PeakGroupsSearchView(BaseSearchView):
             "reverse_path": "animals__samples__msruns__peak_groups",
             "manytomany": {
                 "is": True,
-                "split_rows": False,  # This is a test for only including study records when they match a search term on
-                # this field: Test with obob_fasted and Small OBOB
+                "split_rows": False,
+                "root_annot_fld": "study",
             },
             "fields": {
                 "id": {
@@ -1238,6 +1235,7 @@ class PeakDataSearchView(BaseSearchView):
             "manytomany": {
                 "is": True,
                 "split_rows": False,
+                "root_annot_fld": "study",
             },
             "fields": {
                 "name": {
@@ -1478,6 +1476,7 @@ class FluxCircSearchView(BaseSearchView):
             "manytomany": {
                 "is": True,
                 "split_rows": False,
+                "root_annot_fld": "study",
             },
             "fields": {
                 "name": {

--- a/DataRepo/compositeviews.py
+++ b/DataRepo/compositeviews.py
@@ -204,7 +204,7 @@ class BaseSearchView:
             if (
                 self.model_instances[srch_model_inst_name]["manytomany"]["is"]
                 and self.model_instances[srch_model_inst_name]["manytomany"][
-                    "full_join"
+                    "split_rows"
                 ]
             ):
                 new_qry = self.reRootQry(qry, srch_model_inst_name)
@@ -278,15 +278,15 @@ class BaseSearchView:
             # If this model is many to many related, and we want a full join
             if (
                 self.model_instances[mdl_inst_nm]["manytomany"]["is"]
-                and self.model_instances[mdl_inst_nm]["manytomany"]["full_join"]
+                and self.model_instances[mdl_inst_nm]["manytomany"]["split_rows"]
             ):
-                # If an annotated_pk_field key exists in the "manytomany" dict, use it
+                # If an root_annot_fld key exists in the "manytomany" dict, use it
                 if (
-                    "annotated_pk_field"
+                    "root_annot_fld"
                     in self.model_instances[mdl_inst_nm]["manytomany"].keys()
                 ):
                     annot_fld = self.model_instances[mdl_inst_nm]["manytomany"][
-                        "annotated_pk_field"
+                        "root_annot_fld"
                     ]
                 else:
                     # Otherwise, come up with a reasonable default
@@ -295,8 +295,8 @@ class BaseSearchView:
                     # Check to make sure it doesn't exist
                     if annot_fld in self.rootmodel.__dict__.keys():
                         raise Exception(
-                            f"Many-to-many model {mdl_inst_nm} with full_join=True in format {self.id} must have a "
-                            "value for [annotated_pk_field].  This is the name that will be used to associate a root "
+                            f"Many-to-many model {mdl_inst_nm} with split_rows=True in format {self.id} must have a "
+                            "value for [root_annot_fld].  This is the name that will be used to associate a root "
                             f"table record with its M:M field in a unique combination."
                         )
 
@@ -534,8 +534,8 @@ class BaseSearchView:
 
     def getDistinctFields(self, order_by):
         """
-        Puts together fields required by queryset.distinct() based on the value of each model instance's full_join
-        state.  full_join=True allows us to choose whether the output rows in the html results template will contain
+        Puts together fields required by queryset.distinct() based on the value of each model instance's split_rows
+        state.  split_rows=True allows us to choose whether the output rows in the html results template will contain
         M:M related table values joined in one cell on one row ("merged"), or whether they will be split across
         multiple rows ("split"), and supplying these fields to distinct ensures that the queryset record count reflects
         that html table row (split or merged).
@@ -547,7 +547,7 @@ class BaseSearchView:
         distinct_fields = []
         for mdl_inst_nm in self.model_instances:
             # We only need to include a field if we want to split
-            if self.model_instances[mdl_inst_nm]["manytomany"]["full_join"]:
+            if self.model_instances[mdl_inst_nm]["manytomany"]["split_rows"]:
                 # Django's ordering fields are required when any field is provided to .distinct().  Otherwise, you get
                 # the error: `ProgrammingError: SELECT DISTINCT ON expressions must match initial ORDER BY expressions`
                 tmp_distincts = self.getOrderByFields(mdl_inst_nm)
@@ -560,7 +560,7 @@ class BaseSearchView:
                     self.model_instances[mdl_inst_nm]["path"] + "__pk"
                 )
 
-        # If there are any full_join manytomany related tables, we will need to prepend the ordering (and pk) fields of
+        # If there are any split_rows manytomany related tables, we will need to prepend the ordering (and pk) fields of
         # the root model
         if len(distinct_fields) > 0:
             distinct_fields.insert(0, "pk")
@@ -590,7 +590,7 @@ class PeakGroupsSearchView(BaseSearchView):
             "reverse_path": "peak_groups",
             "manytomany": {
                 "is": False,
-                "full_join": False,
+                "split_rows": False,
             },
             "fields": {
                 "id": {
@@ -614,7 +614,7 @@ class PeakGroupsSearchView(BaseSearchView):
             "reverse_path": "compound__peak_groups",
             "manytomany": {
                 "is": True,
-                "full_join": False,  # This is a test for only including study records when they match a search term on
+                "split_rows": False,  # This is a test for only including study records when they match a search term on
                 # this field: Test with citrate; isocitrate
             },
             "fields": {
@@ -632,7 +632,7 @@ class PeakGroupsSearchView(BaseSearchView):
             "reverse_path": "",
             "manytomany": {
                 "is": False,
-                "full_join": False,
+                "split_rows": False,
             },
             "fields": {
                 "name": {
@@ -679,7 +679,7 @@ class PeakGroupsSearchView(BaseSearchView):
             "reverse_path": "animals__samples__msruns__peak_groups",
             "manytomany": {
                 "is": False,
-                "full_join": False,
+                "split_rows": False,
             },
             "fields": {
                 "id": {
@@ -703,7 +703,7 @@ class PeakGroupsSearchView(BaseSearchView):
             "reverse_path": "msruns__peak_groups",
             "manytomany": {
                 "is": False,
-                "full_join": False,
+                "split_rows": False,
             },
             "fields": {
                 "id": {
@@ -727,7 +727,7 @@ class PeakGroupsSearchView(BaseSearchView):
             "reverse_path": "samples__msruns__peak_groups",
             "manytomany": {
                 "is": False,
-                "full_join": False,
+                "split_rows": False,
             },
             "fields": {
                 "id": {
@@ -751,7 +751,7 @@ class PeakGroupsSearchView(BaseSearchView):
             "reverse_path": "samples__msruns__peak_groups",
             "manytomany": {
                 "is": False,
-                "full_join": False,
+                "split_rows": False,
             },
             "fields": {
                 "id": {
@@ -831,7 +831,7 @@ class PeakGroupsSearchView(BaseSearchView):
             "reverse_path": "animals__samples__msruns__peak_groups",
             "manytomany": {
                 "is": False,
-                "full_join": False,
+                "split_rows": False,
             },
             "fields": {
                 "id": {
@@ -855,9 +855,9 @@ class PeakGroupsSearchView(BaseSearchView):
             "reverse_path": "peak_groups",
             "manytomany": {
                 "is": True,
-                "full_join": True,  # This is a test for only including study records when they match a search term on
+                "split_rows": True,  # This is a test for only including study records when they match a search term on
                 # this field: Test with citrate; isocitrate
-                "annotated_pk_field": "compound",  # This is a name of the field that will be added to the root table
+                "root_annot_fld": "compound",  # This is a name of the field that will be added to the root table
                 # record and can be used to identify the M:M related record that goes with it in the template
             },
             "fields": {
@@ -882,7 +882,7 @@ class PeakGroupsSearchView(BaseSearchView):
             "reverse_path": "animals__samples__msruns__peak_groups",
             "manytomany": {
                 "is": True,
-                "full_join": False,  # This is a test for only including study records when they match a search term on
+                "split_rows": False,  # This is a test for only including study records when they match a search term on
                 # this field: Test with obob_fasted and Small OBOB
             },
             "fields": {
@@ -919,7 +919,7 @@ class PeakDataSearchView(BaseSearchView):
             "reverse_path": "",
             "manytomany": {
                 "is": False,
-                "full_join": False,
+                "split_rows": False,
             },
             "fields": {
                 "labeled_element": {
@@ -973,7 +973,7 @@ class PeakDataSearchView(BaseSearchView):
             "reverse_path": "peak_data",
             "manytomany": {
                 "is": False,
-                "full_join": False,
+                "split_rows": False,
             },
             "fields": {
                 "id": {
@@ -1003,7 +1003,7 @@ class PeakDataSearchView(BaseSearchView):
             "reverse_path": "peak_groups__peak_data",
             "manytomany": {
                 "is": False,
-                "full_join": False,
+                "split_rows": False,
             },
             "fields": {
                 "id": {
@@ -1027,7 +1027,7 @@ class PeakDataSearchView(BaseSearchView):
             "reverse_path": "compound__peak_groups__peak_data",
             "manytomany": {
                 "is": True,
-                "full_join": False,
+                "split_rows": False,
             },
             "fields": {
                 "name": {
@@ -1044,7 +1044,7 @@ class PeakDataSearchView(BaseSearchView):
             "reverse_path": "peak_groups__peak_data",
             "manytomany": {
                 "is": False,
-                "full_join": False,
+                "split_rows": False,
             },
             "fields": {
                 "id": {
@@ -1068,7 +1068,7 @@ class PeakDataSearchView(BaseSearchView):
             "reverse_path": "msruns__peak_groups__peak_data",
             "manytomany": {
                 "is": False,
-                "full_join": False,
+                "split_rows": False,
             },
             "fields": {
                 "id": {
@@ -1092,7 +1092,7 @@ class PeakDataSearchView(BaseSearchView):
             "reverse_path": "samples__msruns__peak_groups__peak_data",
             "manytomany": {
                 "is": False,
-                "full_join": False,
+                "split_rows": False,
             },
             "fields": {
                 "id": {
@@ -1116,7 +1116,7 @@ class PeakDataSearchView(BaseSearchView):
             "reverse_path": "samples__msruns__peak_groups__peak_data",
             "manytomany": {
                 "is": False,
-                "full_join": False,
+                "split_rows": False,
             },
             "fields": {
                 "name": {
@@ -1189,7 +1189,7 @@ class PeakDataSearchView(BaseSearchView):
             "reverse_path": "animals__samples__msruns__peak_groups__peak_data",
             "manytomany": {
                 "is": False,
-                "full_join": False,
+                "split_rows": False,
             },
             "fields": {
                 "name": {
@@ -1213,7 +1213,7 @@ class PeakDataSearchView(BaseSearchView):
             "reverse_path": "animals__samples__msruns__peak_groups__peak_data",
             "manytomany": {
                 "is": False,
-                "full_join": False,
+                "split_rows": False,
             },
             "fields": {
                 "id": {
@@ -1237,7 +1237,7 @@ class PeakDataSearchView(BaseSearchView):
             "reverse_path": "animals__samples__msruns__peak_groups__peak_data",
             "manytomany": {
                 "is": True,
-                "full_join": False,
+                "split_rows": False,
             },
             "fields": {
                 "name": {
@@ -1273,7 +1273,7 @@ class FluxCircSearchView(BaseSearchView):
             "reverse_path": "",
             "manytomany": {
                 "is": False,
-                "full_join": False,
+                "split_rows": False,
             },
             "fields": {
                 "rate_disappearance_average_per_gram": {
@@ -1332,7 +1332,7 @@ class FluxCircSearchView(BaseSearchView):
             "reverse_path": "samples__msruns__peak_groups",
             "manytomany": {
                 "is": False,
-                "full_join": False,
+                "split_rows": False,
             },
             "fields": {
                 "id": {
@@ -1412,7 +1412,7 @@ class FluxCircSearchView(BaseSearchView):
             "reverse_path": "animals__samples__msruns__peak_groups",
             "manytomany": {
                 "is": False,
-                "full_join": False,
+                "split_rows": False,
             },
             "fields": {
                 "name": {
@@ -1436,7 +1436,7 @@ class FluxCircSearchView(BaseSearchView):
             "reverse_path": "msruns__peak_groups",
             "manytomany": {
                 "is": False,
-                "full_join": False,
+                "split_rows": False,
             },
             "fields": {
                 "time_collected": {
@@ -1453,7 +1453,7 @@ class FluxCircSearchView(BaseSearchView):
             "reverse_path": "animals__samples__msruns__peak_groups",
             "manytomany": {
                 "is": False,
-                "full_join": False,
+                "split_rows": False,
             },
             "fields": {
                 "name": {
@@ -1477,7 +1477,7 @@ class FluxCircSearchView(BaseSearchView):
             "reverse_path": "animals__samples__msruns__peak_groups",
             "manytomany": {
                 "is": True,
-                "full_join": False,
+                "split_rows": False,
             },
             "fields": {
                 "name": {

--- a/DataRepo/compositeviews.py
+++ b/DataRepo/compositeviews.py
@@ -518,6 +518,10 @@ class BaseSearchView:
         mdl_nm = model_name
         if mdl_inst_nm is None and model_name is None:
             raise Exception("Either a model instance name or model name is required.")
+        elif mdl_inst_nm is not None and model_name is not None:
+            raise Exception(
+                "mdl_inst_nm and model_name are mutually exclusive options."
+            )
         elif model_name is None:
             mdl_nm = self.model_instances[mdl_inst_nm]["model"]
 
@@ -565,7 +569,7 @@ class BaseSearchView:
             for fld_nm in tmp_distincts:
                 distinct_fields.insert(0, fld_nm)
 
-            if order_by is not None:
+            if order_by is not None and order_by not in distinct_fields:
                 distinct_fields.insert(0, order_by)
 
         return distinct_fields

--- a/DataRepo/templates/DataRepo/search/results/fcirc.html
+++ b/DataRepo/templates/DataRepo/search/results/fcirc.html
@@ -501,14 +501,16 @@
 
                         <!-- Studies -->
                         <td>
+                            <!-- This will work as intended even if pg.msrun.sample.animal.study wasn't added as an anotation (e.g. if split_rows is false or root_annot_fld is not defined) -->
+                            {% get_manytomany_rec pg.msrun.sample.animal.studies pg.msrun.sample.animal.study as studies %}
                             <!-- Put displayed link text first for sorting -->
                             <div style="display:none;">
                                 {% define True as first %}
-                                {% for study in pg.msrun.sample.animal.studies.all %}{% if not first %},<br>{% endif%}{{ study.name }}{% define False as first %}{% endfor %}
+                                {% for study in studies %}{% if not first %},<br>{% endif%}{{ study.name }}{% define False as first %}{% endfor %}
                             </div>
 
                             {% define True as first %}
-                            {% for study in pg.msrun.sample.animal.studies.all %}{% if not first %},<br>{% endif%}<a href="{% url 'study_detail' study.id %}">{{ study.name }}</a>{% define False as first %}{% endfor %}
+                            {% for study in studies %}{% if not first %},<br>{% endif%}<a href="{% url 'study_detail' study.id %}">{{ study.name }}</a>{% define False as first %}{% endfor %}
                         </td>
 
                         <!-- Genotype -->

--- a/DataRepo/templates/DataRepo/search/results/fcirc.html
+++ b/DataRepo/templates/DataRepo/search/results/fcirc.html
@@ -501,7 +501,7 @@
 
                         <!-- Studies -->
                         <td>
-                            <!-- This will work as intended even if pg.msrun.sample.animal.study wasn't added as an anotation (e.g. if split_rows is false or root_annot_fld is not defined) -->
+                            <!-- This will work as intended even if pg.msrun.sample.animal.study wasn't added as an annotation (e.g. if split_rows is false or root_annot_fld is not defined) -->
                             {% get_manytomany_rec pg.msrun.sample.animal.studies pg.msrun.sample.animal.study as studies %}
                             <!-- Put displayed link text first for sorting -->
                             <div style="display:none;">

--- a/DataRepo/templates/DataRepo/search/results/peakdata.html
+++ b/DataRepo/templates/DataRepo/search/results/peakdata.html
@@ -284,7 +284,7 @@
 
                     <!-- Measured Compound(s) -->
                     <td>
-                        <!-- this will work as intended even if pd.peak_group.compound wasn't added as an anotation (e.g. if split_rows is false or root_annot_fld is not defined) -->
+                        <!-- this will work as intended even if pd.peak_group.compound wasn't added as an annotation (e.g. if split_rows is false or root_annot_fld is not defined) -->
                         {% get_manytomany_rec pd.peak_group.compounds pd.peak_group.compound as compounds %}
                         <!-- Put displayed link text first for sorting -->
                         <div style="display:none;">
@@ -420,7 +420,7 @@
 
                     <!-- Studies -->
                     <td>
-                        <!-- This will work as intended even if pd.peak_group.msrun.sample.animal.study wasn't added as an anotation (e.g. if split_rows is false or root_annot_fld is not defined) -->
+                        <!-- This will work as intended even if pd.peak_group.msrun.sample.animal.study wasn't added as an annotation (e.g. if split_rows is false or root_annot_fld is not defined) -->
                         {% get_manytomany_rec pd.peak_group.msrun.sample.animal.studies pd.peak_group.msrun.sample.animal.study as studies %}
                         <!-- Put displayed link text first for sorting -->
                         <div style="display:none;">

--- a/DataRepo/templates/DataRepo/search/results/peakdata.html
+++ b/DataRepo/templates/DataRepo/search/results/peakdata.html
@@ -284,14 +284,16 @@
 
                     <!-- Measured Compound(s) -->
                     <td>
+                        <!-- this will work as intended even if pd.peak_group.compound wasn't added as an anotation (e.g. if split_rows is false or root_annot_fld is not defined) -->
+                        {% get_manytomany_rec pd.peak_group.compounds pd.peak_group.compound as compounds %}
                         <!-- Put displayed link text first for sorting -->
                         <div style="display:none;">
                             {% define True as cpdfirst %}
-                            {% for mcpd in pd.peak_group.compounds.all %}{% if not cpdfirst %}; {% endif%}{{ mcpd.name }}{% define False as cpdfirst %}{% endfor %}
+                            {% for mcpd in compounds %}{% if not cpdfirst %}; {% endif%}{{ mcpd.name }}{% define False as cpdfirst %}{% endfor %}
                         </div>
 
                         {% define True as cpdfirst %}
-                        {% for mcpd in pd.peak_group.compounds.all %}{% if not cpdfirst %}; {% endif%}<a href="{% url 'compound_detail' mcpd.id %}">{{ mcpd.name }}</a>{% define False as cpdfirst %}{% endfor %}
+                        {% for mcpd in compounds %}{% if not cpdfirst %}; {% endif%}<a href="{% url 'compound_detail' mcpd.id %}">{{ mcpd.name }}</a>{% define False as cpdfirst %}{% endfor %}
                     </td>
 
                     <!-- Measured Compound Synonym(s) -->
@@ -299,11 +301,11 @@
                         <!-- Put displayed link text first for sorting -->
                         <div style="display:none;">
                             {% define True as cpdfirst %}
-                            {% for mcpd in pd.peak_group.compounds.all %}{% if not cpdfirst %}; {% endif%}{% define True as synfirst %}{% get_case_insensitive_synonyms mcpd.synonyms as inssyns %}{% for mcpdsyn in inssyns %}{% if not synfirst %}/{% endif%}{{ mcpdsyn }}{% define False as synfirst %}{% endfor %}{% define False as cpdfirst %}{% endfor %}
+                            {% for mcpd in compounds %}{% if not cpdfirst %}; {% endif%}{% define True as synfirst %}{% get_case_insensitive_synonyms mcpd.synonyms as inssyns %}{% for mcpdsyn in inssyns %}{% if not synfirst %}/{% endif%}{{ mcpdsyn }}{% define False as synfirst %}{% endfor %}{% define False as cpdfirst %}{% endfor %}
                         </div>
 
                         {% define True as cpdfirst %}
-                        {% for mcpd in pd.peak_group.compounds.all %}{% if not cpdfirst %}; {% endif%}<a href="{% url 'compound_detail' mcpd.id %}">{% define True as synfirst %}{% get_case_insensitive_synonyms mcpd.synonyms as inssyns %}{% for mcpdsyn in inssyns %}{% if not synfirst %}/{% endif%}{{ mcpdsyn }}{% define False as synfirst %}{% endfor %}</a>{% define False as cpdfirst %}{% endfor %}
+                        {% for mcpd in compounds %}{% if not cpdfirst %}; {% endif%}<a href="{% url 'compound_detail' mcpd.id %}">{% define True as synfirst %}{% get_case_insensitive_synonyms mcpd.synonyms as inssyns %}{% for mcpdsyn in inssyns %}{% if not synfirst %}/{% endif%}{{ mcpdsyn }}{% define False as synfirst %}{% endfor %}</a>{% define False as cpdfirst %}{% endfor %}
                     </td>
 
                     <!-- Labeled Element:Count -->
@@ -418,14 +420,16 @@
 
                     <!-- Studies -->
                     <td>
+                        <!-- This will work as intended even if pd.peak_group.msrun.sample.animal.study wasn't added as an anotation (e.g. if split_rows is false or root_annot_fld is not defined) -->
+                        {% get_manytomany_rec pd.peak_group.msrun.sample.animal.studies pd.peak_group.msrun.sample.animal.study as studies %}
                         <!-- Put displayed link text first for sorting -->
                         <div style="display:none;">
                             {% define True as first %}
-                            {% for study in pd.peak_group.msrun.sample.animal.studies.all %}{% if not first %},<br>{% endif%}{{ study.name }}{% define False as first %}{% endfor %}
+                            {% for study in studies %}{% if not first %},<br>{% endif%}{{ study.name }}{% define False as first %}{% endfor %}
                         </div>
 
                         {% define True as first %}
-                        {% for study in pd.peak_group.msrun.sample.animal.studies.all %}{% if not first %},<br>{% endif%}<a href="{% url 'study_detail' study.id %}">{{ study.name }}</a>{% define False as first %}{% endfor %}
+                        {% for study in studies %}{% if not first %},<br>{% endif%}<a href="{% url 'study_detail' study.id %}">{{ study.name }}</a>{% define False as first %}{% endfor %}
                     </td>
                 </tr>
             {% endfor %}

--- a/DataRepo/templates/DataRepo/search/results/peakgroups.html
+++ b/DataRepo/templates/DataRepo/search/results/peakgroups.html
@@ -274,7 +274,7 @@
                         </div>
 
                         {% define True as cpdfirst %}
-                        {% for mcpd in pg.compounds.all %}{% if not cpdfirst %}; {% endif%}<a href="{% url 'compound_detail' mcpd.id %}">{{ mcpd.name }}</a>{% define False as cpdfirst %}{% endfor %}
+                        {% for mcpd in pg.compounds.all %}{% if pg.compound == mcpd.id %}{% if not cpdfirst %}; {% endif%}<a href="{% url 'compound_detail' mcpd.id %}">{{ mcpd.name }}</a>{% define False as cpdfirst %}{% endif %}{% endfor %}
                     </td>
 
                     <!-- Measured Compound Synonym(s) -->

--- a/DataRepo/templates/DataRepo/search/results/peakgroups.html
+++ b/DataRepo/templates/DataRepo/search/results/peakgroups.html
@@ -267,15 +267,16 @@
 
                     <!-- Measured Compound -->
                     <td>
+                        <!-- This will work as intended even if pg.compound wasn't added as an anotation (e.g. if split_rows is false or root_annot_fld is not defined) -->
+                        {% get_manytomany_rec pg.compounds pg.compound as compounds %}
                         <!-- Put displayed link text first for sorting -->
-                        {% get_manytomany_rec pg.compounds.all pg.compound as compounds %}
                         <div style="display:none;">
                             {% define True as cpdfirst %}
-                            {% for mcpd in compounds %}{% if not cpdfirst %}; {% endif%}{{ mcpd.name }}{% define False as cpdfirst %}{% endfor %}
+                            {% for mcpd in compounds %}{% if not cpdfirst %}; {% endif %}{{ mcpd.name }}{% define False as cpdfirst %}{% endfor %}
                         </div>
 
                         {% define True as cpdfirst %}
-                        {% for mcpd in compounds %}{% if not cpdfirst %}; {% endif%}<a href="{% url 'compound_detail' mcpd.id %}">{{ mcpd.name }}</a>{% define False as cpdfirst %}{% endfor %}
+                        {% for mcpd in compounds %}{% if not cpdfirst %}; {% endif %}<a href="{% url 'compound_detail' mcpd.id %}">{{ mcpd.name }}</a>{% define False as cpdfirst %}{% endfor %}
                     </td>
 
                     <!-- Measured Compound Synonym(s) -->
@@ -283,11 +284,11 @@
                         <!-- Put displayed link text first for sorting -->
                         <div style="display:none;">
                             {% define True as cpdfirst %}
-                            {% for mcpd in pg.compounds.all %}{% if not cpdfirst %}; {% endif%}{% define True as synfirst %}{% get_case_insensitive_synonyms mcpd.synonyms as inssyns %}{% for mcpdsyn in inssyns %}{% if not synfirst %}/{% endif%}{{ mcpdsyn }}{% define False as synfirst %}{% endfor %}{% define False as cpdfirst %}{% endfor %}
+                            {% for mcpd in compounds %}{% if not cpdfirst %}; {% endif %}{% define True as synfirst %}{% get_case_insensitive_synonyms mcpd.synonyms as inssyns %}{% for mcpdsyn in inssyns %}{% if not synfirst %}/{% endif %}{{ mcpdsyn }}{% define False as synfirst %}{% endfor %}{% define False as cpdfirst %}{% endfor %}
                         </div>
 
                         {% define True as cpdfirst %}
-                        {% for mcpd in pg.compounds.all %}{% if not cpdfirst %}; {% endif%}<a href="{% url 'compound_detail' mcpd.id %}">{% define True as synfirst %}{% get_case_insensitive_synonyms mcpd.synonyms as inssyns %}{% for mcpdsyn in inssyns %}{% if not synfirst %}/{% endif%}{{ mcpdsyn }}{% define False as synfirst %}{% endfor %}</a>{% define False as cpdfirst %}{% endfor %}
+                        {% for mcpd in compounds %}{% if not cpdfirst %}; {% endif %}<a href="{% url 'compound_detail' mcpd.id %}">{% define True as synfirst %}{% get_case_insensitive_synonyms mcpd.synonyms as inssyns %}{% for mcpdsyn in inssyns %}{% if not synfirst %}/{% endif %}{{ mcpdsyn }}{% define False as synfirst %}{% endfor %}</a>{% define False as cpdfirst %}{% endfor %}
                     </td>
 
                     <!-- Labeled Element -->
@@ -404,14 +405,16 @@
 
                     <!-- Studies -->
                     <td>
+                        <!-- This will work as intended even if pg.msrun.sample.animal.study wasn't added as an anotation (e.g. if split_rows is false or root_annot_fld is not defined) -->
+                        {% get_manytomany_rec pg.msrun.sample.animal.studies pg.msrun.sample.animal.study as studies %}
                         <!-- Put displayed link text first for sorting -->
                         <div style="display:none;">
                             {% define True as first %}
-                            {% for study in pg.msrun.sample.animal.studies.all %}{% if not first %},<br>{% endif%}{{ study.name }}{% define False as first %}{% endfor %}
+                            {% for study in studies %}{% if not first %},<br>{% endif%}{{ study.name }}{% define False as first %}{% endfor %}
                         </div>
 
                         {% define True as first %}
-                        {% for study in pg.msrun.sample.animal.studies.all %}{% if not first %},<br>{% endif%}<a href="{% url 'study_detail' study.id %}">{{ study.name }}</a>{% define False as first %}{% endfor %}
+                        {% for study in studies %}{% if not first %},<br>{% endif%}<a href="{% url 'study_detail' study.id %}">{{ study.name }}</a>{% define False as first %}{% endfor %}
                     </td>
                 </tr>
             {% endfor %}

--- a/DataRepo/templates/DataRepo/search/results/peakgroups.html
+++ b/DataRepo/templates/DataRepo/search/results/peakgroups.html
@@ -267,7 +267,7 @@
 
                     <!-- Measured Compound -->
                     <td>
-                        <!-- This will work as intended even if pg.compound wasn't added as an anotation (e.g. if split_rows is false or root_annot_fld is not defined) -->
+                        <!-- This will work as intended even if pg.compound wasn't added as an annotation (e.g. if split_rows is false or root_annot_fld is not defined) -->
                         {% get_manytomany_rec pg.compounds pg.compound as compounds %}
                         <!-- Put displayed link text first for sorting -->
                         <div style="display:none;">
@@ -405,7 +405,7 @@
 
                     <!-- Studies -->
                     <td>
-                        <!-- This will work as intended even if pg.msrun.sample.animal.study wasn't added as an anotation (e.g. if split_rows is false or root_annot_fld is not defined) -->
+                        <!-- This will work as intended even if pg.msrun.sample.animal.study wasn't added as an annotation (e.g. if split_rows is false or root_annot_fld is not defined) -->
                         {% get_manytomany_rec pg.msrun.sample.animal.studies pg.msrun.sample.animal.study as studies %}
                         <!-- Put displayed link text first for sorting -->
                         <div style="display:none;">

--- a/DataRepo/templates/DataRepo/search/results/peakgroups.html
+++ b/DataRepo/templates/DataRepo/search/results/peakgroups.html
@@ -268,13 +268,14 @@
                     <!-- Measured Compound -->
                     <td>
                         <!-- Put displayed link text first for sorting -->
+                        {% get_manytomany_rec pg.compounds.all pg.compound as compounds %}
                         <div style="display:none;">
                             {% define True as cpdfirst %}
-                            {% for mcpd in pg.compounds.all %}{% if not cpdfirst %}; {% endif%}{{ mcpd.name }}{% define False as cpdfirst %}{% endfor %}
+                            {% for mcpd in compounds %}{% if not cpdfirst %}; {% endif%}{{ mcpd.name }}{% define False as cpdfirst %}{% endfor %}
                         </div>
 
                         {% define True as cpdfirst %}
-                        {% for mcpd in pg.compounds.all %}{% if pg.compound == mcpd.id %}{% if not cpdfirst %}; {% endif%}<a href="{% url 'compound_detail' mcpd.id %}">{{ mcpd.name }}</a>{% define False as cpdfirst %}{% endif %}{% endfor %}
+                        {% for mcpd in compounds %}{% if not cpdfirst %}; {% endif%}<a href="{% url 'compound_detail' mcpd.id %}">{{ mcpd.name }}</a>{% define False as cpdfirst %}{% endfor %}
                     </td>
 
                     <!-- Measured Compound Synonym(s) -->

--- a/DataRepo/templatetags/customtags.py
+++ b/DataRepo/templatetags/customtags.py
@@ -220,3 +220,24 @@ def uniquify(retval, unused):
     differently in 2 parts of a conditional, but with the same ID.  Just supply a different value to unused.
     """
     return retval
+
+
+@register.simple_tag
+def get_manytomany_rec(recs, pk):
+    """
+    If a M:M ralted table is marked in compositeviews as a full_join, this method identifies the M:M related record
+    that belongs to the root table record, as if this was a proper SQL left join.  While django always returns every
+    related table record with every root table record, this method essentially simulates a proper join by only
+    selecting the join record that was involved in the original query.  It uses an annotated version of the M:M related
+    table record that was added to the root table record using getFullJoinAnnotations().
+
+    It returns a list in each case so that full join can be turned off and on by simply tiggling the `full_join`
+    boolean value in compositeviews.py.
+    """
+    if pk != "":
+        for rec in recs:
+            if rec.pk == pk:
+                return [rec]
+        return None
+    else:
+        return recs

--- a/DataRepo/templatetags/customtags.py
+++ b/DataRepo/templatetags/customtags.py
@@ -1,4 +1,5 @@
 from django import template
+from django.core.exceptions import MultipleObjectsReturned, ObjectDoesNotExist
 from django.template.defaultfilters import floatformat
 from django.urls import reverse
 from django.utils import dateparse
@@ -223,21 +224,36 @@ def uniquify(retval, unused):
 
 
 @register.simple_tag
-def get_manytomany_rec(recs, pk):
+def get_manytomany_rec(mm_set, pk):
     """
-    If a M:M ralted table is marked in compositeviews as a full_join, this method identifies the M:M related record
-    that belongs to the root table record, as if this was a proper SQL left join.  While django always returns every
-    related table record with every root table record, this method essentially simulates a proper join by only
-    selecting the join record that was involved in the original query.  It uses an annotated version of the M:M related
-    table record that was added to the root table record using getFullJoinAnnotations().
+    Takes the value of a ManyToManyField (which is a queryset manager) and the value of the M:M related table primary
+    key that is associated with the root table record via an added annotation, and returns either the one M:M related
+    table record (that matches the primary key) in a list of size 1 or (if there was no annotated primary key value)
+    all the records of the mm_set in a list (what you would get from mm_set.all()).
 
-    It returns a list in each case so that full join can be turned off and on by simply tiggling the `full_join`
+    Further explanation...
+    If a M:M related table is marked in compositeviews with split_rows=True, this method identifies the M:M related
+    record that is associated with the current instance of the root record (which will be a duplicate instance if
+    split_rows is True), as if this was a proper SQL left join.  While django always returns every related table record
+    associated with every root table record on its key path, this method essentially allows the template to reconstruct
+    a full SQL joined table result by providing the M:M related record that was associated with the original left-join
+    query.  It uses an annotated version of the M:M related table record that was added to the root table record using
+    getFullJoinAnnotations().
+
+    It returns a list in each case so that full join can be turned off and on by simply toggling the `split_rows`
     boolean value in compositeviews.py.
     """
     if pk != "":
-        for rec in recs:
-            if rec.pk == pk:
-                return [rec]
-        return None
+        try:
+            mm_rec = [mm_set.get(pk__exact=pk)]
+        except ObjectDoesNotExist:
+            mm_rec = None
+        except MultipleObjectsReturned as mor:
+            raise MultipleObjectsReturned(
+                "Internal error: Primary key is not unique in M:M record list. Was "
+                f"`.distinct()` removed from the Prefetch queryset parameter? {mor}"
+            )
     else:
-        return recs
+        mm_rec = mm_set.all()
+
+    return mm_rec

--- a/DataRepo/tests/test_compositeviews.py
+++ b/DataRepo/tests/test_compositeviews.py
@@ -13,6 +13,8 @@ from DataRepo.tests.tracebase_test_case import TracebaseTestCase
 
 
 class CompositeViewTests(TracebaseTestCase):
+    maxDiff = None
+
     @classmethod
     def setUpTestData(cls):
         call_command("load_study", "DataRepo/example_data/tissues/loading.yaml")
@@ -264,56 +266,18 @@ class CompositeViewTests(TracebaseTestCase):
     def test_getTrueJoinPrefetchPathsAndQrys(self):
         qry = self.getQueryObject2()
         basv = BaseAdvancedSearchView()
+        qry["searches"]["pgtemplate"]["tree"]["queryGroup"][1][
+            "fld"
+        ] = "compounds__name"
+        qry["searches"]["pgtemplate"]["tree"]["queryGroup"][1]["val"] = "citrate"
         prefetches = basv.getTrueJoinPrefetchPathsAndQrys(qry)
         expected_prefetches = [
             "msrun__sample__animal__tracer_compound",
             "msrun__sample__animal__treatment",
-            [
-                "msrun__sample__animal__studies",
-                {
-                    "searches": {
-                        "fctemplate": {
-                            "name": "Fcirc",
-                            "tree": {},
-                        },
-                        "pdtemplate": {
-                            "name": "PeakData",
-                            "tree": {},
-                        },
-                        "pgtemplate": {
-                            "name": "PeakGroups",
-                            "tree": {
-                                "queryGroup": [
-                                    {
-                                        "fld": "name",
-                                        "ncmp": "icontains",
-                                        "pos": "",
-                                        "static": False,
-                                        "type": "query",
-                                        "val": "obob_fasted",
-                                    },
-                                    {
-                                        "fld": "animals__samples__msruns__peak_groups__compounds__synonyms__name",
-                                        "ncmp": "icontains",
-                                        "pos": "",
-                                        "static": False,
-                                        "type": "query",
-                                        "val": "glucose",
-                                    },
-                                ],
-                                "static": False,
-                                "type": "group",
-                                "val": "all",
-                            },
-                        },
-                    },
-                    "selectedtemplate": "pgtemplate",
-                },
-                "Study",
-            ],
+            "msrun__sample__animal__studies",
             "msrun__sample__tissue",
             [
-                "compounds__synonyms",
+                "compounds",
                 {
                     "searches": {
                         "fctemplate": {
@@ -329,7 +293,7 @@ class CompositeViewTests(TracebaseTestCase):
                             "tree": {
                                 "queryGroup": [
                                     {
-                                        "fld": "compound__peak_groups__msrun__sample__animal__studies__name",
+                                        "fld": "peak_groups__msrun__sample__animal__studies__name",
                                         "ncmp": "icontains",
                                         "pos": "",
                                         "static": False,
@@ -342,7 +306,7 @@ class CompositeViewTests(TracebaseTestCase):
                                         "pos": "",
                                         "static": False,
                                         "type": "query",
-                                        "val": "glucose",
+                                        "val": "citrate",
                                     },
                                 ],
                                 "static": False,
@@ -353,8 +317,9 @@ class CompositeViewTests(TracebaseTestCase):
                     },
                     "selectedtemplate": "pgtemplate",
                 },
-                "CompoundSynonym",
+                "Compound",
             ],
+            "compounds__synonyms",
             "peak_group_set",
         ]
 

--- a/DataRepo/tests/test_compositeviews.py
+++ b/DataRepo/tests/test_compositeviews.py
@@ -267,10 +267,18 @@ class CompositeViewTests(TracebaseTestCase):
     def test_getTrueJoinPrefetchPathsAndQrys(self):
         qry = self.getQueryObject2()
         basv = BaseAdvancedSearchView()
-        qry["searches"]["pgtemplate"]["tree"]["queryGroup"][1][
-            "fld"
-        ] = "compounds__name"
-        qry["searches"]["pgtemplate"]["tree"]["queryGroup"][1]["val"] = "citrate"
+        fmt = "pgtemplate"
+
+        # Set all full_join values to False for the test, then...
+        mdl_inst = "MeasuredCompound"
+        pgsv = basv.modeldata[fmt]
+        for inst in pgsv.model_instances.keys():
+            pgsv.model_instances[inst]["manytomany"]["full_join"] = False
+        # Set only MeasuredCompound's full_join=True for the test
+        pgsv.model_instances[mdl_inst]["manytomany"]["full_join"] = True
+
+        qry["searches"][fmt]["tree"]["queryGroup"][1]["fld"] = "compounds__name"
+        qry["searches"][fmt]["tree"]["queryGroup"][1]["val"] = "citrate"
         prefetches = basv.getTrueJoinPrefetchPathsAndQrys(qry)
         expected_prefetches = [
             "msrun__sample__animal__tracer_compound",
@@ -316,7 +324,7 @@ class CompositeViewTests(TracebaseTestCase):
                             },
                         },
                     },
-                    "selectedtemplate": "pgtemplate",
+                    "selectedtemplate": fmt,
                 },
                 "Compound",
             ],

--- a/DataRepo/tests/test_compositeviews.py
+++ b/DataRepo/tests/test_compositeviews.py
@@ -269,13 +269,13 @@ class CompositeViewTests(TracebaseTestCase):
         basv = BaseAdvancedSearchView()
         fmt = "pgtemplate"
 
-        # Set all full_join values to False for the test, then...
+        # Set all split_rows values to False for the test, then...
         mdl_inst = "MeasuredCompound"
         pgsv = basv.modeldata[fmt]
         for inst in pgsv.model_instances.keys():
-            pgsv.model_instances[inst]["manytomany"]["full_join"] = False
-        # Set only MeasuredCompound's full_join=True for the test
-        pgsv.model_instances[mdl_inst]["manytomany"]["full_join"] = True
+            pgsv.model_instances[inst]["manytomany"]["split_rows"] = False
+        # Set only MeasuredCompound's split_rows=True for the test
+        pgsv.model_instances[mdl_inst]["manytomany"]["split_rows"] = True
 
         qry["searches"][fmt]["tree"]["queryGroup"][1]["fld"] = "compounds__name"
         qry["searches"][fmt]["tree"]["queryGroup"][1]["val"] = "citrate"
@@ -339,14 +339,14 @@ class CompositeViewTests(TracebaseTestCase):
         fmt = "pgtemplate"
         annot_name = "compound"
 
-        # Set all full_join values to False for the test, then...
+        # Set all split_rows values to False for the test, then...
         mdl_inst = "MeasuredCompound"
         pgsv = basv.modeldata[fmt]
         for inst in pgsv.model_instances.keys():
-            pgsv.model_instances[inst]["manytomany"]["full_join"] = False
-        # Set only MeasuredCompound's full_join=True and annot_name="compound" for the test
-        pgsv.model_instances[mdl_inst]["manytomany"]["full_join"] = True
-        pgsv.model_instances[mdl_inst]["manytomany"]["annotated_pk_field"] = annot_name
+            pgsv.model_instances[inst]["manytomany"]["split_rows"] = False
+        # Set only MeasuredCompound's split_rows=True and annot_name="compound" for the test
+        pgsv.model_instances[mdl_inst]["manytomany"]["split_rows"] = True
+        pgsv.model_instances[mdl_inst]["manytomany"]["root_annot_fld"] = annot_name
 
         # Do the test
         annots = basv.getFullJoinAnnotations(fmt)
@@ -358,13 +358,13 @@ class CompositeViewTests(TracebaseTestCase):
         fmt = "pgtemplate"
         order_by = "name"
 
-        # Turn off all full_joins for the test, then...
+        # Turn off all split_rows for the test, then...
         mdl_inst = "MeasuredCompound"
         pgsv = basv.modeldata[fmt]
         for inst in pgsv.model_instances.keys():
-            pgsv.model_instances[inst]["manytomany"]["full_join"] = False
-        # Set only MeasuredCompound's full_join value to True for the test
-        pgsv.model_instances[mdl_inst]["manytomany"]["full_join"] = True
+            pgsv.model_instances[inst]["manytomany"]["split_rows"] = False
+        # Set only MeasuredCompound's split_rows value to True for the test
+        pgsv.model_instances[mdl_inst]["manytomany"]["split_rows"] = True
 
         distincts = basv.getDistinctFields(fmt, order_by)
         expected_distincts = [order_by, "pk", "compounds__name", "compounds__pk"]

--- a/DataRepo/tests/test_customtags.py
+++ b/DataRepo/tests/test_customtags.py
@@ -1,16 +1,38 @@
 from django.core.management import call_command
 
-from DataRepo.models import CompoundSynonym
-from DataRepo.templatetags.customtags import get_case_insensitive_synonyms
+from DataRepo.models import CompoundSynonym, PeakGroup, Study
+from DataRepo.templatetags.customtags import (
+    get_case_insensitive_synonyms,
+    get_manytomany_rec,
+)
 from DataRepo.tests.tracebase_test_case import TracebaseTestCase
 
 
 class CustomTagsTests(TracebaseTestCase):
     @classmethod
     def setUpTestData(cls):
+        call_command("load_study", "DataRepo/example_data/tissues/loading.yaml")
         call_command(
             "load_compounds",
             compounds="DataRepo/example_data/consolidated_tracebase_compound_list.tsv",
+        )
+        call_command(
+            "load_samples",
+            "DataRepo/example_data/small_dataset/small_obob_sample_table.tsv",
+            sample_table_headers="DataRepo/example_data/sample_table_headers.yaml",
+        )
+        call_command(
+            "load_samples",
+            "DataRepo/example_data/small_dataset/small_obob_sample_table_2ndstudy.tsv",
+            sample_table_headers="DataRepo/example_data/sample_table_headers.yaml",
+        )
+        call_command(
+            "load_accucor_msruns",
+            protocol="Default",
+            accucor_file="DataRepo/example_data/small_dataset/small_obob_maven_6eaas_inf.xlsx",
+            date="2021-06-03",
+            researcher="Michael Neinast",
+            new_researcher=True,
         )
 
     def test_get_case_insensitive_synonyms(self):
@@ -23,3 +45,23 @@ class CustomTagsTests(TracebaseTestCase):
         # Input case variant list:  ['D-Glucose', 'Glucose', 'glucose', 'Glucose-6-phosphate', 'glucose-6-phosphate']
         csls = get_case_insensitive_synonyms(csqs)
         self.assertListEqual(csls, ["D-Glucose", "glucose", "glucose-6-phosphate"])
+
+    def test_get_manytomany_rec_value(self):
+        """Ensure the one record matching the pk is returned in a 1-member list."""
+        pgs = PeakGroup.objects.filter(
+            msrun__sample__animal__studies__name__iexact="small_obob"
+        )[0:1]
+        of = Study.objects.get(name__iexact="obob_fasted")
+        recs = get_manytomany_rec(pgs[0].msrun.sample.animal.studies, of.pk)
+        self.assertEqual(recs, [of])
+
+    def test_get_manytomany_rec_novalue(self):
+        """Ensure the supplied records are returned if pk is empty."""
+        pgs = PeakGroup.objects.filter(
+            msrun__sample__animal__studies__name__iexact="small_obob"
+        )[0:1]
+        of = Study.objects.filter(name__icontains="obob")
+        recs = get_manytomany_rec(pgs[0].msrun.sample.animal.studies, "")
+        self.assertEqual(recs.count(), of.count())
+        self.assertEqual(recs.count(), 2)
+        self.assertEqual([recs[0].name, recs[1].name], ["obob_fasted", "small_obob"])

--- a/DataRepo/views.py
+++ b/DataRepo/views.py
@@ -992,7 +992,6 @@ def performQuery(
     # This ensures the number of records matches the number of rows desired in the html table based on the
     # full_join values configured in each format in BaseAdvancedSearchView
     distinct_fields = basv.getDistinctFields(fmt, order_by)
-    print(", ".join(distinct_fields))
     results = results.distinct(*distinct_fields)
 
     # Count the total results.  Limit/offset are only used for paging.

--- a/DataRepo/views.py
+++ b/DataRepo/views.py
@@ -969,7 +969,7 @@ def performQuery(
         basv = BaseAdvancedSearchView()
 
     if fmt not in basv.getFormatNames().keys():
-        raise Exception("Invalid selected format: {fmt}")
+        raise KeyError("Invalid selected format: {fmt}")
 
     # If the Q expression is None, get all, otherwise filter
     if q_exp is None:
@@ -990,7 +990,7 @@ def performQuery(
         results = results.order_by(order_by_arg)
 
     # This ensures the number of records matches the number of rows desired in the html table based on the
-    # full_join values configured in each format in BaseAdvancedSearchView
+    # split_rows values configured in each format in BaseAdvancedSearchView
     distinct_fields = basv.getDistinctFields(fmt, order_by)
     results = results.distinct(*distinct_fields)
 
@@ -1038,8 +1038,8 @@ def performQuery(
     if prefetches is not None:
         results = results.prefetch_related(*prefetches)
 
-    full_join_annotations = basv.getFullJoinAnnotations(fmt)
-    for annotation in full_join_annotations:
+    split_row_annotations = basv.getFullJoinAnnotations(fmt)
+    for annotation in split_row_annotations:
         results = results.annotate(**annotation)
 
     return results, cnt


### PR DESCRIPTION
## Summary Change Description

If/when we decide to split the presentation of any records in separate HTML table rows (e.g. show 1 peak group in multiple rows (one for each of multiple labeled elements)), this PR makes that do-able.  It fixes the record count to reflect the number of rows in a "joined" table, as if doing a real SQL left join.

## Affected Issue Numbers

- Resolves #367

## Code Review Notes

This code is actually a work-around.  Django always returns records of the "root" table that was queried only - not a set of joined records.  So in order to get an accurate count of a "joined" table, as would be presented in the template, it needs to return duplicates of the root table, which Django does do based on the relationships, just without the M:M record associations.  Those duplicates exist, but the code was written previously to eliminate them with a call to `distinct()`.  But the point is, at one point, the true join exists with the correct number of duplicate root table records.  I was able to get an accurate count by supplying the fields that I wanted to be distinct (i.e. the keys used in the M:M join for any M:M relationship that we want to split on).

There was one other problem to solve, because after doing that, the M:M related table records were always duplicated on every row whenever it encountered a root table record that linked to them.  (While django's ORM can prefetch related records, it cannot prefetch *multiple* M:M related table records and uniquely combine those records with multiple duplicates of the root table record they link to, because the template doesn't have the full join.  It only has 2 full sets of records.)

So to resolve that, I realized that during the result compilation, I had access to the full join and the duplicate root table records.  So for each root table duplicate, I just annotated the primary key value of the M:M related table record that exists in the join.  Then in the template, I can just grab the record that matches from the set of M:M related records it can retrieve.

For example, if I query for measured compound named `citrate or isocitrate`, the old code would return 56 records from my dev database and each row would show both citrate and isocitrate even though there would be 112 rows in a truly left-joined query.  Now with this PR, I get 112 records (56 are diplicates), and citrate and isocitrate are on their own rows.

I included a change to the PeakGroup display format (not implemented in the download) that splits rows based on measured compound, just to demonstrate how this works.

BTW, Django's ORM requires that the distinct field arguments **must** include the order-bys.  Don't know why, but without those fields, it issues an exception, so whatever.  My guess is that its distinct methodology is dependent on the order of the records, which makes sense as to why they would be required...

To test, I recommend going to the advanced search interface and search for just citrate - then search for citrate OR isocitrate, like this:

<img width="1499" alt="poc_fulljoin" src="https://user-images.githubusercontent.com/2300532/157137209-e9eba79b-e4a8-4224-92d1-86377208dbe1.png">

## Checklist

- [x] All issue requirements satisfied (or no linked issues)
- [x] [Linting passes](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#linting).
- [x] [Migrations created & committed *(or no model changes)*](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#migration-process)
- [x] [Tests implemented *(or no code changes)*](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#test-implementation)
- [x] [All tests pass](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#quality-control)
