### PR TITLE
Fixes the SQL construction bug

### DIFF
--- a/DataRepo/formats/dataformat.py
+++ b/DataRepo/formats/dataformat.py
@@ -563,7 +563,7 @@ class Format:
 
     def getFKModelName(self, mdl, field_ref_name):
         """
-        Given a model class and the name of a foreign key field, this retrieves the name of the model the koreign key
+        Given a model class and the name of a foreign key field, this retrieves the name of the model the foreign key
         links to
         """
         return mdl._meta.get_field(field_ref_name).related_model._meta.model.__name__

--- a/DataRepo/formats/dataformat.py
+++ b/DataRepo/formats/dataformat.py
@@ -531,19 +531,52 @@ class Format:
         # Get a model object
         mdl = apps.get_model("DataRepo", mdl_nm)
 
+        # Retreive any custom ordering
         if "ordering" in mdl._meta.__dict__:
-            return mdl._meta.__dict__["ordering"]
+            # The fields defined in the model's meta ordering - potentially containing non-database field references
+            ordering = mdl._meta.__dict__["ordering"]
+            # We will save the db-only field names here (i.e. no non-DB field references to model objects)
+            db_field_ordering = []
+            # For each order-by field reference
+            for ob_field in ordering:
+                add_flds = []
+                fld = getattr(mdl, ob_field)
+                # If this is a foreign key (i.e. it's a model reference, not an actual DB field)
+                if fld.field.__class__.__name__ == "ForeignKey":
+                    # Get the model name of the linked model
+                    linked_model = self.getFKModelName(mdl, ob_field)
+                    # Recursively get that model's ordering fields
+                    add_flds = self.getOrderByFields(model_name=linked_model)
+                    if len(add_flds) == 0:
+                        # Default when the linking model says to order by an FK that has no custom ordering is to order
+                        # by that model's primary key
+                        db_field_ordering.append(ob_field + "__pk")
+                    else:
+                        # Append each field to the list with the link name prepended
+                        for add_fld in add_flds:
+                            db_field_ordering.append(ob_field + "__" + add_fld)
+                else:
+                    # If it's not a foreign key, just append the field as-is
+                    db_field_ordering.append(ob_field)
+            return db_field_ordering
         return []
 
