### PR TITLE
Search stats

### DIFF
--- a/DataRepo/compositeviews.py
+++ b/DataRepo/compositeviews.py
@@ -622,7 +622,9 @@ class BaseSearchView:
         else:
             if query["val"] == "all":
                 for subquery in query["queryGroup"]:
-                    if not self.meetsAllConditionsByValList(rootrec, subquery, field_order):
+                    if not self.meetsAllConditionsByValList(
+                        rootrec, subquery, field_order
+                    ):
                         return False
                 return True
             else:
@@ -668,7 +670,9 @@ class BaseSearchView:
         elif condition == "not_iendswith":
             return not recval.lower().endswith(searchterm.lower())
         else:
-            raise UnknownComparison(f"Unrecognized negatable comparison (ncmp) value: {condition}.")
+            raise UnknownComparison(
+                f"Unrecognized negatable comparison (ncmp) value: {condition}."
+            )
 
 
 class PeakGroupsSearchView(BaseSearchView):
@@ -2084,7 +2088,9 @@ class BaseAdvancedSearchView:
         annotations, because the Django ORM does not support .distinct(fields).annotate(Count) when duplicate root
         table records exist.
         """
-        return self.modeldata[fmt].meetsAllConditionsByValList(rootrec, query, field_order)
+        return self.modeldata[fmt].meetsAllConditionsByValList(
+            rootrec, query, field_order
+        )
 
 
 def splitPathName(fld):

--- a/DataRepo/compositeviews.py
+++ b/DataRepo/compositeviews.py
@@ -606,6 +606,45 @@ class BaseSearchView:
     def getStatsParams(self):
         return deepcopy(self.stats)
 
+    def meetsCondition(self, recval, condition, searchterm):
+        """
+        Determines whether the recval and search term match, given the matching condition.
+        This is only useful for re-filtering records in a template when the qry includes a fld from a many-to-many
+        related model relative to the root model.
+        Note that any changes to ncmp_choices must also be implemented here.
+        """
+        if condition == "iexact":
+            print("matches?: ", (recval.lower() == searchterm.lower()))
+            return recval.lower() == searchterm.lower()
+        elif condition == "not_iexact":
+            return recval.lower() != searchterm.lower()
+        elif condition == "lt":
+            return recval < searchterm
+        elif condition == "lte":
+            return recval <= searchterm
+        elif condition == "gt":
+            return recval > searchterm
+        elif condition == "gte":
+            return recval >= searchterm
+        elif condition == "isnull":
+            return recval is None
+        elif condition == "not_isnull":
+            return recval is not None
+        elif condition == "icontains":
+            return searchterm.lower() in recval.lower()
+        elif condition == "not_icontains":
+            return searchterm.lower() not in recval.lower()
+        elif condition == "istartswith":
+            return recval.lower().startswith(searchterm.lower())
+        elif condition == "not_istartswith":
+            return not recval.lower().startswith(searchterm.lower())
+        elif condition == "iendswith":
+            return recval.lower().endswith(searchterm.lower())
+        elif condition == "not_iendswith":
+            return not recval.lower().endswith(searchterm.lower())
+        else:
+            raise UnknownComparison(f"Unrecognized negatable comparison (ncmp) value: {condition}.")
+
 
 class PeakGroupsSearchView(BaseSearchView):
     """
@@ -2106,8 +2145,4 @@ def extractFldPathsHelper(subtree):
 
 
 class UnknownComparison(Exception):
-    pass
-
-
-class InvalidQryObject(Exception):
     pass

--- a/DataRepo/compositeviews.py
+++ b/DataRepo/compositeviews.py
@@ -617,6 +617,13 @@ class PeakGroupsSearchView(BaseSearchView):
                 "split_rows": False,
             },
             "fields": {
+                "id": {
+                    "displayname": "(Internal) Compound Synonym Index",
+                    "searchable": True,
+                    "displayed": False,  # Used in link
+                    "handoff": "name",  # This is the field that will be loaded in the search form
+                    "type": "number",
+                },
                 "name": {
                     "displayname": "Measured Compound (Any Synonym)",
                     "searchable": True,
@@ -634,6 +641,13 @@ class PeakGroupsSearchView(BaseSearchView):
                 "split_rows": False,
             },
             "fields": {
+                "id": {
+                    "displayname": "(Internal) Peak Group Index",
+                    "searchable": True,
+                    "displayed": False,  # Used in link
+                    "handoff": "name",  # This is the field that will be loaded in the search form
+                    "type": "number",
+                },
                 "name": {
                     "displayname": "Peak Group",
                     "searchable": True,
@@ -919,6 +933,15 @@ class PeakDataSearchView(BaseSearchView):
                 "split_rows": False,
             },
             "fields": {
+                "id": {
+                    "displayname": "(Internal) Peak Data Index",
+                    "searchable": True,
+                    "displayed": False,  # Used in link
+                    # "handoff": "",
+                    # Using in link will expose the internal index field in the search form because there's no
+                    # searchable unique field for handoff
+                    "type": "number",
+                },
                 "labeled_element": {
                     "displayname": "Labeled Element",
                     "searchable": True,
@@ -1027,6 +1050,13 @@ class PeakDataSearchView(BaseSearchView):
                 "split_rows": False,
             },
             "fields": {
+                "id": {
+                    "displayname": "(Internal) Compound Synonym Index",
+                    "searchable": True,
+                    "displayed": False,  # Used in link
+                    "handoff": "name",  # This is the field that will be loaded in the search form
+                    "type": "number",
+                },
                 "name": {
                     "displayname": "Measured Compound (Any Synonym)",
                     "searchable": True,
@@ -1116,6 +1146,13 @@ class PeakDataSearchView(BaseSearchView):
                 "split_rows": False,
             },
             "fields": {
+                "id": {
+                    "displayname": "(Internal) Animal Index",
+                    "searchable": True,
+                    "displayed": False,  # Used in link
+                    "handoff": "name",  # This is the field that will be loaded in the search form
+                    "type": "number",
+                },
                 "name": {
                     "displayname": "Animal",
                     "searchable": True,
@@ -1189,18 +1226,18 @@ class PeakDataSearchView(BaseSearchView):
                 "split_rows": False,
             },
             "fields": {
-                "name": {
-                    "displayname": "Treatment",
-                    "searchable": True,
-                    "displayed": True,
-                    "type": "string",
-                },
                 "id": {
                     "displayname": "(Internal) Protocol Index",
                     "searchable": True,
                     "displayed": False,  # Used in link
                     "handoff": "name",  # This is the field that will be loaded in the search form
                     "type": "number",
+                },
+                "name": {
+                    "displayname": "Treatment",
+                    "searchable": True,
+                    "displayed": True,
+                    "type": "string",
                 },
             },
         },
@@ -1238,18 +1275,18 @@ class PeakDataSearchView(BaseSearchView):
                 "root_annot_fld": "study",
             },
             "fields": {
-                "name": {
-                    "displayname": "Study",
-                    "searchable": True,
-                    "displayed": True,
-                    "type": "string",
-                },
                 "id": {
                     "displayname": "(Internal) Study Index",
                     "searchable": True,
                     "displayed": False,  # Used in link
                     "handoff": "name",  # This is the field that will be loaded in the search form
                     "type": "number",
+                },
+                "name": {
+                    "displayname": "Study",
+                    "searchable": True,
+                    "displayed": True,
+                    "type": "string",
                 },
             },
         },
@@ -1274,6 +1311,15 @@ class FluxCircSearchView(BaseSearchView):
                 "split_rows": False,
             },
             "fields": {
+                "id": {
+                    "displayname": "(Internal) Peak Group Index",
+                    "searchable": True,
+                    "displayed": False,  # Used in link
+                    # "handoff": "",
+                    # Using in link will expose the internal index field in the search form because there's no
+                    # searchable unique field for handoff
+                    "type": "number",
+                },
                 "rate_disappearance_average_per_gram": {
                     "displayname": "Average Rd (nmol/min/g)",
                     "searchable": False,  # Cannot search cached property
@@ -1413,18 +1459,18 @@ class FluxCircSearchView(BaseSearchView):
                 "split_rows": False,
             },
             "fields": {
-                "name": {
-                    "displayname": "Treatment",
-                    "searchable": True,
-                    "displayed": True,
-                    "type": "string",
-                },
                 "id": {
                     "displayname": "(Internal) Protocol Index",
                     "searchable": True,
                     "displayed": False,  # Used in link
                     "handoff": "name",  # This is the field that will be loaded in the search form
                     "type": "number",
+                },
+                "name": {
+                    "displayname": "Treatment",
+                    "searchable": True,
+                    "displayed": True,
+                    "type": "string",
                 },
             },
         },
@@ -1437,6 +1483,15 @@ class FluxCircSearchView(BaseSearchView):
                 "split_rows": False,
             },
             "fields": {
+                "id": {
+                    "displayname": "(Internal) Sample Index",
+                    "searchable": True,
+                    "displayed": False,  # Used in link
+                    # "handoff": "",
+                    # Using in link will expose the internal index field in the search form because there's no
+                    # searchable unique field for handoff
+                    "type": "number",
+                },
                 "time_collected": {
                     "displayname": "Time Collected (hh:mm:ss since infusion)",
                     "searchable": True,
@@ -1454,18 +1509,18 @@ class FluxCircSearchView(BaseSearchView):
                 "split_rows": False,
             },
             "fields": {
-                "name": {
-                    "displayname": "Tracer Compound",
-                    "searchable": True,
-                    "displayed": True,
-                    "type": "string",
-                },
                 "id": {
                     "displayname": "(Internal) Tracer Index",
                     "searchable": True,
                     "displayed": False,  # Used in link
                     "handoff": "name",  # This is the field that will be loaded in the search form
                     "type": "number",
+                },
+                "name": {
+                    "displayname": "Tracer Compound",
+                    "searchable": True,
+                    "displayed": True,
+                    "type": "string",
                 },
             },
         },
