### PR TITLE
Fixed an issue with sample table load auto-updates.

### DIFF
--- a/.github/workflows/tracebase-tests.yml
+++ b/.github/workflows/tracebase-tests.yml
@@ -52,7 +52,7 @@ jobs:
       - name: Set up Python 3.8
         uses: actions/setup-python@v1
         with:
-          python-version: 3.8
+          python-version: 3.9
       - name: psycopg2 prerequisites
         run: |
           sudo apt-get update

--- a/DataRepo/management/commands/rebuild_maintained_fields.py
+++ b/DataRepo/management/commands/rebuild_maintained_fields.py
@@ -85,7 +85,7 @@ def rebuild_maintained_fields(label_filters=[]):
                         updated[key] = True
 
                 except Exception as e:
-                    raise AutoUpdateFailed(rec, e)
+                    raise AutoUpdateFailed(rec, e, updater_dicts)
 
     # We're done performing buffered updates
     disable_mass_autoupdates()

--- a/DataRepo/models/animal.py
+++ b/DataRepo/models/animal.py
@@ -119,13 +119,6 @@ class Animal(MaintainedModel, HierCachedModel, ElementLabel):
     @property  # type: ignore
     @cached_function
     def tracers(self):
-        print(f"Animal.tracers test1: self: {self}")
-        print(f"Animal.tracers test2: self.id: {self.id}")
-        print(f"Animal.tracers test3: self.name {self.name}")
-        print(f"Animal.tracers test4: self.infusate: {self.infusate}")
-        print(f"Animal.tracers test5: self.infusate.id: {self.infusate.id}")
-        print(f"Animal.tracers test6: self.infusate.tracers: {self.infusate.tracers}")
-        print(f"Animal.tracers test7: self.infusate.tracers.count(): {self.infusate.tracers.count()}")
         if self.infusate.tracers.count() == 0:
             warnings.warn(f"Animal [{self.name}] has no tracers.")
         return self.infusate.tracers.all()

--- a/DataRepo/models/animal.py
+++ b/DataRepo/models/animal.py
@@ -119,6 +119,13 @@ class Animal(MaintainedModel, HierCachedModel, ElementLabel):
     @property  # type: ignore
     @cached_function
     def tracers(self):
+        print(f"Animal.tracers test1: self: {self}")
+        print(f"Animal.tracers test2: self.id: {self.id}")
+        print(f"Animal.tracers test3: self.name {self.name}")
+        print(f"Animal.tracers test4: self.infusate: {self.infusate}")
+        print(f"Animal.tracers test5: self.infusate.id: {self.infusate.id}")
+        print(f"Animal.tracers test6: self.infusate.tracers: {self.infusate.tracers}")
+        print(f"Animal.tracers test7: self.infusate.tracers.count(): {self.infusate.tracers.count()}")
         if self.infusate.tracers.count() == 0:
             warnings.warn(f"Animal [{self.name}] has no tracers.")
         return self.infusate.tracers.all()

--- a/DataRepo/models/maintained_model.py
+++ b/DataRepo/models/maintained_model.py
@@ -801,7 +801,7 @@ def filter_updaters(updaters_list, generation=None, label_filters=[], filter_in=
     return new_updaters_list
 
 
-def perform_buffered_updates(label_filters=[], using=None):
+def perform_buffered_updates(labels=None, using=None):
     """
     Performs a mass update of records in the buffer in a depth-first fashion without repeated updates to the same
     record over and over.  It goes through the buffer in the order added and triggers each record's DFS updates, which
@@ -815,6 +815,10 @@ def perform_buffered_updates(label_filters=[], using=None):
     used for loading, which if done right, doesn't change child records after parent records have been added.
     """
     global update_buffer
+    if labels is None:
+        label_filters=[]
+    else:
+        label_filters=labels
     db = using
 
     if auto_updates:

--- a/DataRepo/models/maintained_model.py
+++ b/DataRepo/models/maintained_model.py
@@ -215,7 +215,7 @@ def maintained_field_function(
     parent model and call the decorated functions to update field supplied to the factory function.  It also propagates
     the updates to the linked dependent model's save methods (if the parent and/or child field name is supplied), the
     assumption being that a change to "this" record's maintained field necessitates a change to another maintained
-    field in the linked parent record.  parent and children field names should only be supplied if a change to "this"
+    field in the linked parent record.  Parent and child field names should only be supplied if a change to "this"
     record means that related foields in parent/child records will need to be recomputed.  There is no need to supply
     parent/child field names if that is not the case.
 
@@ -979,7 +979,7 @@ class NoDecorators(Exception):
 
 class AutoUpdateFailed(Exception):
     def __init__(self, model_object, err, updaters, db=None):
-        database = "" if db is None else f"{db}."
+        database = "unspecified" if db is None else db
         updater_flds = [
             d["update_field"] for d in updaters if d["update_field"] is not None
         ]
@@ -987,7 +987,7 @@ class AutoUpdateFailed(Exception):
             f"Autoupdate of the {model_object.__class__.__name__} model's fields [{', '.join(updater_flds)}] in the "
             f"{database} database failed.  If the record was created and deleted before the buffered update, a catch "
             "for the exception should be added and ignored (or the code should be edited to avoid it).  The "
-            f"triggering exception: [{err}]."
+            f"triggering {err.__class__.__name__} exception: [{err}]."
         )
         super().__init__(message)
 
@@ -1016,11 +1016,11 @@ class TransactionManagementUnsupported(TransactionManagementError):
         updater_flds = [
             d["update_field"] for d in updaters if d["update_field"] is not None
         ]
-        database = "" if db is None else f"{db}."
+        database = "unspecified" if db is None else db
         message = (
             f"Autoupdate of the {model_object.__class__.__name__} model's fields [{', '.join(updater_flds)}] in the "
             f"{database} database failed.  Atomic transactions are not supported by MaintainedModel.  Please move "
             "calls of methods like perform_buffered_updates outside of an atomic transaction block.  The triggering "
-            f"exception: [{err}]."
+            f"{err.__class__.__name__} exception: [{err}]."
         )
         super().__init__(message)

--- a/DataRepo/models/maintained_model.py
+++ b/DataRepo/models/maintained_model.py
@@ -5,7 +5,6 @@ from typing import Dict, List
 from django.conf import settings
 from django.db.models import Model
 from django.db.models.signals import m2m_changed
-from django.db.transaction import TransactionManagementError
 from django.db.utils import IntegrityError
 from psycopg2.errors import ForeignKeyViolation
 
@@ -979,9 +978,14 @@ class AutoUpdateFailed(Exception):
         updater_flds = [
             d["update_field"] for d in updaters if d["update_field"] is not None
         ]
+        try:
+            obj_str = str(model_object)
+        except Exception:
+            # Displaying the offending object is optional, so catch any error
+            obj_str = "unknown"
         message = (
             f"Autoupdate of the {model_object.__class__.__name__} model's fields [{', '.join(updater_flds)}] in the "
-            f"{database} database failed for record {model_object}.  Potential causes: 1. The record was created and "
+            f"{database} database failed for record {obj_str}.  Potential causes: 1. The record was created and "
             "deleted before the buffered update (a catch for the exception should be added and ignored).  2. The "
             "autoupdate buffer is stale and auto-updates are being attempted on partial or deleted records (be sure "
             "to call clear_update_buffer if only updating a subset of the buffered contents).  The triggering "

--- a/DataRepo/models/researcher.py
+++ b/DataRepo/models/researcher.py
@@ -25,7 +25,7 @@ def get_researchers(database=settings.TRACEBASE_DB):
                 model.objects.using(database).values(target_field).distinct(),
             )
         )
