### PR TITLE
Changed the wrapping isotope characters from parenthases to square brackets

### DIFF
--- a/DataRepo/models/tracer.py
+++ b/DataRepo/models/tracer.py
@@ -97,11 +97,11 @@ class Tracer(MaintainedModel, ElementLabel):
         update_label="name",
     )
     def _name(self):
-        # format: `compound - ([) labelname,labelname,... )` (but no spaces)
+        # format: `compound - [ labelname,labelname,... ]` (but no spaces)
         if self.id is None or self.labels is None or self.labels.count() == 0:
             return self.compound.name
         labels_string = ",".join([str(label) for label in self.labels.all()])
-        return f"{self.compound.name}-({labels_string})"
+        return f"{self.compound.name}-[{labels_string}]"
 
     def clean(self):
         for label in self.labels.all():

--- a/DataRepo/tests/models/test_infusate.py
+++ b/DataRepo/tests/models/test_infusate.py
@@ -79,11 +79,11 @@ class InfusateTests(TracebaseTestCase):
 
     def test_infusate_name_method(self):
         self.assertEqual(
-            "ti {C16:0-(5,6-13C2,17O2)[2];glucose-(2,3-13C2,4-17O1)[1]}",
+            "ti {C16:0-[5,6-13C2,17O2][2];glucose-[2,3-13C2,4-17O1][1]}",
             self.INFUSATE1._name(),
         )
         self.assertEqual(
-            "C16:0-(5,6-13C2,17O2)[4];glucose-(2,3-13C2,4-17O1)[3]",
+            "C16:0-(5,6-13C2,17O2)[4];glucose-[2,3-13C2,4-17O1][3]",
             self.INFUSATE2._name(),
         )
 
@@ -100,7 +100,7 @@ class InfusateTests(TracebaseTestCase):
         """
         # Throws DoesNotExist exception if not found
         Infusate.objects.get(
-            name="ti {C16:0-(5,6-13C2,17O2)[2];glucose-(2,3-13C2,4-17O1)[1]}"
+            name="ti {C16:0-[5,6-13C2,17O2][2];glucose-[2,3-13C2,4-17O1][1]}"
         )
 
     def test_name_none(self):
@@ -108,12 +108,12 @@ class InfusateTests(TracebaseTestCase):
         Make sure that the name field was set automatically - triggered by the InfusateTracer record creation.
         """
         self.assertEqual(
-            "C16:0-(5,6-13C2,17O2)[4];glucose-(2,3-13C2,4-17O1)[3]",
+            "C16:0-(5,6-13C2,17O2)[4];glucose-[2,3-13C2,4-17O1][3]",
             self.INFUSATE2.name,
         )
         # Throws DoesNotExist exception if not found
         Infusate.objects.get(
-            name__exact="C16:0-(5,6-13C2,17O2)[4];glucose-(2,3-13C2,4-17O1)[3]"
+            name__exact="C16:0-(5,6-13C2,17O2)[4];glucose-[2,3-13C2,4-17O1][3]"
         )
 
     def test_name_self_autoupdated(self):
@@ -135,10 +135,10 @@ class InfusateTests(TracebaseTestCase):
         i1 = Infusate.objects.get(id__exact=self.INFUSATE1.id)
         i2 = Infusate.objects.get(id__exact=self.INFUSATE2.id)
         # The deletion affects the tracer name (which should have been autoupdated)
-        self.assertEqual("glucose-(4-17O1)", tl.tracer.name)
+        self.assertEqual("glucose-[4-17O1]", tl.tracer.name)
         # The deletion also affects the names of both infusates that had that tracer
-        self.assertEqual("ti {C16:0-(5,6-13C2,17O2)[2];glucose-(4-17O1)[1]}", i1.name)
-        self.assertEqual("C16:0-(5,6-13C2,17O2)[4];glucose-(4-17O1)[3]", i2.name)
+        self.assertEqual("ti {C16:0-[5,6-13C2,17O2][2];glucose-[4-17O1][1]}", i1.name)
+        self.assertEqual("C16:0-(5,6-13C2,17O2)[4];glucose-[4-17O1][3]", i2.name)
 
 
 @tag("multi_working")