@@ -1479,18 +1534,18 @@ class FluxCircSearchView(BaseSearchView):
                 "root_annot_fld": "study",
             },
             "fields": {
-                "name": {
-                    "displayname": "Study",
-                    "searchable": True,
-                    "displayed": True,
-                    "type": "string",
-                },
                 "id": {
                     "displayname": "(Internal) Study Index",
                     "searchable": True,
                     "displayed": False,  # Used in link
                     "handoff": "name",  # This is the field that will be loaded in the search form
                     "type": "number",
+                },
+                "name": {
+                    "displayname": "Study",
+                    "searchable": True,
+                    "displayed": True,
+                    "type": "string",
                 },
             },
         },

--- a/DataRepo/compositeviews.py
+++ b/DataRepo/compositeviews.py
@@ -1012,6 +1012,7 @@ class PeakDataSearchView(BaseSearchView):
                 "labeled_count",
             ],
             "filter": None,
+            "delimiter": ":",
         },
         {
             "displayname": "Feeding Statuses",

--- a/DataRepo/compositeviews.py
+++ b/DataRepo/compositeviews.py
@@ -606,6 +606,23 @@ class BaseSearchView:
     def getStatsParams(self):
         return deepcopy(self.stats)
 
+    def meetsAllConditionsByValList(self, rootrec, query, field_order):
+        if query["type"] == "query":
+            recval = rootrec[field_order.index(query["fld"])]
+            print(f"Comparing {recval} {query['ncmp']} {query['val']}")
+            return self.meetsCondition(recval, query["ncmp"], query["val"])
+        else:
+            if query["val"] == "all":
+                for subquery in query["queryGroup"]:
+                    if not self.meetsAllConditions(rootrec, subquery):
+                        return False
+                return True
+            else:
+                for subquery in query["queryGroup"]:
+                    if self.meetsAllConditions(rootrec, subquery):
+                        return True
+                return False
+
     def meetsCondition(self, recval, condition, searchterm):
         """
         Determines whether the recval and search term match, given the matching condition.

--- a/DataRepo/compositeviews.py
+++ b/DataRepo/compositeviews.py
@@ -634,7 +634,6 @@ class BaseSearchView:
         """
         if query["type"] == "query":
             recval = rootrec[field_order.index(query["fld"])]
-            print(f"Comparing {recval} {query['ncmp']} {query['val']}")
             return self.meetsCondition(recval, query["ncmp"], query["val"])
         else:
             if query["val"] == "all":
@@ -658,7 +657,6 @@ class BaseSearchView:
         Note that any changes to ncmp_choices must also be implemented here.
         """
         if condition == "iexact":
-            print("matches?: ", (recval.lower() == searchterm.lower()))
             return recval.lower() == searchterm.lower()
         elif condition == "not_iexact":
             return recval.lower() != searchterm.lower()

--- a/DataRepo/compositeviews.py
+++ b/DataRepo/compositeviews.py
@@ -13,25 +13,42 @@ from DataRepo.models import (
 )
 
 
-def getSimpleFilter(fld, ncmp, val, static=False):
+def createFilterGroup(all=True, static=False):
+    """
+    This returns a 1-query portion of what is usually under qry[searches][<template>][tree]
+    """
+    val = "any"
+    if all:
+        val = "all"
+    return {
+        "type": "group",
+        "val": val,
+        "static": static,
+        "queryGroup": [],
+    }
+
+
+def createFilterCondition(fld, ncmp, val, static=False):
     """
     This returns a 1-query portion of what is usually under qry[searches][<template>][tree]
     """
     return {
-        "type": "group",
-        "val": "all",
+        "type": "query",
+        "pos": "",
         "static": static,
-        "queryGroup": [
-            {
-                "type": "query",
-                "pos": "",
-                "static": static,
-                "fld": fld,
-                "ncmp": ncmp,
-                "val": val,
-            },
-        ],
+        "fld": fld,
+        "ncmp": ncmp,
+        "val": val,
     }
+
+
+def appendFilterToGroup(parent, filter):
+    """
+    This returns a 1-query portion of what is usually under qry[searches][<template>][tree]
+    """
+    output_filter = deepcopy(parent)
+    output_filter["queryGroup"].append(filter)
+    return output_filter
 
 
 class BaseSearchView:
@@ -1098,7 +1115,10 @@ class PeakDataSearchView(BaseSearchView):
         {
             "displayname": "Corrected Abundances",  # Append " > 0.1" based on filter
             "distincts": ["corrected_abundance"],
-            "filter": getSimpleFilter("corrected_abundance", "gt", 0.1),
+            "filter": appendFilterToGroup(
+                createFilterGroup(),
+                createFilterCondition("corrected_abundance", "gt", 0.1),
+            ),
         },
         {
             "displayname": "Samples",

--- a/DataRepo/forms.py
+++ b/DataRepo/forms.py
@@ -176,6 +176,7 @@ class AdvSearchPageForm(forms.Form):
     adv_search_page_form = forms.CharField(
         widget=forms.HiddenInput()
     )  # Used to distinguish pager form submissions from advanced search submissions
+    show_stats = forms.JSONField(widget=forms.HiddenInput())
 
     def clean(self):
         """
@@ -184,7 +185,10 @@ class AdvSearchPageForm(forms.Form):
         self.saved_data = self.cleaned_data
         return self.cleaned_data
 
-    def update(self, page_id, rows_id, orderby_id, orderdir_id, rows_attrs={}):
+    def update(self, page_id, rows_id, orderby_id, orderdir_id, rows_attrs={}, other_ids=None):
+        """
+        Adds IDs and other attributes to form elements.
+        """
         # Allow IDs for the inputs to be set for javascript to find the inputs and change them
         page = self.fields.get("page")
         rows = self.fields.get("rows")
@@ -213,7 +217,7 @@ class AdvSearchPageForm(forms.Form):
             and rows.widget.attrs["id"] != rows_id
         ):
             raise Exception(
-                "ERROR: AdvSearchPageForm class already has an ID set for the page input"
+                "ERROR: AdvSearchPageForm class already has an ID set for the rows input"
             )
         rows.widget.attrs["id"] = rows_id
 