-    unique_researchers = list(pd.unique(filter(None, researchers)))
+    unique_researchers = list(pd.unique(list(filter(None, researchers))))
     return unique_researchers
 
 

--- a/DataRepo/models/researcher.py
+++ b/DataRepo/models/researcher.py
@@ -25,9 +25,7 @@ def get_researchers(database=settings.TRACEBASE_DB):
                 model.objects.using(database).values(target_field).distinct(),
             )
         )
-    unique_researchers = [
-        r for r in list(pd.unique(researchers)) if r is not None and r != ""
-    ]
+    unique_researchers = list(pd.unique(filter(None, researchers)))
     return unique_researchers
 
 

--- a/DataRepo/models/sample.py
+++ b/DataRepo/models/sample.py
@@ -100,7 +100,7 @@ class Sample(MaintainedModel, HierCachedModel):
         # Get the last peakgroup for each tracer that has this label
         last_peakgroup_ids = []
         (extra_args, is_null_field) = create_is_null_field("msrun__date")
-        print(f"Sample.py PeakGroup: Extra args: {extra_args}")
+
         for tracer in self.animal.tracers.all():
             tracer_peak_group = (
                 PeakGroup.objects.filter(msrun__sample__id__exact=self.id)

--- a/DataRepo/templatetags/customtags.py
+++ b/DataRepo/templatetags/customtags.py
@@ -135,7 +135,7 @@ def obj_hyperlink(id_name_list, obj):
     elif obj == "treatment":
         tmplt_name = "protocol_detail"
 
-    if id_name_list == [None]:
+    if id_name_list == [None] or id_name_list is None:
         return None
     else:
         id_name_dict = {}

--- a/DataRepo/tests/models/test_animal.py
+++ b/DataRepo/tests/models/test_animal.py
@@ -100,7 +100,18 @@ class AnimalTests(TracebaseTestCase):
         # Assert that the animal's last_serum_sample is autoupdated
         self.assertEqual(self.newlss, self.animal.last_serum_sample)
 
-    def test_last_serum_sample_queryable(self):
+    def test_animal_is_queryable(self):
+        """
+        The query below needs some explanation.  It can produce an exception that references
+        "Animal.last_serum_sample".  This is the association:
+
+        This specific query exists inside DataRepo.models.researcher.Researcher.animals().  It was throwing an
+        exception about Animal.last_serum_sample_id not existing in the database. The fix was to add db_column to the
+        ForeignKey arguments.  This test assures that it is there by assuring that the query produces the expected
+        result without an exception.
+
+        The reason it happens is because every Sample links to Animal and Animal *can* link to the "last" serum sample.
+        """
         ac = (
             Animal.objects.filter(samples__researcher="Xianfeng Zeng")
             .distinct()

--- a/DataRepo/tests/models/test_infusate.py
+++ b/DataRepo/tests/models/test_infusate.py
@@ -238,6 +238,8 @@ class MaintainedModelTests(TracebaseTestCase):
                 ),
                 debug=False,
             )
+        # Now clean up the buffer
+        clear_update_buffer()
 
 
 @tag("multi_working")

--- a/DataRepo/tests/models/test_infusate.py
+++ b/DataRepo/tests/models/test_infusate.py
@@ -22,8 +22,12 @@ from DataRepo.tests.tracebase_test_case import TracebaseTestCase
 
 
 def create_infusate_records():