@@ -255,13 +255,13 @@ class MaintainedModelTests(TracebaseTestCase):
         MaintainedModel to be set.
         """
         io, io2 = create_infusate_records()
-        expected_name = "ti {C16:0-(5,6-13C2,17O2)[2];glucose-(2,3-13C2,4-17O1)[1]}"
+        expected_name = "ti {C16:0-[5,6-13C2,17O2][2];glucose-[2,3-13C2,4-17O1][1]}"
         self.assertEqual(expected_name, io.get_name)
 
     def test_pretty_name(self):
         io, io2 = create_infusate_records()
         expected_name = (
-            "ti {\nC16:0-(5,6-13C2,17O2)[2];\nglucose-(2,3-13C2,4-17O1)[1]\n}"
+            "ti {\nC16:0-[5,6-13C2,17O2][2];\nglucose-[2,3-13C2,4-17O1][1]\n}"
         )
         self.assertEqual(expected_name, io.pretty_name)
 
@@ -277,7 +277,7 @@ class MaintainedModelTests(TracebaseTestCase):
         enable_autoupdates()
         # Should be initially none
         self.assertIsNone(io.name)
-        expected_name = "ti {C16:0-(5,6-13C2,17O2)[2];glucose-(2,3-13C2,4-17O1)[1]}"
+        expected_name = "ti {C16:0-[5,6-13C2,17O2][2];glucose-[2,3-13C2,4-17O1][1]}"
         # Returned value should be equal
         self.assertEqual(expected_name, io.get_name)
         # And now the field should be updated

--- a/DataRepo/tests/models/test_infusate.py
+++ b/DataRepo/tests/models/test_infusate.py
@@ -83,7 +83,7 @@ class InfusateTests(TracebaseTestCase):
             self.INFUSATE1._name(),
         )
         self.assertEqual(
-            "C16:0-(5,6-13C2,17O2)[4];glucose-[2,3-13C2,4-17O1][3]",
+            "C16:0-[5,6-13C2,17O2][4];glucose-[2,3-13C2,4-17O1][3]",
             self.INFUSATE2._name(),
         )
 
@@ -108,12 +108,12 @@ class InfusateTests(TracebaseTestCase):
         Make sure that the name field was set automatically - triggered by the InfusateTracer record creation.
         """
         self.assertEqual(
-            "C16:0-(5,6-13C2,17O2)[4];glucose-[2,3-13C2,4-17O1][3]",
+            "C16:0-[5,6-13C2,17O2][4];glucose-[2,3-13C2,4-17O1][3]",
             self.INFUSATE2.name,
         )
         # Throws DoesNotExist exception if not found
         Infusate.objects.get(
-            name__exact="C16:0-(5,6-13C2,17O2)[4];glucose-[2,3-13C2,4-17O1][3]"
+            name__exact="C16:0-[5,6-13C2,17O2][4];glucose-[2,3-13C2,4-17O1][3]"
         )
 
     def test_name_self_autoupdated(self):
@@ -138,7 +138,7 @@ class InfusateTests(TracebaseTestCase):
         self.assertEqual("glucose-[4-17O1]", tl.tracer.name)
         # The deletion also affects the names of both infusates that had that tracer
         self.assertEqual("ti {C16:0-[5,6-13C2,17O2][2];glucose-[4-17O1][1]}", i1.name)
-        self.assertEqual("C16:0-(5,6-13C2,17O2)[4];glucose-[4-17O1][3]", i2.name)
+        self.assertEqual("C16:0-[5,6-13C2,17O2][4];glucose-[4-17O1][3]", i2.name)
 
 
 @tag("multi_working")

--- a/DataRepo/tests/models/test_tracer.py
+++ b/DataRepo/tests/models/test_tracer.py
@@ -29,7 +29,7 @@ def create_tracer_record():
 class TracerTests(TracebaseTestCase):
     def test_tracer_name(self):
         tracer = create_tracer_record()