@@ -224,7 +228,7 @@ class AdvSearchPageForm(forms.Form):
             and order_by.widget.attrs["id"] != orderby_id
         ):
             raise Exception(
-                "ERROR: AdvSearchPageForm class already has an ID set for the page input"
+                "ERROR: AdvSearchPageForm class already has an ID set for the order_by input"
             )
         order_by.widget.attrs["id"] = orderby_id
 
@@ -235,7 +239,7 @@ class AdvSearchPageForm(forms.Form):
             and order_direction.widget.attrs["id"] != orderdir_id
         ):
             raise Exception(
-                "ERROR: AdvSearchPageForm class already has an ID set for the page input"
+                "ERROR: AdvSearchPageForm class already has an ID set for the order_direction input"
             )
         order_direction.widget.attrs["id"] = orderdir_id
 
@@ -251,6 +255,38 @@ class AdvSearchPageForm(forms.Form):
                     "ERROR: AdvSearchPageForm class already has a [{key}] set for the rows input"
                 )
             rows.widget.attrs[key] = val
+        
+        if other_ids is not None:
+            qryjson = self.fields.get("qryjson")
+            show_stats = self.fields.get("show_stats")
+
+            if "show_stats" in other_ids and other_ids["show_stats"] is not None:
+                # show_stats input
+                if (
+                    show_stats.widget.attrs
+                    and "id" in show_stats.widget.attrs
+                    and show_stats.widget.attrs["id"] != other_ids["show_stats"]
+                ):
+                    raise Exception(
+                        "ERROR: AdvSearchPageForm class already has an ID set for the show_stats input"
+                    )
+                print(f"Setting show_stats ID to {other_ids['show_stats']}")
+                show_stats.widget.attrs["id"] = other_ids["show_stats"]
+
+            if "qryjson" in other_ids and other_ids["qryjson"] is not None:
+                # qryjson input
+                if (
+                    qryjson.widget.attrs
+                    and "id" in qryjson.widget.attrs
+                    and qryjson.widget.attrs["id"] != other_ids["qryjson"]
+                ):
+                    raise Exception(
+                        "ERROR: AdvSearchPageForm class already has an ID set for the show_stats input"
+                    )
+                qryjson.widget.attrs["id"] = other_ids["qryjson"]
+        else:
+            print("Not setting other ids")
+
 
     def is_valid(self):
         # This triggers the setting of self.cleaned_data

--- a/DataRepo/forms.py
+++ b/DataRepo/forms.py
@@ -178,7 +178,6 @@ class AdvSearchPageForm(forms.Form):
     )  # Used to distinguish pager form submissions from advanced search submissions
     show_stats = forms.BooleanField(widget=forms.HiddenInput())
     stats = forms.JSONField(widget=forms.HiddenInput())
-    
 
     def clean(self):
         """
@@ -187,7 +186,9 @@ class AdvSearchPageForm(forms.Form):
         self.saved_data = self.cleaned_data
         return self.cleaned_data
 
-    def update(self, page_id, rows_id, orderby_id, orderdir_id, rows_attrs={}, other_ids=None):
+    def update(
+        self, page_id, rows_id, orderby_id, orderdir_id, rows_attrs={}, other_ids=None
+    ):
         """
         Adds IDs and other attributes to form elements.
         """
@@ -257,7 +258,7 @@ class AdvSearchPageForm(forms.Form):
                     "ERROR: AdvSearchPageForm class already has a [{key}] set for the rows input"
                 )
             rows.widget.attrs[key] = val
-        
+
         if other_ids is not None:
             for fld_name in other_ids.keys():
                 fld = self.fields.get(fld_name)

--- a/DataRepo/forms.py
+++ b/DataRepo/forms.py
@@ -270,10 +270,7 @@ class AdvSearchPageForm(forms.Form):
                     raise Exception(
                         f"ERROR: AdvSearchPageForm class already has an ID set for the {fld_name} input"
                     )
-                print(f"Setting {fld_name} ID to {other_ids[fld_name]}")
                 fld.widget.attrs["id"] = other_ids[fld_name]
-        else:
-            print("Not setting other ids")
 
     def is_valid(self):
         # This triggers the setting of self.cleaned_data
@@ -284,6 +281,7 @@ class AdvSearchPageForm(forms.Form):
             "order_by",
             "order_direction",
             "show_stats",
+            "stats",
         ]
         # Make sure all fields besides the order fields are present
         for field in fields:

--- a/DataRepo/pager.py
+++ b/DataRepo/pager.py
@@ -14,7 +14,7 @@ class Pager:
         order_dir_field,
         form_name,  # Relies on multiforms
         num_buttons=5,
-        other_fields=[],
+        other_field_ids=None,  # {fld_name: id}
         # Default form values
         default_rows=10,
         # Default form element attributes
@@ -38,6 +38,7 @@ class Pager:
         self.orderby_input_id = orderby_input_id
         self.orderdir_input_id = orderdir_input_id
         self.rows_attrs = rows_attrs
+        self.other_field_ids = other_field_ids
         self.page_form = self.page_form_class()
         self.page_form.update(
             self.page_input_id,
@@ -45,6 +46,7 @@ class Pager:
             self.orderby_input_id,
             self.orderdir_input_id,
             self.rows_attrs,
+            self.other_field_ids,
         )
         self.rows_per_page_choices = rows_per_page_choices
         self.page_field = page_field
@@ -52,7 +54,6 @@ class Pager:
         self.default_rows = default_rows
         self.order_by_field = order_by_field
         self.order_dir_field = order_dir_field
-        self.other_fields = other_fields
         self.form_name = form_name
         self.form_id = form_id
 
@@ -71,7 +72,7 @@ class Pager:
         end=None,
         order_by=None,
         order_dir=None,
-        other_field_dict=None,
+        other_field_inits=None,  # {fld_name: {init: val, fld_id: val}}
     ):
         """
         This method is used to update the pager object for each new current page being sent to the pagination template
@@ -118,9 +119,9 @@ class Pager:
         }
         if self.form_id_field not in init_dict:
             init_dict[self.form_id_field] = 1
-        if other_field_dict is not None:
-            for fld in self.other_fields:
-                init_dict[fld] = other_field_dict[fld]
+        if other_field_inits is not None:
+            for fld in other_field_inits.keys():
+                init_dict[fld] = other_field_inits[fld]
         kwargs = {"initial": init_dict}
         self.page_form = self.page_form_class(**kwargs)
         self.page_form.update(
@@ -129,6 +130,7 @@ class Pager:
             self.orderby_input_id,
             self.orderdir_input_id,
             self.rows_attrs,
+            self.other_field_ids,
         )
 
         # Set up the paging controls

--- a/DataRepo/pager.py
+++ b/DataRepo/pager.py
@@ -72,7 +72,7 @@ class Pager:
         end=None,
         order_by=None,
         order_dir=None,
