### PR TITLE
Refactor (phase 2) to remove the validation database

### DIFF
--- a/DataRepo/management/commands/load_accucor_msruns.py
+++ b/DataRepo/management/commands/load_accucor_msruns.py
@@ -98,6 +98,13 @@ class Command(BaseCommand):
             type=str,
             help=argparse.SUPPRESS,
         )
+        # Intended for use by load_study to prevent individual loader autoupdates and buffer clearing, then perform all
+        # mass autoupdates/buffer-clearings after all load scripts are complete
+        parser.add_argument(
+            "--defer-autoupdates",
+            action="store_true",
+            help=argparse.SUPPRESS,
+        )
 
     def handle(self, *args, **options):
         fmt = "Accucor"
@@ -128,6 +135,7 @@ class Command(BaseCommand):
             validate=options["validate"],
             isocorr_format=options["isocorr_format"],
             verbosity=options["verbosity"],
+            defer_autoupdates=options["defer_autoupdates"],
         )
 
         loader.load_accucor_data(options["debug"])

--- a/DataRepo/management/commands/load_animals_and_samples.py
+++ b/DataRepo/management/commands/load_animals_and_samples.py
@@ -78,6 +78,13 @@ class Command(BaseCommand):
             type=str,
             help=argparse.SUPPRESS,
         )
+        # Intended for use by load_study to prevent individual loader autoupdates and buffer clearing, then perform all
+        # mass autoupdates/buffer-clearings after all load scripts are complete
+        parser.add_argument(
+            "--defer-autoupdates",
+            action="store_true",
+            help=argparse.SUPPRESS,
+        )
 
     def handle(self, *args, **options):
 
@@ -132,6 +139,7 @@ class Command(BaseCommand):
             validate=options["validate"],
             skip_researcher_check=options["skip_researcher_check"],
             verbosity=options["verbosity"],
+            defer_autoupdates=options["defer_autoupdates"],
         )
         loader.load_sample_table(
             merged.to_dict("records"),

--- a/DataRepo/management/commands/load_samples.py
+++ b/DataRepo/management/commands/load_samples.py
@@ -45,6 +45,13 @@ class Command(BaseCommand):
             type=str,
             help=argparse.SUPPRESS,
         )
+        # Intended for use by load_study to prevent individual loader autoupdates and buffer clearing, then perform all
+        # mass autoupdates/buffer-clearings after all load scripts are complete
+        parser.add_argument(
+            "--defer-autoupdates",
+            action="store_true",
+            help=argparse.SUPPRESS,
+        )
 
     def handle(self, *args, **options):
         print("Reading header definition")
@@ -64,6 +71,7 @@ class Command(BaseCommand):
             validate=options["validate"],
             skip_researcher_check=options["skip_researcher_check"],
             verbosity=options["verbosity"],
