### PR TITLE
Test tag cleanup

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -21,7 +21,5 @@ attention to.  E.g. There are significant logic changes in function X.
 - [ ] [Migrations created & committed *(or no model changes)*](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#migration-process)
 - Tests
   - [ ] [Tests implemented *(or no code changes)*](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#test-implementation)
-  - [ ] [All *multi_working* tag tests pass locally](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#quality-control)
+  - [ ] [All tests pass](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#quality-control)
   - [ ] All example load tests pass (remotely) *(or their failures predated and are unrelated to this branch)*
-  - [ ] `@tag("multi_working")` added to newly passing test functions/classes *(or no newly passing tests)*
-  - [ ] `@tag("multi_broken")`, `@tag("multi_unknown")`, or `@tag("multi_mixed")` removed from newly passing test functions/classes *(or no newly passing tests)*

--- a/.github/workflows/tracebase-tests.yml
+++ b/.github/workflows/tracebase-tests.yml
@@ -75,7 +75,7 @@ jobs:
           python manage.py createcachetable \
           --database validation
       - name: Run tests
-        run: python manage.py test --tag multi_working
+        run: python manage.py test
       - name: Load initial tissue records
         run: |
           python manage.py load_study \

--- a/DataRepo/tests/loading/test_loading_compounds.py
+++ b/DataRepo/tests/loading/test_loading_compounds.py
@@ -11,7 +11,6 @@ from DataRepo.utils.compounds_loader import CompoundExists, CompoundNotFound
 
 @tag("compounds")
 @tag("loading")
-@tag("multi_working")
 class LoadCompoundsTests(TracebaseTestCase):
     """Tests Loading of Compounds"""
 
@@ -39,7 +38,6 @@ class LoadCompoundsTests(TracebaseTestCase):
 
 @override_settings(CACHES=settings.TEST_CACHES)
 @tag("compound_loading")
-@tag("multi_working")
 class CompoundLoadingTests(TracebaseTestCase):
     @classmethod
     def setUpTestData(cls):
@@ -131,7 +129,6 @@ class CompoundLoadingTests(TracebaseTestCase):
 
 @override_settings(CACHES=settings.TEST_CACHES)
 @tag("compound_loading")
-@tag("multi_working")
 class CompoundLoadingTestErrors(TracebaseTestCase):
     """Tests loading of Compounds with errors"""
 
@@ -149,7 +146,6 @@ class CompoundLoadingTestErrors(TracebaseTestCase):
 
 
 @override_settings(CACHES=settings.TEST_CACHES)
-@tag("multi_working")
 class CompoundsLoaderTests(TracebaseTestCase):
     def get_dataframe(self):
         return pd.read_csv(
@@ -184,7 +180,6 @@ class CompoundsLoaderTests(TracebaseTestCase):
 
 @override_settings(CACHES=settings.TEST_CACHES)
 @tag("compound_loading")
-@tag("multi_working")
 class CompoundValidationLoadingTests(TracebaseTestCase):
     @classmethod
     def setUpTestData(cls):

--- a/DataRepo/tests/loading/test_loading_protocols.py
+++ b/DataRepo/tests/loading/test_loading_protocols.py
@@ -12,7 +12,6 @@ from DataRepo.utils.exceptions import LoadingError
 
 
 @tag("protocols")
-@tag("multi_working")
 class ProtocolLoadingTests(TracebaseTestCase):
     """Test ProtocolsLoader"""
 

--- a/DataRepo/tests/loading/test_loading_tissues.py
+++ b/DataRepo/tests/loading/test_loading_tissues.py
@@ -6,7 +6,6 @@ from DataRepo.tests.tracebase_test_case import TracebaseTestCase
 
 
 @tag("tissues")
-@tag("multi_working")
 class TissueLoadingTests(TracebaseTestCase):
     """Test Tissue Loader"""
 

--- a/DataRepo/tests/models/test_animal.py
+++ b/DataRepo/tests/models/test_animal.py
@@ -10,7 +10,6 @@ from DataRepo.tests.tracebase_test_case import TracebaseTestCase
 
 @override_settings(CACHES=settings.TEST_CACHES)
 @tag("animal")
-@tag("multi_working")
 class AnimalTests(TracebaseTestCase):
     def setUp(self):
         super().setUp()

--- a/DataRepo/tests/models/test_compounds.py
+++ b/DataRepo/tests/models/test_compounds.py
@@ -1,13 +1,12 @@
 from django.conf import settings
 from django.db import IntegrityError
-from django.test import override_settings, tag
+from django.test import override_settings
 
 from DataRepo.models import Compound, CompoundSynonym
 from DataRepo.tests.tracebase_test_case import TracebaseTestCase
 
 
 @override_settings(CACHES=settings.TEST_CACHES)
-@tag("multi_working")
 class CompoundTests(TracebaseTestCase):
     def setUp(self):
         super().setUp()
@@ -43,7 +42,6 @@ class CompoundTests(TracebaseTestCase):
 
 
 @override_settings(CACHES=settings.TEST_CACHES)
-@tag("multi_working")
 class CompoundSynonymTests(TracebaseTestCase):
     def setUp(self):
         super().setUp()

--- a/DataRepo/tests/models/test_fcirc.py
+++ b/DataRepo/tests/models/test_fcirc.py
@@ -2,7 +2,7 @@ from datetime import datetime, timedelta
 
 from django.conf import settings
 from django.core.management import call_command
-from django.test import override_settings, tag
+from django.test import override_settings
 
 from DataRepo.models import (
     Animal,
@@ -18,7 +18,6 @@ from DataRepo.tests.tracebase_test_case import TracebaseTestCase
 
 
 @override_settings(CACHES=settings.TEST_CACHES)
-@tag("multi_working")
 class FCircTests(TracebaseTestCase):
     def setUp(self):
         super().setUp()

--- a/DataRepo/tests/models/test_hier_cached_model.py
+++ b/DataRepo/tests/models/test_hier_cached_model.py
@@ -1,5 +1,4 @@
 from django.core.management import call_command
-from django.test import tag
 
 from DataRepo.management.commands.build_caches import cached_function_call
 from DataRepo.models import Animal, MSRun, PeakGroup, Sample
@@ -55,7 +54,6 @@ def load_minimum_data():
     )
 
 
-@tag("multi_working")
 class GlobalCacheTests(TracebaseTestCase):
     @classmethod
     def setUpTestData(cls):
@@ -298,7 +296,6 @@ class GlobalCacheTests(TracebaseTestCase):
         )
 
 
-@tag("multi_working")
 class HierCachedModelTests(TracebaseTestCase):
     @classmethod
     def setUpTestData(cls):
@@ -581,7 +578,6 @@ class HierCachedModelTests(TracebaseTestCase):
         )
 
 
-@tag("multi_working")
 class BuildCachesTests(TracebaseTestCase):
     @classmethod
     def setUpTestData(cls):

--- a/DataRepo/tests/models/test_infusate.py
+++ b/DataRepo/tests/models/test_infusate.py
@@ -52,7 +52,6 @@ def create_infusate_records():
     return io, io2
 
 
-@tag("multi_working")
 @tag("load_study")
 class InfusateTests(TracebaseTestCase):
     def setUp(self):
@@ -142,7 +141,6 @@ class InfusateTests(TracebaseTestCase):
         self.assertEqual("C16:0-[5,6-13C2,17O2][4];glucose-[4-17O1][3]", i2.name)
 
 
-@tag("multi_working")
 @tag("load_study")
 class MaintainedModelTests(TracebaseTestCase):
     def setUp(self):
@@ -281,7 +279,6 @@ class MaintainedModelTests(TracebaseTestCase):
         self.assertEqual(expected_name, io.name)
 
 
-@tag("multi_working")
 class RebuildMaintainedModelFieldsTests(TracebaseTestCase):
     def setUp(self):
         super().setUp()

--- a/DataRepo/tests/models/test_infusate_tracer.py
+++ b/DataRepo/tests/models/test_infusate_tracer.py
@@ -1,5 +1,4 @@
 from django.db.utils import IntegrityError
-from django.test import tag
 
 from DataRepo.models.compound import Compound
 from DataRepo.models.infusate import Infusate
@@ -9,7 +8,6 @@ from DataRepo.models.tracer_label import TracerLabel
 from DataRepo.tests.tracebase_test_case import TracebaseTestCase
 
 
-@tag("multi_working")
 class InfusateTracerTests(TracebaseTestCase):
     def setUp(self):
         super().setUp()

--- a/DataRepo/tests/models/test_model_utilities.py
+++ b/DataRepo/tests/models/test_model_utilities.py
@@ -1,5 +1,4 @@
 from django.apps import apps
-from django.test import tag
 
 from DataRepo.models.utilities import (
     dereference_field,
@@ -9,7 +8,6 @@ from DataRepo.models.utilities import (
 from DataRepo.tests.tracebase_test_case import TracebaseTestCase
 
 
-@tag("multi_working")
 class ModelUtilitiesTests(TracebaseTestCase):
     def test_get_all_models(self):
         """Test that we return all models in the right order"""

--- a/DataRepo/tests/models/test_peak_data.py
+++ b/DataRepo/tests/models/test_peak_data.py
@@ -1,7 +1,6 @@
 from datetime import datetime, timedelta
 
 from django.db.utils import IntegrityError
-from django.test import tag
 
 from DataRepo.models import (
     Animal,
@@ -18,7 +17,6 @@ from DataRepo.models import (
 from DataRepo.tests.tracebase_test_case import TracebaseTestCase
 
 
-@tag("multi_working")
 class PeakDataData(TracebaseTestCase):
     def setUp(self):
         super().setUp()
@@ -69,7 +67,6 @@ class PeakDataData(TracebaseTestCase):
         )
 
 
-@tag("multi_working")
 class PeakDataTests(PeakDataData):
     def test_record(self):
         rec = PeakData.objects.get(raw_abundance=1000.0)
@@ -92,7 +89,6 @@ class PeakDataTests(PeakDataData):
         self.assertEqual(pd.labels.count(), 2)
 
 
-@tag("multi_working")
 class PeakDataLabelTests(PeakDataData):
     def setUp(self):
         super().setUp()

--- a/DataRepo/tests/models/test_sample.py
+++ b/DataRepo/tests/models/test_sample.py
@@ -2,14 +2,13 @@ from datetime import timedelta
 
 from django.conf import settings
 from django.core.management import call_command
-from django.test import override_settings, tag
+from django.test import override_settings
 
 from DataRepo.models import Animal, Sample
 from DataRepo.tests.tracebase_test_case import TracebaseTestCase
 
 
 @override_settings(CACHES=settings.TEST_CACHES)
-@tag("multi_working")
 class SampleTests(TracebaseTestCase):
     @classmethod
     def setUpTestData(cls):

--- a/DataRepo/tests/models/test_tracer.py
+++ b/DataRepo/tests/models/test_tracer.py
@@ -1,5 +1,3 @@
-from django.test import tag
-
 from DataRepo.models.compound import Compound
 from DataRepo.models.maintained_model import (
     MaintainedFieldNotSettable,
@@ -25,7 +23,6 @@ def create_tracer_record():
     return glu_t
 
 
-@tag("multi_working")
 class TracerTests(TracebaseTestCase):
     def test_tracer_name(self):
         tracer = create_tracer_record()

--- a/DataRepo/tests/models/test_tracer_label.py
+++ b/DataRepo/tests/models/test_tracer_label.py
@@ -1,12 +1,9 @@
-from django.test import tag
-
 from DataRepo.models.compound import Compound
 from DataRepo.models.tracer import Tracer
 from DataRepo.models.tracer_label import TracerLabel
 from DataRepo.tests.tracebase_test_case import TracebaseTestCase
 
 
-@tag("multi_working")
 class TracerLabelTests(TracebaseTestCase):
     def setUp(self):
         super().setUp()

--- a/DataRepo/tests/test_customtags.py
+++ b/DataRepo/tests/test_customtags.py
@@ -1,5 +1,4 @@
 from django.core.management import call_command
-from django.test import tag
 
 from DataRepo.models import CompoundSynonym, PeakGroup, Study
 from DataRepo.templatetags.customtags import (
@@ -11,7 +10,6 @@ from DataRepo.templatetags.customtags import (
 from DataRepo.tests.tracebase_test_case import TracebaseTestCase
 
 
-@tag("multi_working")
 class CustomTagsTests(TracebaseTestCase):
     @classmethod
     def setUpTestData(cls):

--- a/DataRepo/tests/test_formats.py
+++ b/DataRepo/tests/test_formats.py
@@ -26,7 +26,6 @@ from DataRepo.templatetags.customtags import get_many_related_rec
 from DataRepo.tests.tracebase_test_case import TracebaseTestCase
 
 
-@tag("multi_working")
 class FormatsTests(TracebaseTestCase):
     maxDiff = None
     orig_split_rows: Dict[str, str] = {}
@@ -1239,7 +1238,6 @@ class FormatsTests(TracebaseTestCase):
 
 
 @tag("search_choices")
-@tag("multi_working")
 class SearchFieldChoicesTests(TracebaseTestCase):
     def test_get_all_comparison_choices(self):
         base_search_view = Format()

--- a/DataRepo/tests/test_infusate_parsing_validation.py
+++ b/DataRepo/tests/test_infusate_parsing_validation.py
@@ -18,7 +18,6 @@ from DataRepo.utils.infusate_name_parser import (
 )
 
 
-@tag("multi_working")
 class InfusateTest(TracebaseTestCase):
     @classmethod
     def setUpTestData(cls):
@@ -138,7 +137,6 @@ class InfusateTest(TracebaseTestCase):
 
 
 @tag("parsing")
-@tag("multi_working")
 class InfusateParsingTests(InfusateTest):
     def test_isotope_parsing_single(self):
         """Test parsing a single isotope string"""
@@ -283,7 +281,6 @@ class InfusateParsingTests(InfusateTest):
         )
 
 
-@tag("multi_working")
 class InfusateValidationTests(InfusateTest):
     def test_tracer_creation(self):
         """Test creation of a valid tracer object from TracerData"""

--- a/DataRepo/tests/test_models.py
+++ b/DataRepo/tests/test_models.py
@@ -86,7 +86,6 @@ class ExampleDataConsumer:
 
 
 @override_settings(CACHES=settings.TEST_CACHES)
-@tag("multi_working")
 class StudyTests(TracebaseTestCase, ExampleDataConsumer):
     def setUp(self):
         super().setUp()
@@ -260,7 +259,6 @@ class StudyTests(TracebaseTestCase, ExampleDataConsumer):
 
 @override_settings(CACHES=settings.TEST_CACHES)
 @tag("protocol")
-@tag("multi_working")
 class ProtocolTests(TracebaseTestCase):
     def setUp(self):
         super().setUp()
@@ -312,7 +310,6 @@ class ProtocolTests(TracebaseTestCase):
 
 
 @override_settings(CACHES=settings.TEST_CACHES)
-@tag("multi_working")
 class DataLoadingTests(TracebaseTestCase):
     @classmethod
     def setUpTestData(cls):
@@ -728,7 +725,6 @@ class DataLoadingTests(TracebaseTestCase):
 
 
 @override_settings(CACHES=settings.TEST_CACHES)
-@tag("multi_working")
 class PropertyTests(TracebaseTestCase):
     @classmethod
     def setUpTestData(cls):
@@ -1454,7 +1450,6 @@ class PropertyTests(TracebaseTestCase):
 
 
 @override_settings(CACHES=settings.TEST_CACHES)
-@tag("multi_working")
 class MultiTracerLabelPropertyTests(TracebaseTestCase):
     @classmethod
     def setUpTestData(cls):
@@ -1541,7 +1536,6 @@ class MultiTracerLabelPropertyTests(TracebaseTestCase):
 
 
 @override_settings(CACHES=settings.TEST_CACHES)
-@tag("multi_working")
 class TracerRateTests(TracebaseTestCase):
     @classmethod
     def setUpTestData(cls):
@@ -1774,7 +1768,6 @@ class TracerRateTests(TracebaseTestCase):
 
 
 @override_settings(CACHES=settings.TEST_CACHES)
-@tag("multi_working")
 class AnimalAndSampleLoadingTests(TracebaseTestCase):
     @classmethod
     def setUpTestData(cls):
@@ -1811,7 +1804,6 @@ class AnimalAndSampleLoadingTests(TracebaseTestCase):
 
 
 @override_settings(CACHES=settings.TEST_CACHES)
-@tag("multi_working")
 class AccuCorDataLoadingTests(TracebaseTestCase):
     @classmethod
     def setUpTestData(cls):
@@ -1895,7 +1887,6 @@ class AccuCorDataLoadingTests(TracebaseTestCase):
 
 
 @override_settings(CACHES=settings.TEST_CACHES)
-@tag("multi_working")
 class IsoCorrDataLoadingTests(TracebaseTestCase):
     @classmethod
     def setUpTestData(cls):
@@ -2337,7 +2328,6 @@ class IsoCorrDataLoadingTests(TracebaseTestCase):
 
 @override_settings(CACHES=settings.TEST_CACHES)
 @tag("load_study")
-@tag("multi_working")
 class StudyLoadingTests(TracebaseTestCase):
     @classmethod
     def setUpTestData(cls):
@@ -2423,7 +2413,6 @@ class StudyLoadingTests(TracebaseTestCase):
 
 
 @override_settings(CACHES=settings.TEST_CACHES)
-@tag("multi_working")
 @tag("load_study")
 class ParseIsotopeLabelTests(TracebaseTestCase):
     @classmethod
@@ -2540,7 +2529,6 @@ class ParseIsotopeLabelTests(TracebaseTestCase):
 @override_settings(CACHES=settings.TEST_CACHES)
 @tag("animal")
 @tag("loading")
-@tag("multi_working")
 class AnimalLoadingTests(TracebaseTestCase):
     """Tests parsing various Animal attributes"""
 

--- a/DataRepo/tests/test_queryset_to_dataframes.py
+++ b/DataRepo/tests/test_queryset_to_dataframes.py
@@ -256,7 +256,6 @@ class QuerysetToPandasDataFrameBaseTests(TracebaseTestCase):
 
 
 @tag("qs2df")
-@tag("multi_working")
 class QuerysetToPandasDataFrameTests(QuerysetToPandasDataFrameBaseTests):
     @classmethod
     def setUpTestData(cls):
@@ -264,7 +263,6 @@ class QuerysetToPandasDataFrameTests(QuerysetToPandasDataFrameBaseTests):
         super().setUpTestData()
 
 
-@tag("multi_working")
 class QuerysetToPandasDataFrameNullToleranceTests(QuerysetToPandasDataFrameBaseTests):
     @classmethod
     def setUpTestData(cls):

--- a/DataRepo/tests/test_views.py
+++ b/DataRepo/tests/test_views.py
@@ -31,7 +31,6 @@ from DataRepo.tests.tracebase_test_case import (
 from DataRepo.views import DataValidationView
 
 
-@tag("multi_working")
 class ViewTests(TracebaseTestCase):
     @classmethod
     def setUpTestData(cls):
@@ -498,7 +497,6 @@ class ViewTests(TracebaseTestCase):
         self.assertEqual(results["data_submission_accucor2.xlsx"], "PASSED")
 
 
-@tag("multi_working")
 class ViewNullToleranceTests(ViewTests):
     """
     This class inherits from the ViewTests class above and overrides the setUpTestData method to load without auto-
@@ -524,7 +522,6 @@ class ViewNullToleranceTests(ViewTests):
         super().test_study_detail()
 
 
-@tag("multi_working")
 @tag("protocol_loading_broken")
 class ValidationViewTests(TracebaseTransactionTestCase):
     """

--- a/DataRepo/tests/test_views.py
+++ b/DataRepo/tests/test_views.py
@@ -522,7 +522,6 @@ class ViewNullToleranceTests(ViewTests):
         super().test_study_detail()
 
 
-@tag("protocol_loading_broken")
 class ValidationViewTests(TracebaseTransactionTestCase):
     """
     Note, without the TransactionTestCase (derived) class (and the with transaction.atomic block below), the infusate-

--- a/DataRepo/tests/views/test_home_views.py
+++ b/DataRepo/tests/views/test_home_views.py
@@ -1,5 +1,4 @@
 from django.core.management import call_command
-from django.test import tag
 from django.urls import reverse
 
 from DataRepo.models import (
@@ -14,7 +13,6 @@ from DataRepo.models import (
 from DataRepo.tests.tracebase_test_case import TracebaseTestCase
 
 
-@tag("multi_working")
 class HomeViewTests(TracebaseTestCase):
     """
     Test hoem views

--- a/DataRepo/tests/views/test_protocol_views.py
+++ b/DataRepo/tests/views/test_protocol_views.py
@@ -1,5 +1,4 @@
 from django.core.management import call_command
-from django.test import tag
 from django.urls import reverse
 
 from DataRepo.models import Protocol
@@ -18,7 +17,6 @@ class ProtocolViewTests(TracebaseTestCase):
     def setUpTestData(cls):
         call_command("load_study", "DataRepo/example_data/test_dataframes/loading.yaml")
 
-    @tag("multi_working")
     def test_animal_treatment_list(self):
         response = self.client.get(reverse("animal_treatment_list"))
         self.assertEqual(response.status_code, 200)
@@ -31,7 +29,6 @@ class ProtocolViewTests(TracebaseTestCase):
             )
         )
 
-    @tag("multi_working")
     def test_msrun_protocol_list(self):
         response = self.client.get(reverse("msrun_protocol_list"))
         self.assertEqual(response.status_code, 200)
@@ -44,7 +41,6 @@ class ProtocolViewTests(TracebaseTestCase):
             )
         )
 
-    @tag("multi_working")
     def test_protocol_detail(self):
         p1 = Protocol.objects.filter(name="Default").get()
         response = self.client.get(reverse("protocol_detail", args=[p1.id]))
@@ -53,7 +49,6 @@ class ProtocolViewTests(TracebaseTestCase):
         self.assertEqual(response.context["protocol"].name, "Default")
         self.assertEqual(response.context["proto_display"], "MSRun Protocol")
 
-    @tag("multi_working")
     def test_protocol_detail_404(self):
         p = Protocol.objects.order_by("id").last()
         response = self.client.get(reverse("protocol_detail", args=[p.id + 1]))


### PR DESCRIPTION
## Summary Change Description

Removed the multi_* test tags.

## Affected Issue Numbers

- Resolves #549

## Code Review Notes

There were minor changes in the `protocol_user_validation` branch that made a few tests pass (a technicality of the inheritance).  Upon request, I can try and transfer that change into this branch to make it not branched off `protocol_user_validation`, but IMO, this branch is not mission critical - there's no effective change - so it can wait until the other branches merge.

## Checklist

- [x] All issue requirements satisfied (or no linked issues)
- [x] [Linting passes](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#linting).
- [x] [Migrations created & committed *(or no model changes)*](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#migration-process)
- Tests
  - [x] [Tests implemented *(or no code changes)*](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#test-implementation)
  - [x] All example load tests pass (remotely) *(or their failures predated and are unrelated to this branch)*
  - [x] All tests pass