-        other_field_inits=None,  # {fld_name: {init: val, fld_id: val}}
+        other_field_inits=None,  # {fld_name: init_val,...}
     ):
         """
         This method is used to update the pager object for each new current page being sent to the pagination template

--- a/DataRepo/templates/DataRepo/search/results/display.html
+++ b/DataRepo/templates/DataRepo/search/results/display.html
@@ -98,6 +98,28 @@
             {% endif %}
 
             {% if mode == "view" or valid_search %}
+                {% if stats %}
+                    <table>
+                        <tr>
+                            <th>Count</th>
+                            <th>Feature</th>
+                            <th>Example</th>
+                        </tr>
+                        {% for stat_name in stats.keys %}
+                            <tr>
+                                <td>{{ stat_name }}</td>
+                                <td>{{ stats|index:stat_name|index:"count" }}</td>
+                                <td>
+                                    {% for val in stats|index:stat_name|index:"sample" %}
+                                        {{ val }}{% if not forloop.last %}, {% endif %}
+                                    {% endfor %}
+                                </td>
+                            </tr>
+                        {% endfor %}
+
+                    </table>
+                {% endif %}
+
                 {% if selfmt == "pgtemplate" %}
                     {% include "DataRepo/search/results/peakgroups.html" with selfmt=selfmt %}
                 {% elif selfmt == "pdtemplate" %}

--- a/DataRepo/templates/DataRepo/search/results/display.html
+++ b/DataRepo/templates/DataRepo/search/results/display.html
@@ -79,6 +79,12 @@
             <hr>
 
             {% if mode != "view" or valid_search %}
+                {% if stats %}
+                    {% comment %} <div style="font-size: 12px !important; width: 60% !important; margin-left: 16px; float: right;"> {% endcomment %}
+                        {% include "DataRepo/search/results/stats.html" %}
+                    {% comment %} </div> {% endcomment %}
+                {% endif %}
+
                 <div style="margin-left: 16px; float: right;">
                     <button class="btn btn-primary mb-2" id="reset" title="Reset Page Settings" onclick="restoreDefaults()"><i class="fa">Reset</i></button>
                 </div>
@@ -98,28 +104,6 @@
             {% endif %}
 
             {% if mode == "view" or valid_search %}
-                {% if stats %}
-                    <table>
-                        <tr>
-                            <th>Count</th>
-                            <th>Feature</th>
-                            <th>Example</th>
-                        </tr>
-                        {% for stat_name in stats.keys %}
-                            <tr>
-                                <td>{{ stat_name }}</td>
-                                <td>{{ stats|index:stat_name|index:"count" }}</td>
-                                <td>
-                                    {% for val in stats|index:stat_name|index:"sample" %}
-                                        {{ val }}{% if not forloop.last %}, {% endif %}
-                                    {% endfor %}
-                                </td>
-                            </tr>
-                        {% endfor %}
-
-                    </table>
-                {% endif %}
-
                 {% if selfmt == "pgtemplate" %}
                     {% include "DataRepo/search/results/peakgroups.html" with selfmt=selfmt %}
                 {% elif selfmt == "pdtemplate" %}

--- a/DataRepo/templates/DataRepo/search/results/display.html
+++ b/DataRepo/templates/DataRepo/search/results/display.html
@@ -80,9 +80,7 @@
 
             {% if mode != "view" or valid_search %}
                 {% if stats %}
-                    {% comment %} <div style="font-size: 12px !important; width: 60% !important; margin-left: 16px; float: right;"> {% endcomment %}
-                        {% include "DataRepo/search/results/stats.html" %}
-                    {% comment %} </div> {% endcomment %}
+                    {% include "DataRepo/search/results/stats.html" %}
                 {% endif %}
 
                 <div style="margin-left: 16px; float: right;">

--- a/DataRepo/templates/DataRepo/search/results/stats.html
+++ b/DataRepo/templates/DataRepo/search/results/stats.html
@@ -1,5 +1,5 @@
 {% load customtags %}
-<div id="resultstats" style="font-size: 12px !important; width: 30% !important; margin-left: 16px; float: right;" class="collapse{% if stats.populated %} show{% endif %}">
+<div id="resultstats" style="font-size: 12px !important; width: 30% !important; margin-left: 16px; float: right;" class="collapse{% if stats.show %} show{% endif %}">
     {% if stats.populated %}
         <table class="table table-condensed table-striped text-xsmall" style="padding: 2px;">
             <tr>

--- a/DataRepo/templates/DataRepo/search/results/stats.html
+++ b/DataRepo/templates/DataRepo/search/results/stats.html
@@ -1,0 +1,25 @@
+{% load customtags %}
+<div id="resultstats" style="font-size: 12px !important; width: 30% !important; margin-left: 16px; float: right;" class="collapse">
+    <table class="table table-condensed table-striped text-xsmall" style="padding: 2px;">
+        <tr>
+            <th class="col-sm-1 text-end" style="padding: 1px 5px !important;">#</th>
+            <th class="col-sm-1" style="padding: 1px 5px !important;">Feature</th>
+            <th class="col-sm-10" style="padding: 1px 5px !important;">Top 10</th>
+        </tr>
+        {% for stat_name in stats.keys %}
+            <tr>
+                <td class="col-sm-1 text-end" style="padding: 1px 5px !important;">{{ stats|index:stat_name|index:"count" }}</td>
+                <td class="col-sm-1" style="padding: 1px 5px !important;">{{ stat_name }}</td>
+                <td class="col-sm-10" style="padding: 1px 5px !important;">
+                    {% compile_stats stats|index:stat_name|index:"sample" 90 as smry %}
+                    <div title="{{ smry.full }}">
+                        {{ smry.short }}
+                    </div>
+                </td>
+            </tr>
+        {% endfor %}
+    </table>
+</div>
+<div style="margin-left: 16px; float: right;">
+    <button class="btn btn-primary mb-2" title="View Stats" data-bs-toggle="collapse" data-bs-target="#resultstats"><i class="fa">Stats</i></button>
+</div>

--- a/DataRepo/templates/DataRepo/search/results/stats.html
+++ b/DataRepo/templates/DataRepo/search/results/stats.html
@@ -9,7 +9,7 @@
         {% for stat_name in stats.keys %}
             <tr>
                 <td class="col-sm-1 text-end" style="padding: 1px 5px !important;">{{ stats|index:stat_name|index:"count" }}</td>
-                <td class="col-sm-1" style="padding: 1px 5px !important;">{{ stat_name }}</td>
+                <td class="col-sm-1" style="padding: 1px 5px !important;">{{ stat_name }}{% if stats|index:stat_name|index:"filter" %} {% display_filter stats|index:stat_name|index:"filter" %}{% endif %}</td>
                 <td class="col-sm-10" style="padding: 1px 5px !important;">
                     {% compile_stats stats|index:stat_name|index:"sample" 90 as smry %}
                     <div title="{{ smry.full }}">

--- a/DataRepo/templates/DataRepo/search/results/stats.html
+++ b/DataRepo/templates/DataRepo/search/results/stats.html
@@ -1,25 +1,29 @@
 {% load customtags %}
-<div id="resultstats" style="font-size: 12px !important; width: 30% !important; margin-left: 16px; float: right;" class="collapse">
-    <table class="table table-condensed table-striped text-xsmall" style="padding: 2px;">
-        <tr>
-            <th class="col-sm-1 text-end" style="padding: 1px 5px !important;">#</th>
-            <th class="col-sm-1" style="padding: 1px 5px !important;">Feature</th>
-            <th class="col-sm-10" style="padding: 1px 5px !important;">Top 10</th>
-        </tr>
-        {% for stat_name in stats.keys %}
+<div id="resultstats" style="font-size: 12px !important; width: 30% !important; margin-left: 16px; float: right;" class="collapse{% if stats.populated %} show{% endif %}">
+    {% if stats.populated %}
+        <table class="table table-condensed table-striped text-xsmall" style="padding: 2px;">
             <tr>
-                <td class="col-sm-1 text-end" style="padding: 1px 5px !important;">{{ stats|index:stat_name|index:"count" }}</td>
-                <td class="col-sm-1" style="padding: 1px 5px !important;">{{ stat_name }}{% if stats|index:stat_name|index:"filter" %} {% display_filter stats|index:stat_name|index:"filter" %}{% endif %}</td>
-                <td class="col-sm-10" style="padding: 1px 5px !important;">
-                    {% compile_stats stats|index:stat_name|index:"sample" 90 as smry %}
-                    <div title="{{ smry.full }}">
-                        {{ smry.short }}
-                    </div>
-                </td>
+                <th class="col-sm-1 text-end" style="padding: 1px 5px !important;">#</th>
+                <th class="col-sm-1" style="padding: 1px 5px !important;">Feature</th>
+                <th class="col-sm-10" style="padding: 1px 5px !important;">Top 10</th>
             </tr>
-        {% endfor %}
-    </table>
+            {% for stat_name in stats.data.keys %}
+                <tr>
+                    <td class="col-sm-1 text-end" style="padding: 1px 5px !important;">{{ stats.data|index:stat_name|index:"count" }}</td>
+                    <td class="col-sm-1" style="padding: 1px 5px !important;">{{ stat_name }}{% if stats.data|index:stat_name|index:"filter" %} {% display_filter stats.data|index:stat_name|index:"filter" %}{% endif %}</td>
+                    <td class="col-sm-10" style="padding: 1px 5px !important;">
+                        {% compile_stats stats.data|index:stat_name|index:"sample" 90 as smry %}
+                        <div title="{{ smry.full }}">
+                            {{ smry.short }}
+                        </div>
+                    </td>
+                </tr>
+            {% endfor %}
+        </table>
+    {% else %}
+        <div>Compiling stats (this could take up to a minute for large result sets...)</div>
+    {% endif %}
 </div>
 <div style="margin-left: 16px; float: right;">
-    <button class="btn btn-primary mb-2" title="View Stats" data-bs-toggle="collapse" data-bs-target="#resultstats"><i class="fa">Stats</i></button>
+    <button class="btn btn-primary mb-2" title="View Stats" data-bs-toggle="collapse" data-bs-target="#resultstats" onclick="toggleStats(this)"><i class="fa">Stats</i></button>
 </div>

--- a/DataRepo/templates/pagination.html
+++ b/DataRepo/templates/pagination.html
@@ -30,6 +30,14 @@
                     submitForm()
                 })
             }
+            // Submits the form with a show_stats true value after the message about it possibly taking a few seconds appears...
+            {% if not stats.populated %}
+                $('#resultstats').on('shown.bs.collapse', function (e) {
+                    var statselem = document.getElementById("{{ pager.other_field_ids.show_stats }}")
+                    statselem.value = true
+                    submitForm()
+                })
+            {% endif %}
 
             updateColumnSortControls()
         })
@@ -95,6 +103,19 @@
             submitForm()
         }
 
+        function toggleStats(obj) {
+            {% if not stats.populated %}
+                var statselem = document.getElementById("{{ pager.other_field_ids.show_stats }}")
+                if (statselem !== "undefined" && statselem) {
+                    $('#resultstats').collapse("show")
+                } else {
+                    console.error("Unable to retrieve the show_stats button.")
+                }
+            {% else %}
+                console.log("Value in stats.populated: " + "{{ stats.populated }}")
+            {% endif %}
+        }
+
         function submitForm() {
             var myform = document.getElementById("{{ pager.form_id }}")
             myform.submit();
@@ -145,6 +166,7 @@
             {{ pager.page_form.order_direction }}
             {{ pager.page_form.page }}
             {{ pager.page_form.adv_search_page_form }}
+            {{ pager.page_form.show_stats }}
             <div style="float: left;">
                 Showing {{ pager.start }} to {{ pager.end }} of {{ pager.tot }} rows, {{ pager.page_form.rows }} rows per page
             </div>

--- a/DataRepo/templates/pagination.html
+++ b/DataRepo/templates/pagination.html
@@ -31,11 +31,18 @@
                 })
             }
             // Submits the form with a show_stats true value after the message about it possibly taking a few seconds appears...
+            var statselem = document.getElementById("{{ pager.other_field_ids.show_stats }}")
             {% if not stats.populated %}
                 $('#resultstats').on('shown.bs.collapse', function (e) {
-                    var statselem = document.getElementById("{{ pager.other_field_ids.show_stats }}")
                     statselem.value = true
                     submitForm()
+                })
+            {% else %}
+                $('#resultstats').on('show.bs.collapse', function () {
+                    statselem.value = true
+                })
+                $('#resultstats').on('hide.bs.collapse', function () {
+                    statselem.value = false
                 })
             {% endif %}
 
@@ -167,6 +174,7 @@
             {{ pager.page_form.page }}
             {{ pager.page_form.adv_search_page_form }}
             {{ pager.page_form.show_stats }}
+            {{ pager.page_form.stats }}
             <div style="float: left;">
                 Showing {{ pager.start }} to {{ pager.end }} of {{ pager.tot }} rows, {{ pager.page_form.rows }} rows per page
             </div>

--- a/DataRepo/templatetags/customtags.py
+++ b/DataRepo/templatetags/customtags.py
@@ -257,3 +257,17 @@ def get_manytomany_rec(mm_set, pk):
         mm_rec = mm_set.all()
 
     return mm_rec
+
+@register.simple_tag
+def compile_stats(stats, num_chars=160):
+    smry = ""
+    for i, val in enumerate(stats):
+        smry += f"{val['val']} ({val['cnt']})"
+        if i != (len(stats) - 1):
+            smry += ", "
+    short = smry
+    if len(smry) > num_chars:
+        short = str(smry[0:(num_chars - 3)])
+        short += "..."
+        print(f"truncating to {short}")
+    return {"full": smry, "short": short}

--- a/DataRepo/templatetags/customtags.py
+++ b/DataRepo/templatetags/customtags.py
@@ -271,3 +271,12 @@ def compile_stats(stats, num_chars=160):
         short += "..."
         print(f"truncating to {short}")
     return {"full": smry, "short": short}
+
+@register.simple_tag
+def display_filter(filter):
+    """
+    This method is an overly simplistic placeholder until we need a more complex filter to support
+    """
+    ncmp = filter["queryGroup"][0]["ncmp"]
+    val = filter["queryGroup"][0]["val"]
+    return f"{ncmp} {val}"

--- a/DataRepo/templatetags/customtags.py
+++ b/DataRepo/templatetags/customtags.py
@@ -273,7 +273,6 @@ def compile_stats(stats, num_chars=160):
         num_chars -= len(more_str)
         short = str(smry[0:num_chars])
         short += more_str
-        print(f"truncating to {short}")
     return {"full": smry, "short": short}
 
 

--- a/DataRepo/templatetags/customtags.py
+++ b/DataRepo/templatetags/customtags.py
@@ -261,6 +261,11 @@ def get_manytomany_rec(mm_set, pk):
 
 @register.simple_tag
 def compile_stats(stats, num_chars=160):
+    """
+    Takes stats, which is a sorted list of dicts that each contain a val and cnt.  It creates a comma-delimited string
+    of the values (annotated with their count).  It also creates a short version of the string based on the supplied
+    num_chars.  If the string is longer, it truncates the string and inserts an ellipsis.
+    """
     more_str = "..."
     smry = ""
     for i, val in enumerate(stats):
@@ -279,8 +284,24 @@ def compile_stats(stats, num_chars=160):
 @register.simple_tag
 def display_filter(filter):
     """
