### PR TITLE
Made atom counting more efficient

### DIFF
--- a/DataRepo/models/peak_group.py
+++ b/DataRepo/models/peak_group.py
@@ -7,6 +7,7 @@ from DataRepo.models.maintained_model import (
     MaintainedModel,
     maintained_model_relation,
 )
+from DataRepo.models.utilities import atom_count_in_formula
 
 
 @maintained_model_relation(
@@ -68,21 +69,14 @@ class PeakGroup(HierCachedModel, MaintainedModel):
     @cached_function
     def peak_labeled_elements(self):
         """
-        Gets labels present among any of the tracers in the infusate IF the elements are present in the supplied
-        (measured) compounds.  Basically, if the supplied compound contains an element that is a labeled element in any
-        of the tracers, included in the returned list.
+        Gets labels present among any of the tracers in the infusate IF the elements are present in the peak group
+        formula.  Basically, if the compound contains an element that is a labeled element in any of the tracers, it is
+        included in the returned list.
         """
         peak_labeled_elements = []
-        compound_recs = self.compounds.all()
-        for compound_rec in compound_recs:
-            for (
-                tracer_labeled_element
-            ) in self.msrun.sample.animal.infusate.tracer_labeled_elements():
-                if (
-                    compound_rec.atom_count(tracer_labeled_element) > 0
-                    and tracer_labeled_element not in peak_labeled_elements
-                ):
-                    peak_labeled_elements.append(tracer_labeled_element)
+        for atom in self.msrun.sample.animal.infusate.tracer_labeled_elements():
+            if atom_count_in_formula(self.formula, atom) > 0:
+                peak_labeled_elements.append(atom)
         return peak_labeled_elements
 
     # @cached_function is *slower* than uncached

--- a/DataRepo/models/tracer.py
+++ b/DataRepo/models/tracer.py
@@ -104,6 +104,9 @@ class Tracer(MaintainedModel, ElementLabel):
         return f"{self.compound.name}-[{labels_string}]"
 
     def clean(self):
+        """
+        Validate this Tracer record.
+        """
         for label in self.labels.all():
             atom_count = self.compound.atom_count(label.element)
             # Ensure isotope elements exist in compound formula

--- a/DataRepo/models/utilities.py
+++ b/DataRepo/models/utilities.py
@@ -54,9 +54,9 @@ def value_from_choices_label(label, choices):
 
 def atom_count_in_formula(formula, atom):
     """
-    Return the number of specified atom in the compound.
-    Returns None if atom is not a recognized symbol
-    Returns 0 if the atom is recognized, but not found in the compound
+    Return the count of supplied atom in the compound.
+    Returns None if atom is not a recognized symbol.
+    Returns 0 if the atom is recognized, but not found in the compound.
     """
     substance = Substance.from_formula(formula)
     try:

--- a/DataRepo/utils/accucor_data_loader.py
+++ b/DataRepo/utils/accucor_data_loader.py
@@ -652,7 +652,7 @@ class AccuCorDataLoader:
                         self.accucor_original_df["compound"] == peak_group_name
                     ]
                     # If we have an accucor_original_df, it's assumed the type is accucor and there's only 1 labeled
-                    # element, hence the use of `peak_group.labels.first().atom_count()`
+                    # element, hence the use of `peak_group.labels.first()`
                     peak_group_label_rec = peak_group.labels.first()
 
                     # Original data skips undetected counts, but corrected data does not, so as we march through the


### PR DESCRIPTION
## Summary Change Description

Replaced calls to Compound.atom_count() when the formular was available in an associated peakgroup, to calls to atom_count_in_formula in models.utilities.

## Affected Issue Numbers

- Resolves #474

## Code Review Notes

I was able to remove loops that involved the 1:M PeakGroup:Compound relationship.

## Checklist

- [x] All issue requirements satisfied (or no linked issues)
- [x] [Linting passes](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#linting).
- [x] [Migrations created & committed *(or no model changes)*](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#migration-process)
- Tests
  - [x] [Tests implemented *(or no code changes)*](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#test-implementation)
  - [x] [All *multi_working* tag tests pass locally](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#quality-control)
  - [x] All example load tests pass (remotely) *(or their failures predated and are unrelated to this branch)*
  - [x] `@tag("multi_working")` added to newly passing test functions/classes *(or no newly passing tests)*
  - [x] `@tag("multi_broken")`, `@tag("multi_unknown")`, or `@tag("multi_mixed")` removed from newly passing test functions/classes *(or no newly passing tests)*
