### PR TITLE
FCirc Multi 4 - Pagination

### DIFF
--- a/DataRepo/pager.py
+++ b/DataRepo/pager.py
@@ -131,9 +131,13 @@ class Pager:
             self.other_field_ids,
         )
 
+        # Default to 1 page of results
+        self.num_pages = 1
+
         # Set up the paging controls
         if tot is not None:
             totpgs = math.ceil(tot / rows)
+            self.num_pages = totpgs
 
             # The number of pages that are shown to either side of the current page
             num_side_controls = int(self.num_buttons / 2)

--- a/DataRepo/templates/pagination.html
+++ b/DataRepo/templates/pagination.html
@@ -140,6 +140,34 @@
             setPageFormValue("{{ pager.page_input_id }}", pagenum)
         }
 
+        function promptForPage(curpage, num_pages){
+            valid = false
+            canceled = false
+            errmsg = ""
+            while(!valid){
+                var newpagestr = prompt(errmsg + "Enter a page number between 1 and " + num_pages + ":", curpage);
+                if(typeof newpagestr === 'undefined' || !newpagestr){
+                    canceled = true
+                    valid = true
+                } else {
+                    var newpagenum = parseInt(newpagestr);
+                    if(isNaN(newpagenum)){
+                        errmsg = "Error: [" + newpagestr + "] is not an integer.\n"
+                    } else if(newpagenum < 1) {
+                        errmsg = "Error: [" + newpagestr + "] must be greater than 0.\n"
+                    } else if(newpagenum > num_pages) {
+                        errmsg = "Error: [" + newpagestr + "] must be less than or equal to the number of pages: [" + num_pages + "].\n"
+                    } else {
+                        valid = true
+                    }
+                }
+            }
+            if(!canceled){
+                setPage(newpagenum)
+                submitForm()
+            }
+        }
+
         function setPageFormValue(elem_id, val) {
             var input_elem = document.getElementById(elem_id)
             if (typeof input_elem !== 'undefined' && input_elem) {
@@ -190,7 +218,11 @@
                                 {% else %}
                                     {% if pg.val == pager.page %}
                                         <li class="page-item active">
-                                            <a class="page-link" href="#">{{ pg.name }} <span class="sr-only">(current)</span></a>
+                                            <div class="page-link">{{ pg.name }} <span class="sr-only">(current)</span></div>
+                                        </li>
+                                    {% elif pg.name == "..." %}
+                                        <li class="page-item" onclick="promptForPage({{ pager.page }}, {{ pager.num_pages }})">
+                                            <a class="page-link" href="#">{{ pg.name }}</a>
                                         </li>
                                     {% else %}
                                         <li class="page-item disabled">


### PR DESCRIPTION
## Summary Change Description

While working on the fcirc view, I got a tad sidetracked and implemented a new feature in the pagination of the advanced search results.  Now users can click the ellipses in the paging widget at the bottom and enter a page number they wish to jump to.

## Affected Issue Numbers

resolves no issue

## Code Review Notes

I turned off the CI tests for this PR.  These changes are just copies of files from the fcirc_multi branch dropped into a new branch off the `infusate_label` branch (the starting point of the master branch for this effort).  I am breaking that code review up into these smaller PRs that are separated by theme.  I am doing it by file simply because it's easier.  If any code here references something you cannot find, just consult to `fcirc_multi` branch/PR.

The PRs I will be submitting are:

- `fcirc_multi_models`
- `fcirc_multi_format`
- `fcirc_multi_validation`
- `fcirc_multi_pagination` (this PR)
- `fcirc_multi_tests`
- `fcirc_multi_minor` (comments/renames/etc)

## Checklist

These are the checks for the overall change set...

- [x] All issue requirements satisfied (or no linked issues)
- [x] [Linting passes](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#linting).
- [x] [Migrations created & committed *(or no model changes)*](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#migration-process)
- Tests
  - [ ] [Tests implemented *(or no code changes)*](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#test-implementation)
  - [x] [All *multi_working* tag tests pass locally](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#quality-control)
  - [x] All example load tests pass (remotely) *(or their failures predated and are unrelated to this branch)*
  - [x] `@tag("multi_working")` added to newly passing test functions/classes *(or no newly passing tests)*
  - [x] `@tag("multi_broken")`, `@tag("multi_unknown")`, or `@tag("multi_mixed")` removed from newly passing test functions/classes *(or no newly passing tests)*