-        self.assertEqual(tracer._name(), "glucose-(2,3-13C2,4-17O1)")
+        self.assertEqual(tracer._name(), "glucose-[2,3-13C2,4-17O1]")
 
     def test_name_not_settable(self):
         c16 = Compound.objects.create(name="C16:0", formula="C16H32O2", hmdb_id=2)
@@ -47,4 +47,4 @@ class TracerTests(TracebaseTestCase):
         # Throws DoesNotExist exception if not found
         self.assertTrue(are_autoupdates_enabled())
         to = create_tracer_record()
-        self.assertEqual("glucose-(2,3-13C2,4-17O1)", to.name)
+        self.assertEqual("glucose-[2,3-13C2,4-17O1]", to.name)

--- a/DataRepo/tests/test_infusate_parsing_validation.py
+++ b/DataRepo/tests/test_infusate_parsing_validation.py
@@ -291,7 +291,7 @@ class InfusateValidationTests(InfusateTest):
             self.tracer_data_l_leucine
         )
         self.assertTrue(created)
-        self.assertEqual(tracer.name, "leucine-(1,2-13C2)")
+        self.assertEqual(tracer.name, "leucine-[1,2-13C2]")
         self.assertEqual(tracer.compound.name, "leucine")
         self.assertEqual(len(tracer.labels.all()), 1)
 
@@ -331,7 +331,7 @@ class InfusateValidationTests(InfusateTest):
         (tracer, _) = Tracer.objects.get_or_create_tracer(
             tracer_data_leucine_fully_labeled
         )
-        self.assertEqual(tracer.name, "leucine-(13C6)")
+        self.assertEqual(tracer.name, "leucine-[13C6]")
 
     def test_tracer_validation_missing_positions(self):
         """Test tracer validation requires positions when partially labeled"""
@@ -351,7 +351,7 @@ class InfusateValidationTests(InfusateTest):
         self.assertTrue(created)
         self.assertEqual(
             infusate.name,
-            "BCAAs {isoleucine-(13C6,15N1)[1];leucine-(13C6,15N1)[2];valine-(13C5,15N1)[3]}",
+            "BCAAs {isoleucine-[13C6,15N1][1];leucine-[13C6,15N1][2];valine-[13C5,15N1][3]}",
         )
         self.assertEqual(infusate.tracer_group_name, "BCAAs")
         self.assertEqual(len(infusate.tracers.all()), 3)
@@ -364,7 +364,7 @@ class InfusateValidationTests(InfusateTest):
         self.assertTrue(created)
         self.assertEqual(
             infusate.name,
-            "leucine-(1,2-13C2)[1.5]",
+            "leucine-[1,2-13C2][1.5]",
         )
         self.assertEqual(infusate.tracer_group_name, None)
         self.assertEqual(len(infusate.tracers.all()), 1)

--- a/DataRepo/tests/test_queryset_to_dataframes.py
+++ b/DataRepo/tests/test_queryset_to_dataframes.py
@@ -98,9 +98,9 @@ class QuerysetToPandasDataFrameBaseTests(TracebaseTestCase):
             "infusate_name": "BCAAs (VLI) {isoleucine-[13C6,15N1][12];leucine-[13C6,15N1][24];valine-[13C5,15N1][20]}",
             "tracer_group_name": "BCAAs (VLI)",
             "tracers": [
-                "isoleucine-(13C6,15N1)",
-                "leucine-(13C6,15N1)",
-                "valine-(13C5,15N1)",
+                "isoleucine-[13C6,15N1]",
+                "leucine-[13C6,15N1]",
+                "valine-[13C5,15N1]",
             ],
             "concentrations": [12, 24, 20],
             "labeled_elements": ["C,N"],

