### PR TITLE
Suggestions for the infusate parsing PR

### DIFF
--- a/DataRepo/tests/test_infusate_name_parser.py
+++ b/DataRepo/tests/test_infusate_name_parser.py
@@ -19,25 +19,25 @@ class InfusateParsingTests(TracebaseTestCase):
     @classmethod
     def setUpTestData(cls):
         cls.isotope_13c6 = IsotopeData(
-            labeled_element="C",
+            element="C",
             mass_number=13,
             labeled_count=6,
             labeled_positions=None,
         )
         cls.isotope_13c5 = IsotopeData(
-            labeled_element="C",
+            element="C",
             mass_number=13,
             labeled_count=5,
             labeled_positions=None,
         )
         cls.isotope_15n1 = IsotopeData(
-            labeled_element="N",
+            element="N",
             mass_number=15,
             labeled_count=1,
             labeled_positions=None,
         )
         cls.isotope_13c2 = IsotopeData(
-            labeled_element="C",
+            element="C",
             mass_number=13,
             labeled_count=2,
             labeled_positions=[1, 2],
@@ -148,7 +148,7 @@ class InfusateParsingTests(TracebaseTestCase):
         # Test back-to-back occurrences of square bracket expressions
         name = "lysine-[13C5]-[19O2]"
         with self.assertRaisesRegex(TracerParsingError, "cannot be parsed"):
-            _ = parse_tracer_string(name, parse_one=True)
+            _ = parse_tracer_string(name)
 
     def test_malformed_tracer_parsing_with_new_line(self):
         # Test multiple labeled compounds delimited by hard return

--- a/DataRepo/utils/infusate_name_parser.py
+++ b/DataRepo/utils/infusate_name_parser.py
@@ -15,14 +15,14 @@ TRACER_ENCODING_PATTERN = re.compile(
 )
 ISOTOPE_ENCODING_JOIN = ","
 ISOTOPE_ENCODING_PATTERN = re.compile(
-    r"(?P<all>(?:(?P<labeled_positions>[0-9,]+)-)?(?P<mass_number>[0-9]+)(?P<labeled_element>["
+    r"(?P<all>(?:(?P<labeled_positions>[0-9,]+)-)?(?P<mass_number>[0-9]+)(?P<element>["
     + KNOWN_ISOTOPES
     + r"]{1,2})(?P<labeled_count>[0-9]+))"
 )
 
 
 class IsotopeData(TypedDict):
-    labeled_element: str
+    element: str
     mass_number: int
     labeled_count: int
     labeled_positions: Optional[List[int]]
@@ -80,7 +80,7 @@ def split_encoded_tracers_string(tracers_string: str) -> List[str]:
     return tracers
 
 
-def parse_tracer_string(tracer: str, parse_one=False) -> TracerData:
+def parse_tracer_string(tracer: str) -> TracerData:
 
     tracer_data: TracerData = {
         "unparsed_string": tracer,
@@ -90,8 +90,6 @@ def parse_tracer_string(tracer: str, parse_one=False) -> TracerData:
 
     match = re.search(TRACER_ENCODING_PATTERN, tracer)
     if match:
-        if parse_one and (match.start != 0 or match.end != len(tracer)):
-            raise TracerParsingError(f'Encoded tracer "{tracer}" cannot be parsed.')
         tracer_data["compound_name"] = match.group("compound_name").strip()
         tracer_data["isotopes"] = parse_isotope_string(match.group("isotopes").strip())
     else:
@@ -125,7 +123,7 @@ def parse_isotope_string(isotopes_string: str) -> List[IsotopeData]:
     for isotope in ISOTOPE_ENCODING_PATTERN.finditer(isotopes_string):
 
         mass_number = int(isotope.group("mass_number"))
-        labeled_element = isotope.group("labeled_element")
+        element = isotope.group("element")
         labeled_count = int(isotope.group("labeled_count"))
         labeled_positions = None
         if isotope.group("labeled_positions"):
@@ -139,7 +137,7 @@ def parse_isotope_string(isotopes_string: str) -> List[IsotopeData]:
 
         isotope_data.append(
             IsotopeData(
-                labeled_element=labeled_element,
+                element=element,
                 mass_number=mass_number,
                 labeled_count=labeled_count,
                 labeled_positions=labeled_positions,


### PR DESCRIPTION
## Summary Change Description

Simplified the regular expressions.  Added the usage of `TracerLabeledClass` to get the element names (which will have to be changed to `ElementLabel` after merge in order to pass tests/linting).

## Affected Issue Numbers

- Resolves review issues in PR #441

## Code Review Notes

There are a few things to note...

- I'll be on vacation during review, so if there are any blocking issues, feel free to fix them or merge #441 and I can address them and merge upon my return
- I changed the string used in test `test_malformed_infusate_parsing` because the original test wasn't testing the infusate pattern - it was testing the isotope pattern, which is tested elsewhere.
- I added a parameter called `parse_one` to `parse_tracer_string` because the regex used is not anchored (because it's used by `findall`.  So set `parse_one` to `True` if the string you're passing is should explicitly be 1 tracer.  There are other ways to solve this, like by creating separate patterns and methods for parsing one or parsing multiple (with a delimiter).  I'm open to other solutions.
- I also added a requirement that a compound name (in a tracer) not contain parsable isotope patterns inside it (instead of dictating disallowed characters).  I felt that constricting the compound name in that way seemed too limiting.  Relaxing the patterns caused one of the tests to have isotope encodings to get into the compound name, which honestly would get caught later anyway when the compound is not found.  The new requirement that the compound not contain an isotope pattern fixed that.  If this is a problem, I could add a restriction that the compound name not match `-\[ISOTOPE_ENCODING_PATTERN\]$` (i.e. **end** with a parsable isotope), which essentially includes the `-[]` that the `ISOTOPE_ENCODING_PATTERN` doesn't include.

## Checklist

- [ ] All issue requirements satisfied (or no linked issues)
- [ ] [Linting passes](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#linting).
- [ ] [Migrations created & committed *(or no model changes)*](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#migration-process)
- [ ] [Tests implemented *(or no code changes)*](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#test-implementation)
- [ ] [All tests pass](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#quality-control)