-    This method is an overly simplistic placeholder until we need a more complex filter to support
+    This method is an overly simplistic placeholder until we need a more complex filter to support.  It handles a
+    single filtering condition only.
     """
+    if (
+        "type" not in filter
+        or "queryGroup" not in filter
+        or filter["type"] != "group"
+        or len(filter["queryGroup"]) != 1
+        or filter["queryGroup"][0]["type"] != "query"
+    ):
+        raise NotYetImplemented(
+            "The display of filtering criterial currently only handles a single condition in a group of size 1.  "
+            "`customtags.display_filter` needs to handle more cases."
+        )
     ncmp = filter["queryGroup"][0]["ncmp"]
     val = filter["queryGroup"][0]["val"]
     return f"{ncmp} {val}"
+
+
+class NotYetImplemented(Exception):
+    pass

--- a/DataRepo/templatetags/customtags.py
+++ b/DataRepo/templatetags/customtags.py
@@ -258,8 +258,10 @@ def get_manytomany_rec(mm_set, pk):
 
     return mm_rec
 
+
 @register.simple_tag
 def compile_stats(stats, num_chars=160):
+    more_str = "..."
     smry = ""
     for i, val in enumerate(stats):
         smry += f"{val['val']} ({val['cnt']})"
@@ -267,10 +269,13 @@ def compile_stats(stats, num_chars=160):
             smry += ", "
     short = smry
     if len(smry) > num_chars:
-        short = str(smry[0:(num_chars - 3)])
-        short += "..."
+        # black and flake8 disagree on how `[0 : (num_chars - 3)]` should be spaced, so...
+        num_chars -= len(more_str)
+        short = str(smry[0:num_chars])
+        short += more_str
         print(f"truncating to {short}")
     return {"full": smry, "short": short}
+
 
 @register.simple_tag
 def display_filter(filter):

--- a/DataRepo/tests/test_compositeviews.py
+++ b/DataRepo/tests/test_compositeviews.py
@@ -6,6 +6,9 @@ from django.db.models import F
 from DataRepo.compositeviews import (
     BaseAdvancedSearchView,
     PeakGroupsSearchView,
+    appendFilterToGroup,
+    createFilterCondition,
+    createFilterGroup,
     extractFldPaths,
     splitCommon,
     splitPathName,
@@ -405,3 +408,63 @@ class CompositeViewTests(TracebaseTestCase):
             Exception, msg="Either a model instance name or model name is required."
         ):
             pgsv.getOrderByFields(mdl_inst_nm=mdl_inst, model_name=mdl)
+
+    def test_createFilterGroup(self):
+        got = createFilterGroup()
+        expected = {
+            "type": "group",
+            "val": "all",
+            "static": False,
+            "queryGroup": [],
+        }
+        self.assertEqual(got, expected)
+
+    def test_createFilterCondition(self):
+        fld = "fldtest"
+        ncmp = "ncmptest"
+        val = "valtest"
+        got = createFilterCondition(fld, ncmp, val)
+        expected = {
+            "type": "query",
+            "pos": "",
+            "static": False,
+            "fld": fld,
+            "ncmp": ncmp,
+            "val": val,
+        }
+        self.assertEqual(got, expected)
+
+    def test_appendFilterToGroup(self):
+        fld = "fldtest"
+        ncmp = "ncmptest"
+        val = "valtest"
+        got = appendFilterToGroup(
+            createFilterGroup(), createFilterCondition(fld, ncmp, val)
+        )
+        expected = {
+            "type": "group",
+            "val": "all",
+            "static": False,
+            "queryGroup": [
+                {
+                    "type": "query",
+                    "pos": "",
+                    "static": False,
+                    "fld": fld,
+                    "ncmp": ncmp,
+                    "val": val,
+                }
+            ],
+        }
+        self.assertEqual(got, expected)
+
+    def test_(self):
+        pgsv = PeakGroupsSearchView()
+        stats = pgsv.getStatsParams()
+        got = stats[2]
+        expected_i2 = {
+            "displayname": "Measured Compounds",
+            "distincts": ["compounds__name"],
+            "filter": None,
+        }
+        self.assertEqual(got, expected_i2)

--- a/DataRepo/tests/test_customtags.py
+++ b/DataRepo/tests/test_customtags.py
@@ -2,6 +2,8 @@ from django.core.management import call_command
 
 from DataRepo.models import CompoundSynonym, PeakGroup, Study
 from DataRepo.templatetags.customtags import (
+    compile_stats,
+    display_filter,
     get_case_insensitive_synonyms,
     get_manytomany_rec,
 )
@@ -65,3 +67,41 @@ class CustomTagsTests(TracebaseTestCase):
         self.assertEqual(recs.count(), of.count())
         self.assertEqual(recs.count(), 2)
         self.assertEqual([recs[0].name, recs[1].name], ["obob_fasted", "small_obob"])
+
+    def test_display_filter(self):
+        filter = {
+            "type": "group",
+            "val": "all",
+            "static": False,
+            "queryGroup": [
+                {
+                    "type": "query",
+                    "pos": "",
+                    "ncmp": "istartswith",
+                    "fld": "msrun__sample__tissue__name",
+                    "val": "brai",
+                    "static": False,
+                },
+            ],
+        }
+        expected = "istartswith brai"
+        got = display_filter(filter)
+        self.assertEqual(got, expected)
+
+    def test_compile_stats(self):
+        dcts = [
+            {
+                "val": "testing",
+                "cnt": 9,
+            },
+            {
+                "val": "trying",
+                "cnt": 100,
+            },
+        ]
+        got = compile_stats(dcts, num_chars=19)
+        expected = {
+            "full": "testing (9), trying (100)",
+            "short": "testing (9), try...",
+        }
+        self.assertEqual(got, expected)

--- a/DataRepo/tests/test_views.py
+++ b/DataRepo/tests/test_views.py
@@ -595,7 +595,7 @@ class ViewTests(TracebaseTestCase):
         basv_metadata = BaseAdvancedSearchView()
         pf = "msrun__sample__animal__studies"
         qs = PeakGroup.objects.all().prefetch_related(pf)
-        res, cnt = getAllBrowseData("pgtemplate", basv_metadata)
+        res, cnt, stats = getAllBrowseData("pgtemplate", basv_metadata)
         self.assertEqual(cnt, qs.count())
 
     def get_basic_qry_inputs(self):
@@ -708,7 +708,7 @@ class ViewTests(TracebaseTestCase):
             "msrun__sample__animal__tracer_compound",
             "msrun__sample__animal__studies",
         ]
-        res, cnt = performQuery(qry, "pgtemplate", basv_metadata)
+        res, cnt, stats = performQuery(qry, "pgtemplate", basv_metadata)
         qs = PeakGroup.objects.filter(
             msrun__sample__tissue__name__iexact="Brain"
         ).prefetch_related(*pf)
@@ -720,7 +720,7 @@ class ViewTests(TracebaseTestCase):
         """
         qry = self.get_advanced_qry2()
         basv_metadata = BaseAdvancedSearchView()
