### PR TITLE
Fixed an exception caused by division by 0.

### DIFF
--- a/DataRepo/models/animal_label.py
+++ b/DataRepo/models/animal_label.py
@@ -123,7 +123,7 @@ class AnimalLabel(HierCachedModel):
                     # This assumes the PeakDataLabel unique constraint: peak_data, element
                     label_rec = label_pd_rec.labels.get(element__exact=self.element)
 
-                    # And this assumes that label_rec must exist because of the filter above the loop
+                    # This assumes that label_rec must exist because of the filter above the loop
                     last_serum_tracers_enrichment_sum += (
                         label_pd_rec.fraction * label_rec.count
                     )
@@ -144,6 +144,12 @@ class AnimalLabel(HierCachedModel):
         except PeakDataLabel.DoesNotExist as pdldne:
             # This is not something the user can recitify via loading. This would be a bug in the loading code
             raise MissingPeakDataLabel(pg, self.element) from pdldne
+        except TypeError as te:
+            if label_pd_rec and label_pd_rec.fraction is None:
+                error = True
+                msg = f" ERROR: PeakData fraction was None.  Original Error: {TypeError.__name__}: {str(te)}"
+            else:
+                raise te
         finally:
             if error:
                 warnings.warn(

--- a/DataRepo/models/peak_group_label.py
+++ b/DataRepo/models/peak_group_label.py
@@ -95,7 +95,8 @@ class PeakGroupLabel(HierCachedModel):
             for label_pd_rec in label_pd_recs:
                 # This assumes the PeakDataLabel unique constraint: peak_data, element
                 label_rec = label_pd_rec.labels.get(element__exact=self.element)
-                # And this assumes that label_rec must exist because of the filter above the loop
+
+                # This assumes that label_rec must exist because of the filter above the loop
                 element_enrichment_sum = element_enrichment_sum + (
                     label_pd_rec.fraction * label_rec.count
                 )
@@ -115,6 +116,11 @@ class PeakGroupLabel(HierCachedModel):
                 # NoCommonLabel is meaningless if there is no formula (above)
                 warning = False
                 raise e
+            elif label_pd_rec.fraction is None:
+                msg = (
+                    f"PeakData fraction was None from record [{label_pd_rec}] likely because the PeakGroup total "
+                    "abundance was 0"
+                )
             elif label_rec.count is None:
                 msg = f"Labeled count missing from PeakDataLabel record [{label_rec}]"
             elif label_rec.element is None:


### PR DESCRIPTION
## Summary Change Description

Caught an exception due to multiplying None by an int in 2 places.  It was causing an exception during download and an exception if the affected record was ever attempted to be displayed.

## Affected Issue Numbers

- Resolves #539

## Code Review Notes

When I reworked this code, I had revamped the exception catches.  Looks like I pruned them back too far.

## Checklist

- [x] All issue requirements satisfied (or no linked issues)
- [x] [Linting passes](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#linting).
- [x] [Migrations created & committed *(or no model changes)*](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#migration-process)
- Tests
  - [ ] [Tests implemented *(or no code changes)*](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#test-implementation)
  - [x] [All *multi_working* tag tests pass locally](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#quality-control)
  - [x] All example load tests pass (remotely) *(or their failures predated and are unrelated to this branch)*
  - [x] `@tag("multi_working")` added to newly passing test functions/classes *(or no newly passing tests)*
  - [x] `@tag("multi_broken")`, `@tag("multi_unknown")`, or `@tag("multi_mixed")` removed from newly passing test functions/classes *(or no newly passing tests)*
