### PR TITLE
Remove extra PeakDataLabel creation from test

### DIFF
--- a/DataRepo/tests/models/test_peak_data.py
+++ b/DataRepo/tests/models/test_peak_data.py
@@ -100,16 +100,9 @@ class PeakDataLabelTests(PeakDataData):
         rec.full_clean()
 
     def test_multiple_labels_with_same_elem(self):
-        # Note, asserting UniqueConstraint is raised doesn't work and... if the assertion clause wraps only the second
-        # create, the assert raises bafflingly doesn't work in either case
+        """Test creating a second PeakDataLabel with the same element"""
+        pd = PeakData.objects.get(raw_abundance=1000.0)
         with self.assertRaisesRegex(IntegrityError, r"\(\d+, C\)"):
-            pd = PeakData.objects.get(raw_abundance=1000.0)
-            PeakDataLabel.objects.create(
-                peak_data=pd,
-                element="C",
-                count=5,
-                mass_number=13,
-            )
             PeakDataLabel.objects.create(
                 peak_data=pd,
                 element="C",


### PR DESCRIPTION
<!-- markdownlint-disable-next-line first-line-heading -->
## Summary Change Description

The `PeakDataLabelTests.setup()` method creates a PeakDataLabel, so the test for a conflict only needs to create a single PeakDataLabel record.

## Affected Issue Numbers


## Code Review Notes


## Checklist

- [ ] All issue requirements satisfied (or no linked issues)
- [ ] [Linting passes](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#linting).
- [ ] [Migrations created & committed *(or no model changes)*](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#migration-process)
- [ ] [Tests implemented *(or no code changes)*](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#test-implementation)
- [ ] [All tests pass](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#quality-control)