-        res, cnt = performQuery(qry, "pgtemplate", basv_metadata)
+        res, cnt, stats = performQuery(qry, "pgtemplate", basv_metadata)
         qs = (
             PeakGroup.objects.filter(msrun__sample__name__iexact="BAT-xz971")
             .filter(msrun__sample__animal__studies__name__iexact="obob_fasted")

--- a/DataRepo/views.py
+++ b/DataRepo/views.py
@@ -265,7 +265,11 @@ def search_basic(request, mdl, fld, cmp, val, fmt):
         form_id_field="adv_search_page_form",
         rows_per_page_choices=AdvSearchPageForm.ROWS_PER_PAGE_CHOICES,
         page_form_class=AdvSearchPageForm,
-        other_field_ids={"qryjson": None, "show_stats": "show_stats_id", "stats": "stats_id"},
+        other_field_ids={
+            "qryjson": None,
+            "show_stats": "show_stats_id",
+            "stats": "stats_id",
+        },
         page_field="page",
         rows_per_page_field="rows",
         order_by_field="order_by",
@@ -301,7 +305,11 @@ def search_basic(request, mdl, fld, cmp, val, fmt):
     )
 
     pager.update(
-        other_field_inits={"qryjson": json.dumps(qry), "show_stats": False, "stats": None},
+        other_field_inits={
+            "qryjson": json.dumps(qry),
+            "show_stats": False,
+            "stats": None,
+        },
         tot=tot,
     )
 
