### PR TITLE
Fixed a minor bug regarding the revealing of the stats button

### DIFF
--- a/DataRepo/compositeviews.py
+++ b/DataRepo/compositeviews.py
@@ -626,6 +626,9 @@ class BaseSearchView:
         """Stats getter"""
         return deepcopy(self.stats)
 
+    def statsAvailable(self):
+        return self.stats is not None
+
     def meetsAllConditionsByValList(self, rootrec, query, field_order):
         """
         This is a python-code version of a complex Q expression, necessary for checking filters in aggregate count
@@ -2099,6 +2102,9 @@ class BaseAdvancedSearchView:
 
     def getStatsParams(self, fmt):
         return self.modeldata[fmt].getStatsParams()
+
+    def statsAvailable(self, fmt):
+        return self.modeldata[fmt].statsAvailable()
 
     def meetsAllConditionsByValList(self, fmt, rootrec, query, field_order):
         """

--- a/DataRepo/templates/DataRepo/search/results/display.html
+++ b/DataRepo/templates/DataRepo/search/results/display.html
@@ -79,7 +79,7 @@
             <hr>
 
             {% if mode != "view" or valid_search %}
-                {% if stats %}
+                {% if stats and stats.available %}
                     {% include "DataRepo/search/results/stats.html" %}
                 {% endif %}
 

--- a/DataRepo/tests/test_views.py
+++ b/DataRepo/tests/test_views.py
@@ -717,10 +717,10 @@ class ViewTests(TracebaseTestCase):
         ).prefetch_related(*pf)
         self.assertEqual(cnt, qs.count())
         expected_stats = {
-            'available': True,
-            'data': {},
-            'populated': False,
-            'show': False,
+            "available": True,
+            "data": {},
+            "populated": False,
+            "show": False,
         }
         self.assertEqual(stats, expected_stats)
 
@@ -975,7 +975,7 @@ class ViewTests(TracebaseTestCase):
 
     def getExpectedStats(self):
         return {
-            'available': True,
+            "available": True,
             "data": {
                 "Animals": {
                     "count": 1,

--- a/DataRepo/tests/test_views.py
+++ b/DataRepo/tests/test_views.py
@@ -717,9 +717,10 @@ class ViewTests(TracebaseTestCase):
         ).prefetch_related(*pf)
         self.assertEqual(cnt, qs.count())
         expected_stats = {
-            "data": {},
-            "populated": False,
-            "show": False,
+            'available': True,
+            'data': {},
+            'populated': False,
+            'show': False,
         }
         self.assertEqual(stats, expected_stats)
 
@@ -974,6 +975,7 @@ class ViewTests(TracebaseTestCase):
 
     def getExpectedStats(self):
         return {
+            'available': True,
             "data": {
                 "Animals": {
                     "count": 1,

--- a/DataRepo/views.py
+++ b/DataRepo/views.py
@@ -260,6 +260,8 @@ def search_basic(request, mdl, fld, cmp, val, fmt):
     # Base Advanced Search Form
     basf = AdvSearchForm()
 
+    fmtkey = basv_metadata.formatNameOrKeyToKey(fmt)
+
     pager = Pager(
         action="/DataRepo/search_advanced/",
         form_id_field="adv_search_page_form",
@@ -278,7 +280,6 @@ def search_basic(request, mdl, fld, cmp, val, fmt):
     )
 
     format_template = "DataRepo/search/query.html"
-    fmtkey = basv_metadata.formatNameOrKeyToKey(fmt)
     if fmtkey is None:
         names = basv_metadata.getFormatNames()
         raise Http404(
@@ -1084,6 +1085,7 @@ def performQuery(
         "data": {},
         "populated": generate_stats,
         "show": False,
+        "available": basv.statsAvailable(fmt),
     }
     if generate_stats:
         stats["data"] = getQueryStats(results, fmt, basv)


### PR DESCRIPTION
## Summary Change Description

The stats button should not appear on the FCirc results page because no stats are defined for that format.  It now does not display when stats are not defined.

## Affected Issue Numbers

- Resolves no documented issue

## Code Review Notes

I believe this worked in an earlier version of the search stats implementation, but when I added the ability to remember stats during paging, it got broken and I didn't notice.

There are no stats configured for the FCirc format - the only stats Michael requested were for cached property fields, which could not be done in the current implementation.  So the stats button should not even appeat to be clicked on the FCirc results page.

It was checking the stats context variable, which originally was None I think, for Fcirc.  But in adding the transit of stats between pages, I wrapped it in a larger structure to track whether the stats are displayed or not, which made the original display logic always true.

I think that the changes are small enough, that it should not be an issue to accomplishing the various refactors.

I also noted that tracebase-dev doesn't have the search stats yet... we probably should push that over there...

## Checklist

- [x] All issue requirements satisfied (or no linked issues)
- [x] [Linting passes](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#linting).
- [x] [Migrations created & committed *(or no model changes)*](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#migration-process)
- [ ] [Tests implemented *(or no code changes)*](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#test-implementation)
- [x] [All tests pass](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#quality-control)
