### PR TITLE
Consistency edits and typo correction

### DIFF
--- a/DataRepo/tests/test_infusate_name_parser.py
+++ b/DataRepo/tests/test_infusate_name_parser.py
@@ -21,26 +21,26 @@ class InfusateParsingTests(TracebaseTestCase):
         cls.isotope_13c6 = IsotopeData(
             element="C",
             mass_number=13,
-            labeled_count=6,
-            labeled_positions=None,
+            count=6,
+            positions=None,
         )
         cls.isotope_13c5 = IsotopeData(
             element="C",
             mass_number=13,
-            labeled_count=5,
-            labeled_positions=None,
+            count=5,
+            positions=None,
         )
         cls.isotope_15n1 = IsotopeData(
             element="N",
             mass_number=15,
-            labeled_count=1,
-            labeled_positions=None,
+            count=1,
+            positions=None,
         )
         cls.isotope_13c2 = IsotopeData(
             element="C",
             mass_number=13,
-            labeled_count=2,
-            labeled_positions=[1, 2],
+            count=2,
+            positions=[1, 2],
         )
         cls.tracer_l_leucine = TracerData(
             unparsed_string="L-Leucine-[1,2-13C2]",

--- a/DataRepo/utils/infusate_name_parser.py
+++ b/DataRepo/utils/infusate_name_parser.py
@@ -133,7 +133,7 @@ def parse_isotope_string(isotopes_string: str) -> List[IsotopeData]:
         if parsed_string is None:
             parsed_string = isotope.group("all")
         else:
-            parsed_string += "," + isotope.group("all")
+            parsed_string += ISOTOPE_ENCODING_JOIN + isotope.group("all")
 
         isotope_data.append(
             IsotopeData(

--- a/DataRepo/utils/infusate_name_parser.py
+++ b/DataRepo/utils/infusate_name_parser.py
@@ -15,17 +15,17 @@ TRACER_ENCODING_PATTERN = re.compile(
 )
 ISOTOPE_ENCODING_JOIN = ","
 ISOTOPE_ENCODING_PATTERN = re.compile(
-    r"(?P<all>(?:(?P<labeled_positions>[0-9,]+)-)?(?P<mass_number>[0-9]+)(?P<element>["
+    r"(?P<all>(?:(?P<positions>[0-9,]+)-)?(?P<mass_number>[0-9]+)(?P<element>["
     + KNOWN_ISOTOPES
-    + r"]{1,2})(?P<labeled_count>[0-9]+))"
+    + r"]{1,2})(?P<count>[0-9]+))"
 )
 
 
 class IsotopeData(TypedDict):
     element: str
     mass_number: int
-    labeled_count: int
-    labeled_positions: Optional[List[int]]
+    count: int
+    positions: Optional[List[int]]
 
 
 class TracerData(TypedDict):
@@ -95,7 +95,7 @@ def parse_tracer_string(tracer: str) -> TracerData:
     else:
         raise TracerParsingError(f'Encoded tracer "{tracer}" cannot be parsed.')
 
-    # Compound names are very premissive, but we should at least make sure a malformed isotope specification didn't
+    # Compound names are very permissive, but we should at least make sure a malformed isotope specification didn't
     # bleed into the compound pattern (like you would get if the wrong delimiter was used
     # - see test_malformed_tracer_parsing_with_improper_delimiter)
     imatch = re.search(ISOTOPE_ENCODING_PATTERN, tracer_data["compound_name"])
@@ -124,11 +124,11 @@ def parse_isotope_string(isotopes_string: str) -> List[IsotopeData]:
 
         mass_number = int(isotope.group("mass_number"))
         element = isotope.group("element")
-        labeled_count = int(isotope.group("labeled_count"))
-        labeled_positions = None
-        if isotope.group("labeled_positions"):
-            positions_str = isotope.group("labeled_positions")
-            labeled_positions = [int(x) for x in positions_str.split(",")]
+        count = int(isotope.group("count"))
+        positions = None
+        if isotope.group("positions"):
+            positions_str = isotope.group("positions")
+            positions = [int(x) for x in positions_str.split(",")]
 
         if parsed_string is None:
             parsed_string = isotope.group("all")
@@ -139,8 +139,8 @@ def parse_isotope_string(isotopes_string: str) -> List[IsotopeData]:
             IsotopeData(
                 element=element,
                 mass_number=mass_number,
-                labeled_count=labeled_count,
-                labeled_positions=labeled_positions,
+                count=count,
+                positions=positions,
             )
         )
 


### PR DESCRIPTION
## Summary Change Description

Given the edit while I was gone, I noted that the choice I'd made after removing the unparsed `labeled_element` and selecting to rename `element` to `labeled_element` for consistency was reverted to `element` to match the model.  I agree with the motivation behind that change and this PR extends that edit to apply to the other dictionary keys as well.

I also note that the removal of the `parse_one` argument was a good one.  It was made redundant when I added the requirement to make the tracer name not contain a match to the isotope encoding pattern.

Fixed a typo.

## Affected Issue Numbers

- already resolved issue / no issue

## Code Review Notes

self-explanatory.

## Checklist

- [x] All issue requirements satisfied (or no linked issues)
- [x] [Linting passes](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#linting).
- [x] [Migrations created & committed *(or no model changes)*](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#migration-process)
- [x] [Tests implemented *(or no code changes)*](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#test-implementation)
- [ ] [All tests pass](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#quality-control)
