### PR TITLE
Added a calculation for the width of the main "panel"

### DIFF
--- a/DataRepo/templates/base.html
+++ b/DataRepo/templates/base.html
@@ -46,7 +46,7 @@
 
         <div class="d-flex" id="wrapper">
             {% include 'sidebar.html' %}
-            <div class="container-fluid" style="width: 90%">
+            <div class="container-fluid main-content">
                 {% block content %}
                 {% endblock %}
 

--- a/static/css/extras.css
+++ b/static/css/extras.css
@@ -56,3 +56,7 @@ body.development > nav.navbar {
 .unitsinfo {
   margin: 0;
 }
+
+.main-content {
+  width: calc(100% - 9rem);
+}


### PR DESCRIPTION
## Summary Change Description

Added a class in extras.css called `main-content` that sets the width as 100% - 9rem.  9rem is the width of the sidebar.

## Affected Issue Numbers

- Resolves #572

## Code Review Notes

If you know how to use a css variable to have the sidebar width of 9rem in 1 place instead of 2, please suggest the change.  Even better, if bootstrap has a builtin way of managing responsive width, then please call attention to it.  I suspect it does, but I don't know how to take advantage of it.  I think that setting a static width for the sidebar is the original edit that created this issue and that the previous content width of 90% just didn't play well with that static width, which caused elements on the right side in floating divs caused them to be pushed further and further off the right side as the window width was reduced.

The result of this change is that no matter how narrow you make the window, floating divs on the right side remain a constant distance from the right edge of the window (unless of course the window width is narrower than the elements...).

Please checkout this branch and poke around various pages, because this is a site-wide change to base.html.  I did some and it looked good.

## Checklist

- [x] All issue requirements satisfied (or no linked issues)
- [x] [Linting passes](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#linting).
- [x] [Migrations created & committed *(or no model changes)*](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#migration-process)
- Tests
  - [x] [Tests implemented *(or no code changes)*](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#test-implementation)
  - [x] [All *multi_working* tag tests pass locally](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#quality-control)
  - [x] All example load tests pass (remotely) *(or their failures predated and are unrelated to this branch)*
  - [x] `@tag("multi_working")` added to newly passing test functions/classes *(or no newly passing tests)*
  - [x] `@tag("multi_broken")`, `@tag("multi_unknown")`, or `@tag("multi_mixed")` removed from newly passing test functions/classes *(or no newly passing tests)*