+            defer_autoupdates=options["defer_autoupdates"],
         )
         loader.load_sample_table(
             DictReader(

--- a/DataRepo/management/commands/load_study.py
+++ b/DataRepo/management/commands/load_study.py
@@ -7,6 +7,10 @@ from django.apps import apps
 from django.conf import settings
 from django.core.management import BaseCommand, call_command
 
+from DataRepo.models.hier_cached_model import (
+    disable_caching_updates,
+    enable_caching_updates,
+)
 from DataRepo.models.maintained_model import (
     UncleanBufferError,
     buffer_size,
@@ -237,9 +241,11 @@ class Command(BaseCommand):
         # Since defer_autoupdates is supplied as True to the sample and accucor load commands, we can do all the mass
         # autoupdates in 1 go.
         disable_autoupdates()
+        disable_caching_updates()
         perform_buffered_updates(using=db)
         # The buffer should be clear, but just for good measure...
         clear_update_buffer()
+        enable_caching_updates()
         enable_autoupdates()
 
         self.stdout.write(self.style.SUCCESS("Done loading study"))

--- a/DataRepo/management/commands/load_study.py
+++ b/DataRepo/management/commands/load_study.py
@@ -237,7 +237,7 @@ class Command(BaseCommand):
         # Since defer_autoupdates is supplied as True to the sample and accucor load commands, we can do all the mass
         # autoupdates in 1 go.
         disable_autoupdates()
-        perform_buffered_updates(using=db)
+        perform_buffered_updates(save_kwargs={"using": db})
         # The buffer should be clear, but just for good measure...
         clear_update_buffer()
         enable_autoupdates()

--- a/DataRepo/management/commands/load_study.py
+++ b/DataRepo/management/commands/load_study.py
@@ -237,7 +237,7 @@ class Command(BaseCommand):
         # Since defer_autoupdates is supplied as True to the sample and accucor load commands, we can do all the mass
         # autoupdates in 1 go.
         disable_autoupdates()
-        perform_buffered_updates(save_kwargs={"using": db})
+        perform_buffered_updates(using=db)
         # The buffer should be clear, but just for good measure...
         clear_update_buffer()
         enable_autoupdates()

--- a/DataRepo/management/commands/load_study.py
+++ b/DataRepo/management/commands/load_study.py
@@ -4,7 +4,18 @@ import os
 import jsonschema
 import yaml  # type: ignore
 from django.apps import apps
+from django.conf import settings
 from django.core.management import BaseCommand, call_command
+
+from DataRepo.models.maintained_model import (
+    UncleanBufferError,
+    buffer_size,
+    clear_update_buffer,
+    disable_autoupdates,
+    enable_autoupdates,
+    perform_buffered_updates,
+)
+from DataRepo.utils.exceptions import ValidationDatabaseSetupError
 
 
 class Command(BaseCommand):
@@ -46,7 +57,6 @@ class Command(BaseCommand):
         # Used internally by the DataValidationView
         parser.add_argument(
             "--validate",
-            required=False,
             action="store_true",
             default=False,
             help=argparse.SUPPRESS,
@@ -58,8 +68,23 @@ class Command(BaseCommand):
             type=str,
             help=argparse.SUPPRESS,
         )
+        # Used internally to load necessary data into the validation database
+        parser.add_argument(
+            "--clear-buffer",
+            action="store_true",
+            default=False,
+            help=argparse.SUPPRESS,
+        )
 
     def handle(self, *args, **options):
+
+        if options["clear_buffer"]:
+            clear_update_buffer()
+        elif buffer_size() > 0:
+            raise UncleanBufferError(
+                "The auto-update buffer is unexpectedly populated.  Add --clear-buffer to your command to flush the "
+                "buffer and proceed with the load."
+            )
 
         # Read load study parameters
         study_params = yaml.safe_load(options["study_params"])
@@ -139,6 +164,7 @@ class Command(BaseCommand):
                 skip_researcher_check=skip_researcher_check,
                 database=options["database"],
                 verbosity=options["verbosity"],
+                defer_autoupdates=True,
             )
 
         if "accucor_data" in study_params:
@@ -193,6 +219,27 @@ class Command(BaseCommand):
                     database=options["database"],
                     validate=options["validate"],
                     isocorr_format=isocorr_format,
+                    defer_autoupdates=True,
                 )
+
+        # Database config
+        db = settings.TRACEBASE_DB
+        # If a database was explicitly supplied
+        if options["database"] is not None:
+            db = options["database"]
+        else:
+            if options["validate"]:
+                if settings.VALIDATION_ENABLED:
+                    db = settings.VALIDATION_DB
+                else:
+                    raise ValidationDatabaseSetupError()
+
+        # Since defer_autoupdates is supplied as True to the sample and accucor load commands, we can do all the mass
+        # autoupdates in 1 go.
+        disable_autoupdates()
+        perform_buffered_updates(using=db)
+        # The buffer should be clear, but just for good measure...
+        clear_update_buffer()
+        enable_autoupdates()
 
         self.stdout.write(self.style.SUCCESS("Done loading study"))

--- a/DataRepo/models/infusate.py
+++ b/DataRepo/models/infusate.py
@@ -169,7 +169,7 @@ class Infusate(MaintainedModel, MultiDBMixin):
     def get_name(self):
         """
         Returns the name field if populated.  If it's not populated, it populates it (in the same manner that the old
-        cache mechanism worked).  Only works on the default database.
+        cache mechanism worked).
         """
         display_name = None
 
@@ -177,8 +177,11 @@ class Infusate(MaintainedModel, MultiDBMixin):
         if self.name:
             display_name = self.name
         elif are_autoupdates_enabled():
+            save_kwargs = {"label_filters": ["name"]}
+            if hasattr(self, "_state") and hasattr(self._state, "db"):
+                save_kwargs["using"] = self._state.db
             # This triggers an auto-update
-            self.save(label_filters=["name"])
+            self.save(**save_kwargs)
             display_name = self.name
 
         # If it's still not set, call the method that generates the name.  It just won't be saved.

--- a/DataRepo/models/infusate.py
+++ b/DataRepo/models/infusate.py
@@ -9,6 +9,7 @@ from django.db import models
 from DataRepo.models.maintained_model import (
     MaintainedModel,
     are_autoupdates_enabled,
+    init_autoupdate_label_filters,
     maintained_field_function,
 )
 from DataRepo.models.multi_db_mixin import MultiDBMixin
@@ -28,14 +29,9 @@ class InfusateQuerySet(models.QuerySet):
     def get_or_create_infusate(
         self,
         infusate_data: InfusateData,
-        save_kwargs=None,
     ) -> tuple[Infusate, bool]:
         """Get Infusate matching the infusate_data, or create a new infusate"""
         db = self._db or settings.DEFAULT_DB
-        if save_kwargs is None:
-            save_kwargs = {"using": db}
-        elif "using" not in save_kwargs.keys():
-            save_kwargs["using"] = db
 
         # Search for matching Infusate
         infusate = self.using(db).get_infusate(infusate_data)
@@ -58,7 +54,6 @@ class InfusateQuerySet(models.QuerySet):
                 if tracer is None:
                     (tracer, _) = Tracer.objects.using(db).get_or_create_tracer(
                         infusate_tracer["tracer"],
-                        save_kwargs,
                     )
                 # associate tracers with specific conectrations
                 InfusateTracer.objects.using(db).create(
@@ -67,7 +62,7 @@ class InfusateQuerySet(models.QuerySet):
                     concentration=infusate_tracer["concentration"],
                 )
             infusate.full_clean()
-            infusate.save(**save_kwargs)
+            infusate.save(using=db)
             created = True
         return (infusate, created)
 
@@ -177,12 +172,14 @@ class Infusate(MaintainedModel, MultiDBMixin):
         if self.name:
             display_name = self.name
         elif are_autoupdates_enabled():
-            save_kwargs = {"label_filters": ["name"]}
+            init_autoupdate_label_filters(label_filters=["name"])
+            save_kwargs = {}
             if hasattr(self, "_state") and hasattr(self._state, "db"):
                 save_kwargs["using"] = self._state.db
             # This triggers an auto-update
             self.save(**save_kwargs)
             display_name = self.name
+            init_autoupdate_label_filters()
 
         # If it's still not set, call the method that generates the name.  It just won't be saved.
         if not display_name:

--- a/DataRepo/models/infusate.py
+++ b/DataRepo/models/infusate.py
@@ -169,7 +169,7 @@ class Infusate(MaintainedModel, MultiDBMixin):
     def get_name(self):
         """
         Returns the name field if populated.  If it's not populated, it populates it (in the same manner that the old
-        cache mechanism worked)
+        cache mechanism worked).  Only works on the default database.
         """
         display_name = None
 
@@ -177,9 +177,8 @@ class Infusate(MaintainedModel, MultiDBMixin):
         if self.name:
             display_name = self.name
         elif are_autoupdates_enabled():
-            db = self._db or settings.DEFAULT_DB
             # This triggers an auto-update
-            self.save(using=db, label_filters=["name"])
+            self.save(label_filters=["name"])
             display_name = self.name
 
         # If it's still not set, call the method that generates the name.  It just won't be saved.

--- a/DataRepo/models/maintained_model.py
+++ b/DataRepo/models/maintained_model.py
@@ -14,6 +14,9 @@ update_buffer = []
 performing_mass_autoupdates = False
 buffering = True
 updater_list: Dict[str, List] = defaultdict(list)
+global_label_filters = None
+global_filter_in = True
+custom_filtering = False
 
 
 def disable_autoupdates():
@@ -21,6 +24,11 @@ def disable_autoupdates():
     Do not allow record changes to trigger the auto-update of maintained fields.  Instead, buffer those updates.
     """
     global auto_updates
+
+    # If custom filtering is in effect, ensure filtering is re-initialized before auto-updates are re-enabled
+    if auto_updates and custom_filtering:
+        raise InitFiltersAfterDisablingAutoupdates()
+
     auto_updates = False
 
 
@@ -29,7 +37,15 @@ def enable_autoupdates():
     Allow record changes to trigger the auto-update of maintained fields and no longer buffer those updates.
     """
     global auto_updates
+
+    print(f"Enabling auto-updates.  Custom filtering is {custom_filtering}.")
+
+    # If custom filtering is in effect, ensure filtering is re-initialized before auto-updates are re-enabled
+    if not auto_updates and custom_filtering:
+        raise ClearFiltersBeforeEnablingAutoupdates()
+
     auto_updates = True
+
     if performing_mass_autoupdates:
         raise StaleAutoupdateMode()
 
@@ -73,7 +89,9 @@ def enable_buffering():
     buffering = True
 
 
-def clear_update_buffer(generation=None, label_filters=[]):
+def clear_update_buffer(
+    generation=None, label_filters=global_label_filters, filter_in=global_filter_in
+):
     """
     Clears buffered auto-updates.  Use after having performed DB updates when auto_updates was False to no perform
     auto-updates.  This method is called automatically during the execution of mass autoupdates.
@@ -91,7 +109,7 @@ def clear_update_buffer(generation=None, label_filters=[]):
     are cleared.
     """
     global update_buffer
-    if generation is None and len(label_filters) == 0:
+    if generation is None and (label_filters is None or len(label_filters) == 0):
         update_buffer = []
         return
     new_buffer = []
@@ -99,9 +117,9 @@ def clear_update_buffer(generation=None, label_filters=[]):
     for buffered_item in update_buffer:
         filtered_updaters = filter_updaters(
             buffered_item.get_my_updaters(),
-            generation,
-            label_filters,
-            filter_in=False,
+            generation=generation,
+            label_filters=label_filters,
+            filter_in=filter_in,
         )
 
         max_gen = 0
@@ -117,7 +135,7 @@ def clear_update_buffer(generation=None, label_filters=[]):
 
     if gen_warns > 0:
         label_str = ""
-        if len(label_filters) > 0:
+        if label_filters is not None and len(label_filters) > 0:
             label_str = f"with labels: [{', '.join(label_filters)}] "
         print(
             f"WARNING: {gen_warns} records {label_str}in the buffer are younger than the generation supplied: "
@@ -128,15 +146,48 @@ def clear_update_buffer(generation=None, label_filters=[]):
     update_buffer = new_buffer
 
 
-def updater_list_has_labels(updaters_list, label_filters):
+def init_autoupdate_label_filters(label_filters=None, filter_in=None):
     """
-    Returns True if any updater dict in updaters_list has 1 of any of the update_labels in the label_filters list.
+    Changing the filtering criteria using label_filters changes what autoupdates will be buffered.  Model objects
+    containing maintained fields with an update_label that matches the filtering criteria will be buffered for a later
+    autoupdate when auto_updates is False.  If auto_updates is True, only fields in model objects with a matching
+    update_label will be auto-updated.  And during a mass autoupdate (perform_buffered_updates), only the fields whose
+    update_label matched during buffering will be updated.
+    """
+    global global_label_filters
+    global global_filter_in
+    global custom_filtering
+
+    if label_filters is not None:
+        print("Activating custom filtering")
+        custom_filtering = True
+        if filter_in is None:
+            filter_in = True  # Default
+    else:
+        print("De-activating custom filtering")
+        custom_filtering = False
+        filter_in = True  # Default
+        # label_filters default is None
+
+    global_label_filters = label_filters
+    global_filter_in = filter_in
+
+
+def updater_list_has_labels(
+    updaters_list, label_filters=global_label_filters, filter_in=global_filter_in
+):
+    """
+    Returns True if any updater dict in updaters_list passes the label filtering criteria.
     """
     for updater_dict in updaters_list:
         label = updater_dict["update_label"]
         has_a_label = label is not None
-        if has_a_label and label in label_filters:
+        if filter_in:
+            if has_a_label and label in label_filters:
+                return True
+        elif not has_a_label or label not in label_filters:
             return True
+
     return False
 
 
@@ -349,6 +400,14 @@ class MaintainedModel(Model):
         This over-ride of the constructor is to prevent developers from explicitly setting values for automatically
         maintained fields.  It also performs a one-time validation check of the updater_dicts.
         """
+        # Members added by MaintainedModel - the global values are set via init_autoupdate_label_filters.  They are
+        # recorded in the object so that during perform_buffered_updates will know what field(s) to update when it
+        # processes the object.  An update would not have been buffered if the model did not contain a maintained field
+        # matching the label filtering.  And label filtering can change during the buffering process (e.g. different
+        # loaders), which is why this is necessary.  Note, this is not thread-safe.
+        self.label_filters = global_label_filters
+        self.filter_in = global_filter_in
+
         class_name = self.__class__.__name__
         for updater_dict in updater_list[class_name]:
 
@@ -438,24 +497,28 @@ class MaintainedModel(Model):
         propagate = kwargs.pop(
             "propagate", True
         )  # Used internally. Do not supply unless you know what you're doing.
-        # Custom argument: label_filters - Only autoupdate fields with (or without - see filter_in) matching labels
-        label_filters = kwargs.pop("label_filters", None)
-        # Custom argument: filter_in - Only autoupdate fields with labels contained in label_filters when this is true,
-        # otherwise filter labels that are NOT in label_filters.  If label_filters is None, autoupdate everything.
-        # Default: True
-        filter_in = kwargs.pop("filter_in", True)
 
         # If auto-updates are turned on, a cascade of updates to linked models will occur, but if they are turned off,
         # the update will be buffered, to be manually triggered later (e.g. upon completion of loading), which
         # mitigates repeated updates to the same record
         if auto_updates is False and performing_mass_autoupdates is False:
+            # When buffering only, apply the global label filters, to be remembered during mass autoupdate
+            self.label_filters = global_label_filters
+            self.filter_in = global_filter_in
+
             # Set the changed value triggering this update
             super().save(*args, **kwargs)
-            self.buffer_update(label_filters, filter_in)
+            self.buffer_update()
             return
+        elif auto_updates:
+            # If autoupdates are happening (and it's not a mass-autoupdate (implied)), set the label filters based on
+            # the currently set global conditions so that only fields matching the filters will be updated.
+            self.label_filters = global_label_filters
+            self.filter_in = global_filter_in
+        # Otherwise, we are performing a mass auto-update and want to update the previously set filter conditions
 
         # Update the fields that change due to the above change (if any)
-        self.update_decorated_fields(label_filters, filter_in)
+        self.update_decorated_fields()
 
         # If the auto-update resulted in no change or if there exists stale buffer contents for objects that were
         # previously saved, it can produce an error about unique constraints.  TransactionManagementErrors shpould have
@@ -502,10 +565,15 @@ class MaintainedModel(Model):
             # Percolate changes up to the parents (if any)
             self.call_dfs_related_updaters()
 
-    def update_decorated_fields(self, label_filters=None, filter_in=True):
+    def update_decorated_fields(self):
         """
         Updates every field identified in each maintained_field_function decorator using the decorated function that
         generates its value.
+
+        This uses 2 data members: self.label_filters and self.filter_in in order to determine which fields should be
+        updated.  They are initially set when the object is created and refreshed when the object is saved to reflect
+        the current filter conditions.  One exception of the refresh, is if performing a mass auto-update, in which
+        case the filters the were in effect during buffering are used.
         """
         for updater_dict in self.get_my_updaters():
             update_fld = updater_dict["update_field"]
@@ -516,18 +584,18 @@ class MaintainedModel(Model):
             # filter criteria
             if update_fld is not None and (
                 # There are no labels for filtering
-                label_filters is None
-                or len(label_filters) == 0
+                self.label_filters is None
+                or len(self.label_filters) == 0
                 # or the update_label matches a filter-in label
                 or (
-                    filter_in
+                    self.filter_in
                     and update_label is not None
-                    and update_label in label_filters
+                    and update_label in self.label_filters
                 )
                 # or the update_label does not match a filter-out label
                 or (
-                    not filter_in
-                    and (update_label is None or update_label not in label_filters)
+                    not self.filter_in
+                    and (update_label is None or update_label not in self.label_filters)
                 )
             ):
                 try:
@@ -800,14 +868,14 @@ class MaintainedModel(Model):
 
         return my_update_fields
 
-    def buffer_update(self, label_filters=None, filter_in=True):
+    def buffer_update(self):
         """
         This is called when MaintainedModel.save is called (if auto_updates is False), so that maintained fields can be
-        updated after loading code finishes (by calling the global method: perform_buffered_updates)
+        updated after loading code finishes (by calling the global method: perform_buffered_updates).
         """
 
         # See if this class contains a field with a matching label (if a populated label_filters array was supplied)
-        if label_filters is not None and len(label_filters) > 0:
+        if self.label_filters is not None and len(self.label_filters) > 0:
             do_buffer = False
             for updater_dict in self.get_my_updaters():
                 update_label = updater_dict["update_label"]
@@ -818,14 +886,17 @@ class MaintainedModel(Model):
                 if (
                     # The update_label matches a filter-in label
                     (
-                        filter_in
+                        self.filter_in
                         and update_label is not None
-                        and update_label in label_filters
+                        and update_label in self.label_filters
                     )
                     # The update_label does not match a filter-out label
                     or (
-                        not filter_in
-                        and (update_label is None or update_label not in label_filters)
+                        not self.filter_in
+                        and (
+                            update_label is None
+                            or update_label not in self.label_filters
+                        )
                     )
                 ):
                     do_buffer = True
@@ -839,6 +910,18 @@ class MaintainedModel(Model):
         # sepecific order.  All auto-update functions should use non-auto-update fields.
         if buffering and self not in update_buffer:
             update_buffer.append(self)
+        elif buffering:
+            # This allows the same object to be updated more than once (in the order encountered) if the fields to be
+            # auto-updated in each instance, differ.  This can cause redundant updates (e.g. when a field matches the
+            # filters in both cases), but given the possibility that update order may depend on the update of related
+            # records, it's better to be on the safe side and do each auto-update, so...
+            # If this is the same object but a different set of fields will be updated...
+            for same_obj in [ubo for ubo in update_buffer if ubo == self]:
+                if (
+                    same_obj.filter_in != self.filter_in
+                    or same_obj.label_filters != same_obj.label_filters
+                ):
+                    update_buffer.append(self)
 
     def buffer_parent_update(self):
         """
@@ -894,7 +977,7 @@ class MaintainedModel(Model):
             "database loads isolated inside setUpTestData and the test function itself.  Note, querys inside setUp() "
             "can trigger this error.  If this is occurring outside of a test run, to avoid errors, the entire "
             "transaction should be done without autoupdates by calling disable_autoupdates() before the transaction "
-            "block, and after the atomic transaction block, call perform_mass_autoupdates() to make the updates.  If "
+            "block, and after the atomic transaction block, call perform_buffered_updates() to make the updates.  If "
             "this is a warning, note that auto-updates can be fixed afterwards by running:\n\n\tpython manage.py "
             "rebuild_maintained_fields\n\n."
         )
@@ -907,7 +990,9 @@ class MaintainedModel(Model):
         abstract = True
 
 
-def buffer_size(generation=None, label_filters=[]):
+def buffer_size(
+    generation=None, label_filters=global_label_filters, filter_in=global_filter_in
+):
     """
     Returns the number of buffered records that contain at least 1 decorated function matching the filter criteria
     (generation and label).
@@ -918,12 +1003,15 @@ def buffer_size(generation=None, label_filters=[]):
             buffered_item.get_my_updaters(),
             generation=generation,
             label_filters=label_filters,
+            filter_in=filter_in,
         )
         cnt += len(updaters_list)
     return cnt
 
 
-def get_max_buffer_generation(label_filters=[]):
+def get_max_buffer_generation(
+    label_filters=global_label_filters, filter_in=global_filter_in
+):
     """
     Takes a list of label filters and searches the buffered records to return the max generation found among the
     decorated functions (matching the filter criteria) associated with the buffered model object's class.
@@ -933,18 +1021,26 @@ def get_max_buffer_generation(label_filters=[]):
     exploded_updater_dicts = []
     for buffered_item in update_buffer:
         exploded_updater_dicts += filter_updaters(
-            buffered_item.get_my_updaters(), label_filters=label_filters
+            buffered_item.get_my_updaters(),
+            label_filters=label_filters,
+            filter_in=filter_in,
         )
-    return get_max_generation(exploded_updater_dicts, label_filters=label_filters)
+    return get_max_generation(
+        exploded_updater_dicts, label_filters=label_filters, filter_in=filter_in
+    )
 
 
-def get_max_generation(updaters_list, label_filters=[]):
+def get_max_generation(
+    updaters_list, label_filters=global_label_filters, filter_in=global_filter_in
+):
     """
     Takes a list of updaters and a list of label filters and returns the max generation found in the updaters list.
     """
     max_gen = None
     for updater_dict in sorted(
-        filter_updaters(updaters_list, label_filters=label_filters),
+        filter_updaters(
+            updaters_list, label_filters=label_filters, filter_in=filter_in
+        ),
         key=lambda x: x["generation"],
         reverse=True,
     ):
@@ -955,20 +1051,27 @@ def get_max_generation(updaters_list, label_filters=[]):
     return max_gen
 
 
-def filter_updaters(updaters_list, generation=None, label_filters=[], filter_in=True):
+def filter_updaters(
+    updaters_list,
+    generation=None,
+    label_filters=global_label_filters,
+    filter_in=global_filter_in,
+):
     """
     Returns a sublist of the supplied updaters_list the meets both the filter criteria (generation matches and
     update_label is in the label_filters), if those filters were supplied.
     """
     new_updaters_list = []
-    no_filters = len(label_filters) == 0
+    no_filters = label_filters is None or len(label_filters) == 0
     no_generation = generation is None
     for updater_dict in updaters_list:
         gen = updater_dict["generation"]
         label = updater_dict["update_label"]
         has_label = label is not None
         if (no_generation or generation == gen) and (
-            no_filters or (has_label and label in label_filters)
+            no_filters
+            or (filter_in and has_label and label in label_filters)
+            or (not filter_in and (not has_label or label not in label_filters))
         ):
             if filter_in:
                 new_updaters_list.append(updater_dict)
@@ -977,7 +1080,7 @@ def filter_updaters(updaters_list, generation=None, label_filters=[], filter_in=
     return new_updaters_list
 
 
-def perform_buffered_updates(save_kwargs=None):
+def perform_buffered_updates(using=None, label_filters=None, filter_in=None):
     """
     Performs a mass update of records in the buffer in a depth-first fashion without repeated updates to the same
     record over and over.  It goes through the buffer in the order added and triggers each record's DFS updates, which
@@ -989,29 +1092,27 @@ def perform_buffered_updates(save_kwargs=None):
     Note that this can fail if a record is changed and then its child (who triggers its parent) is changed (each being
     added to the buffer during a mass auto-update).  This however is not expected to happen, as mass auto-update is
     used for loading, which if done right, doesn't change child records after parent records have been added.
+
+    WARNING: label_filters and filter_in should only be supplied if you know what you are doing.  Every model object
+    buffered for autoupdate saved its filtering criteria that were in effect when it was buffered and that filtering
+    criteria will be applied to selectively update only the fields matching the filtering criteria as applied to each
+    field's "update_label" in its method's decorator.
     """
     global update_buffer
 
-    if save_kwargs is None:
-        save_kwargs = {}
-
-    # Extract/set the filters
-    if (
-        "label_filters" not in save_kwargs.keys()
-        or save_kwargs["label_filters"] is None
-    ):
-        label_filters = []
-    else:
-        label_filters = save_kwargs["label_filters"]
-
-    # Extract/set the database
-    if "using" not in save_kwargs.keys():
-        db = None
-    else:
-        db = save_kwargs["using"]
-
+    save_kwargs = {}
+    db = None
+    if using:
+        db = using
+        save_kwargs["using"] = using
     # Mass autoupdates should turn off propagation for breadth-first transiting of the tree
     save_kwargs["propagate"] = False
+
+    use_object_label_filters = True
+    if label_filters is None:
+        use_object_label_filters = False
+        if filter_in is None:
+            filter_in = global_filter_in
 
     orig_au_mode = are_autoupdates_enabled()
     if orig_au_mode:
@@ -1027,11 +1128,15 @@ def perform_buffered_updates(save_kwargs=None):
     # Track what's been updated to prevent repeated updates triggered by multiple child updates
     updated = []
     new_buffer = []
-    no_filters = len(label_filters) == 0
+    no_filters = label_filters is None or len(label_filters) == 0
 
     # For each record in the buffer
     for buffer_item in update_buffer:
         updater_dicts = buffer_item.get_my_updaters()
+
+        if use_object_label_filters:
+            label_filters = buffer_item.label_filters
+            filter_in = buffer_item.filter_in
 
         # Track updated records to avoid repeated updates
         key = f"{buffer_item.__class__.__name__}.{buffer_item.pk}"
@@ -1039,7 +1144,10 @@ def perform_buffered_updates(save_kwargs=None):
         # Try to perform the update. It could fail if the affected record was deleted
         try:
             if key not in updated and (
-                no_filters or updater_list_has_labels(updater_dicts, label_filters)
+                no_filters
+                or updater_list_has_labels(
+                    updater_dicts, label_filters=label_filters, filter_in=filter_in
+                )
             ):
                 # Saving the record while performing_mass_autoupdates is True, causes auto-updates of every field
                 # included among the model's decorated functions.  It does not only update the fields indicated in
@@ -1084,7 +1192,9 @@ def get_all_updaters():
     return all_updaters
 
 
-def get_classes(generation=None, label_filters=[]):
+def get_classes(
+    generation=None, label_filters=global_label_filters, filter_in=global_filter_in
+):
     """
     Retrieve a list of classes containing maintained fields that match the given criteria.
     Used by rebuild_maintained_fields.
@@ -1092,7 +1202,14 @@ def get_classes(generation=None, label_filters=[]):
     class_list = []
     for class_name in updater_list:
         if (
-            len(filter_updaters(updater_list[class_name], generation, label_filters))
+            len(
+                filter_updaters(
+                    updater_list[class_name],
+                    generation=generation,
+                    label_filters=label_filters,
+                    filter_in=filter_in,
+                )
+            )
             > 0
         ):
             class_list.append(class_name)
@@ -1216,5 +1333,29 @@ class UncleanBufferError(Exception):
             message = (
                 "The auto-update buffer is unexpectedly populated.  Make sure failed or suspended loads clean up the "
                 "buffer when they finish."
+            )
+        super().__init__(message)
+
+
+class InitFiltersAfterDisablingAutoupdates(Exception):
+    def __init__(self, message=None):
+        if message is None:
+            message = (
+                "Custom filtering conditions must be initialized (using init_autoupdate_label_filters()) after "
+                "autoupdates are disabled (using disable_autoupdates()).  If custom filters are used by one loading "
+                "script, those filters must be cleared at the end of that script so that they are not unintentionally "
+                "applied to the next loading script."
+            )
+        super().__init__(message)
+
+
+class ClearFiltersBeforeEnablingAutoupdates(Exception):
+    def __init__(self, message=None):
+        if message is None:
+            message = (
+                "Custom filtering conditions must be cleared (using init_autoupdate_label_filters()) before "
+                "autoupdates are enabled (using enable_autoupdates()).  If custom filters are used by one loading "
+                "script, those filters must be cleared at the end of that script so that they are not unintentionally "
+                "applied to the next loading script."
             )
         super().__init__(message)

--- a/DataRepo/models/tracer.py
+++ b/DataRepo/models/tracer.py
@@ -37,7 +37,9 @@ class TracerQuerySet(models.QuerySet):
             )
             tracer = self.using(db).create(compound=compound)
             for isotope_data in tracer_data["isotopes"]:
-                TracerLabel.objects.using(db).create_tracer_label(tracer, isotope_data, save_kwargs)
+                TracerLabel.objects.using(db).create_tracer_label(
+                    tracer, isotope_data, save_kwargs
+                )
             tracer.full_clean()
             tracer.save(**save_kwargs)
             created = True

--- a/DataRepo/models/tracer.py
+++ b/DataRepo/models/tracer.py
@@ -147,7 +147,7 @@ class Tracer(MaintainedModel, ElementLabel):
     def get_name(self):
         """
         Returns the name field if populated.  If it's not populated, it populates it (in the same manner that the old
-        cache mechanism worked)
+        cache mechanism worked).
         """
         display_name = None
 
@@ -155,9 +155,11 @@ class Tracer(MaintainedModel, ElementLabel):
         if self.name:
             display_name = self.name
         elif are_autoupdates_enabled():
-            db = self._db or settings.DEFAULT_DB
+            save_kwargs = {"label_filters": ["name"]}
+            if hasattr(self, "_state") and hasattr(self._state, "db"):
+                save_kwargs["using"] = self._state.db
             # This triggers an auto-update
-            self.save(using=db, label_filters=["name"])
+            self.save(**save_kwargs)
             display_name = self.name
 
         # If it's still not set, call the method that generates the name.  It just won't be saved.

--- a/DataRepo/models/tracer_label.py
+++ b/DataRepo/models/tracer_label.py
@@ -14,8 +14,15 @@ from DataRepo.utils.infusate_name_parser import IsotopeData
 
 
 class TracerLabelQuerySet(models.QuerySet):
-    def create_tracer_label(self, tracer: Tracer, isotope_data: IsotopeData):
+    def create_tracer_label(
+        self, tracer: Tracer, isotope_data: IsotopeData, save_kwargs=None
+    ):
         db = self._db or settings.DEFAULT_DB
+        if save_kwargs is None:
+            save_kwargs = {"using": db}
+        elif "using" not in save_kwargs.keys():
+            save_kwargs["using"] = db
+
         tracer_label = self.using(db).create(
             tracer=tracer,
             element=isotope_data["element"],
@@ -24,6 +31,7 @@ class TracerLabelQuerySet(models.QuerySet):
             mass_number=isotope_data["mass_number"],
         )
         tracer_label.full_clean()
+        tracer_label.save(**save_kwargs)
         return tracer_label
 
 

--- a/DataRepo/models/tracer_label.py
+++ b/DataRepo/models/tracer_label.py
@@ -14,14 +14,8 @@ from DataRepo.utils.infusate_name_parser import IsotopeData
 
 
 class TracerLabelQuerySet(models.QuerySet):
-    def create_tracer_label(
-        self, tracer: Tracer, isotope_data: IsotopeData, save_kwargs=None
-    ):
+    def create_tracer_label(self, tracer: Tracer, isotope_data: IsotopeData):
         db = self._db or settings.DEFAULT_DB
-        if save_kwargs is None:
-            save_kwargs = {"using": db}
-        elif "using" not in save_kwargs.keys():
-            save_kwargs["using"] = db
 
         tracer_label = self.using(db).create(
             tracer=tracer,
@@ -31,7 +25,7 @@ class TracerLabelQuerySet(models.QuerySet):
             mass_number=isotope_data["mass_number"],
         )
         tracer_label.full_clean()
-        tracer_label.save(**save_kwargs)
+        tracer_label.save(using=db)
         return tracer_label
 
 

--- a/DataRepo/tests/loading/test_loading_autoupdates.py
+++ b/DataRepo/tests/loading/test_loading_autoupdates.py
@@ -1,0 +1,161 @@
+from django.core.management import call_command
+
+from DataRepo.models import (
+    Animal,
+    FCirc,
+    Infusate,
+    Sample,
+    Tracer,
+    TracerLabel,
+)
+from DataRepo.models.maintained_model import buffer_size, clear_update_buffer
+from DataRepo.tests.tracebase_test_case import TracebaseTestCase
+
+
+class AutoupdateLoadingTests(TracebaseTestCase):
+    @classmethod
+    def setUpTestData(cls):
+        call_command(
+            "load_study",
+            "DataRepo/example_data/small_dataset/small_obob_study_prerequisites.yaml",
+        )
+
+    def tearDown(self):
+        clear_update_buffer()
+        super().tearDown()
+
+    def test_defer_autoupdates_animal_accucor(self):
+        self.assert_no_names_to_start()
+        self.assert_no_fcirc_data_to_start()
+
+        call_command(
+            "load_animals_and_samples",
+            animal_and_sample_table_filename="DataRepo/example_data/small_dataset/"
+            "small_obob_animal_and_sample_table.xlsx",
+            defer_autoupdates=True,
+        )
+
+        # Get the current buffer
+        from DataRepo.models.maintained_model import update_buffer
+
+        # Since autoupdates were defered (and we did not run perform_buffered_updates)
+        self.assert_names_are_unupdated()
+        bs1 = buffer_size()
+        self.assertGreater(bs1, 0)
+        first_buffered_model_object = update_buffer[0]
+
+        self.assert_fcirc_data_is_unupdated()
+
+        call_command(
+            "load_accucor_msruns",
+            accucor_file="DataRepo/example_data/small_dataset/small_obob_maven_6eaas_inf_blank_sample.xlsx",
+            skip_samples=("blank"),
+            protocol="Default",
+            date="2021-04-29",
+            researcher="Michael Neinast",
+            new_researcher=True,
+            defer_autoupdates=True,
+        )
+
+        # Get the updated buffer
+        from DataRepo.models.maintained_model import update_buffer
+
+        # Since autoupdates were defered (and we did not run perform_buffered_updates)
+        self.assert_fcirc_data_is_unupdated()
+        # The buffer should have grown
+        self.assertGreater(buffer_size(), bs1)
+        # The first buffered object from the first load script should be the same.  I.e. Running a second load script
+        # without clearing the buffer should just append to the buffer.
+        self.assertEqual(first_buffered_model_object, update_buffer[0])
+
+    def test_defer_autoupdates_sample(self):
+        self.assert_no_names_to_start()
+        self.assert_no_fcirc_data_to_start()
+
+        call_command(
+            "load_samples",
+            "DataRepo/example_data/small_dataset/small_obob_sample_table.tsv",
+            sample_table_headers="DataRepo/example_data/sample_table_headers.yaml",
+            defer_autoupdates=True,
+        )
+
+        # Since autoupdates were defered (and we did not run perform_buffered_updates)
+        self.assert_names_are_unupdated()
+        self.assert_fcirc_data_is_unupdated()
+
+    def test_load_study_runs_autoupdates(self):
+        self.assert_no_names_to_start()
+        self.assert_no_fcirc_data_to_start()
+
+        call_command(
+            "load_study",
+            "DataRepo/example_data/small_dataset/small_obob_study_params.yaml",
+        )
+
+        self.assert_names_are_unupdated(False)
+        self.assert_fcirc_data_is_unupdated(False)
+        self.assertEqual(0, buffer_size())
+
+    def assert_no_names_to_start(self):
+        num_orig_infusates = Infusate.objects.count()
+        self.assertEqual(0, num_orig_infusates)
+        num_orig_tracers = Tracer.objects.count()
+        self.assertEqual(0, num_orig_tracers)
+        num_orig_tracerlabels = TracerLabel.objects.count()
+        self.assertEqual(0, num_orig_tracerlabels)
+
+    def assert_names_are_unupdated(self, unupdated=True):
+        num_infusates = Infusate.objects.count()
+        num_null_infusates = Infusate.objects.filter(name__isnull=unupdated).count()
+        self.assertGreater(num_infusates, 0)
+        self.assertEqual(num_infusates, num_null_infusates)
+
+        num_tracers = Tracer.objects.count()
+        num_null_tracers = Tracer.objects.filter(name__isnull=unupdated).count()
+        self.assertGreater(num_tracers, 0)
+        self.assertEqual(num_tracers, num_null_tracers)
+
+        num_tracerlabels = TracerLabel.objects.count()
+        num_null_tracerlabels = TracerLabel.objects.filter(
+            name__isnull=unupdated
+        ).count()
+        self.assertGreater(num_tracerlabels, 0)
+        self.assertEqual(num_tracerlabels, num_null_tracerlabels)
+
+    def assert_no_fcirc_data_to_start(self):
+        num_orig_animals = Animal.objects.count()
+        self.assertEqual(0, num_orig_animals)
+        num_orig_samples = Sample.objects.count()
+        self.assertEqual(0, num_orig_samples)
+        num_orig_fcircs = FCirc.objects.count()
+        self.assertEqual(0, num_orig_fcircs)
+
+    def assert_fcirc_data_is_unupdated(self, unupdated=True):
+        num_animals = Animal.objects.count()
+        num_null_animals = Animal.objects.filter(
+            last_serum_sample__isnull=unupdated
+        ).count()
+        self.assertGreater(num_animals, 0)
+        self.assertEqual(num_animals, num_null_animals)
+
+        num_samples = Sample.objects.count()
+        self.assertGreater(num_samples, 0)
+        if unupdated:
+            # Test every is_serum_sample is the default (i.e. False)
+            num_default_samples = Sample.objects.filter(is_serum_sample=False).count()
+            self.assertEqual(num_samples, num_default_samples)
+        else:
+            # Test some is_serum_sample are not the default (i.e. True)
+            num_nondefault_samples = Sample.objects.filter(is_serum_sample=True).count()
+            self.assertGreater(num_nondefault_samples, 0)
+
+        num_fcircs = FCirc.objects.count()
+        self.assertGreater(num_fcircs, 0)
+        if unupdated:
+            # Test every is_last is the default (i.e. False)
+            num_default_fcircs = FCirc.objects.filter(is_last=False).count()
+            self.assertEqual(num_fcircs, num_default_fcircs)
+        else:
+            # Test some is_last are not the default (i.e. True)
+            num_nondefault_fcircs = FCirc.objects.filter(is_last=False).count()
+            self.assertGreater(num_nondefault_fcircs, 0)

--- a/DataRepo/utils/accucor_data_loader.py
+++ b/DataRepo/utils/accucor_data_loader.py
@@ -1122,7 +1122,7 @@ class AccuCorDataLoader:
 
         autoupdate_mode = not self.defer_autoupdates
         if not dry_run and autoupdate_mode:
-            perform_buffered_updates(save_kwargs={"using": self.db})
+            perform_buffered_updates(using=self.db)
 
         self.post_load_teardown(autoupdate_mode)
 

--- a/DataRepo/utils/accucor_data_loader.py
+++ b/DataRepo/utils/accucor_data_loader.py
@@ -1122,7 +1122,7 @@ class AccuCorDataLoader:
 
         autoupdate_mode = not self.defer_autoupdates
         if not dry_run and autoupdate_mode:
-            perform_buffered_updates(using=self.db)
+            perform_buffered_updates(save_kwargs={"using": self.db})
 
         self.post_load_teardown(autoupdate_mode)
 


### PR DESCRIPTION
# Please review #599 first

## Summary Change Description

The refactors necessary to remove the validation database will be done in phases and will address the original reasons why the validation interface had to use a second database, primarily: load scripts have side-effects in dry-run mode and loading of the accucor data requires the sample load to have been completed.

*At the same time, given that the scope of the refactor touches most of the code of the load script, touched code will be simplified, streamlined, and standardized in the process.*

This is phase 2 of a loading refactor.  The requirements listed below are planned in phases.  At each phase, I plan to put out a PR (per load script as needed) where the listed requirements for that phase shown below are implemented.

### Current Phase (sample table load)
- Phase 1
  - `sample_table_loader` **(This PR is based on the other refactor PR that addressed these items in the sample_table_loader)**
    - [x] `1.` Load scripts generate as many actionable errors as possible in 1 run
    - [x] `2.` If a load action in the script requires input involved in a previous error, skip that load action
    - [x] `3.` Make it possible to control the verbosity of the loads
    - [x] `4.` Raise error on unknown headers
  - `accucor_data_loader`
    - [x] `1.` Load scripts generate as many actionable errors as possible in 1 run
    - [x] `2.` If a load action in the script requires input involved in a previous error, skip that load action
    - [x] `3.` Make it possible to control the verbosity of the loads
    - [x] `4.` Raise error on unknown headers
----
### Subsequent Phases
- Phase 2 **=== YOU ARE HERE ===**
  - [x] `5.` Make it possible to defer mass auto-updates outside of the load scripts (so it can be run by load_study)
- Phase 3
  - `6.` Dry-run mode has no database side-effects (when not run in `--validate` mode)
    - `6.1.` Wrap loading code in an atomic transaction
- Phase 4
  - `7.` Validation page works by running in dry-run mode on the main database
- Phase 5
  - `8.` Remove the validation database
    - `8.1.` Remove `.using(db)`, `.save(using=db)`, and `if self.db == settings.TRACEBASE_DB: rec.full_clean()`
    - `8.2.` Revert database settings
    - `8.3.` Update docs

## Affected Issue Numbers

- Partially addresses #580 - Implements phase 2

## Code Review Notes

- Added a suppressed `--defer-autoupdates` option to the relevant load scripts.  It is an option only intended to be used by `load_study`.  It's not really for one-off use by someone on the command line, because the result must be cleaned up and unless we provide an additional option to perform that cleanup and catch cases where it has not been cleaned up, it should remain a hidden option.
- In order to support deferring auto-updates to after a series of load calls, I had to augment `MaintainedModel` to be able to keep track of what fields to update in every buffered update.
  - Previously, each load script had the option to restrict autoupdates to specific fields using "label filters".  Each maintained field, in its decorator, has a label named `update_label`.  Then the mass autoupdates were performed at the end of that script, it supplied that same label filter.  However, since the subsequent script has its own specific fields it wants to update, the fields to update in each buffered autoupdate had to be recorded, and to do that, I added the "current" label filtering criteria to the model object (via the MaintainedModel superclass).
  - Initially, I had done this (see the git log history) using added parameters to the `.save()` method, meaning each load script had to have code specific to the filters it used.  I didn't like that, so I rewrote it to use the superclass, which keeps things better encapsulated
  - I also wrote a method that is used to set the filter criteria (`init_autoupdate_label_filters`)
- As a side-effect of the initial attempt using added parameters to the `.save()` method (which was reverted as noted above), there were a couple instances where I kept the concept of constructing a `save_kwargs` variable to supply like `.save(**save_kwargs)`.  In doing so, I realized that there was a way to supply `using=db` where it was missing before.  Note, this will be removed in a subsequent phase, when the validation database is removed.  But, it was added because I realized that the new strategy of handling label filters should be used in the 2 `get_name` methods.
- When testing, I encountered an issue in the checks that ensure custom label filter values do not persist through multiple calls.  It revealed that exceptions in the sample table load were not being caught and thus, the label filters were not being re-initialized, so I wrapped the loading code in a separate method called by `load_sample_data`: `load_data`.  This mimmics the strategy used by the accucor loader.

Note that in implementing the strategy to handle remembered label filters, I standardized the usage of label filters throughout MaintainedModel.  Every method that previously took label filters as input now defaults to what the user sets via `init_autoupdate_label_filters`.

One thing that might be difficult to grasp is the setting of `self.label_filters` and `self.filter_in`.  There are 2 cases where these must be saved/updated, and one where it must not be updated:

- Autoupdates are being performed on the fly = save the filter criteria in the object
- Autoupdates are being buffered = save the filter criteria in the object
- Buffered updates are being performed = do not save the current label filter criteria and go with the criteria that was saved when it was buffered (during the execution of the specific load script)

## Checklist

- [x] All issue requirements satisfied (or no linked issues)
  - Phase 1 for sample table loads
- [x] [Linting passes](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#linting).
- [x] [Migrations created & committed *(or no model changes)*](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#migration-process)
- Tests
  - [x] [Tests implemented *(or no code changes)*](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#test-implementation)
  - [x] [All *multi_working* tag tests pass locally](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#quality-control)
  - [x] All example load tests pass (remotely) *(or their failures predated and are unrelated to this branch)*