--- a/DataRepo/tests/test_queryset_to_dataframes.py
+++ b/DataRepo/tests/test_queryset_to_dataframes.py
@@ -38,7 +38,7 @@ class QuerysetToPandasDataFrameBaseTests(TracebaseTestCase):
     def get_example_animal_dict(self):
         exmaple_animal_dict = {
             "animal": "a1_Lys_13C",
-            "infusate_name": "lysine-(13C6)[15]",
+            "infusate_name": "lysine-[13C6][15]",
             "infusion_rate": 0.11,
             "genotype": "WT",
             "body_weight": 26.2,
@@ -58,9 +58,9 @@ class QuerysetToPandasDataFrameBaseTests(TracebaseTestCase):
     def get_example_sample1_dict(self):
         example_sample1_dict = {
             "animal": "a1_Lys_13C",
-            "infusate_name": "lysine-(13C6)[15]",
+            "infusate_name": "lysine-[13C6][15]",
             "tracer_group_name": None,
-            "tracers": ["lysine-(13C6)"],
+            "tracers": ["lysine-[13C6]"],
             "labeled_elements": ["C"],
             "concentrations": [15],
             "tissue": "kidney",
@@ -75,7 +75,7 @@ class QuerysetToPandasDataFrameBaseTests(TracebaseTestCase):
     def get_example_sample2_dict(self):
         example_sample2_dict = {
             "animal": "a2_VLI_13C15N",
-            "infusate_name": "BCAAs (VLI) {isoleucine-(13C6,15N1)[12];leucine-(13C6,15N1)[24];valine-(13C5,15N1)[20]}",
+            "infusate_name": "BCAAs (VLI) {isoleucine-[13C6,15N1][12];leucine-[13C6,15N1][24];valine-[13C5,15N1][20]}",
             "tissue": "liver",
             "sample": "a2_liv",
             "sample_owner": "Xianfeng Zeng",
@@ -95,7 +95,7 @@ class QuerysetToPandasDataFrameBaseTests(TracebaseTestCase):
 
     def get_example_infusate_dict(self):
         example_infusate_dict = {
-            "infusate_name": "BCAAs (VLI) {isoleucine-(13C6,15N1)[12];leucine-(13C6,15N1)[24];valine-(13C5,15N1)[20]}",
+            "infusate_name": "BCAAs (VLI) {isoleucine-[13C6,15N1][12];leucine-[13C6,15N1][24];valine-[13C5,15N1][20]}",
             "tracer_group_name": "BCAAs (VLI)",
             "tracers": [
                 "isoleucine-(13C6,15N1)",


### PR DESCRIPTION
## Summary Change Description

I changed the tracer model code to wrap the list of isotopes with `[]` instead of `()` and updated the tests to expect square brackets.

## Affected Issue Numbers

- Resolves #542

## Code Review Notes

~~**Important note**: This leaves the dataframe tests broken.  I had started to look into it and realized there would be a learning curve given my unfamiliarity with how the dataframe code works, as I did not understand what was causing the tests to fail, so I decided to request @fkang-pu's help in fixing them.  For all I know, it could be possible that the source of the problem is my code (or the example data?), but the only indication in the tests to get at the source is through the failing dataframe tests.  So Fan would be better suited to efficiently finding the problem, so I suggest branching off the branch in this PR and submit a PR that merges into this branch.  Feel free to hand it back to me if the failures are originating from my code.~~

Also, I had initially tried yesterday to use a single source for the delimiters and bracket characters, but ran into "not straight forward" circular import issues, and given the impending soft-release, I decided to abandon that effort and instead go for this simpler fix.

## Checklist

- [x] All issue requirements satisfied (or no linked issues)
- [x] [Linting passes](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#linting).
- [x] [Migrations created & committed *(or no model changes)*](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#migration-process)
- Tests
  - [x] [Tests implemented *(or no code changes)*](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#test-implementation)
  - [x] [All *multi_working* tag tests pass locally](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#quality-control)
  - [x] All example load tests pass (remotely) *(or their failures predated and are unrelated to this branch)*
  - [x] `@tag("multi_working")` added to newly passing test functions/classes *(or no newly passing tests)*
  - [x] `@tag("multi_broken")`, `@tag("multi_unknown")`, or `@tag("multi_mixed")` removed from newly passing test functions/classes *(or no newly passing tests)*