@@ -370,7 +378,11 @@ class AdvancedSearchView(MultiFormsView):
         form_id_field="adv_search_page_form",
         rows_per_page_choices=AdvSearchPageForm.ROWS_PER_PAGE_CHOICES,
         page_form_class=AdvSearchPageForm,
-        other_field_ids={"qryjson": None, "show_stats": "show_stats_id", "stats": "stats_id"},
+        other_field_ids={
+            "qryjson": None,
+            "show_stats": "show_stats_id",
+            "stats": "stats_id",
+        },
         page_field="page",
         rows_per_page_field="rows",
         order_by_field="order_by",
@@ -479,7 +491,11 @@ class AdvancedSearchView(MultiFormsView):
                 order_direction=None,
             )
             self.pager.update(
-                other_field_inits={"qryjson": json.dumps(qry), "show_stats": False, "stats": json.dumps(stats)},
+                other_field_inits={
+                    "qryjson": json.dumps(qry),
+                    "show_stats": False,
+                    "stats": json.dumps(stats),
+                },
                 tot=tot,
                 page=1,
                 rows=rows_per_page,
@@ -585,7 +601,7 @@ class AdvancedSearchView(MultiFormsView):
                         received_stats = cform["stats"]
                     else:
                         received_stats = None
-                except:
+                except Exception as e:
                     print(
                         f"WARNING: The paging form encountered an exception of type {e.__class__.__name__} during "
                         f"stats field processing: [{e}]."
@@ -654,7 +670,11 @@ class AdvancedSearchView(MultiFormsView):
             stats = received_stats
 
         self.pager.update(
-            other_field_inits={"qryjson": json.dumps(qry), "show_stats": show_stats, "stats": json.dumps(stats)},
+            other_field_inits={
+                "qryjson": json.dumps(qry),
+                "show_stats": show_stats,
+                "stats": json.dumps(stats),
+            },
             tot=tot,
             page=page,
             rows=rows,
@@ -730,7 +750,12 @@ class AdvancedSearchView(MultiFormsView):
                     order_direction=self.pager.order_dir,
                 )
                 context["pager"] = self.pager.update(
-                    other_field_inits={"qryjson": json.dumps(qry), "show_stats": False, "stats": None}, tot=context["tot"]
+                    other_field_inits={
+                        "qryjson": json.dumps(qry),
+                        "show_stats": False,
+                        "stats": None,
+                    },
+                    tot=context["tot"],
                 )
         elif (
             "qry" in context
@@ -748,7 +773,12 @@ class AdvancedSearchView(MultiFormsView):
                 qry, qry["selectedtemplate"], self.basv_metadata
             )
             context["pager"] = self.pager.update(
-                other_field_inits={"qryjson": json.dumps(qry), "show_stats": False, "stats": None}, tot=context["tot"]
+                other_field_inits={
+                    "qryjson": json.dumps(qry),
+                    "show_stats": False,
+                    "stats": None,
+                },
+                tot=context["tot"],
             )
 
 
@@ -829,12 +859,20 @@ class AdvancedSearchTSVView(FormView):
 
 
 def getAllBrowseData(
-    format, basv, limit=None, offset=0, order_by=None, order_direction=None, generate_stats=False,
+    format,
+    basv,
+    limit=None,
+    offset=0,
+    order_by=None,
+    order_direction=None,
+    generate_stats=False,
 ):
     """
     Grabs all data without a filtering match for browsing.
     """
-    return performQuery(None, format, basv, limit, offset, order_by, order_direction, generate_stats)
+    return performQuery(
+        None, format, basv, limit, offset, order_by, order_direction, generate_stats
+    )
 
 
 def createNewBasicQuery(basv_metadata, mdl, fld, cmp, val, fmt):
@@ -1123,8 +1161,13 @@ def getQueryStats(res, fmt, basv=None):
     stats = {}
     cnt_dict = {}
 
-    # order_by(*fmt_distinct_fields) and distinct(*fmt_distinct_fields) are required to get accurate row counts, otherwise, some duplicates will get counted
-    for rec in res.order_by(*fmt_distinct_fields).distinct(*fmt_distinct_fields).values_list(*all_fields):
+    # order_by(*fmt_distinct_fields) and distinct(*fmt_distinct_fields) are required to get accurate row counts,
+    # otherwise, some duplicates will get counted
+    for rec in (
+        res.order_by(*fmt_distinct_fields)
+        .distinct(*fmt_distinct_fields)
+        .values_list(*all_fields)
+    ):
         # For each stats category defined for this format
         for params in params_arrays:
 
@@ -1160,7 +1203,9 @@ def getQueryStats(res, fmt, basv=None):
                     cnt_dict[statskey][valcombo] += 1
             else:
                 # Count values meeting a criteria/filter
-                if basv.meetsAllConditionsByValList(fmt, rec, params["filter"], all_fields):
+                if basv.meetsAllConditionsByValList(
+                    fmt, rec, params["filter"], all_fields
+                ):
                     stats[statskey]["count"] += 1
                     if valcombo not in cnt_dict[statskey]:
                         cnt_dict[statskey][valcombo] = 1
@@ -1174,7 +1219,9 @@ def getQueryStats(res, fmt, basv=None):
         # For the top 10 unique values (delimited-combos), in order of descending number of occurrences
         top10 = []
         # for valcombo in sorted(cnt_dict.keys(), key=lambda x: -cnt_dict[x])[0:10]:
-        for valcombo in sorted(cnt_dict[statskey].keys(), key=lambda vc: -cnt_dict[statskey][vc])[0:10]:
+        for valcombo in sorted(
+            cnt_dict[statskey].keys(), key=lambda vc: -cnt_dict[statskey][vc]
+        )[0:10]:
             top10.append(
                 {
                     "val": valcombo,

--- a/DataRepo/views.py
+++ b/DataRepo/views.py
@@ -1082,10 +1082,30 @@ def getQueryStats(res, fmt, basv=None):
         counted_distincts = params["distincts"]
         counted_distincts.append("cnt")
 
+        if "delimiter" in params:
+            delim = params["delimiter"]
+        else:
+            delim = " "
+        
+        # Create a list of dicts containing a delimiter-joined value and the count
+        top10 = []
+        vals = results.values_list(*counted_distincts, named=False)[0:10]
+        for tpl in vals:
+            lst = []
+            for i, val in enumerate(tpl):
+                if i == (len(tpl) - 1):
+                    vcnt = val
+                else:
+                    lst.append(str(val))
+            top10.append({
+                "val": delim.join(lst),
+                "cnt": vcnt,
+            })
+
         # Compile the stats
         stats[params["displayname"]] = {}
         stats[params["displayname"]]["count"] = results.count()
-        stats[params["displayname"]]["sample"] = results.values_list(*counted_distincts, named=False)[0:10]
+        stats[params["displayname"]]["sample"] = top10
         stats[params["displayname"]]["filter"] = params["filter"]
 
     return stats

--- a/DataRepo/views.py
+++ b/DataRepo/views.py
@@ -1070,6 +1070,91 @@ def getQueryStats(res, fmt, basv=None):
     # result from the possible use of distinct(fields) in the res sent in, we must mix in the distinct fields that
     # uniquely identify records.
     fmt_distinct_fields = basv.getDistinctFields(fmt, assume_distinct=False)
+    stats_fields = [fld for d in params_arrays for fld in d["distincts"]]
+    all_fields = fmt_distinct_fields + stats_fields
+    stats = {}
+    cnt_dict = {}
+
+    for rec in res.values_list(*all_fields):
+        # For each stats category defined for this format
+        for params in params_arrays:
+
+            if "delimiter" in params:
+                delim = params["delimiter"]
+            else:
+                delim = " "
+
+            ##->## Commenting out to test speed.  If it's faster, I will create a plain python filter version using code from the removed refilter code that turns things like 'fld' 'gt' 'val' into `if(rec[fld] > val`
+            # # If this stat has a filter (i.e. sub-query) defined
+            # if params["filter"] is not None:
+            #     # Since we don't have an entire qry object, but just the value under qry["searches"][template]["tree"], we
+            #     # can call the helper method directly
+            #     q_exp = constructAdvancedQueryHelper(params["filter"])
+            #     results = res.filter(q_exp)
+            # else:
+            #     results = res
+
+            # Get distinct fields for the count by taking the union of the record-identifying distinct fields and the
+            # distinct fields whose repeated values we want to count.
+            distinct_fields = params["distincts"]
+
+            statskey = params["displayname"]
+            valcombo = delim.join(
+                # values_list is fast, but can only be indexed by number...
+                list(str(rec[all_fields.index(fld)]) for fld in distinct_fields)
+            )
+
+            # Update the stats
+            if statskey not in stats:
+                stats[statskey] = {
+                    "count": 1,
+                    "filter": params["filter"],
+                }
+                cnt_dict[statskey] = {valcombo: 1}
+            elif valcombo not in cnt_dict[statskey]:
+                cnt_dict[statskey][valcombo] = 1
+                stats[statskey]["count"] += 1
+            else:
+                cnt_dict[statskey][valcombo] += 1
+
+    # For each stats category defined for this format
+    for params in params_arrays:
+        statskey = params["displayname"]
+
+        # For the top 10 unique values (delimited-combos), in order of descending number of occurrences
+        top10 = []
+        # for valcombo in sorted(cnt_dict.keys(), key=lambda x: -cnt_dict[x])[0:10]:
+        for valcombo in sorted(cnt_dict[statskey].keys(), key=lambda vc: -cnt_dict[statskey][vc])[0:10]:
+            top10.append(
+                {
+                    "val": valcombo,
+                    "cnt": cnt_dict[statskey][valcombo],
+                }
+            )
+
+        stats[statskey]["sample"] = top10
+
+    return stats
+
+
+def getQueryStatsOLD(res, fmt, basv=None):
+    """
+    This method takes a queryset (produced by performQuery) and a format (e.g. "pgtemplate") and returns a stats dict
+    keyed on the stat name and containing the counts of  the number of unique values for the fields defined in the
+    basic advanced search view object for the supplied template.  E.g. The results contain 5 distinct tissues.
+    """
+    if basv is None:
+        basv = BaseAdvancedSearchView()
+
+    # Obtain the metadata about what stats we will display
+    params_arrays = basv.getStatsParams(fmt)
+    if params_arrays is None:
+        return None
+
+    # Since `results.values(*distinct_fields).annotate(cnt=Count("pk"))` throws an exception if duplicate records
+    # result from the possible use of distinct(fields) in the res sent in, we must mix in the distinct fields that
+    # uniquely identify records.
+    fmt_distinct_fields = basv.getDistinctFields(fmt, assume_distinct=False)
 
     stats = {}
 
@@ -1119,13 +1204,30 @@ def getQueryStats(res, fmt, basv=None):
             else:
                 cnt_dict[valkey] += 1
 
+        # first10 = []
+        # for rec in results.values_list(*all_distinct_fields)[0:10]:
+        #     # Create the distinct value combo as the dict key
+        #     valkey = delim.join(
+        #         # values_list is fast, but can only be indexed by number...
+        #         map(lambda x: str(rec[all_distinct_fields.index(x)]), distinct_fields)
+        #     )
+        #     first10.append(
+        #         {
+        #             "val": valkey,
+        #             # "cnt": cnt_dict[valcombo],
+        #             "cnt": 1,
+        #         }
+        #     )
+
         # For the top 10 unique values (delimited-combos), in order of descending number of occurrences
         top10 = []
+        # for valcombo in sorted(cnt_dict.keys(), key=lambda x: -cnt_dict[x])[0:10]:
         for valcombo in sorted(cnt_dict.keys(), key=lambda x: -cnt_dict[x])[0:10]:
             top10.append(
                 {
                     "val": valcombo,
                     "cnt": cnt_dict[valcombo],
+                    # "cnt": 1,
                 }
             )
 
@@ -1133,6 +1235,7 @@ def getQueryStats(res, fmt, basv=None):
         stats[params["displayname"]] = {}
         stats[params["displayname"]]["count"] = num_unique
         stats[params["displayname"]]["sample"] = top10
+        # stats[params["displayname"]]["sample"] = first10
         stats[params["displayname"]]["filter"] = params["filter"]
 
     return stats


### PR DESCRIPTION
## Summary Change Description

Added stats for advanced search results as requested [here](https://docs.google.com/document/d/1HCdqFgIDjGeaA8p1M8ElZhWuwxuczVvfwdydhuhLPUo/edit).

## Affected Issue Numbers

- Resolves #159

## Code Review Notes

Here's roughly how it works:

![image](https://user-images.githubusercontent.com/2300532/160005051-bc6baaa3-b4af-4388-a0b9-4ea421a07a4e.gif)

When a search is first performed, the stats are not generated because since it has to look at *all records*, it can take awhile.  Worst case, when I tested with **all peak data** using everything through the fluxomics study, it took 51 seconds.  So in order to not slow down the search, I incorporated the stats compilation with the paging form.  If the user clicks the new stats button, they immediately get a message that it might take a minute.  It calculates all the stats and passes those results from page to page - so it only needs to compile the stats once per search.  If they never click the stats button, it never compiles the stats.

The definition of what is included in the stats is in compositeviews.py.  By default, it simply counts unique values (and for each value, the number of times it occurs).  The stats table has 3 columns: the number of unique values, a label for the stats, and a list of the top 10 values in descending order.  If the final string of the list is longer than 90 characters, it truncates the string and puts it in a tooltip.

Each stats row can either be the unique count or it can use a filter.  Currently, only 1 field has a filter: corrected abundance, based on Michael's requirements.

## Checklist

- [x] All issue requirements satisfied (or no linked issues)
- [x] [Linting passes](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#linting).
- [x] [Migrations created & committed *(or no model changes)*](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#migration-process)
- [x] [Tests implemented *(or no code changes)*](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#test-implementation)
- [x] [All tests pass](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#quality-control)
