### PR TITLE
Refactor DataFrame code for handling null values associated with treatment and infusate

### DIFF
--- a/DataRepo/templatetags/customtags.py
+++ b/DataRepo/templatetags/customtags.py
@@ -7,6 +7,7 @@ from django.utils.html import format_html_join
 from django.utils.safestring import mark_safe
 
 from DataRepo.formats.search_group import SearchGroup
+from DataRepo.utils import QuerysetToPandasDataFrame as qs2df
 
 register = template.Library()
 
@@ -137,7 +138,7 @@ def obj_hyperlink(id_name_list, obj):
         tmplt_name = "protocol_detail"
 
     # the string used to replace null for names and treatments in DataFrames
-    null_rpl_str = "None"
+    null_rpl_str = qs2df.null_rpl_str
 
     if id_name_list == [None] or id_name_list is None:
         return None

--- a/DataRepo/templatetags/customtags.py
+++ b/DataRepo/templatetags/customtags.py
@@ -3,6 +3,7 @@ from django.core.exceptions import MultipleObjectsReturned, ObjectDoesNotExist
 from django.template.defaultfilters import floatformat
 from django.urls import reverse
 from django.utils import dateparse
+from django.utils.safestring import mark_safe
 from django.utils.html import format_html_join
 
 from DataRepo.formats.search_group import SearchGroup
@@ -135,22 +136,28 @@ def obj_hyperlink(id_name_list, obj):
     elif obj == "treatment":
         tmplt_name = "protocol_detail"
 
+    # the string used to replace null for names and treatments in DataFrames
+    null_rpl_str = "None"
+
     if id_name_list == [None] or id_name_list is None:
         return None
     else:
         id_name_dict = {}
         for x in id_name_list:
-            if x is not None and x != "":
+            if x is not None and x != null_rpl_str:
                 k, v = x.split("||")
                 id_name_dict[k] = v
