### PR TITLE
Multiforms refactor

### DIFF
--- a/DataRepo/forms.py
+++ b/DataRepo/forms.py
@@ -69,7 +69,7 @@ class BaseAdvSearchForm(forms.Form):
     def is_valid(self):
         data = self.cleaned_data
         fields = self.base_fields.keys()
-        # Only validate if the pos field contains the posprefix - otherwise, it belongs to a different form class
+        # Only validate if the pos field starts with the posprefix - otherwise, it belongs to a different form class
         if "pos" in data and data["pos"].startswith(self.posprefix + "-"):
             self.selected = True
             for field in fields:
@@ -118,9 +118,8 @@ class AdvSearchForm:
     """
 
     form_classes: Dict[str, BaseAdvSearchForm] = {}
-    # These form field elements are actually (currently) created in javascript.
+    # This form field is actually (currently) created in javascript.
     format_select_list_name = "fmt"
-    hierarchy_path_field_name = "pos"
 
     def __init__(self, *args, **kwargs):
         for form_class in (
@@ -173,9 +172,9 @@ class AdvSearchPageForm(forms.Form):
     page = forms.CharField(widget=forms.HiddenInput())
     order_by = forms.CharField(widget=forms.HiddenInput())
     order_direction = forms.CharField(widget=forms.HiddenInput())
-    adv_search_page_form = forms.CharField(
+    paging = forms.CharField(
         widget=forms.HiddenInput()
-    )  # Used to distinguish pager form submissions from advanced search submissions
+    )  # This field's name ("paging") is used to distinguish pager form submissions from other form submissions
     show_stats = forms.BooleanField(widget=forms.HiddenInput())
     stats = forms.JSONField(widget=forms.HiddenInput())
 

--- a/DataRepo/multiforms.py
+++ b/DataRepo/multiforms.py
@@ -47,7 +47,6 @@ class MultiFormMixin(ContextMixin):
     prefixes: Dict[str, str] = {}
     success_urls: Dict[str, str] = {}
     default_formid_fieldname = "action"
-    default_mixedid_fieldname = "formtype"
 
     identifying_fields: Dict[str, str] = {}
     # Key is a field name and the value indicates whether to look in form_classes ("individual"), grouped_forms

--- a/DataRepo/multiforms.py
+++ b/DataRepo/multiforms.py
@@ -1,6 +1,6 @@
-from typing import Dict, Optional
+from typing import Dict, List, Optional
 
-from django import forms
+from django.forms import Form
 from django.http.response import HttpResponseForbidden, HttpResponseRedirect
 from django.views.generic.base import ContextMixin, TemplateResponseMixin
 from django.views.generic.edit import ProcessFormView
@@ -13,32 +13,190 @@ from django.views.generic.edit import ProcessFormView
 
 
 class MultiFormMixin(ContextMixin):
+    """
+    This class identifies, retrieves, binds, and validates multiple types of form found on a page from a single view.
+    Note, the purpose is not to handle formsets (multiple forms of the same type) though that case is also supported*.
+    It can call multiple custom form_valid/form_invalid, create, and initial methods.  It does not process submitted
+    forms (see ProcessMultipleFormsView).  There are 4 categories into which forms are identified: individual, grouped,
+    mixed, and "all".  All form classes should be set by the user in the form_classes dict.  The keys of the dict
+    depend on the category:
+    
+        - Individual: The name of the form field intended to identify the form
+        - Grouped: Arbitrary key defined by the user, also contained in the grouped_forms list value.  The
+          grouped_forms key instead, must be the name of the form field intended to identify the form as being part of
+          a group of form types expected to be processed together.
+        - Mixed: Arbitrary key defined by the user, also contained in the mixed_forms list value.  The mixed_forms key
+          instead, must be the name of the form field intended to identify the form as being part of a mix of form
+          types expected to be processed together.  The value of the identifying field must be one of the form_classes
+          keys to indicate the form type to validate.
+        - All: The keys in this case do not matter.  If the form contains no field the identifies it as "individual",
+          "grouped", or "mixed", all forms in the form_classes dict are used.^
+    
+    In the mixed case, it is assumed that the field names are the same for each form type and the forms are
+    differentiated based on things like autocomplete, choices in select lists, etc..  It is intended to be used with
+    formsets combined with a single select list that allows the user to select the form type.  One example is an
+    advanced search where the user selects a schema to search and the 3 fields in each form are for "database field",
+    "condition" (e.g. "equals or "contains"), and "search term".
+    
+    * - I'm not entirely certain formsets are supported in the "individual" and "grouped" form cases because I haven't
+        tested those, but it is supported in the mixed forms case.  The user is required to handle formsets in their
+        code (e.g. in their `*form_valid` and `*form_invalid` methods).
+    ^ - I suspect that this could only ever really work if there was only a single form type, but I'm not sure.
+    """
 
-    form_classes: Dict[str, forms.Form] = {}
     prefixes: Dict[str, str] = {}
     success_urls: Dict[str, str] = {}
-    grouped_forms: Dict[str, str] = {}
+    default_formid_fieldname = "action"
+    default_mixedid_fieldname = "formtype"
 
+    identifying_fields: Dict[str, str] = {}
+    # Key is a field name and the value indicates whether to look in form_classes ("individual"), grouped_forms
+    # ("grouped"), or mixed_forms ("mixed") to determine the form type(s)
+
+    form_classes: Dict[str, Form] = {}
+    # Key is the value in the identifying field that defines an individualform.  Value is a form type.
+
+    grouped_forms: Dict[str, List] = {}
+    # Key is the value in the identifying field that defines the group.  Value is a list of form_classes keys.
+    
+    mixed_forms = {
+        "form_type_field": default_mixedid_fieldname,
+        "form_class_keys": [],
+    }
+    # Key is the value in the identifying field that defines the mixed type.  Value is a list of form_classes keys.
+
+    debug = True  # Reports when an expected method is not defined
+    
     # The mixed form type is a single form submission containing any number (>0) of formsets of any
     #   number (>1) of types
     # Only 1 formset type (based on a selected form field) will be validated
-    # To use a mixed form, the following must have values: form_classes, mixedform_selected_formtype,
-    #   mixedform_prefix_field
-
-    # mixedform_selected_formtype defines the name of a form field (added e.g. via javascript) whose
-    # value upon submit contains a value indicating the selected form type to be validated (e.g. a key
-    # from form_classes)
-    mixedform_selected_formtype = ""
-    # mixedform_prefix_field defines the name of a form field whose value upon submit must start with
-    # the value found in the mixedform_selected_formtype field.  Only forms with this match will be
-    # validated (though all forms' values will be submitted).
-    mixedform_prefix_field = ""
+    # To use a mixed form, the following must have values: form_classes and mixed_forms.  The key for mixed_form must
+    # be a single form field (not repeated among formsets, e.g. added by javascript) whose value is one of the keys in
+    # form_classes.  The value in the dict however is all of the keys to the form classes involved in the mix.
 
     # I know that initial is Dict[str, function], but I don't know what the initial function takes or
     # returns, as I don't use it, so I'm leaving it as ignore.
     initial = {}  # type: ignore
     prefix: Optional[str] = None
     success_url: Optional[str] = None
+
+    def add_individual_form(self, identifying_field_name, form_class):
+        """
+        Add a form class that is identified simply by the presence of a field in the form with a specific name.
+        """
+        # Error-check the identifying_field_name
+        if identifying_field_name in self.identifying_fields.keys():
+            raise Exception(
+                f"Identifying form field {identifying_field_name} already exists as a ["
+                f"{self.identifying_fields[identifying_field_name]}] form.  Cannot add an individual form identified "
+                "by the same field name."
+            )
+
+        # Error-check the form_class
+        if (
+            identifying_field_name in self.form_classes.keys()
+            and form_class.__name__ != self.form_classes[identifying_field_name].__name__
+        ):
+            raise Exception(
+                f"A different form class [{self.form_classes[identifying_field_name].__name__}] already exists under "
+                f"key [{identifying_field_name}].  Cannot add form class [{form_class.__name__}]."
+            )
+
+        self.identifying_fields[identifying_field_name] = "individual"
+        if identifying_field_name not in self.form_classes.keys():
+            self.form_classes[identifying_field_name] = form_class
+
+    def add_grouped_forms(self, identifying_field_name, form_classes_dict):
+        """
+        Add a set of form classes that are grouped together.  The group is identified by the presence of a field in the
+        form with a specific name.
+        """
+        # Error-check the identifying_field_name
+        if identifying_field_name in self.identifying_fields.keys():
+            raise Exception(
+                f"Identifying form field {identifying_field_name} already exists as a ["
+                f"{self.identifying_fields[identifying_field_name]}] form.  Cannot add grouped forms identified by "
+                "the same field name."
+            )
+
+        # Error-check the form_classes_dict
+        for key in form_classes_dict.keys():
+            if (
+                key in self.form_classes.keys()
+                and form_classes_dict[key].__name__ != self.form_classes[key].__name__
+            ):
+                raise Exception(
+                    f"A different form class [{self.form_classes[key].__name__}] already exists under key [{key}].  "
+                    f"Cannot add form class [{form_classes_dict[key].__name__}] for group [{identifying_field_name}]."
+                )
+            if key not in self.form_classes.keys():
+                self.form_classes[key] = form_classes_dict[key]
+
+        self.identifying_fields[identifying_field_name] = "grouped"
+        self.grouped_forms[identifying_field_name] = [list(form_classes_dict.keys())]
+
+    def add_mixed_forms(self, identifying_select_field_name, form_type_field_name, form_classes_dict):
+        """
+        Add a set of form classes that are part of a mixed form.  The mix is identified by the presence of a field in
+        the form with a specific name.  The identifying field is the field whose value will indicate the selected form
+        type.
+        """
+        # Error-check the identifying_field_name
+        if identifying_select_field_name in self.identifying_fields.keys():
+            raise Exception(
+                f"Identifying form field {identifying_select_field_name} already exists as a ["
+                f"{self.identifying_fields[identifying_select_field_name]}] form.  Cannot add mixed forms identified "
+                "by the same field name."
+            )
+
+        # Error-check the form_classes_dict
+        for key in form_classes_dict.keys():
+            if (
+                key in self.form_classes.keys()
+                and form_classes_dict[key].__name__ != self.form_classes[key].__name__
+            ):
+                raise Exception(
+                    f"A different form class [{self.form_classes[key].__name__}] already exists under key [{key}].  "
+                    f"Cannot add form class [{form_classes_dict[key].__name__}]."
+                )
+            if key not in self.form_classes.keys():
+                self.form_classes[key] = form_classes_dict[key]
+
+        self.identifying_fields[identifying_select_field_name] = "mixed"
+        self.mixed_forms[identifying_select_field_name]["form_type_field"] = form_type_field_name
+        self.mixed_forms[identifying_select_field_name]["form_class_keys"] = [list(form_classes_dict.keys())]
+
+    def __init__(self, *args, **kwargs):
+        """
+        This ensures everything is configured correctly.
+        """
+        super().__init__(*args, **kwargs)
+        seen_forms = {}
+
+        for group_key in self.grouped_forms.keys():
+            form_classes_dict = {}
+            for form_key in self.grouped_forms[group_key].keys():
+                seen_forms[form_key] = 1
+                if form_key not in self.form_classes:
+                    raise Exception(f"Group [{group_key}]'s form key: [{form_key}] is not in the form_classes dict.")
+                else:
+                    form_classes_dict[form_key] = self.form_classes[form_key]
+            self.add_grouped_forms(group_key, form_classes_dict)
+
+        for mix_key in self.mixed_forms.keys():
+            form_classes_dict = {}
+            for form_key in self.mixed_forms[mix_key]["form_class_keys"]:
+                seen_forms[form_key] = 1
+                if form_key not in self.form_classes:
+                    raise Exception(f"Mix [{mix_key}]'s form key: [{form_key}] is not in the form_classes dict.")
+                else:
+                    form_classes_dict[form_key] = self.form_classes[form_key]
+            self.add_grouped_forms(group_key, form_classes_dict)
+        
+        for form_key in self.form_classes.keys():
+            if form_key not in seen_forms.keys():
+                self.add_individual_form(form_key, seen_forms[form_key])
+
 
     def get_form_classes(self):
         return self.form_classes
@@ -72,33 +230,56 @@ class MultiFormMixin(ContextMixin):
 
         return kwargs
 
-    def forms_valid(self, forms):
+    def forms_valid(self, forms, one_form_name=None):
         calls = []
-        for form_name in forms.keys():
-            form_valid_method = "%s_form_valid" % form_name
+        if one_form_name is not None:
+            if one_form_name not in forms:
+                raise Exception("Form [{one_form_name}] not in the forms submitted.")
+            form_valid_method = "%s_form_valid" % one_form_name
             if hasattr(self, form_valid_method):
-                calls.append([form_valid_method, forms[form_name]])
-                # Originally, there was not a return here. I added it to validate my theory, and it worked, so I added
-                # an elif below to handle this case. The line below this one just originally called the form valid
-                # method and expected it to not return anything
-                # return getattr(self, form_valid_method)(forms[form_name])
-        if self._mixed_exists() and len(calls) == 0:
-            return self.form_valid(forms)
-        elif len(calls) == 1:
-            form_valid_method, form = calls[0]
-            return getattr(self, form_valid_method)(form)
+                calls.append([form_valid_method, forms[one_form_name], one_form_name])
         else:
+            for form_name in forms.keys():
+                form_valid_method = "%s_form_valid" % form_name
+                if hasattr(self, form_valid_method):
+                    calls.append([form_valid_method, forms[form_name], form_name])
+
+        if len(calls) == 0 and hasattr(self, "form_valid"):
+            # Will call form_valid with all forms
+            calls.append(["form_valid", forms, None])
+
+        if len(calls) == 1:
+            form_valid_method, form_or_forms, form_name = calls[0]
+            surl = self.get_success_url(form_name)
+
+            # if there is a success URL
+            if surl is not None and surl != "":
+                getattr(self, form_valid_method)(form_or_forms)
+                return HttpResponseRedirect(surl)
+
+            return getattr(self, form_valid_method)(form_or_forms)
+        else:
+            # calls must have >1 members. Call each form valid method
             for call in calls:
-                form_valid_method, form = call
+                form_valid_method, form, form_name = call
                 getattr(self, form_valid_method)(form)
-            if len(self.success_urls) == 0:
-                if self.success_url == "":
-                    # Not entirely sure this is correct, but with the current code, this should never execute
-                    return self.render_to_response(self.get_context_data(forms=forms))
-                else:
-                    return HttpResponseRedirect(self.success_url)
-            else:
-                return HttpResponseRedirect(self.get_success_url(form_name))
+
+            if self.debug and len(calls) == 1 and calls[0][0] == "form_valid":
+                print(f"WARNING: ({','.join(forms.keys())})_form_valid method(s) not found")
+
+            # Get common success URL for all validated forms
+            surl = self.get_success_url()
+
+            # if there is a success URL (ignoring potentially multiple success URLs)
+            if surl is not None and surl != "":
+                return HttpResponseRedirect(surl)
+
+            if one_form_name is not None:
+                raise Exception("There is no `{one_form_name}_form_valid` method for form type [{one_form_name}].")
+
+            # Default to "same/self" view
+            return self.render_to_response(self.get_context_data(forms=forms))
+
 
     def forms_invalid(self, forms):
         calls = []
@@ -106,20 +287,23 @@ class MultiFormMixin(ContextMixin):
             form_invalid_method = "%s_form_invalid" % form_name
             if hasattr(self, form_invalid_method):
                 calls.append([form_invalid_method, forms[form_name]])
-                # Originally, there was not a return here. I added it to validate my theory, and it worked, so I added
-                # an elif below to handle this case. The line below this one just originally called the form valid
-                # method and expected it to not return anything
-                # return getattr(self, form_invalid_method)(forms[form_name])
-        if self._mixed_exists() and len(calls) == 0:
-            return self.form_invalid(forms)
-        elif len(calls) == 1:
-            form_invalid_method, form = calls[0]
-            return getattr(self, form_invalid_method)(form)
+
+        if self.debug and len(calls) == 0:
+            print(f"WARNING: ({','.join(forms.keys())})_form_invalid method(s) not found")
+
+        if len(calls) == 0 and hasattr(self, "form_invalid"):
+            # Will call form_invalid with all forms
+            calls.append(["form_invalid", forms, None])
+
+        if len(calls) == 1:
+            form_invalid_method, form_or_forms = calls[0]
+            return getattr(self, form_invalid_method)(form_or_forms)
         else:
             for call in calls:
                 form_invalid_method, form = call
                 getattr(self, form_invalid_method)(form)
                 # Not entirely sure this is correct, but with the current code, this should never execute
+
             return self.render_to_response(self.get_context_data(forms=forms))
 
     def get_initial(self, form_name):
@@ -130,9 +314,16 @@ class MultiFormMixin(ContextMixin):
             return self.initial.copy()
 
     def get_prefix(self, form_name):
+        """
+        Tries to get a specific prefix (for use in element IDs) for an optional given form_name, defaulting to a single
+        prefix.
+        """
         return self.prefixes.get(form_name, self.prefix)
 
     def get_success_url(self, form_name=None):
+        """
+        Tries to get a specific URL for the optional given form_name, defaulting to a single success URL.
+        """
         return self.success_urls.get(form_name, self.success_url)
 
     def _create_form(self, form_name, klass, bind_form):
@@ -162,28 +353,6 @@ class MultiFormMixin(ContextMixin):
             return retdict
         return {}
 
-    def _mixed_exists(self):
-        if self.mixedform_prefix_field or self.mixedform_selected_formtype:
-            if not self.mixedform_prefix_field or not self.mixedform_selected_formtype:
-                print(
-                    "ERROR: Both mixedform_prefix_field and mixedform_selected_formtype must be set to use mixed ",
-                    "forms.  The value of the form field defined by mixedform_selected_formtype must be contained in ",
-                    "the value of the form field defined by mixedform_prefix_field.",
-                )
-        elif (
-            self.mixedform_prefix_field
-            and self.mixedform_selected_formtype
-            and len(self.form_classes.keys()) < 2
-        ):
-            print(
-                "ERROR: form_classes must contain at least 2 form classes to used the mixed form type."
-            )
-        return (
-            len(self.form_classes.keys()) > 1
-            and self.mixedform_prefix_field
-            and self.mixedform_selected_formtype
-        )
-
 
 class ProcessMultipleFormsView(ProcessFormView):
     def get(self, request, *args, **kwargs):
@@ -193,22 +362,51 @@ class ProcessMultipleFormsView(ProcessFormView):
 
     def post(self, request, *args, **kwargs):
         form_classes = self.get_form_classes()
-        form_name = request.POST.get("action")
+        form_type, form_key = self._get_forms_type(request)
 
-        if self._individual_exists(form_name) and not self._mixed_exists():
-            return self._process_individual_form(form_name, form_classes)
-        elif self._group_exists(form_name) and not self._mixed_exists():
-            return self._process_grouped_forms(form_name, form_classes)
-        elif self._mixed_exists():
-            return self._process_mixed_forms(form_classes)
-        else:
+        if form_type == "individual":
+            return self._process_individual_form(form_key, form_classes)
+        elif form_type == "grouped":
+            return self._process_grouped_forms(form_key, form_classes)
+        elif form_type == "mixed":
+            return self._process_mixed_forms(form_key, form_classes)
+        elif form_type == "all":
             return self._process_all_forms(form_classes)
+
+    def _get_forms_type(self, request):
+        """
+        This looks through the fields that identify the form types (individual, grouped, mixed, or all) and returns the
+        type (individual, grouped, mixed, or all) and the associated key that identifies an instance of that type.
+        """
+        forms_type = "all"
+        key = None
+        identifying_field = None
+        for id_field in self.identifying_fields.keys():
+            if id_field in request.POST:
+                if key is None:
+                    forms_type = self.identifying_fields[id_field]
+                    key = request.POST.get(id_field)
+                    identifying_field = id_field
+                else:
+                    raise Exception(f"Form matches multiple form types: [{identifying_field}] and [{id_field}]")
+        if key is None and self.default_formid_fieldname in request.POST:
+            key = request.POST.get(self.default_formid_fieldname)
+            if self._individual_exists(key):
+                forms_type = "individual"
+            elif self._group_exists(key):
+                forms_type = "grouped"
+            elif self._mixed_exists(key):
+                forms_type = "mixed"
+        return forms_type, key
 
     def _individual_exists(self, form_name):
         return form_name in self.form_classes
 
     def _group_exists(self, group_name):
         return group_name in self.grouped_forms
+
+    def _mixed_exists(self, mix_name):
+        return mix_name in self.mixed_forms
 
     def _process_individual_form(self, form_name, form_classes):
         forms = self.get_forms(form_classes, (form_name,))
@@ -228,27 +426,35 @@ class ProcessMultipleFormsView(ProcessFormView):
         else:
             return self.forms_invalid(forms)
 
-    def _process_mixed_forms(self, form_classes):
-        # Get the selected form type using the mixedform_selected_formtype
+    def _process_mixed_forms(self, mix_name, form_classes):
+        """
+        This processes the selected form type only (the value contained in the `mix_name` form field).  The form
+        class's `is_valid` method must be able to tell the difference between each form type.
+        """
+        # Get the selected form type from the form using the mix_name input (e.g. a select list)
         form_kwargs = self.get_form_kwargs("", True)
-        selected_formtype = form_kwargs["data"][self.mixedform_selected_formtype]
+        selected_form = form_kwargs["data"][mix_name]
+        if selected_form not in self.form_classes:
+            raise Exception(
+                f"Form type [{selected_form}] obtained from form field [{mix_name}] is not in the form_classes dict.  "
+                f"The form type select list must be populated with one of: [{','.join(self.form_classes.keys())}]."
+            )
 
         # I only want to get the forms in the context of the selected formtype.  That is managed by the content
-        #   of the dict passed to get_forms.  And I want that form data to be bound to kwargs.  That is
-        #   accomplished by supplying the desired key in the second argument to get_forms.
+        #   of the dict passed to get_forms.  And I want that form data to be bound to kwargs.  That can be
+        #   accomplished by supplying the desired key in the second argument to get_forms, or by making the third
+        #   argument True.
         # These 2 together should result in a call to forms_valid with all the form data (including the not-
         #   selected form data - which is what we want, so that the user's entered searches are retained.
         selected_form_classes = {}
-        selected_form_classes[selected_formtype] = form_classes[selected_formtype]
-        formsets = self.get_forms(selected_form_classes, [selected_formtype])
+        selected_form_classes[selected_form] = form_classes[selected_form]
+        forms = self.get_forms(selected_form_classes, None, True)
 
         # Only validate with the selected form type
-        myall = [form.is_valid() for form in formsets.values()]
-        myallall = all(myall)
-        if myallall:
-            return self.forms_valid(formsets)
+        if all([form.is_valid() for form in forms.values()]):
+            return self.forms_valid(forms)
         else:
-            return self.forms_invalid(formsets)
+            return self.forms_invalid(forms)
 
     def _process_all_forms(self, form_classes):
         forms = self.get_forms(form_classes, None, True)

--- a/DataRepo/pager.py
+++ b/DataRepo/pager.py
@@ -116,8 +116,7 @@ class Pager:
             self.order_dir_field: order_dir,
         }
         # Set an arbitrary initial value - doesn't matter what
-        if self.form_id_field not in init_dict:
-            init_dict[self.form_id_field] = 1
+        init_dict.setdefault(self.form_id_field, 1)
         if other_field_inits is not None:
             for fld in other_field_inits.keys():
                 init_dict[fld] = other_field_inits[fld]

--- a/DataRepo/pager.py
+++ b/DataRepo/pager.py
@@ -12,7 +12,6 @@ class Pager:
         rows_per_page_field,
         order_by_field,
         order_dir_field,
-        form_name,  # Relies on multiforms
         num_buttons=5,
         other_field_ids=None,  # {fld_name: id}
         # Default form values
@@ -54,7 +53,6 @@ class Pager:
         self.default_rows = default_rows
         self.order_by_field = order_by_field
         self.order_dir_field = order_dir_field
-        self.form_name = form_name
         self.form_id = form_id
 
         self.min_rows_per_page = None

--- a/DataRepo/pager.py
+++ b/DataRepo/pager.py
@@ -115,6 +115,7 @@ class Pager:
             self.order_by_field: order_by,
             self.order_dir_field: order_dir,
         }
+        # Set an arbitrary initial value - doesn't matter what
         if self.form_id_field not in init_dict:
             init_dict[self.form_id_field] = 1
         if other_field_inits is not None:

--- a/DataRepo/templates/pagination.html
+++ b/DataRepo/templates/pagination.html
@@ -172,7 +172,7 @@
             {{ pager.page_form.order_by }}
             {{ pager.page_form.order_direction }}
             {{ pager.page_form.page }}
-            {{ pager.page_form.adv_search_page_form }}
+            {{ pager.page_form.paging }}
             {{ pager.page_form.show_stats }}
             {{ pager.page_form.stats }}
             <div style="float: left;">

--- a/DataRepo/templates/pagination.html
+++ b/DataRepo/templates/pagination.html
@@ -166,7 +166,7 @@
 
     {% comment %} We need at least a hidden form to support server side sorting {% endcomment %}
     <div class="fixed-table-pagination" style="{% if pager.tot|gt:pager.min_rows_per_page %}padding-top: 10px;{% else %}display:none;{% endif %}">
-        <form action="{{ pager.action }}" id="{{ pager.form_id }}" name="{{ pager.form_name }}" method="POST">
+        <form action="{{ pager.action }}" id="{{ pager.form_id }}" method="POST">
             {% csrf_token %}
             {{ pager.page_form.qryjson }}
             {{ pager.page_form.order_by }}

--- a/DataRepo/views.py
+++ b/DataRepo/views.py
@@ -262,9 +262,9 @@ def search_basic(request, mdl, fld, cmp, val, fmt):
 
     pager = Pager(
         action="/DataRepo/search_advanced/",
+        # form_id_field holds the field *name* used to identify the form type in multiforms.py (among other form
+        # submissions on the same page), not a field ID assignment used in  javascript
         form_id_field="paging",  # Must match the "<>_form_valid" and "<>_form_invalid" methods.
-        # ^^ This is the field *name* used to identify the form type in multiforms.py (among other form submissions on
-        # the same page), not a field ID assignment used in  javascript
         rows_per_page_choices=AdvSearchPageForm.ROWS_PER_PAGE_CHOICES,
         page_form_class=AdvSearchPageForm,
         other_field_ids={
@@ -376,9 +376,9 @@ class AdvancedSearchView(MultiFormsView):
 
     pager = Pager(
         action="/DataRepo/search_advanced/",
+        # form_id_field holds the field *name* used to identify the form type in multiforms.py (among other form
+        # submissions on the same page), not a field ID assignment used in  javascript
         form_id_field="paging",  # Must match the "<>_form_valid" and "<>_form_invalid" methods.
-        # ^^ This is the field *name* used to identify the form type in multiforms.py (among other form submissions on
-        # the same page), not a field ID assignment used in  javascript
         rows_per_page_choices=AdvSearchPageForm.ROWS_PER_PAGE_CHOICES,
         page_form_class=AdvSearchPageForm,
         other_field_ids={

--- a/DataRepo/views.py
+++ b/DataRepo/views.py
@@ -527,7 +527,6 @@ class AdvancedSearchView(MultiFormsView):
         return result
 
     # Invalid form whose multiforms given name is "paging" will call this from the post override in multiforms.py
-    # TODO: See Issue #370's comment on this method.
     def paging_form_invalid(self, formset):
         """
         Upon invalid advanced search form submission, rescues the query to add back to the context.
@@ -555,7 +554,6 @@ class AdvancedSearchView(MultiFormsView):
         )
 
     # Valid form whose multiforms given name is "paging" will call this from the post override in multiforms.py
