### PR TITLE
FCirc Multi 3 - Validation Database Changes

### DIFF
--- a/DataRepo/models/infusate.py
+++ b/DataRepo/models/infusate.py
@@ -18,37 +18,48 @@ if TYPE_CHECKING:
 CONCENTRATION_SIGNIFICANT_FIGURES = 3
 
 
-class InfusateManager(models.Manager):
+# PR REVIEW NOTE: Had to change this to a QuerySet subclass in order to support calls to (e.g.):
+#                     .using(db).get_or_create_infusate
+#                 for the validation database.
+#                 See: https://sayari3.com/articles/32-custom-managers-and-queryset-methods-in-django/
+class InfusateQuerySet(models.QuerySet):
     def get_or_create_infusate(
         self, infusate_data: InfusateData
     ) -> tuple[Infusate, bool]:
         """Get Infusate matching the infusate_data, or create a new infusate"""
 
         # Search for matching Infusate
-        infusate = self.get_infusate(infusate_data)
+        infusate = self.using(self._db).get_infusate(infusate_data)
         created = False
 
         # Matching record not found, create new record
         if infusate is None:
+            print(f"Inserting infusate {infusate_data['unparsed_string']}")
+
             # create infusate
-            infusate = self.create(tracer_group_name=infusate_data["infusate_name"])
+            infusate = self.using(self._db).create(
+                tracer_group_name=infusate_data["infusate_name"]
+            )
 
             # create tracers
             Tracer = get_model_by_name("Tracer")
             InfusateTracer = get_model_by_name("InfusateTracer")
             for infusate_tracer in infusate_data["tracers"]:
-                tracer = Tracer.objects.get_tracer(infusate_tracer["tracer"])
+                tracer = Tracer.objects.using(self._db).get_tracer(
+                    infusate_tracer["tracer"]
+                )
                 if tracer is None:
