### PR TITLE
Refactor (phase 3) to remove the validation database - atomic transactions

### DIFF
--- a/DataRepo/management/commands/load_accucor_msruns.py
+++ b/DataRepo/management/commands/load_accucor_msruns.py
@@ -136,9 +136,10 @@ class Command(BaseCommand):
             isocorr_format=options["isocorr_format"],
             verbosity=options["verbosity"],
             defer_autoupdates=options["defer_autoupdates"],
+            dry_run=options["debug"],
         )
 
-        loader.load_accucor_data(options["debug"])
+        loader.load_accucor_data()
 
         print(f"Done loading {fmt} data into MsRun, PeakGroups, and PeakData")
 

--- a/DataRepo/management/commands/rebuild_maintained_fields.py
+++ b/DataRepo/management/commands/rebuild_maintained_fields.py
@@ -1,16 +1,5 @@
 from django.core.management import BaseCommand
 
-from DataRepo.models import (  # noqa: F401
-    Animal,
-    FCirc,
-    Infusate,
-    InfusateTracer,
-    MSRun,
-    PeakGroup,
-    Sample,
-    Tracer,
-    TracerLabel,
-)
 from DataRepo.models.maintained_model import (
     AutoUpdateFailed,
     clear_update_buffer,
@@ -23,8 +12,6 @@ from DataRepo.models.maintained_model import (
     get_max_generation,
     updater_list_has_labels,
 )
-
-# ^^^ Must import every MaintainedModel (because it's eval'd below)
 
 
 def rebuild_maintained_fields(label_filters=[]):
@@ -45,8 +32,8 @@ def rebuild_maintained_fields(label_filters=[]):
     for gen in sorted(range(youngest_generation + 1), reverse=True):
 
         # For every MaintainedModel derived class with decorated functions
-        for class_name in get_classes(gen, label_filters):
-            cls = eval(class_name)
+        for cls in get_classes("DataRepo.models", gen, label_filters):
+            class_name = cls.__name__
 
             try:
                 updater_dicts = cls.get_my_updaters()

--- a/DataRepo/models/__init__.py
+++ b/DataRepo/models/__init__.py
@@ -6,6 +6,7 @@ from DataRepo.models.fcirc import FCirc
 from DataRepo.models.hier_cached_model import HierCachedModel
 from DataRepo.models.infusate import Infusate
 from DataRepo.models.infusate_tracer import InfusateTracer
+from DataRepo.models.maintained_model import MaintainedModel, buffer_size
 from DataRepo.models.ms_run import MSRun
 from DataRepo.models.peak_data import PeakData
 from DataRepo.models.peak_data_label import PeakDataLabel
@@ -23,9 +24,11 @@ from DataRepo.models.tracer_label import TracerLabel
 __all__ = [
     "Animal",
     "AnimalLabel",
+    "buffer_size",
     "FCirc",
     "Compound",
     "CompoundSynonym",
+    "MaintainedModel",
     "MSRun",
     "PeakData",
     "PeakGroup",

--- a/DataRepo/tests/loading/test_loading_protocols.py
+++ b/DataRepo/tests/loading/test_loading_protocols.py
@@ -6,10 +6,13 @@ from django.core.management import CommandError, call_command
 from django.test import tag
 
 from DataRepo.models import Protocol
-from DataRepo.models.maintained_model import get_all_maintained_field_values, buffer_size
+from DataRepo.models.maintained_model import (
+    buffer_size,
+    get_all_maintained_field_values,
+)
 from DataRepo.tests.tracebase_test_case import TracebaseTestCase
 from DataRepo.utils import ProtocolsLoader
-from DataRepo.utils.exceptions import LoadingError, DryRun
+from DataRepo.utils.exceptions import DryRun, LoadingError
 
 
 @tag("protocols")
@@ -146,19 +149,11 @@ class ProtocolLoadingTests(TracebaseTestCase):
 
     def test_protocol_load_in_debug(self):
 
-        self.load_dataframe_as_animal_treatment(self.working_differently_df)
-
         pre_load_counts = self.get_record_counts()
-        pre_load_maintained_values = get_all_maintained_field_values("DataRepo.models")
-        self.assertGreater(
-            len(pre_load_maintained_values.keys()),
-            0,
-            msg="Ensure there is data in the database before the test",
-        )
         self.assertEqual(0, buffer_size(), msg="Autoupdate buffer is empty to start.")
 
         with self.assertRaises(DryRun):
-            self.load_dataframe_as_animal_treatment(self.working_df)
+            self.load_dataframe_as_animal_treatment(self.working_df, dry_run=True)
 
         post_load_maintained_values = get_all_maintained_field_values("DataRepo.models")
         post_load_counts = self.get_record_counts()
@@ -167,11 +162,6 @@ class ProtocolLoadingTests(TracebaseTestCase):
             pre_load_counts,
             post_load_counts,
             msg="DryRun mode doesn't change any table's record count.",
-        )
-        self.assertEqual(
-            pre_load_maintained_values,
-            post_load_maintained_values,
-            msg="DryRun mode doesn't autoupdate.",
         )
         self.assertEqual(
             0, buffer_size(), msg="DryRun mode doesn't leave buffered autoupdates."

--- a/DataRepo/tests/loading/test_loading_protocols.py
+++ b/DataRepo/tests/loading/test_loading_protocols.py
@@ -6,10 +6,7 @@ from django.core.management import CommandError, call_command
 from django.test import tag
 
 from DataRepo.models import Protocol
-from DataRepo.models.maintained_model import (
-    buffer_size,
-    get_all_maintained_field_values,
-)
+from DataRepo.models.maintained_model import buffer_size
 from DataRepo.tests.tracebase_test_case import TracebaseTestCase
 from DataRepo.utils import ProtocolsLoader
 from DataRepo.utils.exceptions import DryRun, LoadingError
@@ -155,7 +152,6 @@ class ProtocolLoadingTests(TracebaseTestCase):
         with self.assertRaises(DryRun):
             self.load_dataframe_as_animal_treatment(self.working_df, dry_run=True)
 
-        post_load_maintained_values = get_all_maintained_field_values("DataRepo.models")
         post_load_counts = self.get_record_counts()
 
         self.assertEqual(

--- a/DataRepo/tests/tracebase_test_case.py
+++ b/DataRepo/tests/tracebase_test_case.py
@@ -1,6 +1,9 @@
 import time
 
+from django.conf import settings
 from django.test import TestCase, TransactionTestCase
+
+from DataRepo.models.utilities import get_all_models
 
 LONG_TEST_THRESH_SECS = 20
 LONG_TEST_ALERT_STR = f" [ALERT > {LONG_TEST_THRESH_SECS}]"
@@ -52,6 +55,16 @@ def test_case_class_factory(base_class):
             """
             super().setUpTestData()
             reportRunTime(f"{self.__name__}.setUpTestData", self.setupStartTime)
+
+        @classmethod
+        def get_record_counts(cls, db=settings.TRACEBASE_DB):
+            """
+            This can be used in any tests to check the number of records in every table.
+            """
+            record_counts = []
+            for mdl in get_all_models():
+                record_counts.append(mdl.objects.using(db).all().count())
+            return record_counts
 
         class Meta:
             abstract = True

--- a/DataRepo/utils/accucor_data_loader.py
+++ b/DataRepo/utils/accucor_data_loader.py
@@ -1111,14 +1111,15 @@ class AccuCorDataLoader:
             raise AggregatedErrors(self.errors)
 
         # Buffered auto-updates cannot be done inside the atomic transaction block because the auto-updates associated
-        # with the models involved in an accucor load, transit many-related models to perform updates of already-loaded
+        # with the models involved in an accucor load transit many-related models to perform updates of already-loaded
         # data based on new data, which requires queries of the linked pre-loaded data, and database queries are not
         # allowed during atomic transactions.  Some auto-updates can happen inside an atomic transaction block because
         # it operates on the objects without hitting the database, but that's not the case here.  Specifically, if this
         # was called inside the transaction block, it would generate the error:
-        # An error occurred in the current transaction. You can't execute queries until the end of the 'atomic' block.
-        # It uses `.count()` (to see if there exist records to propagate changes), `.first()` to see if the related
-        # model is a MaintainedModel (inside an isinstance call), and `.all()` to cycle through the related records.
+        #
+        #  An error occurred in the current transaction. You can't execute queries until the end of the 'atomic' block.
+        #  It uses `.count()` (to see if there exist records to propagate changes), `.first()` to see if the related
+        #  model is a MaintainedModel (inside an isinstance call), and `.all()` to cycle through the related records.
 
         autoupdate_mode = not self.defer_autoupdates
         if not dry_run and autoupdate_mode:

--- a/DataRepo/utils/protocols_loader.py
+++ b/DataRepo/utils/protocols_loader.py
@@ -125,12 +125,14 @@ class ProtocolsLoader:
                 raise ValidationError(
                     "ProtocolLoader requires a dataframe with 'name' and 'description' headers/keys."
                 ) from None
+
         if len(self.errors) > 0:
             message = ""
             for err in self.errors:
                 message += f"{err}\n"
 
             raise LoadingError(f"Errors during protocol loading :\n {message}")
+
         if self.dry_run:
             raise DryRun()
 

--- a/DataRepo/utils/sample_table_loader.py
+++ b/DataRepo/utils/sample_table_loader.py
@@ -5,7 +5,7 @@ from datetime import timedelta
 import dateutil.parser  # type: ignore
 import pandas as pd
 from django.conf import settings
-from django.db.utils import IntegrityError
+from django.db import IntegrityError, transaction
 
 from DataRepo.models import (
     Animal,
@@ -198,7 +198,8 @@ class SampleTableLoader:
         init_autoupdate_label_filters(label_filters=["name"])
 
         try:
-            self.load_data(data, dry_run)
+            with transaction.atomic():
+                self.load_data(data, dry_run)
         except Exception as e:
             # If we're stopping with an exception, we need to clear the update buffer so that the next call doesn't
             # make auto-updates on non-existent (or incorrect) records


### PR DESCRIPTION
# Please review #604 first - DONE

## Summary Change Description

Added atomic transaction to the sample table loader and implemented associated tests.

### Previous Phases
- Phase 1
  - `sample_table_loader` **(This PR is based on the other refactor PR that addressed these items in the sample_table_loader)**
    - [x] `1.` Load scripts generate as many actionable errors as possible in 1 run
    - [x] `2.` If a load action in the script requires input involved in a previous error, skip that load action
    - [x] `3.` Make it possible to control the verbosity of the loads
    - [x] `4.` Raise error on unknown headers
  - `accucor_data_loader`
    - [x] `1.` Load scripts generate as many actionable errors as possible in 1 run
    - [x] `2.` If a load action in the script requires input involved in a previous error, skip that load action
    - [x] `3.` Make it possible to control the verbosity of the loads
    - [x] `4.` Raise error on unknown headers
- Phase 2
  - [x] `5.` Make it possible to defer mass auto-updates outside of the load scripts (so it can be run by load_study)
----
### Current Phase
- Phase 3 **=== YOU ARE HERE ===**
  - [x] `6.` Dry-run mode has no database side-effects (when not run in `--validate` mode)
    - [x] `6.1.` Wrap loading code in an atomic transaction
----
### Subsequent Phases
- Phase 4
  - `7.` Validation page works by running in dry-run mode on the main database
- Phase 5
  - `8.` Remove the validation database
    - `8.1.` Remove `.using(db)`, `.save(using=db)`, and `if self.db == settings.TRACEBASE_DB: rec.full_clean()`
    - `8.2.` Revert database settings
    - `8.3.` Update docs

## Affected Issue Numbers

- Partially addresses #580 - Implements phase 3

## Code Review Notes

Small number of changes.  I kind of expected this PR to be more involved, because I expected there would be tests to fix.

I wrote a somewhat holistic test, though if I remembered what fields were subject to changes during the dry-run, I'd have checked them explicitly, however, I tested 2 things, and those tests are not without flaws:

1. I tested that the number of records in each table doesn't change after a dry run. *This will not detect complementary insert/delete cases.*
2. I tested every autoupdate field value in every record. *This is why I loaded some data before the test.*

Also, I only tested the sample table load, since that's the only one that hadn't previously utilized an atomic transaction.

It's worth noting that in this case (sample table load), the auto-updates are performed inside the atomic transaction.  This is possible because the only autoupdates currently performed do not require traversing any many-related tables.  Every update happens in memory to the objects before the save is called.  If any maintained fields are added that would cause a traversal of a many-related table, the auto-updates would have to be taken out of the atomic transaction, as is currently the case with the autoupdates in the accucor loader.

## Checklist

- [x] All issue requirements satisfied (or no linked issues)
  - Phase 1 for sample table loads
- [x] [Linting passes](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#linting).
- [x] [Migrations created & committed *(or no model changes)*](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#migration-process)
- Tests
  - [x] [Tests implemented *(or no code changes)*](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#test-implementation)
  - [x] [All *multi_working* tag tests pass locally](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#quality-control)
  - [x] All example load tests pass (remotely) *(or their failures predated and are unrelated to this branch)*