-    # TODO: See Issue #370's comment on this method.
     def paging_form_valid(self, form):
         cform = form.cleaned_data
 


### PR DESCRIPTION
## Summary Change Description

`multiforms.py` was refactored so that the advanced search class in views.py no longer needs to override the post method.

I misunderstood both the intent of multiforms and how it was implemented, thus when I applied it, my efforts did not jive with the original code.  Now it does.  Here are some of my key misconceptions about multiforms, what I originally did, and how I changed it to conform to the original design:

- Multiforms was written so that a single view can handle multiple types of form submissions (in no way does it do anything special to handle formsets (multiple instances of the same form type (i.e. copies of the same form inside one pair of form tags)).  This involves a few key mechanisms:
   - Identify the form that was submitted
   - Bind the correct form class to the submitted form data
   - Validate the form data
   - Return the correct response
- Multiforms uses a modified version of a django-y trick to identify form types.  It uses a field in the form data "string" to identify a form.
   - Multiforms assumes that the form-identifying field is named "action"
   - The "action" field contains a string that is used as a key in a dict lookup to get the class in order to bind it to the form data and process the form.
   - It also uses that key to call different versions of methods like, `<key_>form_valid`, `<key_>form_invalid`, and other methods, I did not utilize.
   - And it turns out that in the case of "grouped forms", the value in the action field was a key into the `grouped_forms` dict, whose value was a list of keys into the `form_classes` dict and specified forms that should be processed in a single submission, which was similar to my mixed form case, but not exactly.

Since multiforms.py overloaded the term "form name" (which I took literally as the name of the form element in the HTML), I originally did not understand why the methods I wrote were not getting called.  Plus, the fallback was to call the generic methods, so I had trouble debugging.

After newly understanding the way forms were identified, I decided I didn't want to go to the effort to add an "action" field to each form.  Instead, I allowed forms to be identified by simply the presence of a field with a specific name, instead of the value of a field that every form was required to have.

And, I made my mixed form case be much like the grouped forms case, except the only form that is bound is the "selected" form (indicated by the value in that field).

## Affected Issue Numbers

- Resolves #370

## Code Review Notes

I tried to add comments to help reviewers and others who read the code, but it all hinges on the post method override.  I also made the form setup more transparent by adding the form types in a new __init__ method in the advanced search class.  There are 2 types that are added: an "individual" form type for the paging form, and a "mixed" form type for the 3 advanced search form types (peak group, peak data, and FCirc).

When post is called upon form submission, the post method iterates through the keys `fmt` (the format select list) and `paging` (a hidden field to identify the paging form) to see if fields exist by either of those names.

If it's the paging form, the form is validated and either `paging_form_valid` or `paging_form_invalid` is called and the response they return is returned by post.

If it's the advanced search form, the selected form type is identified from the `fmt` select list, that type is bound, and every instance of all the advanced search forms is validated using the `is_valid` method of the selected form class.  Then either `form_valid` or `form_invalid` is called (since the `fmt_form_[in]valid` methods don't exist).

I added some exceptions and other feedback to make it easier to debug any issues should they arise in the future.

## Checklist

- [x] All issue requirements satisfied (or no linked issues)
- [x] [Linting passes](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#linting).
- [x] [Migrations created & committed *(or no model changes)*](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#migration-process)
- [ ] [Tests implemented *(or no code changes)*](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#test-implementation)
- [x] [All tests pass](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#quality-control)