-                    (tracer, _) = Tracer.objects.get_or_create_tracer(
+                    (tracer, _) = Tracer.objects.using(self._db).get_or_create_tracer(
                         infusate_tracer["tracer"]
                     )
                 # associate tracers with specific conectrations
-                InfusateTracer.objects.create(
+                InfusateTracer.objects.using(self._db).create(
                     infusate=infusate,
                     tracer=tracer,
                     concentration=infusate_tracer["concentration"],
                 )
             infusate.full_clean()
+            infusate.save(using=self._db)
             created = True
         return (infusate, created)
 
@@ -57,19 +68,23 @@ class InfusateManager(models.Manager):
         matching_infusate = None
 
         # Check for infusates with the same name and same number of tracers
-        infusates = Infusate.objects.annotate(
-            num_tracers=models.Count("tracers")
-        ).filter(
-            tracer_group_name=infusate_data["infusate_name"],
-            num_tracers=len(infusate_data["tracers"]),
+        infusates = (
+            Infusate.objects.using(self._db)
+            .annotate(num_tracers=models.Count("tracers"))
+            .filter(
+                tracer_group_name=infusate_data["infusate_name"],
+                num_tracers=len(infusate_data["tracers"]),
+            )
         )
         # Check that the tracers match
         for infusate_tracer in infusate_data["tracers"]:
             Tracer = get_model_by_name("Tracer")
-            tracer = Tracer.objects.get_tracer(infusate_tracer["tracer"])
+            tracer = Tracer.objects.using(self._db).get_tracer(
+                infusate_tracer["tracer"]
+            )
             infusates = infusates.filter(
-                infusatetracer__tracer=tracer,
-                infusatetracer__concentration=infusate_tracer["concentration"],
+                tracer_links__tracer=tracer,
+                tracer_links__concentration=infusate_tracer["concentration"],
             )
         if infusates.count() == 1:
             matching_infusate = infusates.first()
@@ -77,7 +92,7 @@ class InfusateManager(models.Manager):
 
 
 class Infusate(MaintainedModel):
-    objects = InfusateManager()
+    objects = InfusateQuerySet().as_manager()
 
     id = models.AutoField(primary_key=True)
     name = models.CharField(
@@ -124,7 +139,7 @@ class Infusate(MaintainedModel):
         if self.id is None or self.tracers is None or self.tracers.count() == 0:
             return self.tracer_group_name
 
-        link_recs = self.tracers.through.objects.filter(infusate__exact=self.id)
+        link_recs = self.tracers.through.objects.filter(infusate__id__exact=self.id)
 
         name = ";".join(
             sorted(

--- a/DataRepo/models/infusate_tracer.py
+++ b/DataRepo/models/infusate_tracer.py
@@ -9,8 +9,16 @@ from DataRepo.models.maintained_model import (
 
 class InfusateTracer(MaintainedModel):
     id = models.AutoField(primary_key=True)
-    infusate = models.ForeignKey("DataRepo.Infusate", on_delete=models.CASCADE)
-    tracer = models.ForeignKey("DataRepo.Tracer", on_delete=models.CASCADE)
+    infusate = models.ForeignKey(
+        "DataRepo.Infusate",
+        on_delete=models.CASCADE,
+        related_name="tracer_links",
+    )
+    tracer = models.ForeignKey(
+        "DataRepo.Tracer",
+        on_delete=models.CASCADE,
+        related_name="infusate_links",
+    )
     concentration = models.FloatField(
         null=False,
         blank=False,
@@ -34,7 +42,9 @@ class InfusateTracer(MaintainedModel):
     )
     def _name(self):
         """
-        No name field to update, but we want to propagate changes to Infusate.name when links are created, changed, or
-        deleted.  This method is not called when the decorator above does not supply update_field_name
+        No name field to update, but we want to changes to these records (i.e. their creation) to trigger Infusate.name
+        to update.  That happens in this class's override to .save() in the MaintainedModel class, from which this
+        class is derived.  But we don't actually want this method to be called because there is no field to update, so
+        we leave out the update_field_name argument to the decorator.
         """
         pass

--- a/DataRepo/models/tracer_label.py
+++ b/DataRepo/models/tracer_label.py
@@ -12,9 +12,13 @@ from DataRepo.models.maintained_model import (
 from DataRepo.utils.infusate_name_parser import IsotopeData
 
 
-class TracerLabelManager(models.Manager):
+# PR REVIEW NOTE: Had to change this to a QuerySet subclass in order to support calls to (e.g.):
+#                     .using(db).create_tracer_label
+#                 for the validation database.
+#                 See: https://sayari3.com/articles/32-custom-managers-and-queryset-methods-in-django/
+class TracerLabelQuerySet(models.QuerySet):
     def create_tracer_label(self, tracer: Tracer, isotope_data: IsotopeData):
-        tracer_label = self.create(
+        tracer_label = self.using(self._db).create(
             tracer=tracer,
             element=isotope_data["element"],
             count=isotope_data["count"],
@@ -27,7 +31,7 @@ class TracerLabelManager(models.Manager):
 
 class TracerLabel(MaintainedModel, ElementLabel):
 
-    objects = TracerLabelManager()
+    objects = TracerLabelQuerySet().as_manager()
 
     id = models.AutoField(primary_key=True)
     name = models.CharField(

--- a/DataRepo/tests/test_views.py
+++ b/DataRepo/tests/test_views.py
@@ -2,6 +2,7 @@ import json
 
 from django.conf import settings
 from django.core.management import call_command
+from django.db import transaction
 from django.test import override_settings, tag
 from django.urls import reverse
 
@@ -19,11 +20,14 @@ from DataRepo.models import (
     Tissue,
 )
 from DataRepo.models.utilities import get_all_models
-from DataRepo.tests.tracebase_test_case import TracebaseTestCase
+from DataRepo.tests.tracebase_test_case import (
+    TracebaseTestCase,
+    TracebaseTransactionTestCase,
+)
 from DataRepo.views import DataValidationView
 
 
-@tag("multi_unknown")
+@tag("multi_mixed")
 class ViewTests(TracebaseTestCase):
     @classmethod
     def setUpTestData(cls):
@@ -72,19 +76,23 @@ class ViewTests(TracebaseTestCase):
         cls.SERUM_PEAKDATA_ROWS = 13
         cls.SERUM_PEAKGROUP_COUNT = cls.SERUM_COMPOUNDS_COUNT * cls.SERUM_SAMPLES_COUNT
 
+    @tag("multi_working")
     def test_home_url_exists_at_desired_location(self):
         response = self.client.get("/")
         self.assertEqual(response.status_code, 200)
 
+    @tag("multi_working")
     def test_home_url_accessible_by_name(self):
         response = self.client.get(reverse("home"))
         self.assertEqual(response.status_code, 200)
 
+    @tag("multi_working")
     def test_home_uses_correct_template(self):
         response = self.client.get(reverse("home"))
         self.assertEqual(response.status_code, 200)
         self.assertTemplateUsed(response, "home.html")
 
+    @tag("multi_broken")
     def test_home_card_attr_list(self):
         # spot check: counts, urls for card attributes
         animal_count = Animal.objects.all().count()
@@ -114,6 +122,7 @@ class ViewTests(TracebaseTestCase):
         self.assertEqual(advance_search_url, "/DataRepo/search_advanced/")
         self.assertEqual(len(response.context["card_rows"]), 2)
 
+    @tag("multi_broken")
     def test_compound_list(self):
         response = self.client.get(reverse("compound_list"))
         self.assertEqual(response.status_code, 200)
@@ -122,6 +131,7 @@ class ViewTests(TracebaseTestCase):
             len(response.context["compound_list"]), self.ALL_COMPOUNDS_COUNT
         )
 
+    @tag("multi_broken")
     def test_compound_detail(self):
         lysine = Compound.objects.filter(name="lysine").get()
         response = self.client.get(reverse("compound_detail", args=[lysine.id]))
@@ -129,11 +139,13 @@ class ViewTests(TracebaseTestCase):
         self.assertTemplateUsed(response, "DataRepo/compound_detail.html")
         self.assertEqual(response.context["compound"].name, "lysine")
 
+    @tag("multi_working")
     def test_compound_detail_404(self):
         c = Compound.objects.order_by("id").last()
         response = self.client.get(reverse("compound_detail", args=[c.id + 1]))
         self.assertEqual(response.status_code, 404)
 
+    @tag("multi_broken")
     @tag("study")
     def test_study_list(self):
         response = self.client.get(reverse("study_list"))
@@ -142,12 +154,14 @@ class ViewTests(TracebaseTestCase):
         self.assertEqual(len(response.context["study_list"]), 1)
         self.assertEqual(len(response.context["df"]), 1)
 
+    @tag("multi_broken")
     @tag("study")
     def test_study_summary(self):
         response = self.client.get("/DataRepo/studies/study_summary/")
         self.assertEqual(response.status_code, 200)
         self.assertTemplateUsed(response, "DataRepo/study_summary.html")
 
+    @tag("multi_broken")
     @tag("study")
     def test_study_detail(self):
         obob_fasted = Study.objects.filter(name="obob_fasted").get()
@@ -157,18 +171,21 @@ class ViewTests(TracebaseTestCase):
         self.assertEqual(response.context["study"].name, "obob_fasted")
         self.assertEqual(len(response.context["stats_df"]), 1)
 
+    @tag("multi_working")
     @tag("study")
     def test_study_detail_404(self):
         s = Study.objects.order_by("id").last()
         response = self.client.get(reverse("study_detail", args=[s.id + 1]))
         self.assertEqual(response.status_code, 404)
 
+    @tag("multi_working")
     def test_protocol_list(self):
         response = self.client.get(reverse("protocol_list"))
         self.assertEqual(response.status_code, 200)
         self.assertTemplateUsed(response, "DataRepo/protocol_list.html")
         self.assertEqual(len(response.context["protocol_list"]), 1)
 
+    @tag("multi_working")
     def test_protocol_detail(self):
         p1 = Protocol.objects.filter(name="Default").get()
         response = self.client.get(reverse("protocol_detail", args=[p1.id]))
@@ -176,11 +193,13 @@ class ViewTests(TracebaseTestCase):
         self.assertTemplateUsed(response, "DataRepo/protocol_detail.html")
         self.assertEqual(response.context["protocol"].name, "Default")
 
+    @tag("multi_working")
     def test_protocol_detail_404(self):
         p = Protocol.objects.order_by("id").last()
         response = self.client.get(reverse("protocol_detail", args=[p.id + 1]))
         self.assertEqual(response.status_code, 404)
 
+    @tag("multi_broken")
     @tag("animal")
     def test_animal_list(self):
         response = self.client.get(reverse("animal_list"))
@@ -189,6 +208,7 @@ class ViewTests(TracebaseTestCase):
         self.assertEqual(len(response.context["animal_list"]), self.ALL_ANIMALS_COUNT)
         self.assertEqual(len(response.context["df"]), self.ALL_ANIMALS_COUNT)
 
+    @tag("multi_broken")
     @tag("animal")
     def test_animal_detail(self):
         a1 = Animal.objects.filter(name="971").get()
@@ -198,12 +218,14 @@ class ViewTests(TracebaseTestCase):
         self.assertEqual(response.context["animal"].name, "971")
         self.assertEqual(len(response.context["df"]), self.ALL_SAMPLES_COUNT)
 
+    @tag("multi_working")
     @tag("animal")
     def test_animal_detail_404(self):
         a = Animal.objects.order_by("id").last()
         response = self.client.get(reverse("animal_detail", args=[a.id + 1]))
         self.assertEqual(response.status_code, 404)
 
+    @tag("multi_broken")
     @tag("tissue")
     def test_tissue_list(self):
         response = self.client.get(reverse("tissue_list"))
@@ -211,6 +233,7 @@ class ViewTests(TracebaseTestCase):
         self.assertTemplateUsed(response, "DataRepo/tissue_list.html")
         self.assertEqual(len(response.context["tissue_list"]), self.ALL_TISSUES_COUNT)
 
+    @tag("multi_working")
     @tag("tissue")
     def test_tissue_detail(self):
         t1 = Tissue.objects.filter(name="brown_adipose_tissue").get()
@@ -219,12 +242,14 @@ class ViewTests(TracebaseTestCase):
         self.assertTemplateUsed(response, "DataRepo/tissue_detail.html")
         self.assertEqual(response.context["tissue"].name, "brown_adipose_tissue")
 
+    @tag("multi_working")
     @tag("tissue")
     def test_tissue_detail_404(self):
         t = Tissue.objects.order_by("id").last()
         response = self.client.get(reverse("tissue_detail", args=[t.id + 1]))
         self.assertEqual(response.status_code, 404)
 
+    @tag("multi_broken")
     @tag("sample")
     def test_sample_list(self):
         response = self.client.get("/DataRepo/samples/")
@@ -233,6 +258,7 @@ class ViewTests(TracebaseTestCase):
         self.assertEqual(len(response.context["sample_list"]), self.ALL_SAMPLES_COUNT)
         self.assertEqual(len(response.context["df"]), self.ALL_SAMPLES_COUNT)
 
+    @tag("multi_broken")
     @tag("sample")
     def test_sample_list_per_animal(self):
         a1 = Animal.objects.filter(name="971").get()
@@ -243,6 +269,7 @@ class ViewTests(TracebaseTestCase):
         self.assertEqual(len(response.context["sample_list"]), s1.count())
         self.assertEqual(len(response.context["df"]), s1.count())
 
+    @tag("multi_working")
     @tag("sample")
     def test_sample_detail(self):
         s1 = Sample.objects.filter(name="BAT-xz971").get()
@@ -251,18 +278,21 @@ class ViewTests(TracebaseTestCase):
         self.assertTemplateUsed(response, "DataRepo/sample_detail.html")
         self.assertEqual(response.context["sample"].name, "BAT-xz971")
 
+    @tag("multi_working")
     @tag("sample")
     def test_sample_detail_404(self):
         s = Sample.objects.order_by("id").last()
         response = self.client.get(reverse("sample_detail", args=[s.id + 1]))
         self.assertEqual(response.status_code, 404)
 
+    @tag("multi_working")
     def test_msrun_list(self):
         response = self.client.get(reverse("msrun_list"))
         self.assertEqual(response.status_code, 200)
         self.assertTemplateUsed(response, "DataRepo/msrun_list.html")
         self.assertEqual(len(response.context["msrun_list"]), self.ALL_SAMPLES_COUNT)
 
+    @tag("multi_working")
     def test_msrun_detail(self):
         ms1 = MSRun.objects.filter(sample__name="BAT-xz971").get()
         response = self.client.get(reverse("msrun_detail", args=[ms1.id]))
@@ -270,17 +300,20 @@ class ViewTests(TracebaseTestCase):
         self.assertTemplateUsed(response, "DataRepo/msrun_detail.html")
         self.assertEqual(response.context["msrun"].sample.name, "BAT-xz971")
 
+    @tag("multi_working")
     def test_msrun_detail_404(self):
         ms = MSRun.objects.order_by("id").last()
         response = self.client.get(reverse("msrun_detail", args=[ms.id + 1]))
         self.assertEqual(response.status_code, 404)
 
+    @tag("multi_working")
     def test_peakgroupset_list(self):
         response = self.client.get(reverse("peakgroupset_list"))
         self.assertEqual(response.status_code, 200)
         self.assertTemplateUsed(response, "DataRepo/peakgroupset_list.html")
         self.assertEqual(len(response.context["peakgroupset_list"]), 2)
 
+    @tag("multi_working")
     def test_peakgroupset_detail(self):
         pgs1 = PeakGroupSet.objects.filter(
             filename="small_obob_maven_6eaas_inf.xlsx"
@@ -292,11 +325,13 @@ class ViewTests(TracebaseTestCase):
             response.context["peakgroupset"].filename, "small_obob_maven_6eaas_inf.xlsx"
         )
 
+    @tag("multi_working")
     def test_peakgroupset_detail_404(self):
         pgs = PeakGroupSet.objects.order_by("id").last()
         response = self.client.get(reverse("peakgroupset_detail", args=[pgs.id + 1]))
         self.assertEqual(response.status_code, 404)
 
+    @tag("multi_working")
     def test_peakgroup_list(self):
         response = self.client.get("/DataRepo/peakgroups/")
         self.assertEqual(response.status_code, 200)
@@ -306,6 +341,7 @@ class ViewTests(TracebaseTestCase):
             self.INF_PEAKGROUP_COUNT + self.SERUM_PEAKGROUP_COUNT,
         )
 
+    @tag("multi_working")
     def test_peakgroup_list_per_msrun(self):
         ms1 = MSRun.objects.filter(sample__name="BAT-xz971").get()
         pg1 = PeakGroup.objects.filter(msrun_id=ms1.id)
@@ -314,6 +350,7 @@ class ViewTests(TracebaseTestCase):
         self.assertTemplateUsed(response, "DataRepo/peakgroup_list.html")
         self.assertEqual(len(response.context["peakgroup_list"]), pg1.count())
 
+    @tag("multi_working")
     def test_peakgroup_detail(self):
         ms1 = MSRun.objects.filter(sample__name="BAT-xz971").get()
         pg1 = PeakGroup.objects.filter(msrun_id=ms1.id).first()
@@ -322,11 +359,13 @@ class ViewTests(TracebaseTestCase):
         self.assertTemplateUsed(response, "DataRepo/peakgroup_detail.html")
         self.assertEqual(response.context["peakgroup"].name, pg1.name)
 
+    @tag("multi_working")
     def test_peakgroup_detail_404(self):
         pg = PeakGroup.objects.order_by("id").last()
         response = self.client.get(reverse("peakgroup_detail", args=[pg.id + 1]))
         self.assertEqual(response.status_code, 404)
 
+    @tag("multi_working")
     def test_peakdata_list(self):
         """
         the total rows loaded may be greater than total rows in file for each sample,
@@ -338,6 +377,7 @@ class ViewTests(TracebaseTestCase):
         self.assertTemplateUsed(response, "DataRepo/peakdata_list.html")
         self.assertEqual(len(response.context["peakdata_list"]), pd.count())
 
+    @tag("multi_working")
     def test_peakdata_list_per_peakgroup(self):
         pg1 = PeakGroup.objects.filter(msrun__sample__name="serum-xz971").first()
         pd1 = PeakData.objects.filter(peak_group_id=pg1.pk)
@@ -346,6 +386,7 @@ class ViewTests(TracebaseTestCase):
         self.assertTemplateUsed(response, "DataRepo/peakdata_list.html")
         self.assertEqual(len(response.context["peakdata_list"]), pd1.count())
 
+    @tag("multi_working")
     def test_search_advanced_browse(self):
         """
         Load the advanced search page in browse mode and make sure the mode is added to the context data
@@ -358,6 +399,7 @@ class ViewTests(TracebaseTestCase):
         self.assertEqual(response.context["mode"], "browse")
         self.assertEqual(response.context["format"], "pdtemplate")
 
+    @tag("multi_working")
     def test_search_advanced_search(self):
         """
         Load the advanced search page in the default search mode and make sure the mode is added to the context data
@@ -458,6 +500,7 @@ class ViewTests(TracebaseTestCase):
             },
         }
 
+    @tag("multi_broken")
     def test_search_advanced_valid(self):
         """
         Do a simple advanced search and make sure the results are correct
@@ -472,6 +515,7 @@ class ViewTests(TracebaseTestCase):
         self.assertEqual(len(response.context["res"]), qs.count())
         self.assertEqual(response.context["qry"], qry)
 
+    @tag("multi_broken")
     def test_search_advanced_invalid(self):
         """
         Do a simple advanced search and make sure the results are correct
@@ -487,6 +531,7 @@ class ViewTests(TracebaseTestCase):
         self.assertEqual(len(response.context["res"]), 0)
         self.assertEqual(response.context["qry"], qry)
 
+    @tag("multi_working")
     def test_search_advanced_tsv(self):
         """
         Download a simple advanced search and make sure the results are correct
@@ -503,6 +548,7 @@ class ViewTests(TracebaseTestCase):
         self.assertTrue("PeakGroups" in contentdisp)
         self.assertTrue(".tsv" in contentdisp)
 
+    @tag("multi_working")
     def test_validate_files(self):
         """
         Do a file validation test
@@ -521,8 +567,17 @@ class ViewTests(TracebaseTestCase):
         self.assertEqual(results["data_submission_accucor2.xlsx"], "PASSED")
 
 
-@tag("multi_unknown")
-class ValidationViewTests(TracebaseTestCase):
+@tag("multi_working")
+class ValidationViewTests(TracebaseTransactionTestCase):
+    """
+    Note, without the TransactionTestCase (derived) class, the infusate-related model managers produce the following
+    error:
+        django.db.transaction.TransactionManagementError: An error occurred in the current transaction. You can't
+        execute queries until the end of the 'atomic' block.
+    ...associated with the outer atomic transaction of any normal test case.  See:
+    https://stackoverflow.com/questions/21458387/transactionmanagementerror-you-cant-execute-queries-until-the-end-of-the-atom
+    """
+
     @classmethod
     def initialize_databases(cls):
         call_command("load_study", "DataRepo/example_data/tissues/loading.yaml")
@@ -566,6 +621,7 @@ class ValidationViewTests(TracebaseTestCase):
         self.assertEqual(response.status_code, 200)
         self.assertTemplateUsed(response, "DataRepo/validate_submission.html")
 
+    @override_settings(DEBUG=True)
     def test_validate_files(self):
         """
         Do a file validation test
@@ -662,28 +718,31 @@ class ValidationViewTests(TracebaseTestCase):
         """
         Test to ensure that the validation database is never loaded with samples, animals, and accucor data by default
         """
-        self.clear_database(settings.TRACEBASE_DB)
-        self.clear_database(settings.VALIDATION_DB)
-        self.initialize_databases()
-        tb_init_sum = self.sum_record_counts(settings.TRACEBASE_DB)
-        vd_init_sum = self.sum_record_counts(settings.VALIDATION_DB)
-        call_command(
-            "load_samples",
-            "DataRepo/example_data/small_dataset/small_obob_sample_table.tsv",
-            sample_table_headers="DataRepo/example_data/sample_table_headers.yaml",
-        )
-        call_command(
-            "load_accucor_msruns",
-            protocol="Default",
-            accucor_file="DataRepo/example_data/small_dataset/small_obob_maven_6eaas_inf.xlsx",
-            date="2021-06-03",
-            researcher="Michael Neinast",
-            new_researcher=True,
-        )
-        tb_post_sum = self.sum_record_counts(settings.TRACEBASE_DB)
-        vd_post_sum = self.sum_record_counts(settings.VALIDATION_DB)
-        self.assertGreater(tb_post_sum, tb_init_sum)
-        self.assertEqual(vd_post_sum, vd_init_sum)
+        with transaction.atomic():
+            tb_init_sum = self.sum_record_counts(settings.TRACEBASE_DB)
+            vd_init_sum = self.sum_record_counts(settings.VALIDATION_DB)
+            self.clear_database(settings.TRACEBASE_DB)
+            self.clear_database(settings.VALIDATION_DB)
+            self.initialize_databases()
+            tb_init_sum = self.sum_record_counts(settings.TRACEBASE_DB)
+            vd_init_sum = self.sum_record_counts(settings.VALIDATION_DB)
+            call_command(
+                "load_samples",
+                "DataRepo/example_data/small_dataset/small_obob_sample_table.tsv",
+                sample_table_headers="DataRepo/example_data/sample_table_headers.yaml",
+            )
+            call_command(
+                "load_accucor_msruns",
+                protocol="Default",
+                accucor_file="DataRepo/example_data/small_dataset/small_obob_maven_6eaas_inf.xlsx",
+                date="2021-06-03",
+                researcher="Michael Neinast",
+                new_researcher=True,
+            )
+            tb_post_sum = self.sum_record_counts(settings.TRACEBASE_DB)
+            vd_post_sum = self.sum_record_counts(settings.VALIDATION_DB)
+            self.assertGreater(tb_post_sum, tb_init_sum)
+            self.assertEqual(vd_post_sum, vd_init_sum)
 
     @override_settings(VALIDATION_ENABLED=False)
     def test_validate_view_disabled_redirect(self):
@@ -730,7 +789,13 @@ def validate_some_files(testobj):
     # last possible check on the file on purpose so that everything else is guaranteed to be OK
     testobj.assertTrue(not valid)
 
-    testobj.assertEqual(results["data_submission_animal_sample_table.xlsx"], "WARNING")
+    # There should only be a warning about the researcher in the sample file not existing - no other errors
+    testobj.assertEqual(
+        results["data_submission_animal_sample_table.xlsx"],
+        "WARNING",
+        msg="There sould only be a researcher warning among the following errors:\n"
+        + "\n".join(errors["data_submission_animal_sample_table.xlsx"]),
+    )
     testobj.assertTrue(len(errors["data_submission_animal_sample_table.xlsx"]) == 1)
     testobj.assertTrue(
         "1 researchers from the sample file: [Anonymous]"

--- a/DataRepo/tests/tracebase_test_case.py
+++ b/DataRepo/tests/tracebase_test_case.py
@@ -1,7 +1,19 @@
-from django.test import TestCase
+from django.test import TestCase, TransactionTestCase
 
 
 class TracebaseTestCase(TestCase):
+    """
+    This wrapper of TestCase makes the necessary/desirable settings for all test classes.
+    """
+
+    maxDiff = None
+    databases = "__all__"
+
+    class Meta:
+        abstract = True
+
+
+class TracebaseTransactionTestCase(TransactionTestCase):
     """
     This wrapper of TestCase makes the necessary/desirable settings for all test classes.
     """


### PR DESCRIPTION
## Summary Change Description

Almost everything changed in here relates to changes necessary to make the file validation code and validation database work with the new multi tracer/label related models (infusate, tracer, tracer label, etc.  The maitained model had to change as well because of the previously un-encountered issue of performing maintained field operations on a different database.  When validation failed, the buffered updates had to be flushed and the model managers had to be aware of which database to update.  The managers were changed from plain managers to querysets "as managers" so that `.using(db)` could be applied to them.

## Affected Issue Numbers

- Resolves #395
- Resolves #398

## Code Review Notes

The only substantial portion of these changes that are not related to the theme of this PR are the fcirc, animal_label, and possibly peak_group_label loads in the sample table loader and `.using(db)` changes in the sample table loader code (which is also in a separate PR).

I turned off the CI tests for this PR.  These changes are just copies of files from the fcirc_multi branch dropped into a new branch off the `infusate_label` branch (the starting point of the master branch for this effort).  I am breaking that code review up into these smaller PRs that are separated by theme.  I am doing it by file simply because it's easier.  If any code here references something you cannot find, just consult to `fcirc_multi` branch/PR.

The PRs I will be submitting are:

- `fcirc_multi_models`
- `fcirc_multi_format`
- `fcirc_multi_validation` (this PR)
- `fcirc_multi_pagination`
- `fcirc_multi_tests`
- `fcirc_multi_minor` (comments/renames/etc)

## Checklist

These are the checks for the overall change set...

- [x] All issue requirements satisfied (or no linked issues)
- [x] [Linting passes](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#linting).
- [x] [Migrations created & committed *(or no model changes)*](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#migration-process)
- Tests
  - [ ] [Tests implemented *(or no code changes)*](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#test-implementation)
  - [x] [All *multi_working* tag tests pass locally](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#quality-control)
  - [x] All example load tests pass (remotely) *(or their failures predated and are unrelated to this branch)*
  - [x] `@tag("multi_working")` added to newly passing test functions/classes *(or no newly passing tests)*
  - [x] `@tag("multi_broken")`, `@tag("multi_unknown")`, or `@tag("multi_mixed")` removed from newly passing test functions/classes *(or no newly passing tests)*
