### PR TITLE
Update TracerLabeledClass base class in migrations

### DIFF
--- a/DataRepo/migrations/0001_initial.py
+++ b/DataRepo/migrations/0001_initial.py
@@ -135,7 +135,7 @@ class Migration(migrations.Migration):
                 "verbose_name": "animal",
                 "verbose_name_plural": "animals",
             },
-            bases=(models.Model, DataRepo.models.TracerLabeledClass),
+            bases=(models.Model, DataRepo.models.tracerlabeledclass.TracerLabeledClass),
         ),
         migrations.CreateModel(
             name="Compound",
@@ -485,7 +485,7 @@ class Migration(migrations.Migration):
                 "verbose_name_plural": "peak data",
                 "ordering": ["peak_group", "labeled_count"],
             },
-            bases=(models.Model, DataRepo.models.TracerLabeledClass),
+            bases=(models.Model, DataRepo.models.tracerlabeledclass.TracerLabeledClass),
         ),
         migrations.AddField(
             model_name="msrun",

--- a/DataRepo/models/animal.py
+++ b/DataRepo/models/animal.py
@@ -1,4 +1,7 @@
-from datetime import date, timedelta
+import warnings
+from datetime import timedelta
+
+from django.core.exceptions import ValidationError
 from django.core.validators import MaxValueValidator, MinValueValidator
 from django.db import models
 from django.utils.functional import cached_property
@@ -8,7 +11,9 @@ from DataRepo.hier_cached_model import HierCachedModel, cached_function
 from .compound import Compound
 from .protocol import Protocol
 from .study import Study
+from .tissue import Tissue
 from .tracerlabeledclass import TracerLabeledClass
+
 
 class Animal(HierCachedModel, TracerLabeledClass):
     # No parent_related_key_name, because this is a root
@@ -406,4 +411,3 @@ class Animal(HierCachedModel, TracerLabeledClass):
                     "Protocol category for an Animal must be of type "
                     f"{Protocol.ANIMAL_TREATMENT}"
                 )
-

--- a/DataRepo/models/compound.py
+++ b/DataRepo/models/compound.py
@@ -1,5 +1,9 @@
 from django.conf import settings
+from django.core.exceptions import ValidationError
 from django.db import models
+from django.db.models import Q
+
+from .utilities import atom_count_in_formula
 
 
 class Compound(models.Model):
@@ -87,6 +91,7 @@ class Compound(models.Model):
     def __str__(self):
         return str(self.name)
 
+
 class CompoundSynonym(models.Model):
 
     # Instance / model fields
@@ -109,4 +114,3 @@ class CompoundSynonym(models.Model):
 
     def __str__(self):
         return str(self.name)
-

--- a/DataRepo/models/msrun.py
+++ b/DataRepo/models/msrun.py
@@ -1,10 +1,11 @@
-
+from django.core.exceptions import ValidationError
 from django.db import models
 
-from DataRepo.hier_cached_model import HierCachedModel, cached_function
+from DataRepo.hier_cached_model import HierCachedModel
 
 from .protocol import Protocol
 from .sample import Sample
+
 
 class MSRun(HierCachedModel):
     parent_related_key_name = "sample"
@@ -65,4 +66,3 @@ class MSRun(HierCachedModel):
                 "Protocol category for an MSRun must be of type "
                 f"{Protocol.MSRUN_PROTOCOL}"
             )
-

--- a/DataRepo/models/peakgroup.py
+++ b/DataRepo/models/peakgroup.py
@@ -1,4 +1,7 @@
+import warnings
+
 from django.db import models
+from django.db.models import Sum
 from django.utils.functional import cached_property
 
 from DataRepo.hier_cached_model import HierCachedModel, cached_function
@@ -6,6 +9,9 @@ from DataRepo.hier_cached_model import HierCachedModel, cached_function
 from .compound import Compound
 from .msrun import MSRun
 from .peakgroupset import PeakGroupSet
+from .tissue import Tissue
+from .utilities import atom_count_in_formula
+
 
 class PeakGroup(HierCachedModel):
     parent_related_key_name = "msrun"
@@ -116,6 +122,8 @@ class PeakGroup(HierCachedModel):
         tracer compound from the final serum timepoint.
         ThisPeakGroup.enrichment_fraction / SerumTracerPeakGroup.enrichment_fraction
         """
+
+        from .sample import Sample
 
         try:
             # An animal can have no tracer_compound (#312 & #315)
@@ -242,6 +250,8 @@ class PeakGroup(HierCachedModel):
         peakdata.  Returns the peakdata.fraction, if it exists and is greater
         than zero.
         """
+        from .peakdata import PeakData
+
         if not self.can_compute_tracer_rates:
             warnings.warn(f"{self.name} cannot compute tracer rates.")
             return False
@@ -453,4 +463,3 @@ class PeakGroup(HierCachedModel):
 
     def __str__(self):
         return str(self.name)
-

--- a/DataRepo/models/researcher.py
+++ b/DataRepo/models/researcher.py
@@ -1,11 +1,13 @@
+import pandas as pd
 from django.conf import settings
 from django.core.exceptions import ObjectDoesNotExist
 from django.utils.functional import cached_property
 
-from .utilities import get_all_fields_named
 from .animal import Animal
 from .peakgroup import PeakGroup
 from .study import Study
+from .utilities import get_all_fields_named
+
 
 def get_researchers(database=settings.TRACEBASE_DB):
     """
@@ -25,6 +27,7 @@ def get_researchers(database=settings.TRACEBASE_DB):
         )
     unique_researchers = list(pd.unique(researchers))
     return unique_researchers
+
 
 class Researcher:
     """
