### PR TITLE
Parse isotope data

### DIFF
--- a/DataRepo/tests/test_infusate_name_parser.py
+++ b/DataRepo/tests/test_infusate_name_parser.py
@@ -1,43 +1,109 @@
 from django.test import tag
 
 from DataRepo.tests.tracebase_test_case import TracebaseTestCase
-from DataRepo.utils.infusate_name_parser import parse_infusate_name
+from DataRepo.utils.infusate_name_parser import (
+    InfusateData,
+    IsotopeData,
+    TracerData,
+    TracerParsingError,
+    parse_infusate_name,
+    parse_isotope_string,
+    parse_tracer_string,
+)
 
 
 @tag("parsing")
 class InfusateParsingTests(TracebaseTestCase):
     @classmethod
     def setUpTestData(cls):
+        cls.isotope_13c6 = IsotopeData(
+            labeled_element="13C",
+            labeled_count=6,
+            labeled_positions=None,
+        )
+        cls.isotope_13c5 = IsotopeData(
+            labeled_element="13C",
+            labeled_count=5,
+            labeled_positions=None,
+        )
+        cls.isotope_15n1 = IsotopeData(
+            labeled_element="15N",
+            labeled_count=1,
+            labeled_positions=None,
+        )
+        cls.isotope_13c2 = IsotopeData(
+            labeled_element="13C",
+            labeled_count=2,
+            labeled_positions=[1, 2],
+        )
+        cls.tracer_l_leucine = TracerData(
+            original_tracer="L-Leucine-[1,2-13C2]",
+            compound_name="L-Leucine",
+            isotopes=[cls.isotope_13c2],
+        )
+        cls.infusate_bcaas = InfusateData(
+            original_infusate="BCAAs {isoleucine-[13C6,15N1];leucine-[13C6,15N1];valine-[13C5,15N1]}",
+            infusate_name="BCAAs",
+            tracers=[
+                TracerData(
+                    original_tracer="isoleucine-[13C6,15N1]",
+                    compound_name="isoleucine",
+                    isotopes=[cls.isotope_13c6, cls.isotope_15n1],
+                ),
+                TracerData(
+                    original_tracer="leucine-[13C6,15N1]",
+                    compound_name="leucine",
+                    isotopes=[cls.isotope_13c6, cls.isotope_15n1],
+                ),
+                TracerData(
+                    original_tracer="valine-[13C5,15N1]",
+                    compound_name="valine",
+                    isotopes=[cls.isotope_13c5, cls.isotope_15n1],
+                ),
+            ],
+        )
+        cls.infusate_l_leucine = InfusateData(
+            original_infusate="L-Leucine-[1,2-13C2]",
+            infusate_name=None,
+            tracers=[cls.tracer_l_leucine],
+        )
+
         pass
 
+    def test_isotope_parsing_single(self):
+        isotope_string = "13C6"
+        self.assertEqual(parse_isotope_string(isotope_string), [self.isotope_13c6])
+
+    def test_isotope_parsing_double(self):
+        isotope_string = "13C6,15N1"
+        self.assertEqual(
+            parse_isotope_string(isotope_string), [self.isotope_13c6, self.isotope_15n1]
+        )
+
+    def test_isotope_parsing_positions(self):
+        isotope_string = "1,2-13C2"
+        self.assertEqual(parse_isotope_string(isotope_string), [self.isotope_13c2])
+
+    def test_tracer_parsing(self):
+        tracer_string = "L-Leucine-[1,2-13C2]"
+        self.assertEqual(parse_tracer_string(tracer_string), self.tracer_l_leucine)
+
     def test_infusate_parsing_with_name_1(self):
-        name = "BCAAs {isoleucine-[13C6,15N1];leucine-[13C6,15N1];valine-[13C5,15N1]}"
-        data = parse_infusate_name(name)
-        self.assertEqual(data["infusate_name"], "BCAAs")
-        self.assertEqual(len(data["tracer_names"]), 3)
-        self.assertEqual(len(data["compound_names"]), 3)
-        self.assertEqual(data["tracer_names"][1], "leucine-[13C6,15N1]")
-        self.assertEqual(data["compound_names"][2], "valine")
-        self.assertEqual(data["isotope_labels"][0], "13C6,15N1")
+        infusate_string = (
+            "BCAAs {isoleucine-[13C6,15N1];leucine-[13C6,15N1];valine-[13C5,15N1]}"
+        )
+        self.assertEqual(parse_infusate_name(infusate_string), self.infusate_bcaas)
 
     def test_infusate_parsing_without_name_1(self):
-        name = "L-Leucine-[1,2-13C2]"
-        data = parse_infusate_name(name)
-        self.assertEqual(data["infusate_name"], None)
-        self.assertEqual(len(data["tracer_names"]), 1)
-        self.assertEqual(len(data["compound_names"]), 1)
-        self.assertEqual(data["tracer_names"][0], name)
-        self.assertEqual(data["compound_names"][0], "L-Leucine")
-        self.assertEqual(data["isotope_labels"][0], "1,2-13C2")
+        infusate_string = "L-Leucine-[1,2-13C2]"
+        self.assertEqual(parse_infusate_name(infusate_string), self.infusate_l_leucine)
 
     def test_malformed_infusate_parsing_1(self):
         name = "not a {properly encoded tracer-[NAME1]}"
-        with self.assertRaises(Exception) as context:
-            data = parse_infusate_name(name)  # noqa: F841
-        self.assertTrue("cannot be parsed" in str(context.exception))
+        with self.assertRaisesRegex(TracerParsingError, "cannot be parsed"):
+            _ = parse_infusate_name(name)
 
     def test_malformed_infusate_parsing_2(self):
         name = "not a properly encoded tracer name"
-        with self.assertRaises(Exception) as context:
-            data = parse_infusate_name(name)  # noqa: F841
-        self.assertTrue("cannot be parsed" in str(context.exception))
+        with self.assertRaisesRegex(TracerParsingError, "cannot be parsed"):
+            _ = parse_infusate_name(name)


### PR DESCRIPTION
<!-- markdownlint-disable-next-line first-line-heading -->
## Summary Change Description

* Added parsing of isotope data into constituent parts
* Use custom exceptions
* Added some tests for isotope and tracer level parsing

## Affected Issue Numbers

## Code Review Notes

@jcmatese, I took the liberty of adding some additional parsing to this PR. I mostly built off of what you already had. I believe there may be some edge cases that aren't well handled right now, so I'd appreciate some additional tests being written for this. Just having the example string and desired output dictionary (or exception) would be helpful to make it simpler to add in any additional checks are modifications to regular expressions.

## Checklist

- [ ] All issue requirements satisfied (or no linked issues)
- [ ] [Linting passes](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#linting).
- [ ] [Migrations created & committed *(or no model changes)*](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#migration-process)
- [ ] [Tests implemented *(or no code changes)*](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#test-implementation)
- [ ] [All tests pass](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#quality-control)