-        obj_format_html = format_html_join(
+        obj_format_html1 = format_html_join(
             ", ",
-            '<a href="{}">{}</a>',
+            # use defined css for "white-space: nowrap;"
+            '</div><div class="nobr"><a href="{}">{}</a>',
             [
                 (reverse(tmplt_name, args=[str(id)]), id_name_dict[id])
                 for id in id_name_dict
             ],
         )
+        # remove first "</div>" in formatted hmtl string
+        obj_format_html = mark_safe(obj_format_html1[6:])
         return obj_format_html
 
 

--- a/DataRepo/templatetags/customtags.py
+++ b/DataRepo/templatetags/customtags.py
@@ -3,8 +3,8 @@ from django.core.exceptions import MultipleObjectsReturned, ObjectDoesNotExist
 from django.template.defaultfilters import floatformat
 from django.urls import reverse
 from django.utils import dateparse
-from django.utils.safestring import mark_safe
 from django.utils.html import format_html_join
+from django.utils.safestring import mark_safe
 
 from DataRepo.formats.search_group import SearchGroup
 

--- a/DataRepo/templatetags/customtags.py
+++ b/DataRepo/templatetags/customtags.py
@@ -137,15 +137,12 @@ def obj_hyperlink(id_name_list, obj):
     elif obj == "treatment":
         tmplt_name = "protocol_detail"
 
-    # the string used to replace null for names and treatments in DataFrames
-    null_rpl_str = qs2df.null_rpl_str
-
     if id_name_list == [None] or id_name_list is None:
         return None
     else:
         id_name_dict = {}
         for x in id_name_list:
-            if x is not None and x != null_rpl_str:
+            if x is not None and x != qs2df.null_rpl_str:
                 k, v = x.split("||")
                 id_name_dict[k] = v
         obj_format_html1 = format_html_join(

--- a/DataRepo/tests/test_queryset_to_dataframes.py
+++ b/DataRepo/tests/test_queryset_to_dataframes.py
@@ -4,14 +4,8 @@ import pandas as pd
 from django.core.management import call_command
 from django.utils import dateparse
 
+from DataRepo.models import Animal, Infusate, Tracer, TracerLabel
 from DataRepo.tests.tracebase_test_case import TracebaseTestCase
-
-from DataRepo.models import (
-    Animal,
-    Infusate,
-    Tracer,
-    TracerLabel,
-)
 from DataRepo.utils import QuerysetToPandasDataFrame as qs2df
 
 

--- a/DataRepo/tests/test_queryset_to_dataframes.py
+++ b/DataRepo/tests/test_queryset_to_dataframes.py
@@ -2,33 +2,27 @@ import json
 
 import pandas as pd
 from django.core.management import call_command
-from django.test import tag
 from django.utils import dateparse
 
-from DataRepo.models.maintained_model import (
-    disable_buffering,
-    enable_buffering,
-)
 from DataRepo.tests.tracebase_test_case import TracebaseTestCase
+
+from DataRepo.models import (
+    Animal,
+    Infusate,
+    Tracer,
+    TracerLabel,
+)
 from DataRepo.utils import QuerysetToPandasDataFrame as qs2df
 
 
 class QuerysetToPandasDataFrameBaseTests(TracebaseTestCase):
-    """
-    Do not pass or tag this class or the methods in it.  Instead override any tests in the derived classes and call
-    their `super()` version because these tests are re-used under difference conditions
-    """
-
     @classmethod
     def setUpTestData(cls):
-        cls.load_data()
-
-    @classmethod
-    def load_data(self):
+        # load small set of data
         call_command("load_study", "DataRepo/example_data/test_dataframes/loading.yaml")
 
-    def get_example_study_dict(self):
-        exmaple_study_dict = {
+        # define expected data in dictionaries
+        cls.study1_dict = {
             "study": "Study Test1",
             "total_animal": 3,
             "total_tissue": 3,
@@ -37,10 +31,14 @@ class QuerysetToPandasDataFrameBaseTests(TracebaseTestCase):
             "sample_owners": ["Xianfeng Zeng"],
             "genotypes": ["C57BL/6N", "WT", "ob/ob"],
         }
-        return exmaple_study_dict
 
-    def get_example_animal_dict(self):
-        exmaple_animal_dict = {
+        cls.study2_dict = {
+            "study": "Study Test2",
+            "animal1": "a1_Lys_13C",
+            "animal2": "a4_Val_13C5",
+        }
+
+        cls.animal1_dict = {
             "animal": "a1_Lys_13C",
             "infusate_name": "lysine-[13C6][15]",
             "infusion_rate": 0.11,
@@ -57,10 +55,15 @@ class QuerysetToPandasDataFrameBaseTests(TracebaseTestCase):
             "sample_owners": ["Xianfeng Zeng"],
             "studies": ["Study Test1", "Study Test2"],
         }
-        return exmaple_animal_dict
 
-    def get_example_sample1_dict(self):
-        example_sample1_dict = {
+        cls.animal2_dict = {
+            "animal": "a4_Val_13C5",
+            "infusate_name": "valine-[13C2][22]",
+            "treatment": "no treatment",
+            "studies": ["Study Test2"],
+        }
+
+        cls.sample1_dict = {
             "animal": "a1_Lys_13C",
             "infusate_name": "lysine-[13C6][15]",
             "tracer_group_name": None,
@@ -74,20 +77,16 @@ class QuerysetToPandasDataFrameBaseTests(TracebaseTestCase):
             "msrun_protocol": "Default",
             "studies": ["Study Test1", "Study Test2"],
         }
-        return example_sample1_dict
 
-    def get_example_sample2_dict(self):
-        example_sample2_dict = {
+        cls.sample2_dict = {
             "animal": "a2_VLI_13C15N",
             "infusate_name": "BCAAs (VLI) {isoleucine-[13C6,15N1][12];leucine-[13C6,15N1][24];valine-[13C5,15N1][20]}",
             "tissue": "liver",
             "sample": "a2_liv",
             "sample_owner": "Xianfeng Zeng",
         }
-        return example_sample2_dict
 
-    def get_example_compound_dict(self):
-        example_compound_dict = {
+        cls.compound_dict = {
             "compound_name": "lysine",
             "formula": "C6H14N2O2",
             "hmdb_id": "HMDB0000182",
@@ -95,10 +94,16 @@ class QuerysetToPandasDataFrameBaseTests(TracebaseTestCase):
             "total_animal_by_compound": 2,
             "total_infusate_by_compound": 2,
         }
-        return example_compound_dict
 
-    def get_example_infusate_dict(self):
-        example_infusate_dict = {
+        cls.infusate1_dict = {
+            "infusate_name": "lysine-[13C6][15]",
+            "tracer_group_name": None,
+            "tracers": ["lysine-[13C6]"],
+            "concentrations": [15],
+            "labeled_elements": ["C"],
+        }
+
+        cls.infusate2_dict = {
             "infusate_name": "BCAAs (VLI) {isoleucine-[13C6,15N1][12];leucine-[13C6,15N1][24];valine-[13C5,15N1][20]}",
             "tracer_group_name": "BCAAs (VLI)",
             "tracers": [
@@ -109,82 +114,81 @@ class QuerysetToPandasDataFrameBaseTests(TracebaseTestCase):
             "concentrations": [12, 24, 20],
             "labeled_elements": ["C,N"],
         }
-        return example_infusate_dict
+
+        super().setUpTestData()
 
     def test_study_list_stat_df(self):
         """
-        get data from the data frame for selected study with selected columns,
-        then convert the data to dictionary to compare with the example data.
+        get data from the DataFrame for a selected study with selected columns,
+        then convert the data to dictionary to compare with expected data.
         """
-        example_study_dict = self.get_example_study_dict()
+        stud1_dict = self.study1_dict
+        stud1_name = stud1_dict["study"]
         study_list_stats_df = qs2df.get_study_list_stats_df()
+        # slicing DataFrame for selected study
         stud1_list_stats_df = study_list_stats_df[
-            study_list_stats_df["study"] == "Study Test1"
+            study_list_stats_df["study"] == stud1_name
         ]
-        selected_columns = list(example_study_dict.keys())
+        selected_columns = list(stud1_dict.keys())
         out_df = stud1_list_stats_df[selected_columns]
         stud1_list_stats_dict = qs2df.df_to_list_of_dict(out_df)[0]
 
         # Sort the lists so that they can be equated
         stud1_list_stats_dict["genotypes"] = sorted(stud1_list_stats_dict["genotypes"])
-        example_study_dict["genotypes"] = sorted(example_study_dict["genotypes"])
+        stud1_dict["genotypes"] = sorted(stud1_dict["genotypes"])
 
-        self.assertEqual(stud1_list_stats_dict, example_study_dict)
+        self.assertEqual(stud1_list_stats_dict, stud1_dict)
 
-    def test_animal_list_stat_df(self, example_animal_dict=None):
+    def test_animal_list_stat_df(self):
         """
-        get data from the data frame for selected animal with selected columns,
-        then convert the data to dictionary to compare with the example data.
+        get data from the DataFrame for a selected animal with selected columns,
+        then convert the data to dictionary to compare with expected data.
         test studies as an unordered list
         """
+        anim1_dict = self.animal1_dict
+        anim1_name = anim1_dict["animal"]
 
-        if example_animal_dict is None:
-            example_animal_dict = self.get_example_animal_dict()
         anim_list_stats_df = qs2df.get_animal_list_stats_df()
-
+        # slicing DataFrame for selected animal
         anim1_list_stats_df = anim_list_stats_df[
-            anim_list_stats_df["animal"] == "a1_Lys_13C"
+            anim_list_stats_df["animal"] == anim1_name
         ]
-        selected_columns = list(example_animal_dict.keys())
+        selected_columns = list(anim1_dict.keys())
         out_df = anim1_list_stats_df[selected_columns]
         anim1_list_stats_dict = qs2df.df_to_list_of_dict(out_df)[0]
-        self.assertEqual(anim1_list_stats_dict, example_animal_dict)
+        self.assertEqual(anim1_list_stats_dict, anim1_dict)
 
-    def test_animal_sample_msrun_df(
-        self, example_sample1_dict=None, example_sample2_dict=None
-    ):
+    def test_animal_sample_msrun_df(self):
         """
-        get data from the data frame for selected sample with selected columns,
-        then convert the data to dictionary to compare with the example data.
+        get data from the DataFrame for selected samples with selected columns,
+        then convert the data to dictionary to compare with expected data.
         test studies as an unordered list
         """
         # get data for examples
-        if example_sample1_dict is None:
-            example_sample1_dict = self.get_example_sample1_dict()
-        if example_sample2_dict is None:
-            example_sample2_dict = self.get_example_sample2_dict()
-
+        sam1_dict = self.sample1_dict
+        sam2_dict = self.sample2_dict
+        sam1_name = sam1_dict["sample"]
+        sam2_name = sam2_dict["sample"]
         anim_msrun_df = qs2df.get_animal_msrun_all_df()
 
-        # sample1 test
-        sam1_msrun_df = anim_msrun_df[anim_msrun_df["sample"] == "a1_kd"]
-        sam1_columns = list(example_sample1_dict.keys())
+        # test for sample 1
+        sam1_msrun_df = anim_msrun_df[anim_msrun_df["sample"] == sam1_name]
+        sam1_columns = list(sam1_dict.keys())
         out_df = sam1_msrun_df[sam1_columns]
         sam1_msrun_dict = qs2df.df_to_list_of_dict(out_df)[0]
-        self.assertEqual(sam1_msrun_dict, example_sample1_dict)
+        self.assertEqual(sam1_msrun_dict, sam1_dict)
 
-        # sample2 test
-        sam2_msrun_df = anim_msrun_df[anim_msrun_df["sample"] == "a2_liv"]
-        sam2_columns = list(example_sample2_dict.keys())
+        # test for sample 2
+        sam2_msrun_df = anim_msrun_df[anim_msrun_df["sample"] == sam2_name]
+        sam2_columns = list(sam2_dict.keys())
         sam2_msrun_sel_dict = sam2_msrun_df[sam2_columns].iloc[0].to_dict()
         sam2_msrun_all_dict = sam2_msrun_df.iloc[0].to_dict()
-
-        self.assertEqual(sam2_msrun_sel_dict, example_sample2_dict)
+        self.assertEqual(sam2_msrun_sel_dict, sam2_dict)
 
         # test values for age and sample_time_collected
         # expected values
-        expected_sam2_age_week = 21.0
-        expected_sam2_time_collected_mins = 120.0
+        exp_sam2_age_week = 21.0
+        exp_sam2_time_collected_mins = 120.0
 
         # verify the values from the Dataframe
         sam2_age_to_week = (sam2_msrun_all_dict["age"]).days // 7
@@ -198,8 +202,8 @@ class QuerysetToPandasDataFrameBaseTests(TracebaseTestCase):
         sam2_age_in_json_data_to_weeks = (
             dateparse.parse_duration(sam2_age_in_json_data).days // 7
         )
-        self.assertEqual(sam2_age_to_week, expected_sam2_age_week)
-        self.assertEqual(sam2_age_in_json_data_to_weeks, expected_sam2_age_week)
+        self.assertEqual(sam2_age_to_week, exp_sam2_age_week)
+        self.assertEqual(sam2_age_in_json_data_to_weeks, exp_sam2_age_week)
 
         # sample_time_collected: timedelta64[ns] type in DataFrame vs. isoformat in json output
         sam2_time_collected_to_mins = (
@@ -211,9 +215,9 @@ class QuerysetToPandasDataFrameBaseTests(TracebaseTestCase):
         sam2_time_collected_in_json_data_to_mins = (
             dateparse.parse_duration(sam2_time_collected_in_json_data).seconds // 60
         )
-        self.assertEqual(sam2_time_collected_to_mins, expected_sam2_time_collected_mins)
+        self.assertEqual(sam2_time_collected_to_mins, exp_sam2_time_collected_mins)
         self.assertEqual(
-            sam2_time_collected_in_json_data_to_mins, expected_sam2_time_collected_mins
+            sam2_time_collected_in_json_data_to_mins, exp_sam2_time_collected_mins
         )
 
         # sample2 has no MSRun data
@@ -222,80 +226,156 @@ class QuerysetToPandasDataFrameBaseTests(TracebaseTestCase):
 
     def test_comp_list_stats_df(self):
         """
-        get data from the data frame for selected compound with selected columns,
-        then convert the data to dictionary to compare with the example data.
+        get data from the DataFrame for a selected compound with selected columns,
+        then convert the data to dictionary to compare with expected data.
         """
-        example_compound_dict = self.get_example_compound_dict()
+        comp1_dict = self.compound_dict
+        comp1_name = comp1_dict["compound_name"]
 
         comp_list_stats_df = qs2df.get_compound_list_stats_df()
-        comp1_df = comp_list_stats_df[comp_list_stats_df["compound_name"] == "lysine"]
+        comp1_df = comp_list_stats_df[comp_list_stats_df["compound_name"] == comp1_name]
 
-        selected_columns = list(example_compound_dict.keys())
+        selected_columns = list(comp1_dict.keys())
         out_df = comp1_df[selected_columns]
-        comp1_dict = qs2df.df_to_list_of_dict(out_df)[0]
+        comp1_out_dict = qs2df.df_to_list_of_dict(out_df)[0]
 
-        self.assertEqual(comp1_dict, example_compound_dict)
+        self.assertEqual(comp1_out_dict, comp1_dict)
 
     def test_infusate_list_df(self):
         """
-        get data from the data frame for selected infusate with selected columns,
-        then convert the data to dictionary to compare with the example data.
+        get data from the DataFrame for selected infusate with selected columns,
+        then convert the data to dictionary to compare with expected data.
         """
-        example_infusate_dict = self.get_example_infusate_dict()
-
         infusate_list_df = qs2df.get_infusate_list_df()
+        # infusate 1
+        inf1_dict = self.infusate1_dict
         inf1_df = infusate_list_df[
-            infusate_list_df["infusate_name"] == example_infusate_dict["infusate_name"]
+            infusate_list_df["infusate_name"] == inf1_dict["infusate_name"]
         ]
+        inf1_columns = list(inf1_dict.keys())
+        out1_df = inf1_df[inf1_columns]
+        inf1_out_dict = qs2df.df_to_list_of_dict(out1_df)[0]
+        self.assertEqual(inf1_out_dict, inf1_dict)
+        # infusate 2
+        inf2_dict = self.infusate2_dict
+        inf2_df = infusate_list_df[
+            infusate_list_df["infusate_name"] == inf2_dict["infusate_name"]
+        ]
+        set2_columns = list(inf2_dict.keys())
+        out2_df = inf2_df[set2_columns]
+        inf2_out_dict = qs2df.df_to_list_of_dict(out2_df)[0]
+        self.assertEqual(inf2_out_dict, inf2_dict)
 
-        selected_columns = list(example_infusate_dict.keys())
-        out_df = inf1_df[selected_columns]
-        inf1_dict = qs2df.df_to_list_of_dict(out_df)[0]
+    def test_treatment_null(self):
+        """
+        test null values handled by DataFrames if Animal.treatment_id is null
+        """
+        # get IDs and names for selected studies and animal before update
+        stud2_name = self.study2_dict["study"]
+        anim1_name = self.study2_dict["animal1"]
+        anim2_name = self.study2_dict["animal2"]
+        anim1_id = Animal.objects.get(name=anim1_name).id
 
-        self.assertEqual(inf1_dict, example_infusate_dict)
+        # update treatment_id to null for animal1
+        Animal.objects.filter(id=anim1_id).update(treatment_id=None)
 
+        # check values in queryset, DataFrame, output dictionary after update
+        self.assertEqual(Animal.objects.get(id=anim1_id).name, anim1_name)
+        self.assertEqual(Animal.objects.get(id=anim1_id).treatment, None)
+        # get DataFrame and output dictonary after update
+        anim1_df = qs2df().get_per_animal_msrun_df(anim1_id)
+        anim1_out_dict = qs2df.df_to_list_of_dict(anim1_df)[0]
+        # expected values in DataFrame
+        self.assertTrue(anim1_df.iloc[0]["treatment_id"] is pd.NA)
+        self.assertTrue(anim1_df.iloc[0]["treatment"] is pd.NA)
+        self.assertTrue(anim1_df.iloc[0]["treatment_category"] is pd.NA)
+        # expected values in output dictionary
+        self.assertEqual(anim1_out_dict["treatment_id"], None)
+        self.assertEqual(anim1_out_dict["treatment"], None)
+        self.assertEqual(anim1_out_dict["treatment_category"], None)
 
-@tag("qs2df")
-class QuerysetToPandasDataFrameTests(QuerysetToPandasDataFrameBaseTests):
-    @classmethod
-    def setUpTestData(cls):
-        enable_buffering()
-        super().setUpTestData()
+        # check string in study list when treatment_id is null
+        stud_list_stats_df = qs2df.get_study_list_stats_df()
+        stud2_df = stud_list_stats_df[stud_list_stats_df["study"] == stud2_name]
+        # the string used to replace null value in DataFrame for study list
+        # no update was made for treatment for animal2
+        anim2_treatment = Animal.objects.get(name=anim2_name).treatment
+        anim2_treatment_id_name = str(anim2_treatment.id) + "||" + anim2_treatment.name
+        # the treatment_id_name for animal1 was replaced by null_rpl_str in DataFrame
+        null_rpl_str = "None"
+        anim1_treatment_id_name = null_rpl_str
+        exp_treatment_id_name_list = [anim1_treatment_id_name, anim2_treatment_id_name]
+        # compare sorted lists
+        out_list = sorted(stud2_df.iloc[0]["treatment_id_name_list"])
+        exp_list = sorted(exp_treatment_id_name_list)
+        self.assertEqual(len(out_list), 2)
+        self.assertEqual(out_list, exp_list)
 
+    def test_infusate_tracer_name_null(self):
+        """
+        The following names are allowed to be null:
+          Animal.treatment, Infusate.name. Tracer.name, TracerLabel.name
+          e.g. data loading with dis-allow auto-updates by disabling buffering
+          test missing names are handled properly in DataFrames, expecially for study list
+        """
+        # the string used to replace null value in DataFrames
+        null_rpl_str = "None"
+        # use study 2 including two animals/infusates for tests
+        stud2_name = self.study2_dict["study"]
+        anim1_name = self.study2_dict["animal1"]
+        anim2_name = self.study2_dict["animal2"]
+        inf2_id = Animal.objects.get(name=anim2_name).infusate.id
+        inf2_name = Animal.objects.get(name=anim2_name).infusate.name
 
-class QuerysetToPandasDataFrameNullToleranceTests(QuerysetToPandasDataFrameBaseTests):
-    @classmethod
-    def setUpTestData(cls):
-        # Silently dis-allow auto-updates by disabling buffering
-        disable_buffering()
-        try:
-            super().setUpTestData()
-        except Exception as e:
-            raise e
-        finally:
-            enable_buffering()
+        # infusate1
+        inf1_name = self.infusate1_dict["infusate_name"]
+        inf1_id = Infusate.objects.get(name=inf1_name).id
+        tracer_name = self.infusate1_dict["tracers"][0]
+        tracer_id = Tracer.objects.get(name=tracer_name).id
+        tracerlabel_id = TracerLabel.objects.get(
+            tracer_id=tracer_id, element="C", count="6", mass_number=13
+        ).id
+        # animal1 infusated with infusate1
+        self.assertEqual(Animal.objects.get(name=anim1_name).infusate_id, inf1_id)
+        self.assertEqual(inf1_name, "lysine-[13C6][15]")
+        self.assertEqual(tracer_name, "lysine-[13C6]")
 
-    def test_study_list_stat_df(self):
-        super().test_study_list_stat_df()
+        # update name values for infusate1
+        Infusate.objects.filter(id=inf1_id).update(name=None)
+        Tracer.objects.filter(id=tracer_id).update(name=None)
+        TracerLabel.objects.filter(id=tracerlabel_id).update(name=None)
 
-    def test_animal_list_stat_df(self):
-        example_animal_dict = self.get_example_animal_dict()
-        example_animal_dict["infusate_name"] = None
-        super().test_animal_list_stat_df(example_animal_dict=example_animal_dict)
+        # check null values for name fileds are replaced by null_rpl_str in DataFrames
+        # no changes to IDs
+        # check IDs and Names in infusate DataFrame
+        infusate_all_df = qs2df.get_infusate_all_df()
+        inf1_df = infusate_all_df[infusate_all_df["infusate_id"] == inf1_id]
+        self.assertEqual(inf1_df.iloc[0]["infusate_id"], inf1_id)
+        self.assertEqual(inf1_df.iloc[0]["tracer_id"], tracer_id)
+        self.assertEqual(inf1_df.iloc[0]["infusate_name"], null_rpl_str)
+        self.assertEqual(inf1_df.iloc[0]["tracer_name"], null_rpl_str)
+        self.assertEqual(inf1_df.iloc[0]["tracer_label"], null_rpl_str)
 
-    def test_animal_sample_msrun_df(self):
-        example_sample1_dict = self.get_example_sample1_dict()
-        example_sample1_dict["concentrations"] = None
-        example_sample1_dict["infusate_name"] = None
-        example_sample1_dict["labeled_elements"] = None
-        example_sample1_dict["tracers"] = None
-        example_sample2_dict = self.get_example_sample2_dict()
-        example_sample2_dict["infusate_name"] = None
-        super().test_animal_sample_msrun_df(
-            example_sample1_dict=example_sample1_dict,
-            example_sample2_dict=example_sample2_dict,
-        )
+        # check infusate and tracer names in animal list DataFrame
+        anim_list_stats_df = qs2df.get_animal_list_stats_df()
+        # slicing DataFrame for selected animal
+        anim1_list_stats_df = anim_list_stats_df[
+            anim_list_stats_df["animal"] == anim1_name
+        ]
+        self.assertEqual(anim1_list_stats_df.iloc[0]["infusate_name"], null_rpl_str)
+        self.assertEqual(anim1_list_stats_df.iloc[0]["tracers"], [null_rpl_str])
 
-    def test_infusate_list_df(self):
-        with self.assertRaises(IndexError):
-            super().test_infusate_list_df()
+        # check infusate_id_name_list in study list DataFrame
+        stud_list_stats_df = qs2df.get_study_list_stats_df()
+        # slicing DataFrame for selected animal
+        stud2_list_stats_df = stud_list_stats_df[
+            stud_list_stats_df["study"] == stud2_name
+        ]
+        # id_name and id_name_list: output vs. expected
+        exp_inf1_id_name = str(inf1_id) + "||" + null_rpl_str
+        exp_inf2_id_name = str(inf2_id) + "||" + inf2_name
+        exp_infusate_id_name_list = [exp_inf1_id_name, exp_inf2_id_name]
+        # compare sorted lists
+        out_list = sorted(stud2_list_stats_df.iloc[0]["infusate_id_name_list"])
+        exp_list = sorted(exp_infusate_id_name_list)
+        self.assertEqual(out_list, exp_list)

--- a/DataRepo/tests/test_queryset_to_dataframes.py
+++ b/DataRepo/tests/test_queryset_to_dataframes.py
@@ -109,9 +109,6 @@ class QuerysetToPandasDataFrameBaseTests(TracebaseTestCase):
             "labeled_elements": ["C,N"],
         }
 
-        # defined string for replacing null values
-        cls.null_rpl_str = qs2df.null_rpl_str
-
         super().setUpTestData()
 
     def test_study_list_stat_df(self):
@@ -299,8 +296,7 @@ class QuerysetToPandasDataFrameBaseTests(TracebaseTestCase):
         anim2_treatment = Animal.objects.get(name=anim2_name).treatment
         anim2_treatment_id_name = str(anim2_treatment.id) + "||" + anim2_treatment.name
         # the treatment_id_name for animal1 was replaced by null_rpl_str in DataFrame
-        null_rpl_str = self.null_rpl_str
-        anim1_treatment_id_name = null_rpl_str
+        anim1_treatment_id_name = qs2df.null_rpl_str
         exp_treatment_id_name_list = [anim1_treatment_id_name, anim2_treatment_id_name]
         # compare sorted lists
         out_list = sorted(stud2_df.iloc[0]["treatment_id_name_list"])
@@ -316,7 +312,7 @@ class QuerysetToPandasDataFrameBaseTests(TracebaseTestCase):
           test missing names are handled properly in DataFrames, expecially for study list
         """
         # the string used to replace null value in DataFrames
-        null_rpl_str = self.null_rpl_str
+        null_rpl_str = qs2df.null_rpl_str
         # use study 2 including two animals/infusates for tests
         stud2_name = self.study2_dict["study"]
         anim1_name = self.study2_dict["animal1"]

--- a/DataRepo/tests/test_queryset_to_dataframes.py
+++ b/DataRepo/tests/test_queryset_to_dataframes.py
@@ -109,6 +109,9 @@ class QuerysetToPandasDataFrameBaseTests(TracebaseTestCase):
             "labeled_elements": ["C,N"],
         }
 
+        # defined string for replacing null values
+        cls.null_rpl_str = qs2df.null_rpl_str
+
         super().setUpTestData()
 
     def test_study_list_stat_df(self):
@@ -296,7 +299,7 @@ class QuerysetToPandasDataFrameBaseTests(TracebaseTestCase):
         anim2_treatment = Animal.objects.get(name=anim2_name).treatment
         anim2_treatment_id_name = str(anim2_treatment.id) + "||" + anim2_treatment.name
         # the treatment_id_name for animal1 was replaced by null_rpl_str in DataFrame
-        null_rpl_str = "None"
+        null_rpl_str = self.null_rpl_str
         anim1_treatment_id_name = null_rpl_str
         exp_treatment_id_name_list = [anim1_treatment_id_name, anim2_treatment_id_name]
         # compare sorted lists
@@ -313,7 +316,7 @@ class QuerysetToPandasDataFrameBaseTests(TracebaseTestCase):
           test missing names are handled properly in DataFrames, expecially for study list
         """
         # the string used to replace null value in DataFrames
-        null_rpl_str = "None"
+        null_rpl_str = self.null_rpl_str
         # use study 2 including two animals/infusates for tests
         stud2_name = self.study2_dict["study"]
         anim1_name = self.study2_dict["animal1"]


### PR DESCRIPTION
<!-- markdownlint-disable-next-line first-line-heading -->
## Summary Change Description

- Made changes to several methods in "queryset_to_pandas_dataframe.py" for handling null values in the following cases
  - Animal.treatment_id
  - Infusate.name
  - Tracer.name
  - TracerLabel.name

- Modified test code for DataFrames
  - Simplified code for calling example datasets
  - Consolidated tests into one class, and reconstructed cases for null tolerance tests.
  
## Affected Issue Numbers

- Resolves #585 

## Code Review Notes

 - The main change made to DataFrame code is to replace "null" values with a string assigned to `null_rpl_str`.  I opt to use "None" as it is consistent with web display of null values stored in database.

- Modified code for `obj_hyperlink` filter in `customtags` to control wrapping of values in lists (e.g. webpages for study, animal, and infusate). The webpages are more user-friendly with such change while the search/filter/download features still work. Could explore other setting for tables using Bootstrap-table plugin to make more improvements in the future.

## Checklist

- [x] All issue requirements satisfied (or no linked issues)
- [x] [Linting passes](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#linting).
- [x] [Migrations created & committed *(or no model changes)*](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#migration-process)
- Tests
  - [x] [Tests implemented *(or no code changes)*](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#test-implementation)
  - [x] [All tests pass](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#quality-control)
  - [x] All example load tests pass (remotely) *(or their failures predated and are unrelated to this branch)*