@@ -68,4 +71,3 @@ class Researcher:
 
     def __str__(self):
         return self.name
-

--- a/DataRepo/models/sample.py
+++ b/DataRepo/models/sample.py
@@ -1,4 +1,5 @@
 from datetime import date, timedelta
+
 from django.core.validators import MaxValueValidator, MinValueValidator
 from django.db import models
 
@@ -6,6 +7,7 @@ from DataRepo.hier_cached_model import HierCachedModel, cached_function
 
 from .animal import Animal
 from .tissue import Tissue
+
 
 class Sample(HierCachedModel):
     parent_related_key_name = "animal"
@@ -64,6 +66,8 @@ class Sample(HierCachedModel):
         [if multiple PeakGroupSets exist].
         """
 
+        from .peakgroup import PeakGroup
+
         peak_groups = PeakGroup.objects.filter(msrun__sample_id=self.id)
         if compound:
             peak_groups = peak_groups.filter(compounds__id=compound.id)
@@ -74,9 +78,9 @@ class Sample(HierCachedModel):
         Retrieve a list of PeakData objects for a sample instance.  If an optional compound is passed (e.g.
         animal.tracer_compound), then is it used to filter the PeakData queryset to a specific peakgroup.
         """
+        from .peakdata import PeakData
 
         peakdata = PeakData.objects.filter(peak_group__msrun__sample_id=self.id)
-
         if compound:
             peakdata = peakdata.filter(peak_group__compounds__id=compound.id)
 
@@ -101,4 +105,3 @@ class Sample(HierCachedModel):
 
     def __str__(self):
         return str(self.name)
-

--- a/DataRepo/models/utilities.py
+++ b/DataRepo/models/utilities.py
@@ -1,5 +1,12 @@
+import warnings
+
+import pandas as pd
+from chempy import Substance
+from chempy.util.periodic import atomic_number
+from django.apps import apps
 from django.conf import settings
 from django.core.exceptions import ValidationError
+
 
 def value_from_choices_label(label, choices):
     """
@@ -97,4 +104,3 @@ def get_researchers(database=settings.TRACEBASE_DB):
         )
     unique_researchers = list(pd.unique(researchers))
     return unique_researchers
-

--- a/DataRepo/tests/test_models.py
+++ b/DataRepo/tests/test_models.py
@@ -9,21 +9,18 @@ from django.db.models.deletion import RestrictedError
 from django.test import override_settings, tag
 
 from DataRepo.hier_cached_model import set_cache
-from DataRepo.models import (
-    Animal,
-    Compound,
-    CompoundSynonym,
-    MSRun,
-    PeakData,
-    PeakGroup,
-    PeakGroupSet,
-    Protocol,
-    Researcher,
-    Sample,
-    Study,
-    Tissue,
-    TracerLabeledClass,
-)
+from DataRepo.models.animal import Animal
+from DataRepo.models.compound import Compound, CompoundSynonym
+from DataRepo.models.msrun import MSRun
+from DataRepo.models.peakdata import PeakData
+from DataRepo.models.peakgroup import PeakGroup
+from DataRepo.models.peakgroupset import PeakGroupSet
+from DataRepo.models.protocol import Protocol
+from DataRepo.models.researcher import Researcher
+from DataRepo.models.sample import Sample
+from DataRepo.models.study import Study
+from DataRepo.models.tissue import Tissue
+from DataRepo.models.tracerlabeledclass import TracerLabeledClass
 from DataRepo.tests.tracebase_test_case import TracebaseTestCase
 from DataRepo.utils import (
     AccuCorDataLoader,

--- a/DataRepo/utils.py
+++ b/DataRepo/utils.py
@@ -16,38 +16,19 @@ from DataRepo.hier_cached_model import (
     disable_caching_updates,
     enable_caching_updates,
 )
-
-from .models.animal import Animal
-from .models.compound import Compound, CompoundSynonym
-from .models.msrun import MSRun
-from .models.peakdata import PeakData
-from .models.peakgroup import PeakGroup
-from .models.peakgroupset import PeakGroupSet
-from .models.protocol import Protocol
-from .models.researcher import Researcher
-from .models.sample import Sample
-from .models.study import Study
-from .models.tissue import Tissue
-from .models.tracerlabeledclass import TracerLabeledClass
-
-
-""" from DataRepo.models import (
-    Animal,
-    Compound,
-    CompoundSynonym,
-    MSRun,
-    PeakData,
-    PeakGroup,
-    PeakGroupSet,
-    Protocol,
-    Researcher,
-    Sample,
-    Study,
-    Tissue,
-    TracerLabeledClass,
-    get_researchers,
-    value_from_choices_label,
-) """
+from DataRepo.models.animal import Animal
+from DataRepo.models.compound import Compound, CompoundSynonym
+from DataRepo.models.msrun import MSRun
+from DataRepo.models.peakdata import PeakData
+from DataRepo.models.peakgroup import PeakGroup
+from DataRepo.models.peakgroupset import PeakGroupSet
+from DataRepo.models.protocol import Protocol
+from DataRepo.models.researcher import Researcher
+from DataRepo.models.sample import Sample
+from DataRepo.models.study import Study
+from DataRepo.models.tissue import Tissue
+from DataRepo.models.tracerlabeledclass import TracerLabeledClass
+from DataRepo.models.utilities import get_researchers, value_from_choices_label
 
 
 class SampleTableLoader:


### PR DESCRIPTION
Since `TracerLabeledClass` is used as model baseclass, we had to update
it's location after moving it.

Also, this fixed imports to get the tests in `test_models.py` running.

```bash
python manage.py test --pattern="test_models.py"
```