-    glu = Compound.objects.get(name="glucose")
-    c16 = Compound.objects.get(name="C16:0")
+    glu = Compound.objects.create(
+        name="glucose", formula="C6H12O6", hmdb_id="HMDB0000122"
+    )
+    c16 = Compound.objects.create(
+        name="C16:0", formula="C16H32O2", hmdb_id="HMDB0000220"
+    )
     glu_t = Tracer.objects.create(compound=glu)
     c16_t = Tracer.objects.create(compound=c16)
     TracerLabel.objects.create(

--- a/DataRepo/tests/models/test_infusate.py
+++ b/DataRepo/tests/models/test_infusate.py
@@ -54,6 +54,7 @@ def create_infusate_records():
 class InfusateTests(TracebaseTestCase):
     def setUp(self):
         super().setUp()
+        clear_update_buffer()
         self.INFUSATE1, self.INFUSATE2 = create_infusate_records()
 
     @classmethod

--- a/DataRepo/tests/models/test_infusate.py
+++ b/DataRepo/tests/models/test_infusate.py
@@ -22,10 +22,10 @@ from DataRepo.tests.tracebase_test_case import TracebaseTestCase
 
 
 def create_infusate_records():
-    glu = Compound.objects.create(
+    (glu, gc) = Compound.objects.get_or_create(
         name="glucose", formula="C6H12O6", hmdb_id="HMDB0000122"
     )
-    c16 = Compound.objects.create(
+    (c16, cc) = Compound.objects.get_or_create(
         name="C16:0", formula="C16H32O2", hmdb_id="HMDB0000220"
     )
     glu_t = Tracer.objects.create(compound=glu)

--- a/DataRepo/tests/models/test_sample.py
+++ b/DataRepo/tests/models/test_sample.py
@@ -11,26 +11,6 @@ from DataRepo.tests.tracebase_test_case import TracebaseTestCase
 @override_settings(CACHES=settings.TEST_CACHES)
 @tag("multi_working")
 class SampleTests(TracebaseTestCase):
-    def setUp(self):
-        super().setUp()
-        # Get an animal (assuming it has an infusate/tracers/etc)
-        animal = Animal.objects.last()
-        # Get its last serum sample
-        lss = animal.last_serum_sample
-
-        # For the validity of the test, assert there exist FCirc records and that they are for the last peak groups
-        self.assertTrue(lss.fcircs.count() > 0)
-        for fco in lss.fcircs.all():
-            self.assertTrue(fco.is_last)
-
-        # Now create a new last serum sample (without any peak groups)
-        tissue = lss.tissue
-        tc = lss.time_collected + timedelta(seconds=1)
-        nlss = Sample.objects.create(animal=animal, tissue=tissue, time_collected=tc)
-
-        self.lss = lss
-        self.newlss = nlss
-
     @classmethod
     def setUpTestData(cls):
         super().setUpTestData()
@@ -69,5 +49,20 @@ class SampleTests(TracebaseTestCase):
           1. Create a new serum sample whose time collected is later than existing serum samples.
             2. Confirm the new sample's Sample.is_serum_sample is True.
         """
+        # Get an animal (assuming it has an infusate/tracers/etc)
+        animal = Animal.objects.last()
+        # Get its last serum sample
+        lss = animal.last_serum_sample
+
+        # For the validity of the test, assert there exist FCirc records and that they are for the last peak groups
+        self.assertTrue(lss.fcircs.count() > 0)
+        for fco in lss.fcircs.all():
+            self.assertTrue(fco.is_last)
+
+        # Now create a new last serum sample (without any peak groups)
+        tissue = lss.tissue
+        tc = lss.time_collected + timedelta(seconds=1)
+        nlss = Sample.objects.create(animal=animal, tissue=tissue, time_collected=tc)
+
         # Assert that the new serum sample's is_serum_sample is autoupdated to True
-        self.assertTrue(self.newlss.is_serum_sample)
+        self.assertTrue(nlss.is_serum_sample)

--- a/DataRepo/tests/test_infusate_parsing_validation.py
+++ b/DataRepo/tests/test_infusate_parsing_validation.py
@@ -13,6 +13,7 @@ from DataRepo.utils.infusate_name_parser import (
     TracerParsingError,
     parse_infusate_name,
     parse_isotope_string,
+    parse_tracer_concentrations,
     parse_tracer_string,
 )
 
@@ -275,6 +276,11 @@ class InfusateParsingTests(InfusateTest):
         name = ""
         with self.assertRaisesRegex(IsotopeParsingError, "requires a defined string"):
             _ = parse_isotope_string(name)
+
+    def test_parse_tracer_concentrations(self):
+        self.assertAlmostEqual(
+            [10.0, 20.0, 30.0], parse_tracer_concentrations("10; 20;30")
+        )
 
 
 @tag("multi_working")

--- a/DataRepo/tests/test_queryset_to_dataframes.py
+++ b/DataRepo/tests/test_queryset_to_dataframes.py
@@ -20,9 +20,8 @@ class QuerysetToPandasDataFrameBaseTests(TracebaseTestCase):
     """
 
     @classmethod
-    def setUpTestData(cls):
+    def load_data(self):
         call_command("load_study", "DataRepo/example_data/test_dataframes/loading.yaml")
-        super().setUpTestData()
 
     def get_example_study_dict(self):
         exmaple_study_dict = {
@@ -246,7 +245,12 @@ class QuerysetToPandasDataFrameBaseTests(TracebaseTestCase):
 @tag("qs2df")
 @tag("multi_working")
 class QuerysetToPandasDataFrameTests(QuerysetToPandasDataFrameBaseTests):
-    pass
+    @classmethod
+    def setUpTestData(cls):
+        enable_buffering()
+        cls.load_data()
+        super().setUpTestData()
+
 
 
 @tag("multi_mixed")
@@ -256,11 +260,12 @@ class QuerysetToPandasDataFrameNullToleranceTests(QuerysetToPandasDataFrameBaseT
         # Silently dis-allow auto-updates by disabling buffering
         disable_buffering()
         try:
-            super().setUpTestData()
+            cls.load_data()
         except Exception as e:
             enable_buffering()
             raise e
         enable_buffering()
+        super().setUpTestData()
 
     @tag("multi_broken")
     def test_study_list_stat_df(self):

--- a/DataRepo/tests/test_queryset_to_dataframes.py
+++ b/DataRepo/tests/test_queryset_to_dataframes.py
@@ -13,9 +13,11 @@ from DataRepo.tests.tracebase_test_case import TracebaseTestCase
 from DataRepo.utils import QuerysetToPandasDataFrame as qs2df
 
 
-@tag("qs2df")
-@tag("multi_working")
-class QuerysetToPandasDataFrameTests(TracebaseTestCase):
+class QuerysetToPandasDataFrameBaseTests(TracebaseTestCase):
+    """
+    Do not pass or tag this class or the methods in it.  Instead override any tests in the derived classes and call
+    their `super()` version because these tests are re-used under difference conditions
+    """
     @classmethod
     def setUpTestData(cls):
         call_command("load_study", "DataRepo/example_data/test_dataframes/loading.yaml")
@@ -240,13 +242,23 @@ class QuerysetToPandasDataFrameTests(TracebaseTestCase):
         self.assertEqual(inf1_dict, example_infusate_dict)
 
 
+@tag("qs2df")
+@tag("multi_working")
+class QuerysetToPandasDataFrameTests(QuerysetToPandasDataFrameBaseTests):
+    pass
+
+
 @tag("multi_mixed")
-class QuerysetToPandasDataFrameNullToleranceTests(QuerysetToPandasDataFrameTests):
+class QuerysetToPandasDataFrameNullToleranceTests(QuerysetToPandasDataFrameBaseTests):
     @classmethod
     def setUpTestData(cls):
         # Silently dis-allow auto-updates by disabling buffering
         disable_buffering()
-        super().setUpTestData()
+        try:
+            super().setUpTestData()
+        except Exception as e:
+            enable_buffering()
+            raise e
         enable_buffering()
 
     @tag("multi_broken")

--- a/DataRepo/tests/test_queryset_to_dataframes.py
+++ b/DataRepo/tests/test_queryset_to_dataframes.py
@@ -5,16 +5,21 @@ from django.core.management import call_command
 from django.test import tag
 from django.utils import dateparse
 
+from DataRepo.models.maintained_model import (
+    disable_buffering,
+    enable_buffering,
+)
 from DataRepo.tests.tracebase_test_case import TracebaseTestCase
 from DataRepo.utils import QuerysetToPandasDataFrame as qs2df
 
 
 @tag("qs2df")
-@tag("multi_mixed")
+@tag("multi_working")
 class QuerysetToPandasDataFrameTests(TracebaseTestCase):
     @classmethod
     def setUpTestData(cls):
         call_command("load_study", "DataRepo/example_data/test_dataframes/loading.yaml")
+        super().setUpTestData()
 
     def get_example_study_dict(self):
         exmaple_study_dict = {
@@ -100,7 +105,6 @@ class QuerysetToPandasDataFrameTests(TracebaseTestCase):
         }
         return example_infusate_dict
 
-    @tag("multi_broken")
     def test_study_list_stat_df(self):
         """
         get data from the data frame for selected study with selected columns,
@@ -117,7 +121,6 @@ class QuerysetToPandasDataFrameTests(TracebaseTestCase):
 
         self.assertEqual(stud1_list_stats_dict, example_study_dict)
 
-    @tag("multi_broken")
     def test_animal_list_stat_df(self):
         """
         get data from the data frame for selected animal with selected columns,
@@ -136,7 +139,6 @@ class QuerysetToPandasDataFrameTests(TracebaseTestCase):
         anim1_list_stats_dict = qs2df.df_to_list_of_dict(out_df)[0]
         self.assertEqual(anim1_list_stats_dict, example_animal_dict)
 
-    @tag("multi_broken")
     def test_animal_sample_msrun_df(self):
         """
         get data from the data frame for selected sample with selected columns,
@@ -203,7 +205,6 @@ class QuerysetToPandasDataFrameTests(TracebaseTestCase):
         self.assertTrue(sam2_msrun_all_dict["msrun_id"] is pd.NA)
         self.assertTrue(sam2_msrun_all_dict["msrun_owner"] is pd.NA)
 
-    @tag("multi_working")
     def test_comp_list_stats_df(self):
         """
         get data from the data frame for selected compound with selected columns,
@@ -220,7 +221,6 @@ class QuerysetToPandasDataFrameTests(TracebaseTestCase):
 
         self.assertEqual(comp1_dict, example_compound_dict)
 
-    @tag("multi_broken")
     def test_infusate_list_df(self):
         """
         get data from the data frame for selected infusate with selected columns,
@@ -238,3 +238,29 @@ class QuerysetToPandasDataFrameTests(TracebaseTestCase):
         inf1_dict = qs2df.df_to_list_of_dict(out_df)[0]
 
         self.assertEqual(inf1_dict, example_infusate_dict)
+
+
+@tag("multi_mixed")
+class QuerysetToPandasDataFrameNullToleranceTests(QuerysetToPandasDataFrameTests):
+    @classmethod
+    def setUpTestData(cls):
+        # Silently dis-allow auto-updates by disabling buffering
+        disable_buffering()
+        super().setUpTestData()
+        enable_buffering()
+
+    @tag("multi_broken")
+    def test_study_list_stat_df(self):
+        super().test_study_list_stat_df()
+
+    @tag("multi_broken")
+    def test_animal_list_stat_df(self):
+        super().test_animal_list_stat_df()
+
+    @tag("multi_broken")
+    def test_animal_sample_msrun_df(self):
+        super().test_animal_sample_msrun_df()
+
+    @tag("multi_broken")
+    def test_infusate_list_df(self):
+        super().test_infusate_list_df()

--- a/DataRepo/tests/test_queryset_to_dataframes.py
+++ b/DataRepo/tests/test_queryset_to_dataframes.py
@@ -31,7 +31,7 @@ class QuerysetToPandasDataFrameBaseTests(TracebaseTestCase):
             "total_sample": 7,
             "total_msrun": 3,
             "sample_owners": ["Xianfeng Zeng"],
-            "genotypes": ["ob/ob", "C57BL/6N", "WT"],
+            "genotypes": ["C57BL/6N", "WT","ob/ob"],
         }
         return exmaple_study_dict
 
@@ -120,6 +120,10 @@ class QuerysetToPandasDataFrameBaseTests(TracebaseTestCase):
         selected_columns = list(example_study_dict.keys())
         out_df = stud1_list_stats_df[selected_columns]
         stud1_list_stats_dict = qs2df.df_to_list_of_dict(out_df)[0]
+
+        # Sort the lists so that they can be equated
+        stud1_list_stats_dict["genotypes"] = sorted(stud1_list_stats_dict["genotypes"])
+        example_study_dict["genotypes"] = sorted(example_study_dict["genotypes"])
 
         self.assertEqual(stud1_list_stats_dict, example_study_dict)
 

--- a/DataRepo/tests/test_queryset_to_dataframes.py
+++ b/DataRepo/tests/test_queryset_to_dataframes.py
@@ -252,7 +252,6 @@ class QuerysetToPandasDataFrameTests(QuerysetToPandasDataFrameBaseTests):
         super().setUpTestData()
 
 
-
 @tag("multi_mixed")
 class QuerysetToPandasDataFrameNullToleranceTests(QuerysetToPandasDataFrameBaseTests):
     @classmethod

--- a/DataRepo/tests/test_queryset_to_dataframes.py
+++ b/DataRepo/tests/test_queryset_to_dataframes.py
@@ -31,7 +31,7 @@ class QuerysetToPandasDataFrameBaseTests(TracebaseTestCase):
             "total_sample": 7,
             "total_msrun": 3,
             "sample_owners": ["Xianfeng Zeng"],
-            "genotypes": ["C57BL/6N", "WT","ob/ob"],
+            "genotypes": ["C57BL/6N", "WT", "ob/ob"],
         }
         return exmaple_study_dict
 

--- a/DataRepo/tests/test_queryset_to_dataframes.py
+++ b/DataRepo/tests/test_queryset_to_dataframes.py
@@ -31,7 +31,7 @@ class QuerysetToPandasDataFrameBaseTests(TracebaseTestCase):
             "total_sample": 7,
             "total_msrun": 3,
             "sample_owners": ["Xianfeng Zeng"],
-            "genotypes": ["WT", "ob/ob", "C57BL/6N"],
+            "genotypes": ["ob/ob", "C57BL/6N", "WT"],
         }
         return exmaple_study_dict
 
@@ -121,7 +121,7 @@ class QuerysetToPandasDataFrameBaseTests(TracebaseTestCase):
         out_df = stud1_list_stats_df[selected_columns]
         stud1_list_stats_dict = qs2df.df_to_list_of_dict(out_df)[0]
 
-        self.assertDictEqual(stud1_list_stats_dict, example_study_dict)
+        self.assertEqual(stud1_list_stats_dict, example_study_dict)
 
     def test_animal_list_stat_df(self):
         """

--- a/DataRepo/tests/test_queryset_to_dataframes.py
+++ b/DataRepo/tests/test_queryset_to_dataframes.py
@@ -121,7 +121,7 @@ class QuerysetToPandasDataFrameBaseTests(TracebaseTestCase):
         out_df = stud1_list_stats_df[selected_columns]
         stud1_list_stats_dict = qs2df.df_to_list_of_dict(out_df)[0]
 
-        self.assertEqual(stud1_list_stats_dict, example_study_dict)
+        self.assertDictEqual(stud1_list_stats_dict, example_study_dict)
 
     def test_animal_list_stat_df(self):
         """

--- a/DataRepo/tests/test_queryset_to_dataframes.py
+++ b/DataRepo/tests/test_queryset_to_dataframes.py
@@ -18,6 +18,7 @@ class QuerysetToPandasDataFrameBaseTests(TracebaseTestCase):
     Do not pass or tag this class or the methods in it.  Instead override any tests in the derived classes and call
     their `super()` version because these tests are re-used under difference conditions
     """
+
     @classmethod
     def setUpTestData(cls):
         call_command("load_study", "DataRepo/example_data/test_dataframes/loading.yaml")

--- a/DataRepo/tests/test_views.py
+++ b/DataRepo/tests/test_views.py
@@ -20,6 +20,10 @@ from DataRepo.models import (
     Study,
     Tissue,
 )
+from DataRepo.models.maintained_model import (
+    disable_buffering,
+    enable_buffering,
+)
 from DataRepo.models.utilities import get_all_models
 from DataRepo.tests.tracebase_test_case import (
     TracebaseTestCase,
@@ -79,23 +83,19 @@ class ViewTests(TracebaseTestCase):
 
         super().setUpTestData()
 
-    @tag("multi_working")
     def test_home_url_exists_at_desired_location(self):
         response = self.client.get("/")
         self.assertEqual(response.status_code, 200)
 
-    @tag("multi_working")
     def test_home_url_accessible_by_name(self):
         response = self.client.get(reverse("home"))
         self.assertEqual(response.status_code, 200)
 
-    @tag("multi_working")
     def test_home_uses_correct_template(self):
         response = self.client.get(reverse("home"))
         self.assertEqual(response.status_code, 200)
         self.assertTemplateUsed(response, "home.html")
 
-    @tag("multi_working")
     def test_home_card_attr_list(self):
         # spot check: counts, urls for card attributes
         animal_count = Animal.objects.all().count()
@@ -126,7 +126,6 @@ class ViewTests(TracebaseTestCase):
         self.assertEqual(len(response.context["card_rows"]), 2)
 
     @tag("compound")
-    @tag("multi_working")
     def test_compound_list(self):
         response = self.client.get(reverse("compound_list"))
         self.assertEqual(response.status_code, 200)
@@ -136,7 +135,6 @@ class ViewTests(TracebaseTestCase):
         )
 
     @tag("compound")
-    @tag("multi_broken")
     def test_compound_detail(self):
         lysine = Compound.objects.filter(name="lysine").get()
         response = self.client.get(reverse("compound_detail", args=[lysine.id]))
@@ -145,29 +143,27 @@ class ViewTests(TracebaseTestCase):
         self.assertEqual(response.context["compound"].name, "lysine")
 
     @tag("compound")
-    @tag("multi_broken")
     def test_compound_detail_404(self):
         c = Compound.objects.order_by("id").last()
         response = self.client.get(reverse("compound_detail", args=[c.id + 1]))
         self.assertEqual(response.status_code, 404)
 
     @tag("compound")
-    @tag("multi_broken")
     def test_infusate_detail(self):
-        infusate = Infusate.objects.filter(name__icontains="lysine").first()
+        infusate = Infusate.objects.filter(
+            tracers__compound__name__icontains="lysine"
+        ).first()
         response = self.client.get(reverse("infusate_detail", args=[infusate.id]))
         self.assertEqual(response.status_code, 200)
         self.assertTemplateUsed(response, "DataRepo/infusate_detail.html")
 
     @tag("compound")
-    @tag("multi_working")
     def test_infusate_detail_404(self):
         inf = Infusate.objects.order_by("id").last()
         response = self.client.get(reverse("infusate_detail", args=[inf.id + 1]))
         self.assertEqual(response.status_code, 404)
 
     @tag("study")
-    @tag("multi_broken")
     def test_study_list(self):
         response = self.client.get(reverse("study_list"))
         self.assertEqual(response.status_code, 200)
@@ -175,14 +171,12 @@ class ViewTests(TracebaseTestCase):
         self.assertEqual(len(response.context["study_list"]), 1)
         self.assertEqual(len(response.context["df"]), 1)
 
-    @tag("multi_broken")
     @tag("study")
     def test_study_summary(self):
         response = self.client.get("/DataRepo/studies/study_summary/")
         self.assertEqual(response.status_code, 200)
         self.assertTemplateUsed(response, "DataRepo/study_summary.html")
 
-    @tag("multi_broken")
     @tag("study")
     def test_study_detail(self):
         obob_fasted = Study.objects.filter(name="obob_fasted").get()
@@ -192,21 +186,18 @@ class ViewTests(TracebaseTestCase):
         self.assertEqual(response.context["study"].name, "obob_fasted")
         self.assertEqual(len(response.context["stats_df"]), 1)
 
-    @tag("multi_working")
     @tag("study")
     def test_study_detail_404(self):
         s = Study.objects.order_by("id").last()
         response = self.client.get(reverse("study_detail", args=[s.id + 1]))
         self.assertEqual(response.status_code, 404)
 
-    @tag("multi_working")
     def test_protocol_list(self):
         response = self.client.get(reverse("protocol_list"))
         self.assertEqual(response.status_code, 200)
         self.assertTemplateUsed(response, "DataRepo/protocol_list.html")
         self.assertEqual(len(response.context["protocol_list"]), 1)
 
-    @tag("multi_working")
     def test_protocol_detail(self):
         p1 = Protocol.objects.filter(name="Default").get()
         response = self.client.get(reverse("protocol_detail", args=[p1.id]))
@@ -214,13 +205,11 @@ class ViewTests(TracebaseTestCase):
         self.assertTemplateUsed(response, "DataRepo/protocol_detail.html")
         self.assertEqual(response.context["protocol"].name, "Default")
 
-    @tag("multi_working")
     def test_protocol_detail_404(self):
         p = Protocol.objects.order_by("id").last()
         response = self.client.get(reverse("protocol_detail", args=[p.id + 1]))
         self.assertEqual(response.status_code, 404)
 
-    @tag("multi_broken")
     @tag("animal")
     def test_animal_list(self):
         response = self.client.get(reverse("animal_list"))
@@ -229,7 +218,6 @@ class ViewTests(TracebaseTestCase):
         self.assertEqual(len(response.context["animal_list"]), self.ALL_ANIMALS_COUNT)
         self.assertEqual(len(response.context["df"]), self.ALL_ANIMALS_COUNT)
 
-    @tag("multi_working")
     @tag("animal")
     def test_animal_detail(self):
         a1 = Animal.objects.filter(name="971").get()
@@ -239,14 +227,12 @@ class ViewTests(TracebaseTestCase):
         self.assertEqual(response.context["animal"].name, "971")
         self.assertEqual(len(response.context["df"]), self.ALL_SAMPLES_COUNT)
 
-    @tag("multi_working")
     @tag("animal")
     def test_animal_detail_404(self):
         a = Animal.objects.order_by("id").last()
         response = self.client.get(reverse("animal_detail", args=[a.id + 1]))
         self.assertEqual(response.status_code, 404)
 
-    @tag("multi_working")
     @tag("tissue")
     def test_tissue_list(self):
         response = self.client.get(reverse("tissue_list"))
@@ -254,7 +240,6 @@ class ViewTests(TracebaseTestCase):
         self.assertTemplateUsed(response, "DataRepo/tissue_list.html")
         self.assertEqual(len(response.context["tissue_list"]), self.ALL_TISSUES_COUNT)
 
-    @tag("multi_working")
     @tag("tissue")
     def test_tissue_detail(self):
         t1 = Tissue.objects.filter(name="brown_adipose_tissue").get()
@@ -263,14 +248,12 @@ class ViewTests(TracebaseTestCase):
         self.assertTemplateUsed(response, "DataRepo/tissue_detail.html")
         self.assertEqual(response.context["tissue"].name, "brown_adipose_tissue")
 
-    @tag("multi_working")
     @tag("tissue")
     def test_tissue_detail_404(self):
         t = Tissue.objects.order_by("id").last()
         response = self.client.get(reverse("tissue_detail", args=[t.id + 1]))
         self.assertEqual(response.status_code, 404)
 
-    @tag("multi_working")
     @tag("sample")
     def test_sample_list(self):
         response = self.client.get("/DataRepo/samples/")
@@ -279,7 +262,6 @@ class ViewTests(TracebaseTestCase):
         self.assertEqual(len(response.context["sample_list"]), self.ALL_SAMPLES_COUNT)
         self.assertEqual(len(response.context["df"]), self.ALL_SAMPLES_COUNT)
 
-    @tag("multi_working")
     @tag("sample")
     def test_sample_list_per_animal(self):
         a1 = Animal.objects.filter(name="971").get()
@@ -290,7 +272,6 @@ class ViewTests(TracebaseTestCase):
         self.assertEqual(len(response.context["sample_list"]), s1.count())
         self.assertEqual(len(response.context["df"]), s1.count())
 
-    @tag("multi_working")
     @tag("sample")
     def test_sample_detail(self):
         s1 = Sample.objects.filter(name="BAT-xz971").get()
@@ -299,21 +280,18 @@ class ViewTests(TracebaseTestCase):
         self.assertTemplateUsed(response, "DataRepo/sample_detail.html")
         self.assertEqual(response.context["sample"].name, "BAT-xz971")
 
-    @tag("multi_working")
     @tag("sample")
     def test_sample_detail_404(self):
         s = Sample.objects.order_by("id").last()
         response = self.client.get(reverse("sample_detail", args=[s.id + 1]))
         self.assertEqual(response.status_code, 404)
 
-    @tag("multi_working")
     def test_msrun_list(self):
         response = self.client.get(reverse("msrun_list"))
         self.assertEqual(response.status_code, 200)
         self.assertTemplateUsed(response, "DataRepo/msrun_list.html")
         self.assertEqual(len(response.context["msrun_list"]), self.ALL_SAMPLES_COUNT)
 
-    @tag("multi_working")
     def test_msrun_detail(self):
         ms1 = MSRun.objects.filter(sample__name="BAT-xz971").get()
         response = self.client.get(reverse("msrun_detail", args=[ms1.id]))
@@ -321,20 +299,17 @@ class ViewTests(TracebaseTestCase):
         self.assertTemplateUsed(response, "DataRepo/msrun_detail.html")
         self.assertEqual(response.context["msrun"].sample.name, "BAT-xz971")
 
-    @tag("multi_working")
     def test_msrun_detail_404(self):
         ms = MSRun.objects.order_by("id").last()
         response = self.client.get(reverse("msrun_detail", args=[ms.id + 1]))
         self.assertEqual(response.status_code, 404)
 
-    @tag("multi_working")
     def test_peakgroupset_list(self):
         response = self.client.get(reverse("peakgroupset_list"))
         self.assertEqual(response.status_code, 200)
         self.assertTemplateUsed(response, "DataRepo/peakgroupset_list.html")
         self.assertEqual(len(response.context["peakgroupset_list"]), 2)
 
-    @tag("multi_working")
     def test_peakgroupset_detail(self):
         pgs1 = PeakGroupSet.objects.filter(
             filename="small_obob_maven_6eaas_inf.xlsx"
@@ -346,13 +321,11 @@ class ViewTests(TracebaseTestCase):
             response.context["peakgroupset"].filename, "small_obob_maven_6eaas_inf.xlsx"
         )
 
-    @tag("multi_working")
     def test_peakgroupset_detail_404(self):
         pgs = PeakGroupSet.objects.order_by("id").last()
         response = self.client.get(reverse("peakgroupset_detail", args=[pgs.id + 1]))
         self.assertEqual(response.status_code, 404)
 
-    @tag("multi_working")
     def test_peakgroup_list(self):
         response = self.client.get("/DataRepo/peakgroups/")
         self.assertEqual(response.status_code, 200)
@@ -362,7 +335,6 @@ class ViewTests(TracebaseTestCase):
             self.INF_PEAKGROUP_COUNT + self.SERUM_PEAKGROUP_COUNT,
         )
 
-    @tag("multi_working")
     def test_peakgroup_list_per_msrun(self):
         ms1 = MSRun.objects.filter(sample__name="BAT-xz971").get()
         pg1 = PeakGroup.objects.filter(msrun_id=ms1.id)
@@ -371,7 +343,6 @@ class ViewTests(TracebaseTestCase):
         self.assertTemplateUsed(response, "DataRepo/peakgroup_list.html")
         self.assertEqual(len(response.context["peakgroup_list"]), pg1.count())
 
-    @tag("multi_working")
     def test_peakgroup_detail(self):
         ms1 = MSRun.objects.filter(sample__name="BAT-xz971").get()
         pg1 = PeakGroup.objects.filter(msrun_id=ms1.id).first()
@@ -380,13 +351,11 @@ class ViewTests(TracebaseTestCase):
         self.assertTemplateUsed(response, "DataRepo/peakgroup_detail.html")
         self.assertEqual(response.context["peakgroup"].name, pg1.name)
 
-    @tag("multi_working")
     def test_peakgroup_detail_404(self):
         pg = PeakGroup.objects.order_by("id").last()
         response = self.client.get(reverse("peakgroup_detail", args=[pg.id + 1]))
         self.assertEqual(response.status_code, 404)
 
-    @tag("multi_working")
     def test_peakdata_list(self):
         """
         the total rows loaded may be greater than total rows in file for each sample,
@@ -398,7 +367,6 @@ class ViewTests(TracebaseTestCase):
         self.assertTemplateUsed(response, "DataRepo/peakdata_list.html")
         self.assertEqual(len(response.context["peakdata_list"]), pd.count())
 
-    @tag("multi_working")
     def test_peakdata_list_per_peakgroup(self):
         pg1 = PeakGroup.objects.filter(msrun__sample__name="serum-xz971").first()
         pd1 = PeakData.objects.filter(peak_group_id=pg1.pk)
@@ -407,7 +375,6 @@ class ViewTests(TracebaseTestCase):
         self.assertTemplateUsed(response, "DataRepo/peakdata_list.html")
         self.assertEqual(len(response.context["peakdata_list"]), pd1.count())
 
-    @tag("multi_working")
     def test_search_advanced_browse(self):
         """
         Load the advanced search page in browse mode and make sure the mode is added to the context data
@@ -420,7 +387,6 @@ class ViewTests(TracebaseTestCase):
         self.assertEqual(response.context["mode"], "browse")
         self.assertEqual(response.context["format"], "pdtemplate")
 
-    @tag("multi_working")
     def test_search_advanced_search(self):
         """
         Load the advanced search page in the default search mode and make sure the mode is added to the context data
@@ -521,7 +487,6 @@ class ViewTests(TracebaseTestCase):
             },
         }
 
-    @tag("multi_working")
     def test_search_advanced_valid(self):
         """
         Do a simple advanced search and make sure the results are correct
@@ -536,7 +501,6 @@ class ViewTests(TracebaseTestCase):
         self.assertEqual(len(response.context["res"]), qs.count())
         self.assertEqual(qry, response.context["qry"])
 
-    @tag("multi_working")
     def test_search_advanced_invalid(self):
         """
         Do a simple advanced search and make sure the results are correct
@@ -552,7 +516,6 @@ class ViewTests(TracebaseTestCase):
         self.assertEqual(len(response.context["res"]), 0)
         self.assertEqual(qry, response.context["qry"])
 
-    @tag("multi_working")
     def test_search_advanced_tsv(self):
         """
         Download a simple advanced search and make sure the results are correct
@@ -569,7 +532,6 @@ class ViewTests(TracebaseTestCase):
         self.assertTrue("PeakGroups" in contentdisp)
         self.assertTrue(".tsv" in contentdisp)
 
-    @tag("multi_working")
     def test_validate_files(self):
         """
         Do a file validation test
@@ -586,6 +548,34 @@ class ViewTests(TracebaseTestCase):
         self.assertTrue(len(errors["data_submission_accucor2.xlsx"]) == 0)
         self.assertEqual(results["data_submission_accucor1.xlsx"], "PASSED")
         self.assertEqual(results["data_submission_accucor2.xlsx"], "PASSED")
+
+
+@tag("multi_mixed")
+class ViewNullToleranceTests(ViewTests):
+    """
+    This class inherits from the ViewTests class above and overrides the setUpTestData method to load without auto-
+    updates.
+
+    All super tests are executed.  Those that are broken are overridden here to have something to apply the broken tags
+    to.
+    """
+
+    @classmethod
+    def setUpTestData(cls):
+        # Silently dis-allow auto-updates by disabling buffering
+        disable_buffering()
+        super().setUpTestData()
+        enable_buffering()
+
+    @tag("multi_broken")
+    def test_study_list(self):
+        """Make sure this page works when infusate/tracer, and/or tracer label names are None"""
+        super().test_study_list()
+
+    @tag("multi_broken")
+    def test_study_detail(self):
+        """Make sure this page works when infusate/tracer, and/or tracer label names are None"""
+        super().test_study_detail()
 
 
 @tag("multi_working")

--- a/DataRepo/tests/tracebase_test_case.py
+++ b/DataRepo/tests/tracebase_test_case.py
@@ -53,9 +53,6 @@ def reportRunTime(id, startTime):
     Print the runtime of a test given the test ID and start time.
     """
 
-    # TODO: When issue #480 is implemented, a test should be added here to ensure each test runs in under some
-    #       reasonable threshold.  There might even be a way to ensure the data setup runs quickly as well.
-
     t = time.time() - startTime
     heads_up = ""  # String to include for tests that run too long
 

--- a/DataRepo/utils/sample_table_loader.py
+++ b/DataRepo/utils/sample_table_loader.py
@@ -476,6 +476,8 @@ class SampleTableLoader:
         # Cannot perform buffered updates of FCirc, Sample, or Animal's last serum tracer peak group because no peak
         # groups have been loaded yet, so only update the ones labeled "name".
         perform_buffered_updates(labels=["name"], using=self.db)
+        # Since we only updated some of the buffered items, clear the rest of the buffer
+        clear_update_buffer()
         enable_autoupdates()
         enable_buffering()
 

--- a/DataRepo/utils/sample_table_loader.py
+++ b/DataRepo/utils/sample_table_loader.py
@@ -25,7 +25,6 @@ from DataRepo.models.maintained_model import (
     enable_autoupdates,
     enable_buffering,
     perform_buffered_updates,
-    buffer_size,
 )
 from DataRepo.models.researcher import get_researchers
 from DataRepo.models.utilities import value_from_choices_label

--- a/DataRepo/utils/sample_table_loader.py
+++ b/DataRepo/utils/sample_table_loader.py
@@ -22,9 +22,10 @@ from DataRepo.models.hier_cached_model import (
 from DataRepo.models.maintained_model import (
     clear_update_buffer,
     disable_autoupdates,
-    disable_buffering,
     enable_autoupdates,
     enable_buffering,
+    perform_buffered_updates,
+    buffer_size,
 )
 from DataRepo.models.researcher import get_researchers
 from DataRepo.models.utilities import value_from_choices_label
@@ -148,7 +149,6 @@ class SampleTableLoader:
         self.debug = debug
 
         disable_autoupdates()
-        disable_buffering()
         disable_caching_updates()
         animals_to_uncache = []
 
@@ -475,7 +475,8 @@ class SampleTableLoader:
             print("Expiring done.")
 
         # Cannot perform buffered updates of FCirc, Sample, or Animal's last serum tracer peak group because no peak
-        # groups have been loaded yet
+        # groups have been loaded yet, so only update the ones labeled "name".
+        perform_buffered_updates(labels=["name"], using=self.db)
         enable_autoupdates()
         enable_buffering()
 


### PR DESCRIPTION
## Summary Change Description

Replaced the buffered update U erroneously removed 8 commits ago.

## Affected Issue Numbers

- Resolves no issue

## Code Review Notes

self explanatory.  I should probably add a test, but I gotta run.

## Checklist

- [x] All issue requirements satisfied (or no linked issues)
- [x] [Linting passes](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#linting).
- [x] [Migrations created & committed *(or no model changes)*](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#migration-process)
- Tests
  - [x] [Tests implemented *(or no code changes)*](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#test-implementation)
  - [x] [All *multi_working* tag tests pass locally](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#quality-control)
  - [x] All example load tests pass (remotely) *(or their failures predated and are unrelated to this branch)*
  - [x] `@tag("multi_working")` added to newly passing test functions/classes *(or no newly passing tests)*
  - [x] `@tag("multi_broken")`, `@tag("multi_unknown")`, or `@tag("multi_mixed")` removed from newly passing test functions/classes *(or no newly passing tests)*
