### PR TITLE
Fixed overlooked updates of labeled_element and labeled_count

### DIFF
--- a/DataRepo/models/peak_group_label.py
+++ b/DataRepo/models/peak_group_label.py
@@ -56,8 +56,7 @@ class PeakGroupLabel(HierCachedModel):
         A weighted average of the fraction of labeled atoms for this PeakGroup
         in this sample with this (labeled) element.
         i.e. The fraction of carbons that are labeled in this.PeakGroup compound
-        Sum of all (PeakData.fraction * PeakData.labeled_count) /
-            PeakGroup.Compound.num_atoms(PeakData.labeled_element)
+        Sum of all (fraction * count) / num_atoms(element)
         """
         from DataRepo.models.peak_data import PeakData
         from DataRepo.models.peak_data_label import PeakDataLabel

--- a/DataRepo/templates/DataRepo/search/results/peakdata.html
+++ b/DataRepo/templates/DataRepo/search/results/peakdata.html
@@ -110,7 +110,7 @@
                 <th data-valign="top" class="idgrp" data-visible="{% get_template_cookie selfmt 'Labeled_Element_Count-data-visible' 'true' %}" data-field="Labeled_Element_Count">
                     {% with colhead1="Labeled<br>Element:<br>" colhead2="Count" %}
                         {% if mode == "view" %}{{ colhead1 }}{{ colhead2 }}{% else %}
-                            <div onclick="sortColumn(this)" class="sortable" id="labeled_element">{{ colhead1 }}</div><div onclick="sortColumn(this)" class="sortable" id="labeled_count">{{ colhead2 }}</div>
+                            <div onclick="sortColumn(this)" class="sortable" id="labels__element">{{ colhead1 }}</div><div onclick="sortColumn(this)" class="sortable" id="labels__count">{{ colhead2 }}</div>
                         {% endif %}
                     {% endwith %}
                 </th>

--- a/DataRepo/tests/test_formats.py
+++ b/DataRepo/tests/test_formats.py
@@ -713,7 +713,7 @@ class FormatsTests(TracebaseTestCase):
                                 "pos": "",
                                 "ncmp": "iexact",
                                 "static": "",
-                                "fld": "labeled_element",
+                                "fld": "labels__element",
                                 "val": "",
                             }
                         ],


### PR DESCRIPTION
## Summary Change Description

Fixed overlooked updates of `labeled_element` and `labeled_count` to `labels__element` and `labels__count`.

## Affected Issue Numbers

- Resolves an issue [Michael mentioned on slack](https://tracebase.slack.com/archives/C01M97YLQE5/p1668110922610469).

## Code Review Notes

This was just an overlooked field path in a template.  I didn't check for others.  Easy-peasy.  I will merge upon first approved review.

## Checklist

- [x] All issue requirements satisfied (or no linked issues)
- [x] [Linting passes](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#linting).
- [x] [Migrations created & committed *(or no model changes)*](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#migration-process)
- Tests
  - [x] [Tests implemented *(or no code changes)*](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#test-implementation)
  - [x] [All *multi_working* tag tests pass locally](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#quality-control)
  - [x] All example load tests pass (remotely) *(or their failures predated and are unrelated to this branch)*
