### PR TITLE
Functions and tests for infusate name parsing

### DIFF
--- a/DataRepo/tests/test_infusate_name_parser.py
+++ b/DataRepo/tests/test_infusate_name_parser.py
@@ -5,6 +5,7 @@ from DataRepo.tests.tracebase_test_case import TracebaseTestCase
 from DataRepo.utils.infusate_name_parser import (
     InfusateData,
     IsotopeData,
+    IsotopeParsingError,
     TracerData,
     TracerParsingError,
     parse_infusate_name,
@@ -148,8 +149,14 @@ class InfusateParsingTests(TracebaseTestCase):
     def test_malformed_tracer_parsing_with_bad_isotopic_specification(self):
         # Test bad isotope pattern not silently skipped
         name = "1,2,3-13C3,badlabel,19O2"
-        with self.assertRaisesRegex(TracerParsingError, "cannot be parsed"):
-            _ = parse_infusate_name(name)
+        with self.assertRaisesRegex(IsotopeParsingError, "disallowed characters"):
+            _ = parse_isotope_string(name)
+
+    def test_malformed_tracer_parsing_with_null_isotopic_specification_6(self):
+        # Test bad isotope pattern not silently skipped
+        name = "13F"
+        with self.assertRaisesRegex(IsotopeParsingError, "disallowed characters"):
+            _ = parse_isotope_string(name)
 
     def test_malformed_tracer_parsing_with_improper_delimiter(self):
         # Test bad tracer delimiter (',' instead of ';')

--- a/DataRepo/tests/test_infusate_name_parser.py
+++ b/DataRepo/tests/test_infusate_name_parser.py
@@ -4,6 +4,7 @@ from DataRepo.tests.tracebase_test_case import TracebaseTestCase
 from DataRepo.utils.infusate_name_parser import (
     InfusateData,
     IsotopeData,
+    IsotopeParsingError,
     TracerData,
     TracerParsingError,
     parse_infusate_name,
@@ -106,4 +107,58 @@ class InfusateParsingTests(TracebaseTestCase):
     def test_malformed_infusate_parsing_2(self):
         name = "not a properly encoded tracer name"
         with self.assertRaisesRegex(TracerParsingError, "cannot be parsed"):
+            _ = parse_infusate_name(name)
+
+    def test_malformed_infusate_parsing_3(self):
+        # Test back-to-back occurrences of curlies expressions
+        name = "short_name{tracers1}{tracers2}"
+        with self.assertRaisesRegex(TracerParsingError, "cannot be parsed"):
+            _ = parse_infusate_name(name)
+
+    def test_malformed_infusate_parsing_4(self):
+        # Test multiple names delimited by hard return
+        name = "short_name1{tracers1}\nshortname2{tracers2}"
+        with self.assertRaisesRegex(TracerParsingError, "cannot be parsed"):
+            _ = parse_infusate_name(name)
+
+    def test_malformed_infusate_parsing_5(self):
+        # Test leading & trailing whitespace
+        name = "  short_name1{tracers1}  "
+        with self.assertRaisesRegex(TracerParsingError, "cannot be parsed"):
+            _ = parse_infusate_name(name)
+
+    def test_malformed_infusate_parsing_6(self):
+        # Test trailing whitespace in short_name
+        name = "short_name1  {tracers1}"
+        with self.assertRaisesRegex(TracerParsingError, "cannot be parsed"):
+            _ = parse_infusate_name(name)
+
+    def test_malformed_tracer_parsing_1(self):
+        # Test back-to-back occurrences of square bracket expressions
+        name = "lysine-[13C5]-[19O2]"
+        with self.assertRaisesRegex(TracerParsingError, "cannot be parsed"):
+            _ = parse_tracer_string(name)
+
+    def test_malformed_tracer_parsing_2(self):
+        # Test multiple labeled compounds delimited by hard return
+        name = "lysine-[13C5]\nlysine-[19O2]"
+        with self.assertRaisesRegex(TracerParsingError, "cannot be parsed"):
+            _ = parse_tracer_string(name)
+
+    def test_malformed_tracer_parsing_3(self):
+        # Test bad isotope pattern not silently skipped
+        name = "lys1,2,3-13C3,badlabel,19O2"
+        with self.assertRaisesRegex(TracerParsingError, "cannot be parsed"):
+            _ = parse_infusate_name(name)
+
+    def test_malformed_tracer_parsing_4(self):
+        # Test bad tracer delimiter (',' instead of ';')
+        name = "lysine-[13C5],glucose-[19O2]"
+        with self.assertRaisesRegex(TracerParsingError, "cannot be parsed"):
+            _ = parse_tracer_string(name)
+
+    def test_malformed_isotope_parsing_1(self):
+        # Test empty labels list
+        name = "lysine-[]"
+        with self.assertRaisesRegex(IsotopeParsingError, "cannot be parsed"):
             _ = parse_infusate_name(name)

--- a/DataRepo/tests/test_infusate_name_parser.py
+++ b/DataRepo/tests/test_infusate_name_parser.py
@@ -1,3 +1,4 @@
+from string import whitespace
 from django.test import tag
 
 from DataRepo.tests.tracebase_test_case import TracebaseTestCase
@@ -88,75 +89,75 @@ class InfusateParsingTests(TracebaseTestCase):
         tracer_string = "L-Leucine-[1,2-13C2]"
         self.assertEqual(parse_tracer_string(tracer_string), self.tracer_l_leucine)
 
-    def test_infusate_parsing_with_name_1(self):
+    def test_infusate_parsing_with_named_complex(self):
         infusate_string = (
             "BCAAs {isoleucine-[13C6,15N1];leucine-[13C6,15N1];valine-[13C5,15N1]}"
         )
         self.assertEqual(parse_infusate_name(infusate_string), self.infusate_bcaas)
 
-    def test_infusate_parsing_without_name_1(self):
+    def test_infusate_parsing_without_optional_name(self):
         infusate_string = "L-Leucine-[1,2-13C2]"
         self.assertEqual(parse_infusate_name(infusate_string), self.infusate_l_leucine)
 
-    def test_whitespace_infusate_parsing(self):
+    def test_infusate_parsing_with_intervening_whitespace(self):
+        # Test trailing whitespace after short_name
+        name = "short_name1 {lysine-[13C5]}"
+        data = parse_infusate_name(name)
+        self.assertEqual(data["infusate_name"], "short_name1")
+
+    def test_infusate_parsing_with_whitespace(self):
         # Test leading & trailing whitespace
         name = "  myshortname{lysine-[13C5]}  "
         data = parse_infusate_name(name)
         self.assertEqual(data["infusate_name"], "myshortname")
 
-    def test_malformed_infusate_parsing_1(self):
+    def test_malformed_infusate_parsing(self):
         name = "not a {properly encoded tracer-[NAME1]}"
         with self.assertRaisesRegex(TracerParsingError, "cannot be parsed"):
             _ = parse_infusate_name(name)
 
-    def test_malformed_infusate_parsing_2(self):
+    def test_malformed_infusate_parsing_no_isotope_encoding(self):
         name = "not a properly encoded tracer name"
         with self.assertRaisesRegex(TracerParsingError, "cannot be parsed"):
             _ = parse_infusate_name(name)
 
-    def test_malformed_infusate_parsing_3(self):
+    def test_malformed_infusate_parsing_multiple_brace_groups(self):
         # Test back-to-back occurrences of curlies expressions
         name = "myshortname{lysine-[13C5]}{glucose-[13C4]}"
         with self.assertRaisesRegex(TracerParsingError, "cannot be parsed"):
             _ = parse_infusate_name(name)
 
-    def test_malformed_infusate_parsing_4(self):
+    def test_malformed_infusate_parsing_with_new_line(self):
         # Test multiple names delimited by hard return
         name = "myshortname1{lysine-[13C5]}\nmyshortname2{glucose-[13C4]}"
         with self.assertRaisesRegex(TracerParsingError, "cannot be parsed"):
             _ = parse_infusate_name(name)
 
-    def test_malformed_infusate_parsing_5(self):
-        # Test trailing whitespace in short_name
-        name = "short_name1 {lysine-[13C5]}"
-        data = parse_infusate_name(name)
-        self.assertEqual(data["infusate_name"], "short_name1")
-
-    def test_malformed_tracer_parsing_1(self):
+    def test_malformed_tracer_parsing_multiple_isotopic_definitions(self):
         # Test back-to-back occurrences of square bracket expressions
         name = "lysine-[13C5]-[19O2]"
         with self.assertRaisesRegex(TracerParsingError, "cannot be parsed"):
             _ = parse_tracer_string(name)
 
-    def test_malformed_tracer_parsing_2(self):
+    def test_malformed_tracer_parsing_with_new_line(self):
         # Test multiple labeled compounds delimited by hard return
         name = "lysine-[13C5]\nlysine-[19O2]"
         with self.assertRaisesRegex(TracerParsingError, "cannot be parsed"):
             _ = parse_tracer_string(name)
 
-    def test_malformed_tracer_parsing_3(self):
+    def test_malformed_tracer_parsing_with_bad_isotopic_specification(self):
         # Test bad isotope pattern not silently skipped
         name = "1,2,3-13C3,badlabel,19O2"
         with self.assertRaisesRegex(TracerParsingError, "cannot be parsed"):
             _ = parse_infusate_name(name)
 
-    def test_malformed_tracer_parsing_4(self):
+    def test_malformed_tracer_parsing_with_improper_delimiter(self):
         # Test bad tracer delimiter (',' instead of ';')
         name = "lysine-[13C5],glucose-[19O2]"
         with self.assertRaisesRegex(TracerParsingError, "cannot be parsed"):
             _ = parse_tracer_string(name)
 
-    def test_malformed_isotope_parsing_1(self):
+    def test_malformed_tracer_parsing_with_null_isotopic_specification(self):
         # Test empty labels list
         name = "lysine-[]"
         with self.assertRaisesRegex(TracerParsingError, "cannot be parsed"):

--- a/DataRepo/tests/test_infusate_name_parser.py
+++ b/DataRepo/tests/test_infusate_name_parser.py
@@ -19,21 +19,29 @@ class InfusateParsingTests(TracebaseTestCase):
     def setUpTestData(cls):
         cls.isotope_13c6 = IsotopeData(
             labeled_element="13C",
+            element="C",
+            mass_number=13,
             labeled_count=6,
             labeled_positions=None,
         )
         cls.isotope_13c5 = IsotopeData(
             labeled_element="13C",
+            element="C",
+            mass_number=13,
             labeled_count=5,
             labeled_positions=None,
         )
         cls.isotope_15n1 = IsotopeData(
             labeled_element="15N",
+            element="N",
+            mass_number=15,
             labeled_count=1,
             labeled_positions=None,
         )
         cls.isotope_13c2 = IsotopeData(
             labeled_element="13C",
+            element="C",
+            mass_number=13,
             labeled_count=2,
             labeled_positions=[1, 2],
         )

--- a/DataRepo/tests/test_infusate_name_parser.py
+++ b/DataRepo/tests/test_infusate_name_parser.py
@@ -1,0 +1,43 @@
+from django.test import tag
+
+from DataRepo.tests.tracebase_test_case import TracebaseTestCase
+from DataRepo.utils.infusate_name_parser import parse_infusate_name
+
+
+@tag("parsing")
+class InfusateParsingTests(TracebaseTestCase):
+    @classmethod
+    def setUpTestData(cls):
+        pass
+
+    def test_infusate_parsing_with_name_1(self):
+        name = "BCAAs {isoleucine-[13C6,15N1];leucine-[13C6,15N1];valine-[13C5,15N1]}"
+        data = parse_infusate_name(name)
+        self.assertEqual(data["infusate_name"], "BCAAs")
+        self.assertEqual(len(data["tracer_names"]), 3)
+        self.assertEqual(len(data["compound_names"]), 3)
+        self.assertEqual(data["tracer_names"][1], "leucine-[13C6,15N1]")
+        self.assertEqual(data["compound_names"][2], "valine")
+        self.assertEqual(data["isotope_labels"][0], "13C6,15N1")
+
+    def test_infusate_parsing_without_name_1(self):
+        name = "L-Leucine-[1,2-13C2]"
+        data = parse_infusate_name(name)
+        self.assertEqual(data["infusate_name"], None)
+        self.assertEqual(len(data["tracer_names"]), 1)
+        self.assertEqual(len(data["compound_names"]), 1)
+        self.assertEqual(data["tracer_names"][0], name)
+        self.assertEqual(data["compound_names"][0], "L-Leucine")
+        self.assertEqual(data["isotope_labels"][0], "1,2-13C2")
+
+    def test_malformed_infusate_parsing_1(self):
+        name = "not a {properly encoded tracer-[NAME1]}"
+        with self.assertRaises(Exception) as context:
+            data = parse_infusate_name(name)  # noqa: F841
+        self.assertTrue("cannot be parsed" in str(context.exception))
+
+    def test_malformed_infusate_parsing_2(self):
+        name = "not a properly encoded tracer name"
+        with self.assertRaises(Exception) as context:
+            data = parse_infusate_name(name)  # noqa: F841
+        self.assertTrue("cannot be parsed" in str(context.exception))

--- a/DataRepo/tests/test_infusate_name_parser.py
+++ b/DataRepo/tests/test_infusate_name_parser.py
@@ -151,6 +151,14 @@ class InfusateParsingTests(TracebaseTestCase):
         with self.assertRaisesRegex(IsotopeParsingError, "disallowed characters"):
             _ = parse_isotope_string(name)
 
+    def test_malformed_tracer_parsing_with_incomplete_parsing(self):
+        # Test bad isotope pattern not silently skipped
+        name = "1,2,3-13C3,S5,19O2"
+        with self.assertRaisesRegex(
+            IsotopeParsingError, "cannot be completely interpreted"
+        ):
+            _ = parse_isotope_string(name)
+
     def test_malformed_tracer_parsing_with_null_isotopic_specification_6(self):
         # Test bad isotope pattern not silently skipped
         name = "13F"

--- a/DataRepo/tests/test_infusate_name_parser.py
+++ b/DataRepo/tests/test_infusate_name_parser.py
@@ -38,33 +38,33 @@ class InfusateParsingTests(TracebaseTestCase):
             labeled_positions=[1, 2],
         )
         cls.tracer_l_leucine = TracerData(
-            original_tracer="L-Leucine-[1,2-13C2]",
+            unparsed_string="L-Leucine-[1,2-13C2]",
             compound_name="L-Leucine",
             isotopes=[cls.isotope_13c2],
         )
         cls.infusate_bcaas = InfusateData(
-            original_infusate="BCAAs {isoleucine-[13C6,15N1];leucine-[13C6,15N1];valine-[13C5,15N1]}",
+            unparsed_string="BCAAs {isoleucine-[13C6,15N1];leucine-[13C6,15N1];valine-[13C5,15N1]}",
             infusate_name="BCAAs",
             tracers=[
                 TracerData(
-                    original_tracer="isoleucine-[13C6,15N1]",
+                    unparsed_string="isoleucine-[13C6,15N1]",
                     compound_name="isoleucine",
                     isotopes=[cls.isotope_13c6, cls.isotope_15n1],
                 ),
                 TracerData(
-                    original_tracer="leucine-[13C6,15N1]",
+                    unparsed_string="leucine-[13C6,15N1]",
                     compound_name="leucine",
                     isotopes=[cls.isotope_13c6, cls.isotope_15n1],
                 ),
                 TracerData(
-                    original_tracer="valine-[13C5,15N1]",
+                    unparsed_string="valine-[13C5,15N1]",
                     compound_name="valine",
                     isotopes=[cls.isotope_13c5, cls.isotope_15n1],
                 ),
             ],
         )
         cls.infusate_l_leucine = InfusateData(
-            original_infusate="L-Leucine-[1,2-13C2]",
+            unparsed_string="L-Leucine-[1,2-13C2]",
             infusate_name=None,
             tracers=[cls.tracer_l_leucine],
         )

--- a/DataRepo/tests/test_infusate_name_parser.py
+++ b/DataRepo/tests/test_infusate_name_parser.py
@@ -1,43 +1,109 @@
 from django.test import tag
 
 from DataRepo.tests.tracebase_test_case import TracebaseTestCase
-from DataRepo.utils.infusate_name_parser import parse_infusate_name
+from DataRepo.utils.infusate_name_parser import (
+    InfusateData,
+    IsotopeData,
+    TracerData,
+    TracerParsingError,
+    parse_infusate_name,
+    parse_isotope_string,
+    parse_tracer_string,
+)
 
 
 @tag("parsing")
 class InfusateParsingTests(TracebaseTestCase):
     @classmethod
     def setUpTestData(cls):
+        cls.isotope_13c6 = IsotopeData(
+            labeled_element="13C",
+            labeled_count=6,
+            labeled_positions=None,
+        )
+        cls.isotope_13c5 = IsotopeData(
+            labeled_element="13C",
+            labeled_count=5,
+            labeled_positions=None,
+        )
+        cls.isotope_15n1 = IsotopeData(
+            labeled_element="15N",
+            labeled_count=1,
+            labeled_positions=None,
+        )
+        cls.isotope_13c2 = IsotopeData(
+            labeled_element="13C",
+            labeled_count=2,
+            labeled_positions=[1, 2],
+        )
+        cls.tracer_l_leucine = TracerData(
+            original_tracer="L-Leucine-[1,2-13C2]",
+            compound_name="L-Leucine",
+            isotopes=[cls.isotope_13c2],
+        )
+        cls.infusate_bcaas = InfusateData(
+            original_infusate="BCAAs {isoleucine-[13C6,15N1];leucine-[13C6,15N1];valine-[13C5,15N1]}",
+            infusate_name="BCAAs",
+            tracers=[
+                TracerData(
+                    original_tracer="isoleucine-[13C6,15N1]",
+                    compound_name="isoleucine",
+                    isotopes=[cls.isotope_13c6, cls.isotope_15n1],
+                ),
+                TracerData(
+                    original_tracer="leucine-[13C6,15N1]",
+                    compound_name="leucine",
+                    isotopes=[cls.isotope_13c6, cls.isotope_15n1],
+                ),
+                TracerData(
+                    original_tracer="valine-[13C5,15N1]",
+                    compound_name="valine",
+                    isotopes=[cls.isotope_13c5, cls.isotope_15n1],
+                ),
+            ],
+        )
+        cls.infusate_l_leucine = InfusateData(
+            original_infusate="L-Leucine-[1,2-13C2]",
+            infusate_name=None,
+            tracers=[cls.tracer_l_leucine],
+        )
+
         pass
 
+    def test_isotope_parsing_single(self):
+        isotope_string = "13C6"
+        self.assertEqual(parse_isotope_string(isotope_string), [self.isotope_13c6])
+
+    def test_isotope_parsing_double(self):
+        isotope_string = "13C6,15N1"
+        self.assertEqual(
+            parse_isotope_string(isotope_string), [self.isotope_13c6, self.isotope_15n1]
+        )
+
+    def test_isotope_parsing_positions(self):
+        isotope_string = "1,2-13C2"
+        self.assertEqual(parse_isotope_string(isotope_string), [self.isotope_13c2])
+
+    def test_tracer_parsing(self):
+        tracer_string = "L-Leucine-[1,2-13C2]"
+        self.assertEqual(parse_tracer_string(tracer_string), self.tracer_l_leucine)
+
     def test_infusate_parsing_with_name_1(self):
-        name = "BCAAs {isoleucine-[13C6,15N1];leucine-[13C6,15N1];valine-[13C5,15N1]}"
-        data = parse_infusate_name(name)
-        self.assertEqual(data["infusate_name"], "BCAAs")
-        self.assertEqual(len(data["tracer_names"]), 3)
-        self.assertEqual(len(data["compound_names"]), 3)
-        self.assertEqual(data["tracer_names"][1], "leucine-[13C6,15N1]")
-        self.assertEqual(data["compound_names"][2], "valine")
-        self.assertEqual(data["isotope_labels"][0], "13C6,15N1")
+        infusate_string = (
+            "BCAAs {isoleucine-[13C6,15N1];leucine-[13C6,15N1];valine-[13C5,15N1]}"
+        )
+        self.assertEqual(parse_infusate_name(infusate_string), self.infusate_bcaas)
 
     def test_infusate_parsing_without_name_1(self):
-        name = "L-Leucine-[1,2-13C2]"
-        data = parse_infusate_name(name)
-        self.assertEqual(data["infusate_name"], None)
-        self.assertEqual(len(data["tracer_names"]), 1)
-        self.assertEqual(len(data["compound_names"]), 1)
-        self.assertEqual(data["tracer_names"][0], name)
-        self.assertEqual(data["compound_names"][0], "L-Leucine")
-        self.assertEqual(data["isotope_labels"][0], "1,2-13C2")
+        infusate_string = "L-Leucine-[1,2-13C2]"
+        self.assertEqual(parse_infusate_name(infusate_string), self.infusate_l_leucine)
 
     def test_malformed_infusate_parsing_1(self):
         name = "not a {properly encoded tracer-[NAME1]}"
-        with self.assertRaises(Exception) as context:
-            data = parse_infusate_name(name)  # noqa: F841
-        self.assertTrue("cannot be parsed" in str(context.exception))
+        with self.assertRaisesRegex(TracerParsingError, "cannot be parsed"):
+            _ = parse_infusate_name(name)
 
     def test_malformed_infusate_parsing_2(self):
         name = "not a properly encoded tracer name"
-        with self.assertRaises(Exception) as context:
-            data = parse_infusate_name(name)  # noqa: F841
-        self.assertTrue("cannot be parsed" in str(context.exception))
+        with self.assertRaisesRegex(TracerParsingError, "cannot be parsed"):
+            _ = parse_infusate_name(name)

--- a/DataRepo/tests/test_infusate_name_parser.py
+++ b/DataRepo/tests/test_infusate_name_parser.py
@@ -145,26 +145,6 @@ class InfusateParsingTests(TracebaseTestCase):
         with self.assertRaisesRegex(TracerParsingError, "cannot be parsed"):
             _ = parse_tracer_string(name)
 
-    def test_malformed_tracer_parsing_with_bad_isotopic_specification(self):
-        # Test bad isotope pattern not silently skipped
-        name = "1,2,3-13C3,badlabel,19O2"
-        with self.assertRaisesRegex(IsotopeParsingError, "disallowed characters"):
-            _ = parse_isotope_string(name)
-
-    def test_malformed_tracer_parsing_with_incomplete_parsing(self):
-        # Test bad isotope pattern not silently skipped
-        name = "1,2,3-13C3,S5,19O2"
-        with self.assertRaisesRegex(
-            IsotopeParsingError, "cannot be completely interpreted"
-        ):
-            _ = parse_isotope_string(name)
-
-    def test_malformed_tracer_parsing_with_null_isotopic_specification_6(self):
-        # Test bad isotope pattern not silently skipped
-        name = "13F"
-        with self.assertRaisesRegex(IsotopeParsingError, "disallowed characters"):
-            _ = parse_isotope_string(name)
-
     def test_malformed_tracer_parsing_with_improper_delimiter(self):
         # Test bad tracer delimiter (',' instead of ';')
         name = "lysine-[13C5],glucose-[19O2]"
@@ -176,3 +156,29 @@ class InfusateParsingTests(TracebaseTestCase):
         name = "lysine-[]"
         with self.assertRaisesRegex(TracerParsingError, "cannot be parsed"):
             _ = parse_infusate_name(name)
+
+    def test_malformed_tracer_parsing_with_bad_isotopic_specification(self):
+        # Test bad isotope pattern not silently skipped
+        name = "1,2,3-13C3,badlabel,19O2"
+        with self.assertRaisesRegex(IsotopeParsingError, "disallowed characters"):
+            _ = parse_isotope_string(name)
+
+    def test_malformed_isotope_parsing_with_incomplete_parsing(self):
+        # Test bad isotope pattern not silently skipped
+        name = "1,2,3-13C3,S5,19O2"
+        with self.assertRaisesRegex(
+            IsotopeParsingError, "cannot be completely interpreted"
+        ):
+            _ = parse_isotope_string(name)
+
+    def test_malformed_isotope_parsing_with_bad_isotopic_specification(self):
+        # Test bad isotope pattern not silently skipped
+        name = "13F"
+        with self.assertRaisesRegex(IsotopeParsingError, "disallowed characters"):
+            _ = parse_isotope_string(name)
+
+    def test_malformed_isotope_parsing_with_null_isotopic_specification(self):
+        # Test empty labels list
+        name = ""
+        with self.assertRaisesRegex(IsotopeParsingError, "requires a defined string"):
+            _ = parse_isotope_string(name)

--- a/DataRepo/tests/test_infusate_name_parser.py
+++ b/DataRepo/tests/test_infusate_name_parser.py
@@ -4,7 +4,6 @@ from DataRepo.tests.tracebase_test_case import TracebaseTestCase
 from DataRepo.utils.infusate_name_parser import (
     InfusateData,
     IsotopeData,
-    IsotopeParsingError,
     TracerData,
     TracerParsingError,
     parse_infusate_name,
@@ -130,14 +129,15 @@ class InfusateParsingTests(TracebaseTestCase):
     def test_malformed_infusate_parsing_6(self):
         # Test trailing whitespace in short_name
         name = "short_name1 {lysine-[13C5]}"
-        with self.assertRaisesRegex(TracerParsingError, "cannot be parsed"):
-            _ = parse_infusate_name(name)
+        data = parse_infusate_name(name)
+        self.assertEqual(data["infusate_name"], "short_name1")
 
     def test_malformed_tracer_parsing_1(self):
         # Test back-to-back occurrences of square bracket expressions
         name = "lysine-[13C5]-[19O2]"
         with self.assertRaisesRegex(TracerParsingError, "cannot be parsed"):
             _ = parse_tracer_string(name)
+            print(_)
 
     def test_malformed_tracer_parsing_2(self):
         # Test multiple labeled compounds delimited by hard return
@@ -156,9 +156,10 @@ class InfusateParsingTests(TracebaseTestCase):
         name = "lysine-[13C5],glucose-[19O2]"
         with self.assertRaisesRegex(TracerParsingError, "cannot be parsed"):
             _ = parse_tracer_string(name)
+            print(_)
 
     def test_malformed_isotope_parsing_1(self):
         # Test empty labels list
         name = "lysine-[]"
-        with self.assertRaisesRegex(IsotopeParsingError, "cannot be parsed"):
+        with self.assertRaisesRegex(TracerParsingError, "cannot be parsed"):
             _ = parse_infusate_name(name)

--- a/DataRepo/tests/test_infusate_name_parser.py
+++ b/DataRepo/tests/test_infusate_name_parser.py
@@ -137,7 +137,6 @@ class InfusateParsingTests(TracebaseTestCase):
         name = "lysine-[13C5]-[19O2]"
         with self.assertRaisesRegex(TracerParsingError, "cannot be parsed"):
             _ = parse_tracer_string(name)
-            print(_)
 
     def test_malformed_tracer_parsing_2(self):
         # Test multiple labeled compounds delimited by hard return
@@ -156,7 +155,6 @@ class InfusateParsingTests(TracebaseTestCase):
         name = "lysine-[13C5],glucose-[19O2]"
         with self.assertRaisesRegex(TracerParsingError, "cannot be parsed"):
             _ = parse_tracer_string(name)
-            print(_)
 
     def test_malformed_isotope_parsing_1(self):
         # Test empty labels list

--- a/DataRepo/tests/test_infusate_name_parser.py
+++ b/DataRepo/tests/test_infusate_name_parser.py
@@ -1,4 +1,3 @@
-from string import whitespace
 from django.test import tag
 
 from DataRepo.tests.tracebase_test_case import TracebaseTestCase

--- a/DataRepo/tests/test_infusate_name_parser.py
+++ b/DataRepo/tests/test_infusate_name_parser.py
@@ -111,25 +111,25 @@ class InfusateParsingTests(TracebaseTestCase):
 
     def test_malformed_infusate_parsing_3(self):
         # Test back-to-back occurrences of curlies expressions
-        name = "short_name{tracers1}{tracers2}"
+        name = "myshortname{lysine-[13C5]}{glucose-[13C4]}"
         with self.assertRaisesRegex(TracerParsingError, "cannot be parsed"):
             _ = parse_infusate_name(name)
 
     def test_malformed_infusate_parsing_4(self):
         # Test multiple names delimited by hard return
-        name = "short_name1{tracers1}\nshortname2{tracers2}"
+        name = "myshortname1{lysine-[13C5]}\nmyshortname2{glucose-[13C4]}"
         with self.assertRaisesRegex(TracerParsingError, "cannot be parsed"):
             _ = parse_infusate_name(name)
 
     def test_malformed_infusate_parsing_5(self):
         # Test leading & trailing whitespace
-        name = "  short_name1{tracers1}  "
+        name = "  myshortname{lysine-[13C5]}  "
         with self.assertRaisesRegex(TracerParsingError, "cannot be parsed"):
             _ = parse_infusate_name(name)
 
     def test_malformed_infusate_parsing_6(self):
         # Test trailing whitespace in short_name
-        name = "short_name1  {tracers1}"
+        name = "short_name1 {lysine-[13C5]}"
         with self.assertRaisesRegex(TracerParsingError, "cannot be parsed"):
             _ = parse_infusate_name(name)
 
@@ -147,7 +147,7 @@ class InfusateParsingTests(TracebaseTestCase):
 
     def test_malformed_tracer_parsing_3(self):
         # Test bad isotope pattern not silently skipped
-        name = "lys1,2,3-13C3,badlabel,19O2"
+        name = "1,2,3-13C3,badlabel,19O2"
         with self.assertRaisesRegex(TracerParsingError, "cannot be parsed"):
             _ = parse_infusate_name(name)
 

--- a/DataRepo/tests/test_infusate_name_parser.py
+++ b/DataRepo/tests/test_infusate_name_parser.py
@@ -98,6 +98,12 @@ class InfusateParsingTests(TracebaseTestCase):
         infusate_string = "L-Leucine-[1,2-13C2]"
         self.assertEqual(parse_infusate_name(infusate_string), self.infusate_l_leucine)
 
+    def test_whitespace_infusate_parsing(self):
+        # Test leading & trailing whitespace
+        name = "  myshortname{lysine-[13C5]}  "
+        data = parse_infusate_name(name)
+        self.assertEqual(data["infusate_name"], "myshortname")
+
     def test_malformed_infusate_parsing_1(self):
         name = "not a {properly encoded tracer-[NAME1]}"
         with self.assertRaisesRegex(TracerParsingError, "cannot be parsed"):
@@ -121,12 +127,6 @@ class InfusateParsingTests(TracebaseTestCase):
             _ = parse_infusate_name(name)
 
     def test_malformed_infusate_parsing_5(self):
-        # Test leading & trailing whitespace
-        name = "  myshortname{lysine-[13C5]}  "
-        with self.assertRaisesRegex(TracerParsingError, "cannot be parsed"):
-            _ = parse_infusate_name(name)
-
-    def test_malformed_infusate_parsing_6(self):
         # Test trailing whitespace in short_name
         name = "short_name1 {lysine-[13C5]}"
         data = parse_infusate_name(name)

--- a/DataRepo/utils/infusate_name_parser.py
+++ b/DataRepo/utils/infusate_name_parser.py
@@ -25,6 +25,8 @@ ISOTOPE_DISALLOWED_CHARACTERS = re.compile(r"[^\d\[\]\-," + KNOWN_ISOTOPES + "]"
 
 class IsotopeData(TypedDict):
     labeled_element: str
+    element: str
+    mass_number: int
     labeled_count: int
     labeled_positions: Optional[List[int]]
 
@@ -114,7 +116,15 @@ def parse_isotope_string(isotopes_string: str) -> List[IsotopeData]:
     first_time = True
     for isotope in ISOTOPE_ENCODING_PATTERN.finditer(isotopes_string):
         labeled_element = isotope.group("labeled_element")
+        if labeled_element:
+            match = re.search(
+                r"(?P<mass_number>[\d]+)(?P<element>[" + KNOWN_ISOTOPES + "]{1})",
+                labeled_element,
+            )
+            mass_number = int(match.group("mass_number"))
+            element = match.group("element")
         labeled_count = int(isotope.group("labeled_count"))
+
         recomposited_isotope = labeled_element + str(labeled_count)
         if isotope.group("labeled_positions"):
             positions_str = isotope.group("labeled_positions")
@@ -131,6 +141,8 @@ def parse_isotope_string(isotopes_string: str) -> List[IsotopeData]:
         isotope_data.append(
             IsotopeData(
                 labeled_element=labeled_element,
+                element=element,
+                mass_number=mass_number,
                 labeled_count=labeled_count,
                 labeled_positions=labeled_positions,
             )

--- a/DataRepo/utils/infusate_name_parser.py
+++ b/DataRepo/utils/infusate_name_parser.py
@@ -30,13 +30,13 @@ class IsotopeData(TypedDict):
 
 
 class TracerData(TypedDict):
-    original_tracer: str
+    unparsed_string: str
     compound_name: str
     isotopes: List[IsotopeData]
 
 
 class InfusateData(TypedDict):
-    original_infusate: str
+    unparsed_string: str
     infusate_name: Optional[str]
     tracers: List[TracerData]
 
@@ -51,7 +51,7 @@ def parse_infusate_name(infusate_string: str) -> InfusateData:
     # assume the string lacks the optional name, and it is all tracer encodings
     infusate_string = infusate_string.strip()
     parsed_data: InfusateData = {
-        "original_infusate": infusate_string,
+        "unparsed_string": infusate_string,
         "infusate_name": None,
         "tracers": list(),
     }
@@ -80,7 +80,7 @@ def split_encoded_tracers_string(tracers_string: str) -> List[str]:
 def parse_tracer_string(tracer: str) -> TracerData:
 
     tracer_data: TracerData = {
-        "original_tracer": tracer,
+        "unparsed_string": tracer,
         "compound_name": "",
         "isotopes": list(),
     }

--- a/DataRepo/utils/infusate_name_parser.py
+++ b/DataRepo/utils/infusate_name_parser.py
@@ -1,4 +1,5 @@
 import re
+from typing import Optional, TypedDict
 
 # infusate with a name have the tracer(s) grouped in braces
 INFUSATE_ENCODING_PATTERN = r"(.*)\s*\{(.*)\}"
@@ -6,19 +7,34 @@ TRACERS_ENCODING_JOIN = ";"
 TRACER_ENCODING_PATTERN = r"(.*)\-\[([0-9CNHOS,\-]*)\]"
 
 
-def parse_infusate_name(infusate_string: str) -> dict:
+class ParsedInfusate(TypedDict):
+    original_infusate: str
+    infusate_name: Optional[str]
+    tracer_names: list
+    compound_names: list
+    isotope_labels: list
+
+
+class ParsedTracer(TypedDict):
+    compound_names: list
+    isotope_labels: list
+
+
+def parse_infusate_name(infusate_string: str) -> ParsedInfusate:
     """
     Takes a complex infusate, coded as a string, and parses it into its optional
     name, lists of tracer(s) and compounds.
     """
 
     # defaults
-    parsed_data = {}
-    parsed_data["original_infusate"] = infusate_string
-    # assume the string lacks the optional name, and it is all trace encodings
-    parsed_data["infusate_name"] = None
-    parsed_data["tracer_names"] = split_encoded_tracers_string(infusate_string)
-    parsed_data["compound_names"] = []
+    # assume the string lacks the optional name, and it is all tracer encodings
+    parsed_data: ParsedInfusate = {
+        "original_infusate": infusate_string,
+        "infusate_name": None,
+        "tracer_names": split_encoded_tracers_string(infusate_string),
+        "compound_names": list(),
+        "isotope_labels": list(),
+    }
 
     match = re.search(INFUSATE_ENCODING_PATTERN, infusate_string)
 
@@ -42,10 +58,9 @@ def split_encoded_tracers_string(tracers_string: str) -> list:
     return tracers
 
 
-def parse_tracer_strings(tracers: list) -> dict:
-    tracers_data = {}
-    tracers_data["compound_names"] = []
-    tracers_data["isotope_labels"] = []
+def parse_tracer_strings(tracers: list[str]) -> ParsedTracer:
+
+    tracers_data: ParsedTracer = {"compound_names": list(), "isotope_labels": list()}
 
     for tracer in tracers:
         match = re.search(TRACER_ENCODING_PATTERN, tracer)

--- a/DataRepo/utils/infusate_name_parser.py
+++ b/DataRepo/utils/infusate_name_parser.py
@@ -97,6 +97,9 @@ def parse_tracer_string(tracer: str) -> TracerData:
 
 def parse_isotope_string(isotopes_string: str) -> List[IsotopeData]:
 
+    if not isotopes_string:
+        raise IsotopeParsingError("parse_isotope_string requires a defined string.")
+
     rejected_match = re.search(ISOTOPE_DISALLOWED_CHARACTERS, isotopes_string)
     if rejected_match:
         raise IsotopeParsingError(

--- a/DataRepo/utils/infusate_name_parser.py
+++ b/DataRepo/utils/infusate_name_parser.py
@@ -1,0 +1,60 @@
+import re
+
+# infusate with a name have the tracer(s) grouped in braces
+INFUSATE_ENCODING_PATTERN = r"(.*)\s*\{(.*)\}"
+TRACERS_ENCODING_JOIN = ";"
+TRACER_ENCODING_PATTERN = r"(.*)\-\[([0-9CNHOS,\-]*)\]"
+
+
+def parse_infusate_name(infusate_string: str) -> dict:
+    """
+    Takes a complex infusate, coded as a string, and parses it into its optional
+    name, lists of tracer(s) and compounds.
+    """
+
+    # defaults
+    parsed_data = {}
+    parsed_data["original_infusate"] = infusate_string
+    # assume the string lacks the optional name, and it is all trace encodings
+    parsed_data["infusate_name"] = None
+    parsed_data["tracer_names"] = split_encoded_tracers_string(infusate_string)
+    parsed_data["compound_names"] = []
+
+    match = re.search(INFUSATE_ENCODING_PATTERN, infusate_string)
+
+    if match:
+        parsed_data["infusate_name"] = match.group(1).strip()
+        tracers_string = match.group(2).strip()
+        # over-write the defaults
+        tracer_names = split_encoded_tracers_string(tracers_string)
+        parsed_data["tracer_names"] = tracer_names
+
+    tracer_data = parse_tracer_strings(parsed_data["tracer_names"])
+
+    parsed_data["compound_names"] = tracer_data["compound_names"]
+    parsed_data["isotope_labels"] = tracer_data["isotope_labels"]
+
+    return parsed_data
+
+
+def split_encoded_tracers_string(tracers_string: str) -> list:
+    tracers = tracers_string.split(TRACERS_ENCODING_JOIN)
+    return tracers
+
+
+def parse_tracer_strings(tracers: list) -> dict:
+    tracers_data = {}
+    tracers_data["compound_names"] = []
+    tracers_data["isotope_labels"] = []
+
+    for tracer in tracers:
+        match = re.search(TRACER_ENCODING_PATTERN, tracer)
+        if match:
+            compound = match.group(1).strip()
+            labeling = match.group(2).strip()
+            tracers_data["compound_names"].append(compound)
+            tracers_data["isotope_labels"].append(labeling)
+        else:
+            raise Exception(f'Encoded tracer "{tracer}" cannot be parsed.')
+
+    return tracers_data

--- a/DataRepo/utils/infusate_name_parser.py
+++ b/DataRepo/utils/infusate_name_parser.py
@@ -121,8 +121,9 @@ def parse_isotope_string(isotopes_string: str) -> List[IsotopeData]:
                 r"(?P<mass_number>[\d]+)(?P<element>[" + KNOWN_ISOTOPES + "]{1})",
                 labeled_element,
             )
-            mass_number = int(match.group("mass_number"))
-            element = match.group("element")
+            if match:
+                mass_number = int(match.group("mass_number"))
+                element = match.group("element")
         labeled_count = int(isotope.group("labeled_count"))
 
         recomposited_isotope = labeled_element + str(labeled_count)

--- a/DataRepo/utils/infusate_name_parser.py
+++ b/DataRepo/utils/infusate_name_parser.py
@@ -2,9 +2,11 @@ import re
 from typing import List, Optional, TypedDict
 
 # infusate with a name have the tracer(s) grouped in braces
-INFUSATE_ENCODING_PATTERN = r"(.*)\s*\{(.*)\}"
+# INFUSATE_ENCODING_PATTERN = r"^(.*)\s*\{(.*)\}$"
+INFUSATE_ENCODING_PATTERN = r"^([^\{\}]*?)\s*\{([^\{\}]*?)\}$"
 TRACERS_ENCODING_JOIN = ";"
-TRACER_ENCODING_PATTERN = r"(.*)\-\[([0-9CNHOS,\-]*)\]"
+TRACER_ENCODING_PATTERN = r"^(.*)\-\[([0-9CNHOS,\-]*)\]$"
+# TRACER_ENCODING_PATTERN = r"^(.*)(?:\-\[([0-9CNHOS,\-]+)\])?$"
 ISOTOPE_ENCODING_JOIN = ","
 ISOTOPE_ENCODING_PATTERN = re.compile(
     r"(?:(?P<labeled_positions>[0-9,]+)-){0,1}(?P<labeled_element>[0-9]+[CHNOS])(?P<labeled_count>[0-9+])"

--- a/DataRepo/utils/infusate_name_parser.py
+++ b/DataRepo/utils/infusate_name_parser.py
@@ -2,9 +2,13 @@ import re
 from typing import List, Optional, TypedDict
 
 # infusate with a name have the tracer(s) grouped in braces
-INFUSATE_ENCODING_PATTERN = r"^([^\{\}]*?)\s*\{([^\{\}]*?)\}$"
+INFUSATE_ENCODING_PATTERN = (
+    r"^(?P<infusate_name>[^\{\}]*?)\s*\{(?P<tracers_string>[^\{\}]*?)\}$"
+)
 TRACERS_ENCODING_JOIN = ";"
-TRACER_ENCODING_PATTERN = r"^([^\[\]][\w,\-]+)(?:\-\[([^\[\]][0-9CNHOS,\-]+)\])$"
+TRACER_ENCODING_PATTERN = (
+    r"^(?P<compound_name>[^\[\]][\w,\-]+)(?:\-\[(?P<isotopes>[^\[\]][0-9CNHOS,\-]+)\])$"
+)
 ISOTOPE_ENCODING_JOIN = ","
 ISOTOPE_ENCODING_PATTERN = re.compile(
     r"(?:(?P<labeled_positions>[0-9,]+)-){0,1}(?P<labeled_element>[0-9]+[CHNOS])(?P<labeled_count>[0-9+])"
@@ -46,8 +50,10 @@ def parse_infusate_name(infusate_string: str) -> InfusateData:
     match = re.search(INFUSATE_ENCODING_PATTERN, infusate_string)
 
     if match:
-        parsed_data["infusate_name"] = match.group(1).strip()
-        tracer_strings = split_encoded_tracers_string(match.group(2).strip())
+        parsed_data["infusate_name"] = match.group("infusate_name").strip()
+        tracer_strings = split_encoded_tracers_string(
+            match.group("tracers_string").strip()
+        )
     else:
         tracer_strings = [infusate_string]
 
@@ -72,8 +78,8 @@ def parse_tracer_string(tracer: str) -> TracerData:
 
     match = re.search(TRACER_ENCODING_PATTERN, tracer)
     if match:
-        tracer_data["compound_name"] = match.group(1).strip()
-        tracer_data["isotopes"] = parse_isotope_string(match.group(2).strip())
+        tracer_data["compound_name"] = match.group("compound_name").strip()
+        tracer_data["isotopes"] = parse_isotope_string(match.group("isotopes").strip())
     else:
         raise TracerParsingError(f'Encoded tracer "{tracer}" cannot be parsed.')
 

--- a/DataRepo/utils/infusate_name_parser.py
+++ b/DataRepo/utils/infusate_name_parser.py
@@ -2,11 +2,9 @@ import re
 from typing import List, Optional, TypedDict
 
 # infusate with a name have the tracer(s) grouped in braces
-# INFUSATE_ENCODING_PATTERN = r"^(.*)\s*\{(.*)\}$"
 INFUSATE_ENCODING_PATTERN = r"^([^\{\}]*?)\s*\{([^\{\}]*?)\}$"
 TRACERS_ENCODING_JOIN = ";"
-TRACER_ENCODING_PATTERN = r"^(.*)\-\[([0-9CNHOS,\-]*)\]$"
-# TRACER_ENCODING_PATTERN = r"^(.*)(?:\-\[([0-9CNHOS,\-]+)\])?$"
+TRACER_ENCODING_PATTERN = r"^([^\[\]][\w,\-]+)(?:\-\[([^\[\]][0-9CNHOS,\-]+)\])$"
 ISOTOPE_ENCODING_JOIN = ","
 ISOTOPE_ENCODING_PATTERN = re.compile(
     r"(?:(?P<labeled_positions>[0-9,]+)-){0,1}(?P<labeled_element>[0-9]+[CHNOS])(?P<labeled_count>[0-9+])"

--- a/DataRepo/utils/infusate_name_parser.py
+++ b/DataRepo/utils/infusate_name_parser.py
@@ -1,22 +1,27 @@
 import re
 from typing import List, Optional, TypedDict
 
-KNOWN_ISOTOPES = 'CNHOS'
+KNOWN_ISOTOPES = "CNHOS"
 
 # infusate with a name have the tracer(s) grouped in braces
-INFUSATE_ENCODING_PATTERN = (
+INFUSATE_ENCODING_PATTERN = re.compile(
     r"^(?P<infusate_name>[^\{\}]*?)\s*\{(?P<tracers_string>[^\{\}]*?)\}$"
 )
 TRACERS_ENCODING_JOIN = ";"
-TRACER_ENCODING_PATTERN = (
-    r"^(?P<compound_name>[^\[\]][\w,\-]+)(?:\-\[(?P<isotopes>[^\[\]][0-9" + KNOWN_ISOTOPES + ",\-]+)\])$"
+TRACER_ENCODING_PATTERN = re.compile(
+    r"^(?P<compound_name>[^\[\]][\w,\-]+)(?:\-\[(?P<isotopes>[^\[\]][0-9"
+    + KNOWN_ISOTOPES
+    + r",\-]+)\])$"
 )
 ISOTOPE_ENCODING_JOIN = ","
 ISOTOPE_ENCODING_PATTERN = re.compile(
-    r"(?:(?P<labeled_positions>[0-9,]+)-){0,1}(?P<labeled_element>[0-9]+[^\[\]][" + KNOWN_ISOTOPES + "])(?P<labeled_count>[0-9+])"
+    r"(?:(?P<labeled_positions>[0-9,]+)-){0,1}(?P<labeled_element>[0-9]+[^\[\]]["
+    + KNOWN_ISOTOPES
+    + r"])(?P<labeled_count>[0-9+])"
 )
 # only allow digits, brackets, dashes, commas, and  isotope symbols
-ISOTOPE_DISALLOWED_CHARACTERS = r"[^\d\[\]\-," + KNOWN_ISOTOPES + "]"
+ISOTOPE_DISALLOWED_CHARACTERS = re.compile(r"[^\d\[\]\-," + KNOWN_ISOTOPES + "]")
+
 
 class IsotopeData(TypedDict):
     labeled_element: str
@@ -92,9 +97,11 @@ def parse_tracer_string(tracer: str) -> TracerData:
 
 def parse_isotope_string(isotopes_string: str) -> List[IsotopeData]:
 
-    rejected_match = match = re.search(ISOTOPE_DISALLOWED_CHARACTERS, isotopes_string)
+    rejected_match = re.search(ISOTOPE_DISALLOWED_CHARACTERS, isotopes_string)
     if rejected_match:
-        raise IsotopeParsingError(f'Encoded isotopes "{isotopes_string}" contains disallowed characters.')
+        raise IsotopeParsingError(
+            f'Encoded isotopes "{isotopes_string}" contains disallowed characters.'
+        )
 
     isotope_data = list()
     isotopes = re.findall(ISOTOPE_ENCODING_PATTERN, isotopes_string)

--- a/DataRepo/utils/infusate_name_parser.py
+++ b/DataRepo/utils/infusate_name_parser.py
@@ -41,6 +41,7 @@ def parse_infusate_name(infusate_string: str) -> InfusateData:
 
     # defaults
     # assume the string lacks the optional name, and it is all tracer encodings
+    infusate_string = infusate_string.strip()
     parsed_data: InfusateData = {
         "original_infusate": infusate_string,
         "infusate_name": None,


### PR DESCRIPTION
<!-- markdownlint-disable-next-line first-line-heading -->
## Summary Change Description

Just adding a utility file and some basic tests for **_parsing_** the initial infusate naming specification.

## Affected Issue Numbers

- touches part of #407 based on proposal in #364 
  
## Code Review Notes

**_Important: It does NO validation_**, yet.

My assumption is that these functions will/might not remain in this new file(s), but might be moved elsewhere in the codebase including possibly the new models.

It would be helpful for reviewers to focus on 

- the regular expressions for infusate and tracers, if they can be usefully improved
- the data structures used to store the parsed bits, because presumably other code that consumes these pieces (validators, etc) will have to access them
- additional positive and negative tests, beyond the basics in the PR
- a proposed fix for this [error](https://github.com/Princeton-LSI-ResearchComputing/tracebase/runs/6574963958?check_suite_focus=true#step:12:20311) which does not occur on my home environment.
```
- ----------------------------------------------------------------------
Ran 257 tests in 99.844s

OK
```


## Checklist

- [ ] All issue requirements satisfied (or no linked issues)
- [ ] [Linting passes](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#linting).
- [ ] [Migrations created & committed *(or no model changes)*](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#migration-process)
- [ ] [Tests implemented *(or no code changes)*](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#test-implementation)
- [ ] [All tests pass](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#quality-control)