-    def getDistinctFields(
-        self, order_by=None, assume_distinct=True, included_paths=None
-    ):
+    def getFKModelName(self, mdl, field_ref_name):
+        """
+        Given a model class and the name of a foreign key field, this retrieves the name of the model the koreign key
+        links to
+        """
+        return mdl._meta.get_field(field_ref_name).related_model._meta.model.__name__
+
+    def getDistinctFields(self, order_by=None, assume_distinct=True, split_all=False):
         """
         Puts together fields required by queryset.distinct() based on the value of each model instance's split_rows
-        state.  split_rows=True allows us to choose whether the output rows in the html results template will contain
-        M:M related table values joined in one cell on one row ("merged"), or whether they will be split across
+        state (or if split_all is True).
+
+        split_rows=True in the format allows us to choose whether the output rows in the html results template will
+        contain M:M related table values joined in one cell on one row ("merged"), or whether they will be split across
         multiple rows ("split"), and supplying these fields to distinct ensures that the queryset record count reflects
-        that html table row (split or merged).
+        that html table row (split or merged).  split_all overrides this.
 
         An order_by field (including its key path) is required if the queryset will be non-default ordered, because
         .distinct() requires them to be present.  Otherwise, you will encounter an exception when the queryset is made
@@ -557,9 +590,7 @@ class Format:
         for mdl_inst_nm in self.model_instances:
             # We only need to include a field if we want to split
             if self.model_instances[mdl_inst_nm]["manytomany"]["split_rows"] or (
-                included_paths is not None
-                and self.model_instances[mdl_inst_nm]["manytomany"]["is"]
-                and self.model_instances[mdl_inst_nm]["path"] in included_paths
+                self.model_instances[mdl_inst_nm]["manytomany"]["is"] and split_all
             ):
                 # Django's ordering fields are required when any field is provided to .distinct().  Otherwise, you get
                 # the error: `ProgrammingError: SELECT DISTINCT ON expressions must match initial ORDER BY expressions`
@@ -569,6 +600,8 @@ class Format:
                     distinct_fields.append(fld)
                 # Don't assume the ordering fields are populated/unique, so include the primary key.  Duplicate fields
                 # should be OK (though I haven't tested it).
+                # Note, this assumes that being here means we're in a related table and not the root table, so path is
+                # not an empty string
                 distinct_fields.append(
                     self.model_instances[mdl_inst_nm]["path"] + "__pk"
                 )

--- a/DataRepo/formats/dataformat_group.py
+++ b/DataRepo/formats/dataformat_group.py
@@ -13,7 +13,6 @@ from DataRepo.formats.dataformat_group_query import (
     getNumEmptyQueries,
     getSelectedFormat,
     setFirstEmptyQuery,
-    splitPathName,
 )
 
 
@@ -326,10 +325,10 @@ class FormatGroup:
         return self.modeldata[fmt].reRootQry(qry, new_root_model_instance_name)
 
     def getDistinctFields(
-        self, fmt, order_by=None, assume_distinct=True, included_paths=None
+        self, fmt, order_by=None, assume_distinct=True, split_all=False
     ):
         return self.modeldata[fmt].getDistinctFields(
-            order_by, assume_distinct, included_paths
+            order_by, assume_distinct, split_all
         )
 
     def getFullJoinAnnotations(self, fmt):
@@ -575,27 +574,11 @@ class FormatGroup:
         # uniquely identify records.
         stats_fields = [fld for d in params_arrays for fld in d["distincts"]]
 
-        # This extracts a unique list of table paths among the database fields that are included in the stats table.
-        # We will supply it to getDistinctFields to supplement the list of many-to-many tables whose split_rows is true
-        # so that we can get an accurate count of unique field values in M:M records.  This is overkill because we're
-        # supplying all tables included in the stats, most of which are not going to be M:M tables and they will be
-        # ignored.  It would be easier to simply include all M:M tables, but it turns out that Django has a bug in its
-        # distinct SQL construction.  When it goes through compounds (M:M with PeakGroup) and then through
-        # CompoundSynonym (1:M with Compound), it fails to un-alias (or conversely alias) all of the `DISTINCT ON`
-        # fields, and it's check that those fields match the `ORDER BY` fields fails - because one uses an alias and
-        # the other doesn't.  So this is a work-around that happens to work because CompoundSynonym is not among the
-        # stats fields...
-        stats_paths = []
-        for field_path in stats_fields:
-            path, name = splitPathName(field_path)
-            if path not in stats_paths:
-                stats_paths.append(path)
-
         # These are the distinct fields that that dictate the number of rows in the view's output table
         fmt_distinct_fields = self.getDistinctFields(fmt, assume_distinct=False)
         # These are the distinct fields necessary to get an accurate count of unique values
         all_distinct_fields = self.getDistinctFields(
-            fmt, assume_distinct=False, included_paths=stats_paths
+            fmt, assume_distinct=False, split_all=True
         )
         all_fields = all_distinct_fields + stats_fields
         stats = {}


### PR DESCRIPTION
## Summary Change Description

Django's resolving of model field references to database fields uses different strategies in the `.distinct()` method than it does in the `.order_by()` method.  If there's a foreign key in the `meta.ordering` that is supplied to order_by(), it resolves to the referenced model's `meta.ordering`.  But the same field supplied to distinct resolves to the ID field saved in the referring table.

This fix recursively resolves the fields in both cases, because django requires the ordering fields and distinct fields to match.  Otherwise, there's a programming error.

## Affected Issue Numbers

- Resolves #424

## Code Review Notes

Comments in-line to explain things.

## Checklist

- [x] All issue requirements satisfied (or no linked issues)
- [x] [Linting passes](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#linting).
- [x] [Migrations created & committed *(or no model changes)*](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#migration-process)
- [x] [Tests implemented *(or no code changes)*](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#test-implementation)
- [x] [All tests pass](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#quality-control)
