### PR TITLE
Added a test to ensure C12 PARENT records do not introduce a labeled carbon

### DIFF
--- a/DataRepo/tests/test_models.py
+++ b/DataRepo/tests/test_models.py
@@ -2493,6 +2493,18 @@ class ParseIsotopeLabelTests(TracebaseTestCase):
                 tracer_labeled_elements,
             )
 
+    def test_parse_isotope_label_no_carbon(self):
+        tracer_labeled_elements = [
+            IsotopeObservationData(element="N", mass_number=14, count=2, parent=True),
+            IsotopeObservationData(element="O", mass_number=16, count=1, parent=True),
+        ]
+        self.assertEqual(
+            AccuCorDataLoader.parse_isotope_string(
+                "C12 PARENT", tracer_labeled_elements
+            ),
+            tracer_labeled_elements,
+        )
+
     def test_dupe_compound_isotope_pairs(self):
         # Error must contain:
         #   all compound/isotope pairs that were dupes


### PR DESCRIPTION
## Summary Change Description

While the C12 from the parent record is parsed, the parser only returns the labeled elements that came from the tracers (and optionally filtered by commonality with the measured compound).  This adds a test that confirms that.

Also added some comments.

## Affected Issue Numbers

- Resolves #470

## Code Review Notes

self explanatory

## Checklist

- [x] All issue requirements satisfied (or no linked issues)
- [x] [Linting passes](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#linting).
- [x] [Migrations created & committed *(or no model changes)*](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#migration-process)
- Tests
  - [x] [Tests implemented *(or no code changes)*](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#test-implementation)
  - [x] [All *multi_working* tag tests pass locally](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#quality-control)
  - [x] All example load tests pass (remotely) *(or their failures predated and are unrelated to this branch)*
  - [x] `@tag("multi_working")` added to newly passing test functions/classes *(or no newly passing tests)*
  - [x] `@tag("multi_broken")`, `@tag("multi_unknown")`, or `@tag("multi_mixed")` removed from newly passing test functions/classes *(or no newly passing tests)*
