### PR TITLE
FCirc Multi 5 - Tests

### DIFF
--- a/DataRepo/tests/models/test_hier_cached_model.py
+++ b/DataRepo/tests/models/test_hier_cached_model.py
@@ -63,7 +63,7 @@ class GlobalCacheTests(TracebaseTestCase):
 
     def test_load_not_cached(self):
         a = Animal.objects.all().first()
-        f = "final_serum_sample"
+        f = "last_serum_sample"
         v, s = get_cache(a, f)
         self.assertEqual(
             v,
@@ -77,15 +77,15 @@ class GlobalCacheTests(TracebaseTestCase):
 
     def test_get_cache_disabled(self):
         a = Animal.objects.all().first()
-        f = "final_serum_sample"
+        f = "last_serum_sample"
         # Ensure I get the value not using the cache
         disable_caching_retrievals()
-        v = getattr(a, f)  # same as `v = a.final_serum_sample`
+        v = getattr(a, f)  # same as `v = a.last_serum_sample`
         delete_all_caches()
         enable_caching_updates()
-        set_cache(a, "final_serum_sample", v)
+        set_cache(a, "last_serum_sample", v)
         disable_caching_retrievals()
-        res, sts = get_cache(a, "final_serum_sample")
+        res, sts = get_cache(a, "last_serum_sample")
         self.assertEqual(
             res,
             None,
@@ -98,7 +98,7 @@ class GlobalCacheTests(TracebaseTestCase):
 
     def test_get_cache_uncached(self):
         a = Animal.objects.all().first()
-        f = "final_serum_sample"
+        f = "last_serum_sample"
         delete_all_caches()
         enable_caching_retrievals()
         res, sts = get_cache(a, f)
@@ -112,15 +112,15 @@ class GlobalCacheTests(TracebaseTestCase):
 
     def test_get_cache_enabled(self):
         a = Animal.objects.all().first()
-        f = "final_serum_sample"
+        f = "last_serum_sample"
         # Ensure I get the value not using the cache
         disable_caching_retrievals()
-        v = getattr(a, f)  # same as `v = a.final_serum_sample`
+        v = getattr(a, f)  # same as `v = a.last_serum_sample`
         delete_all_caches()
         enable_caching_updates()
-        set_cache(a, "final_serum_sample", v)
+        set_cache(a, "last_serum_sample", v)
         enable_caching_retrievals()
-        res, sts = get_cache(a, "final_serum_sample")
+        res, sts = get_cache(a, "last_serum_sample")
         self.assertEqual(
             res,
             v,
@@ -133,13 +133,13 @@ class GlobalCacheTests(TracebaseTestCase):
 
     def test_set_cache_disabled(self):
         a = Animal.objects.all().first()
-        f = "final_serum_sample"
+        f = "last_serum_sample"
         # Ensure I get the value not using the cache
         disable_caching_retrievals()
-        v = getattr(a, f)  # same as `v = a.final_serum_sample`
+        v = getattr(a, f)  # same as `v = a.last_serum_sample`
         delete_all_caches()
         disable_caching_updates()
-        sts = set_cache(a, "final_serum_sample", v)
+        sts = set_cache(a, "last_serum_sample", v)
         self.assertFalse(
             sts,
             msg="Cache save status should be false when caching updates are disabled",
@@ -153,8 +153,8 @@ class GlobalCacheTests(TracebaseTestCase):
         rr, rf = a.get_representative_root_rec_and_method()
         rv = getattr(rr, rf)  # Representative value
         # Value in question
-        f = "final_serum_sample_id"  # Field
-        v = getattr(a, f)  # same as `v = a.final_serum_sample`
+        f = "last_serum_sample"  # Field
+        v = getattr(a, f)  # same as `v = a.last_serum_sample`
 
         delete_all_caches()
         enable_caching_retrievals()
@@ -201,8 +201,24 @@ class GlobalCacheTests(TracebaseTestCase):
             msg="After cache save representative retrieval status must be true for the next assertion to be meaningful",
         )
         self.assertEqual(
-            grvres,
-            rv,
+            grvres.count(),
+            rv.count(),
+            msg=(
+                "Caching a child value should trigger a caching of the root model's representative value, which should "
+                "be the same as before it was saved in the cache"
+            ),
+        )
+        self.assertEqual(
+            grvres.count(),
+            1,
+            msg=(
+                "Caching a child value should trigger a caching of the root model's representative value, which should "
+                "be the same as before it was saved in the cache"
+            ),
+        )
+        self.assertEqual(
+            grvres.first().id,
+            rv.first().id,
             msg=(
                 "Caching a child value should trigger a caching of the root model's representative value, which should "
                 "be the same as before it was saved in the cache"
@@ -211,7 +227,7 @@ class GlobalCacheTests(TracebaseTestCase):
 
     def test_get_cache_key(self):
         a = Animal.objects.all().first()
-        f = "final_serum_sample"
+        f = "last_serum_sample"
         expected_key = f"Animal.{a.id}.{f}"
         res = get_cache_key(a, f)
         self.assertEqual(
@@ -222,32 +238,24 @@ class GlobalCacheTests(TracebaseTestCase):
         res = get_cached_method_names()
         expected_structure = {
             "Animal": [
-                "final_serum_sample",
-                "final_serum_sample_id",
-                "all_serum_samples_tracer_peak_groups",
-                "final_serum_sample_tracer_peak_group",
-                "intact_tracer_peak_data",
-                "final_serum_tracer_rate_disappearance_intact_per_gram",
-                "final_serum_tracer_rate_appearance_intact_per_gram",
-                "final_serum_tracer_rate_disappearance_intact_per_animal",
-                "final_serum_tracer_rate_appearance_intact_per_animal",
-                "final_serum_tracer_rate_disappearance_average_per_gram",
-                "final_serum_tracer_rate_appearance_average_per_gram",
-                "final_serum_tracer_rate_disappearance_average_per_animal",
-                "final_serum_tracer_rate_appearance_average_per_animal",
-                "final_serum_tracer_rate_appearance_average_atom_turnover",
+                "tracers",
+                "last_serum_sample",
+                "last_serum_tracer_peak_groups",
             ],
             "AnimalLabel": [
+                "tracers",
+                "last_serum_tracer_label_peak_groups",
                 "serum_tracers_enrichment_fraction",
             ],
-            "Sample": ["is_serum_sample"],
-            "PeakGroup": [
-                "peak_labeled_elements",
-                "is_tracer_compound_group",
-                "from_serum_sample",
-                "can_compute_tracer_rates",
-                "can_compute_intact_tracer_rates",
-                "can_compute_average_tracer_rates",
+            "Sample": [
+                "is_serum_sample",
+                "last_tracer_peak_groups",
+            ],
+            "PeakGroup": ["peak_labeled_elements"],
+            "FCirc": [
+                "is_last_serum_peak_group",
+                "last_peak_group",
+                "peak_groups",
                 "rate_disappearance_intact_per_gram",
                 "rate_appearance_intact_per_gram",
                 "rate_disappearance_intact_per_animal",
@@ -256,17 +264,35 @@ class GlobalCacheTests(TracebaseTestCase):
                 "rate_appearance_average_per_gram",
                 "rate_disappearance_average_per_animal",
                 "rate_appearance_average_per_animal",
-                "rate_appearance_average_atom_turnover",
             ],
             "PeakGroupLabel": [
                 "enrichment_fraction",
                 "enrichment_abundance",
                 "normalized_labeling",
+                "tracer",
+                "tracer_label_count",
+                "tracer_concentration",
+                "get_peak_group_label_tracer_info",
+                "is_tracer_label_compound_group",
+                "from_serum_sample",
+                "can_compute_tracer_label_rates",
+                "can_compute_body_weight_intact_tracer_label_rates",
+                "can_compute_body_weight_average_tracer_label_rates",
+                "can_compute_intact_tracer_label_rates",
+                "can_compute_average_tracer_label_rates",
+                "rate_disappearance_intact_per_gram",
+                "rate_appearance_intact_per_gram",
+                "rate_disappearance_intact_per_animal",
+                "rate_appearance_intact_per_animal",
+                "rate_disappearance_average_per_gram",
+                "rate_appearance_average_per_gram",
+                "rate_disappearance_average_per_animal",
+                "rate_appearance_average_per_animal",
             ],
         }
         self.assertEqual(
-            res,
             expected_structure,
+            res,
             "The methods with @cached_function decorators are not what is expected.",
         )
 
@@ -279,7 +305,7 @@ class HierCachedModelTests(TracebaseTestCase):
 
     def test_cached_function_decorator(self):
         delete_all_caches()
-        pg = PeakGroup.objects.all().first().peak_group_labels.first()
+        pg = PeakGroup.objects.all().first().labels.first()
         f = "normalized_labeling"
 
         # Get uncached value
@@ -356,7 +382,7 @@ class HierCachedModelTests(TracebaseTestCase):
 
     def test_delete_override(self):
         delete_all_caches()
-        pg = PeakGroup.objects.all().first().peak_group_labels.first()
+        pg = PeakGroup.objects.all().first().labels.first()
         f = "enrichment_fraction"
 
         enable_caching_retrievals()
@@ -447,26 +473,10 @@ class HierCachedModelTests(TracebaseTestCase):
 
     def test_get_my_cached_method_names(self):
         pg = PeakGroup.objects.all().first()
-        expected = [
-            "peak_labeled_elements",
-            "is_tracer_compound_group",
-            "from_serum_sample",
-            "can_compute_tracer_rates",
-            "can_compute_intact_tracer_rates",
-            "can_compute_average_tracer_rates",
-            "rate_disappearance_intact_per_gram",
-            "rate_appearance_intact_per_gram",
-            "rate_disappearance_intact_per_animal",
-            "rate_appearance_intact_per_animal",
-            "rate_disappearance_average_per_gram",
-            "rate_appearance_average_per_gram",
-            "rate_disappearance_average_per_animal",
-            "rate_appearance_average_per_animal",
-            "rate_appearance_average_atom_turnover",
-        ]
+        expected = ["peak_labeled_elements"]
         self.assertEqual(
-            pg.get_my_cached_method_names(),
             expected,
+            pg.get_my_cached_method_names(),
             msg="Ensure get_my_cached_method_names returns all expected cache_functions.",
         )
 
@@ -480,7 +490,7 @@ class HierCachedModelTests(TracebaseTestCase):
         s2pg = (
             PeakGroup.objects.filter(msrun__sample__id__exact=s2.id)
             .first()
-            .peak_group_labels.first()
+            .labels.first()
         )
         pgf = "enrichment_fraction"
 
@@ -577,7 +587,7 @@ class BuildCachesTests(TracebaseTestCase):
 
     def test_cached_function_call(self):
         c = Animal
-        f = "final_serum_sample_id"
+        f = "last_serum_sample"
         a = Animal.objects.all().first()
         la = Animal.objects.all().last()
         disable_caching_retrievals()

--- a/DataRepo/tests/models/test_infusate.py
+++ b/DataRepo/tests/models/test_infusate.py
@@ -45,21 +45,28 @@ def create_infusate_records():
     InfusateTracer.objects.create(infusate=io2, tracer=glu_t, concentration=3.0)
     InfusateTracer.objects.create(infusate=io2, tracer=c16_t, concentration=4.0)
 
+    return io.id, io2.id
+
 
 @tag("multi_working")
 class InfusateTests(TracebaseTestCase):
     def setUp(self):
-        create_infusate_records()
+        self.INFUSATE1, self.INFUSATE2 = create_infusate_records()
 
     def test_infusate_record(self):
         infusate = Infusate.objects.first()
         infusate.full_clean()
 
     def test_infusate_name_method(self):
-        infusate = Infusate.objects.last()
+        infusate = Infusate.objects.get(id__exact=self.INFUSATE1)
         self.assertEqual(
-            infusate._name(),
             "ti {C16:0-(5,6-13C2,17O2)[2];glucose-(2,3-13C2,4-17O1)[1]}",
+            infusate._name(),
+        )
+        infusate2 = Infusate.objects.get(id__exact=self.INFUSATE2)
+        self.assertEqual(
+            "C16:0-(5,6-13C2,17O2)[4];glucose-(2,3-13C2,4-17O1)[3]",
+            infusate2._name(),
         )
 
     def test_name_not_settable(self):

--- a/DataRepo/tests/models/test_model_utilities.py
+++ b/DataRepo/tests/models/test_model_utilities.py
@@ -12,7 +12,7 @@ from DataRepo.tests.tracebase_test_case import TracebaseTestCase
 @tag("multi_working")
 class ModelUtilitiesTests(TracebaseTestCase):
     def test_get_all_models(self):
-        """Test that we return all models"""
+        """Test that we return all models in the right order"""
         all_models = set(apps.get_app_config("DataRepo").get_models())
         test_all_models = set(get_all_models())
         # Test for duplicates
@@ -29,6 +29,37 @@ class ModelUtilitiesTests(TracebaseTestCase):
             extra_models,
             set(),
             msg="Models returned by DataRepo.models.utilities.get_all_models() includes these non-existant models.",
+        )
+
+        # Generally, child tables are at the top and parent tables are at the bottom
+        ordered_model_name_list = [
+            "Compound",
+            "CompoundSynonym",
+            "Tissue",
+            "PeakDataLabel",
+            "PeakData",
+            "PeakGroup",
+            "PeakGroupLabel",
+            "PeakGroupSet",
+            "MSRun",
+            "FCirc",
+            "Sample",
+            "Animal",
+            "AnimalLabel",
+            "TracerLabel",
+            "Tracer",
+            "Infusate",
+            "InfusateTracer",
+            "Protocol",
+            "Study",
+        ]
+        self.assertEqual(
+            ordered_model_name_list,
+            list(map(lambda x: x.__name__, list(get_all_models()))),
+            msg=(
+                "Models returned by DataRepo.models.utilities.get_all_models() must be returned in this safe deletion "
+                f"order: {list(map(lambda x: x.__name__, list(apps.get_app_config('DataRepo').get_models())))}."
+            ),
         )
 
     def test_dereference_field(self):


### PR DESCRIPTION
## Summary Change Description

These are the meaty test updates.  Tests with unrelated or insignificant changes are in other FCirc Multi PRs.

## Affected Issue Numbers

- Resolves #395
- Resolves #398

## Code Review Notes

It's worthwhile to take a serious look at the tests.  There are only a handful of tests still marked as `multi_broken`.  This PR fixed a huge number of tests.  Many were simply just the removal of the broken tag because updates (either in this effort or a previous effort) happened to fix them.

I turned off the CI tests for this PR.  These changes are just copies of files from the fcirc_multi branch dropped into a new branch off the `infusate_label` branch (the starting point of the master branch for this effort).  I am breaking that code review up into these smaller PRs that are separated by theme.  I am doing it by file simply because it's easier.  If any code here references something you cannot find, just consult to `fcirc_multi` branch/PR.

The PRs I will be submitting are:

- `fcirc_multi_models`
- `fcirc_multi_format`
- `fcirc_multi_validation`
- `fcirc_multi_pagination`
- `fcirc_multi_tests` (this PR)
- `fcirc_multi_minor` (comments/renames/etc)

## Checklist

These are the checks for the overall change set...

- [x] All issue requirements satisfied (or no linked issues)
- [x] [Linting passes](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#linting).
- [x] [Migrations created & committed *(or no model changes)*](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#migration-process)
- Tests
  - [ ] [Tests implemented *(or no code changes)*](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#test-implementation)
  - [x] [All *multi_working* tag tests pass locally](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#quality-control)
  - [x] All example load tests pass (remotely) *(or their failures predated and are unrelated to this branch)*
  - [x] `@tag("multi_working")` added to newly passing test functions/classes *(or no newly passing tests)*
  - [x] `@tag("multi_broken")`, `@tag("multi_unknown")`, or `@tag("multi_mixed")` removed from newly passing test functions/classes *(or no newly passing tests)*
