### PR TITLE
Fix for dataframe null tracer name values causing 500 internal server errors

### DIFF
--- a/DataRepo/templatetags/customtags.py
+++ b/DataRepo/templatetags/customtags.py
@@ -140,7 +140,7 @@ def obj_hyperlink(id_name_list, obj):
     else:
         id_name_dict = {}
         for x in id_name_list:
-            if x is not None:
+            if x is not None and x != "":
                 k, v = x.split("||")
                 id_name_dict[k] = v
         obj_format_html = format_html_join(

--- a/DataRepo/tests/test_queryset_to_dataframes.py
+++ b/DataRepo/tests/test_queryset_to_dataframes.py
@@ -261,7 +261,7 @@ class QuerysetToPandasDataFrameTests(QuerysetToPandasDataFrameBaseTests):
         super().setUpTestData()
 
 
-@tag("multi_mixed")
+@tag("multi_working")
 class QuerysetToPandasDataFrameNullToleranceTests(QuerysetToPandasDataFrameBaseTests):
     @classmethod
     def setUpTestData(cls):
@@ -275,17 +275,14 @@ class QuerysetToPandasDataFrameNullToleranceTests(QuerysetToPandasDataFrameBaseT
         enable_buffering()
         super().setUpTestData()
 
-    @tag("multi_broken")
     def test_study_list_stat_df(self):
         super().test_study_list_stat_df()
 
-    @tag("multi_broken")
     def test_animal_list_stat_df(self):
         example_animal_dict = self.get_example_animal_dict()
         example_animal_dict["infusate_name"] = None
         super().test_animal_list_stat_df(example_animal_dict=example_animal_dict)
 
-    @tag("multi_broken")
     def test_animal_sample_msrun_df(self):
         example_sample1_dict = self.get_example_sample1_dict()
         example_sample1_dict["concentrations"] = None
@@ -299,7 +296,6 @@ class QuerysetToPandasDataFrameNullToleranceTests(QuerysetToPandasDataFrameBaseT
             example_sample2_dict=example_sample2_dict,
         )
 
-    @tag("multi_broken")
     def test_infusate_list_df(self):
         with self.assertRaises(IndexError):
             super().test_infusate_list_df()

--- a/DataRepo/tests/test_queryset_to_dataframes.py
+++ b/DataRepo/tests/test_queryset_to_dataframes.py
@@ -127,14 +127,15 @@ class QuerysetToPandasDataFrameBaseTests(TracebaseTestCase):
 
         self.assertEqual(stud1_list_stats_dict, example_study_dict)
 
-    def test_animal_list_stat_df(self):
+    def test_animal_list_stat_df(self, example_animal_dict=None):
         """
         get data from the data frame for selected animal with selected columns,
         then convert the data to dictionary to compare with the example data.
         test studies as an unordered list
         """
 
-        example_animal_dict = self.get_example_animal_dict()
+        if example_animal_dict is None:
+            example_animal_dict = self.get_example_animal_dict()
         anim_list_stats_df = qs2df.get_animal_list_stats_df()
 
         anim1_list_stats_df = anim_list_stats_df[
@@ -145,15 +146,19 @@ class QuerysetToPandasDataFrameBaseTests(TracebaseTestCase):
         anim1_list_stats_dict = qs2df.df_to_list_of_dict(out_df)[0]
         self.assertEqual(anim1_list_stats_dict, example_animal_dict)
 
-    def test_animal_sample_msrun_df(self):
+    def test_animal_sample_msrun_df(
+        self, example_sample1_dict=None, example_sample2_dict=None
+    ):
         """
         get data from the data frame for selected sample with selected columns,
         then convert the data to dictionary to compare with the example data.
         test studies as an unordered list
         """
         # get data for examples
-        example_sample1_dict = self.get_example_sample1_dict()
-        example_sample2_dict = self.get_example_sample2_dict()
+        if example_sample1_dict is None:
+            example_sample1_dict = self.get_example_sample1_dict()
+        if example_sample2_dict is None:
+            example_sample2_dict = self.get_example_sample2_dict()
 
         anim_msrun_df = qs2df.get_animal_msrun_all_df()
 
@@ -276,12 +281,25 @@ class QuerysetToPandasDataFrameNullToleranceTests(QuerysetToPandasDataFrameBaseT
 
     @tag("multi_broken")
     def test_animal_list_stat_df(self):
-        super().test_animal_list_stat_df()
+        example_animal_dict = self.get_example_animal_dict()
+        example_animal_dict["infusate_name"] = None
+        super().test_animal_list_stat_df(example_animal_dict=example_animal_dict)
 
     @tag("multi_broken")
     def test_animal_sample_msrun_df(self):
-        super().test_animal_sample_msrun_df()
+        example_sample1_dict = self.get_example_sample1_dict()
+        example_sample1_dict["concentrations"] = None
+        example_sample1_dict["infusate_name"] = None
+        example_sample1_dict["labeled_elements"] = None
+        example_sample1_dict["tracers"] = None
+        example_sample2_dict = self.get_example_sample2_dict()
+        example_sample2_dict["infusate_name"] = None
+        super().test_animal_sample_msrun_df(
+            example_sample1_dict=example_sample1_dict,
+            example_sample2_dict=example_sample2_dict,
+        )
 
     @tag("multi_broken")
     def test_infusate_list_df(self):
-        super().test_infusate_list_df()
+        with self.assertRaises(IndexError):
+            super().test_infusate_list_df()

--- a/DataRepo/tests/test_views.py
+++ b/DataRepo/tests/test_views.py
@@ -32,7 +32,7 @@ from DataRepo.tests.tracebase_test_case import (
 from DataRepo.views import DataValidationView
 
 
-@tag("multi_mixed")
+@tag("multi_working")
 class ViewTests(TracebaseTestCase):
     @classmethod
     def setUpTestData(cls):
@@ -558,7 +558,7 @@ class ViewTests(TracebaseTestCase):
         self.assertEqual(results["data_submission_accucor2.xlsx"], "PASSED")
 
 
-@tag("multi_mixed")
+@tag("multi_working")
 class ViewNullToleranceTests(ViewTests):
     """
     This class inherits from the ViewTests class above and overrides the setUpTestData method to load without auto-
@@ -575,12 +575,10 @@ class ViewNullToleranceTests(ViewTests):
         super().setUpTestData()
         enable_buffering()
 
-    @tag("multi_broken")
     def test_study_list(self):
         """Make sure this page works when infusate/tracer, and/or tracer label names are None"""
         super().test_study_list()
 
-    @tag("multi_broken")
     def test_study_detail(self):
         """Make sure this page works when infusate/tracer, and/or tracer label names are None"""
         super().test_study_detail()


### PR DESCRIPTION
## Summary Change Description

It took a lot of digging, but I found the source of the exceptions that were caused by null tracer names.  And I think it was isolated to tracer names and not infusate names.

## Affected Issue Numbers

- Resolves #513

## Code Review Notes

I didn't craft the NullTolerance tests to do anything other that test that an exception isn't raised (other than an expected IndexError, because no results are expected when you search with a name and it's not there).

To do this, I added parameters/arguments to the appropriate superclass tests and call those tests from the derived test classes with modified dicts to account for the None values.

In the dataframe code itself, I added a couple try/catch blocks around some joins that were complaining about the null values.  I added tracer IDs to the dataframes so that the construction of the dataframes would work (because they now rely on a field that is null=False).  I also had to modify a custom tag to check for empty string values instead of None.  (I'd tried setting None, but that caused other more complex problems).

I think that this fix should allow for us to remove the `multi_` test tags from the ci tests.

## Checklist

- [x] All issue requirements satisfied (or no linked issues)
- [x] [Linting passes](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#linting).
- [x] [Migrations created & committed *(or no model changes)*](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#migration-process)
- Tests
  - [x] [Tests implemented *(or no code changes)*](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#test-implementation)
  - [x] [All *multi_working* tag tests pass locally](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#quality-control)
  - [x] All example load tests pass (remotely) *(or their failures predated and are unrelated to this branch)*
  - [x] `@tag("multi_working")` added to newly passing test functions/classes *(or no newly passing tests)*
  - [x] `@tag("multi_broken")`, `@tag("multi_unknown")`, or `@tag("multi_mixed")` removed from newly passing test functions/classes *(or no newly passing tests)*
