### PR TITLE
Prevent the search structure from getting deeper and deeper when last/prev checkboxes manipulated

### DIFF
--- a/DataRepo/templates/DataRepo/search/results/fcirc.html
+++ b/DataRepo/templates/DataRepo/search/results/fcirc.html
@@ -170,12 +170,30 @@
                 query.val = 'dummy'
             }
 
+            let last_form_pos = getFirstFieldFormNum('is_last')
+            let reroot_mode = true
+            if (last_form_pos === 1) {
+                let rootSize = getRootGroupSize()
+                // If the root search hoerarchy level has 2 members and 1 is a form (that we assume is 'is_last')
+                // Note, this could be a false assumption if the first member is a group whose first form is for is_last
+                if (rootSize.members === 2 && rootSize.forms === 1) {
+                    reroot_mode = false
+                }
+            }
+
             // Remove any search terms for the is_last field
             removeFieldSearchForms('is_last')
             // Remove incomplete search forms
             removeIncompleteSearchForms()
-            // Insert a new 'and'-group with a single query at the root and append the existing search group (formerly the root) as a sibling of that query, if any
-            reRootSearch(group, query, 'fctemplate')
+
+            if (reroot_mode) {
+                // Insert a new 'and'-group with a single query at the root and append the existing search group (formerly the root) as a sibling of that query, if any
+                reRootSearch(group, query, 'fctemplate')
+            } else {
+                // This essentially does the same thing as above.  It just doesn't create or move-around the group select lists when there exists filled-out user search criteria
+                insertFirstSearch(query, 'fctemplate')
+            }
+
             // Commit (/save) the form, i.e. prepare for submission
             var myform = document.getElementById("hierarchical-search-form")
             saveSearchQueryHierarchy(document.querySelector('.hierarchical-search'))


### PR DESCRIPTION
## Summary Change Description

Added a way to detect in the search form if the search had already been manipulated and if so, use a different strategy to change the search based on the checkboxes that prevents the groups to keep propagating.

## Affected Issue Numbers

- Resolves review issue in PR #516

## Code Review Notes

It looks like a lot of code, but it's variations on a theme.  Definitely could be streamlined or made simpler.  If you have any suggestions in that regard, please make them.

The basic concept is:

1. Is the first search row for the `is_last` field?
2. If not, use the original strategy
3. If so, and the group has 2 members, the second being a group: Remove the is_last search criteria and prepend the new is_last search criteria

## Checklist

- [x] All issue requirements satisfied (or no linked issues)
- [x] [Linting passes](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#linting).
- [x] [Migrations created & committed *(or no model changes)*](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#migration-process)
- Tests
  - [ ] [Tests implemented *(or no code changes)*](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#test-implementation)
  - [x] [All *multi_working* tag tests pass locally](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#quality-control)
  - [x] All example load tests pass (remotely) *(or their failures predated and are unrelated to this branch)*
  - [x] `@tag("multi_working")` added to newly passing test functions/classes *(or no newly passing tests)*
  - [x] `@tag("multi_broken")`, `@tag("multi_unknown")`, or `@tag("multi_mixed")` removed from newly passing test functions/classes *(or no newly passing tests)*
