### PR TITLE
Refactor list templates - part 2

### DIFF
--- a/DataRepo/templates/DataRepo/animal_treatments.html
+++ b/DataRepo/templates/DataRepo/animal_treatments.html
@@ -9,14 +9,11 @@
 {% endblock %}
 
 {% block content %}
-<br>
+<h4>Animal Treatment Protocols</h4>
 {% if animal_treatment_list %}
-<div>
-    <h4>Animal Treatment Protocols</h4>
     {% with protocols=animal_treatment_list %}
         {% include "DataRepo/includes/protocol_table.html" %}
     {% endwith %}
-</div>
 {% else %}
     <p>There are no protocols for animal treatment.</p>
 {% endif %}

--- a/DataRepo/templates/DataRepo/animal_treatments.html
+++ b/DataRepo/templates/DataRepo/animal_treatments.html
@@ -1,6 +1,12 @@
 {% extends "base.html" %}
+{% load static %}
+{% load customtags %}
 
 {% block title %}Animal Treatments{% endblock %}
+
+{% block head_extras %}
+    <link href="{% static 'css/bootstrap_table_cus2.css' %}" rel="stylesheet">
+{% endblock %}
 
 {% block content %}
 <br>
@@ -14,4 +20,18 @@
 {% else %}
     <p>There are no protocols for animal treatment.</p>
 {% endif %}
+{% endblock %}
+
+{% block js_extras %}
+    {{ block.super }}
+    <script src="{% static 'js/setTableHeight.js' %}"></script>
+    <script>
+        let divID = "div_out_tab";
+        let pctVH = 0.85;
+        let vHeight = setTableHeight(divID, pctVH);
+        $('#protocol_list').bootstrapTable({
+            height: vHeight,
+            virtualScroll: true
+        })
+    </script>
 {% endblock %}

--- a/DataRepo/templates/DataRepo/compound_list.html
+++ b/DataRepo/templates/DataRepo/compound_list.html
@@ -1,11 +1,16 @@
 {% extends "base.html" %}
+{% load static %}
 {% load customtags %}
 
 {% block title %}Compounds{% endblock %}
 
+{% block head_extras %}
+    <link href="{% static 'css/bootstrap_table_cus1.css' %}" rel="stylesheet">
+{% endblock %}
+
 {% block content %}
-<div>
-    <h4>List of Compounds</h4>
+<h4>List of Compounds</h4>
+<div id="div_out_tab">
     {% if df %}
     <table class="table table-sm table-hover table-bordered table-responsive-xl table-striped"
         id="comp_tracer_list"
@@ -58,4 +63,18 @@
     </table>
     {% endif %}
 </div>
+{% endblock %}
+
+{% block js_extras %}
+    {{ block.super }}
+    <script src="{% static 'js/setTableHeight.js' %}"></script>
+    <script>
+        let divID = "div_out_tab";
+        let pctVH = 0.80;
+        let vHeight = setTableHeight(divID, pctVH);
+        $('#comp_tracer_list').bootstrapTable({
+            height: vHeight,
+            virtualScroll: true
+        })
+    </script>
 {% endblock %}

--- a/DataRepo/templates/DataRepo/includes/protocol_table.html
+++ b/DataRepo/templates/DataRepo/includes/protocol_table.html
@@ -5,6 +5,7 @@
         data-toggle="table"
         data-buttons-class="primary"
         data-buttons-align="left"
+        data-filter-control="true"
         data-search="true"
         data-search-align="left"
         data-show-search-clear-button="true"
@@ -15,7 +16,7 @@
         data-show-export="true"
         data-export-types="['csv', 'txt', 'excel']"
         data-pagination="true"
-        data-page-size="10"
+        data-page-size="25"
         data-page-list="[10, 25, 50, 100, 200, 500, All]">
     <thead>
         <tr>

--- a/DataRepo/templates/DataRepo/includes/protocol_table.html
+++ b/DataRepo/templates/DataRepo/includes/protocol_table.html
@@ -1,7 +1,7 @@
 {% if protocols %}
-<div>
+<div id="div_out_tab">
     <table class="table table-sm table-hover table-bordered table-responsive-xl table-striped"
-        id="protocol_table"
+        id="protocol_list"
         data-toggle="table"
         data-buttons-class="primary"
         data-buttons-align="left"
@@ -14,7 +14,6 @@
         data-show-fullscreen="true"
         data-show-export="true"
         data-export-types="['csv', 'txt', 'excel']"
-        data-virtual-scroll="true"
         data-pagination="true"
         data-page-size="10"
         data-page-list="[10, 25, 50, 100, 200, 500, All]">

--- a/DataRepo/templates/DataRepo/infusate_list.html
+++ b/DataRepo/templates/DataRepo/infusate_list.html
@@ -1,11 +1,16 @@
 {% extends "base.html" %}
+{% load static %}
 {% load customtags %}
 
 {% block title %}Infusates{% endblock %}
 
+{% block head_extras %}
+    <link href="{% static 'css/bootstrap_table_cus1.css' %}" rel="stylesheet">
+{% endblock %}
+
 {% block content %}
 <h4>List of Infusates</h4>
-<div>
+<div id="div_out_tab">
     {% if df %}
     <table class="table table-sm table-hover table-bordered table-responsive-xl table-striped"
         id="infusate_list"
@@ -22,8 +27,6 @@
         data-show-fullscreen="true"
         data-show-export="true"
         data-export-types="['csv', 'txt', 'excel']"
-        data-height="1200"
-        data-virtual-scroll="true"
         data-pagination="true"
         data-page-size="100"
         data-page-list="[25, 50, 100, 200, 500, All]">
@@ -32,7 +35,7 @@
                 <th data-filter-control="input" data-sortable="true" data-sorter ="htmlSorter" data-field="Infusate">Infusate</th>
                 <th data-filter-control="input" data-sortable="true" data-field="Tracer-Group">Tracer Group</th>
                 <th data-filter-control="select" data-sortable="true" data-field="Labeled-Elements">Labeled Element(s)</th>
-                <th data-filter-control="input" data-sortable="true" data-sorter ="htmlSorter" data-field="Compounds">Parent Compound(s) for Tracer(s)</th>
+                <th data-filter-control="input" data-sortable="true" data-sorter ="htmlSorter" data-field="Compounds">Tracer Compound(s)</th>
                 <th data-filter-control="input" data-sortable="true" data-sorter ="htmlSorter" data-field="Tracers">Tracer(s)</th>
                 <th data-filter-control="input" data-sortable="true" data-field="Concentrations">Infusion Concentration(s) (mM)</th>
         </thead>
@@ -52,4 +55,18 @@
     {% endif %}
 </div>
 
+{% endblock %}
+
+{% block js_extras %}
+    {{ block.super }}
+    <script src="{% static 'js/setTableHeight.js' %}"></script>
+    <script>
+        let divID = "div_out_tab";
+        let pctVH = 0.85;
+        let vHeight = setTableHeight(divID, pctVH);
+        $('#infusate_list').bootstrapTable({
+            height: vHeight,
+            virtualScroll: true
+        })
+    </script>
 {% endblock %}

--- a/DataRepo/templates/DataRepo/infusate_list.html
+++ b/DataRepo/templates/DataRepo/infusate_list.html
@@ -5,13 +5,13 @@
 {% block title %}Infusates{% endblock %}
 
 {% block head_extras %}
-    <link href="{% static 'css/bootstrap_table_cus1.css' %}" rel="stylesheet">
+    <link href="{% static 'css/bootstrap_table_cus2.css' %}" rel="stylesheet">
 {% endblock %}
 
 {% block content %}
 <h4>List of Infusates</h4>
+{% if df %}
 <div id="div_out_tab">
-    {% if df %}
     <table class="table table-sm table-hover table-bordered table-responsive-xl table-striped"
         id="infusate_list"
         data-toggle="table"
@@ -28,7 +28,7 @@
         data-show-export="true"
         data-export-types="['csv', 'txt', 'excel']"
         data-pagination="true"
-        data-page-size="100"
+        data-page-size="25"
         data-page-list="[25, 50, 100, 200, 500, All]">
         <thead>
             <tr>
@@ -52,7 +52,7 @@
             {% endfor %}
         </tbody>
     </table>
-    {% endif %}
+{% endif %}
 </div>
 
 {% endblock %}

--- a/DataRepo/templates/DataRepo/msrun_protocols.html
+++ b/DataRepo/templates/DataRepo/msrun_protocols.html
@@ -9,14 +9,11 @@
 {% endblock %}
 
 {% block content %}
-<br>
+<h4>MSRun Protocols</h4>
 {% if msrun_protocol_list %}
-<div>
-    <h4>MSRun Protocols</h4>
     {% with protocols=msrun_protocol_list %}
         {% include "DataRepo/includes/protocol_table.html" %}
     {% endwith %}
-</div>
 {% else %}
     <p>There are no protocols for MSRuns.</p>
 {% endif %}

--- a/DataRepo/templates/DataRepo/msrun_protocols.html
+++ b/DataRepo/templates/DataRepo/msrun_protocols.html
@@ -1,6 +1,12 @@
 {% extends "base.html" %}
+{% load static %}
+{% load customtags %}
 
 {% block title %}MSRun Protocols{% endblock %}
+
+{% block head_extras %}
+    <link href="{% static 'css/bootstrap_table_cus2.css' %}" rel="stylesheet">
+{% endblock %}
 
 {% block content %}
 <br>
@@ -14,4 +20,18 @@
 {% else %}
     <p>There are no protocols for MSRuns.</p>
 {% endif %}
+{% endblock %}
+
+{% block js_extras %}
+    {{ block.super }}
+    <script src="{% static 'js/setTableHeight.js' %}"></script>
+    <script>
+        let divID = "div_out_tab";
+        let pctVH = 0.85;
+        let vHeight = setTableHeight(divID, pctVH);
+        $('#protocol_list').bootstrapTable({
+            height: vHeight,
+            virtualScroll: true
+        })
+    </script>
 {% endblock %}

--- a/DataRepo/templates/DataRepo/peakgroupset_list.html
+++ b/DataRepo/templates/DataRepo/peakgroupset_list.html
@@ -1,11 +1,16 @@
 {% extends "base.html" %}
+{% load static %}
+{% load customtags %}
 
 {% block title %}PeakGroup Sets{% endblock %}
 
+{% block head_extras %}
+    <link href="{% static 'css/bootstrap_table_cus2.css' %}" rel="stylesheet">
+{% endblock %}
+
 {% block content %}
 <h4>List of Peak Group Sets</h4>
-<br>
-<div>
+<div id="div_out_tab">
     {% if peakgroupset_list %}
     <table class="table table-sm table-hover table-bordered table-responsive-xl table-striped"
         id="file_list"
@@ -22,8 +27,6 @@
         data-show-fullscreen="true"
         data-show-export="true"
         data-export-types="['csv', 'txt', 'excel']"
-        data-height="1200"
-        data-virtual-scroll="true"
         data-pagination="true"
         data-page-size="25"
         data-page-list="[25, 50, 100, 200, 500, All]">
@@ -54,4 +57,18 @@
         <p>There are no PeakGroup Set.</p>
     {% endif %}
 </div>
+{% endblock %}
+
+{% block js_extras %}
+    {{ block.super }}
+    <script src="{% static 'js/setTableHeight.js' %}"></script>
+    <script>
+        let divID = "div_out_tab";
+        let pctVH = 0.85;
+        let vHeight = setTableHeight(divID, pctVH);
+        $('#file_list').bootstrapTable({
+            height: vHeight,
+            virtualScroll: true
+        })
+    </script>
 {% endblock %}

--- a/DataRepo/templates/DataRepo/tissue_list.html
+++ b/DataRepo/templates/DataRepo/tissue_list.html
@@ -1,16 +1,20 @@
 {% extends "base.html" %}
+{% load static %}
+{% load customtags %}
 
 {% block title %}Tissues{% endblock %}
 
-{% block content %}
-<div>
-    <ul>
-        <h4>List of Tissues</h4>
+{% block head_extras %}
+    <link href="{% static 'css/bootstrap_table_cus2.css' %}" rel="stylesheet">
+{% endblock %}
 
-        {% if tissue_list %}
-        <br>
+{% block content %}
+<h4>List of Tissues</h4>
+
+<div id="div_out_tab">
+    {% if tissue_list %}
         <table class="table table-sm table-hover table-bordered table-responsive-xl table-striped"
-            id="table"
+            id="tissue_list"
             data-toggle="table"
             data-buttons-class="primary"
             data-buttons-align="left"
@@ -24,11 +28,9 @@
             data-show-fullscreen="true"
             data-show-export="true"
             data-export-types="['csv', 'txt', 'excel']"
-            data-height="1200"
-            data-virtual-scroll="true"
             data-pagination="true"
             data-page-size="100"
-            data-page-list="[25, 50, 100, 200, 500, All]">
+            data-page-list="[10, 25, 50, 100, 200, 500, All]">
             <thead>
             <tr>
                 <th data-field="Tissue" data-filter-control="input" data-sortable="true" data-sorter="htmlSorter">Tissue</th>
@@ -44,9 +46,22 @@
                 {% endfor %}
             </tbody>
         </table>
-        {% else %}
+    {% else %}
         <p>There are no tissues.</p>
-        {% endif %}
-    </ul>
+    {% endif %}
 </div>
+{% endblock %}
+
+{% block js_extras %}
+    {{ block.super }}
+    <script src="{% static 'js/setTableHeight.js' %}"></script>
+    <script>
+        let divID = "div_out_tab";
+        let pctVH = 0.85;
+        let vHeight = setTableHeight(divID, pctVH);
+        $('#tissue_list').bootstrapTable({
+            height: vHeight,
+            virtualScroll: true
+        })
+    </script>
 {% endblock %}

--- a/changelog.md
+++ b/changelog.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Pages/views
   - Created CSS file "bootstrap_table_cus1.css" to customize table options with Bootstrap-table plugin.
+  - Created CSS file "bootstrap_table_cus2.css" to customize table options with Bootstrap-table plugin.
   - Created JavaScript "setTableHeight.js" to set table height dynamically with Bootstrap-table plugin.
 
 ### Changed
@@ -20,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Modified code for customtag filter "obj_hyperlink" to display list with or without line breaks.
   - Improved display of infusates in study and aninal templates.
   - Changed column width for some columns in study and animal tables.
+  - Improved table height and vertical scrollbar for all list pages.
 
 ## [2.0.1] - 2023-01-05
 

--- a/static/css/bootstrap_table_cus2.css
+++ b/static/css/bootstrap_table_cus2.css
@@ -1,0 +1,35 @@
+/*
+hide scrollbar but allow scrolling
+note: set body didn't work for Firefox, need to set for html
+*/
+html {
+  scrollbar-width: none !important;  /* for Firefox */
+}
+
+body {
+  -ms-overflow-style: none; /* for Internet Explorer, Edge */
+}
+
+body::-webkit-scrollbar {
+  display: none !important; /* for Chrome, Safari */
+}
+
+/* customize Bootstrap-table settings for th */
+.bootstrap-table .fixed-table-container .table thead th .th-inner {
+  padding: 0.75rem;
+  vertical-align: top; /* change from bottom to top  */
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: normal !important; /* change from nowrap to normal */
+  height: 3rem; /* added new variable and value */
+  min-width: 2rem !important; /* added new variable and value */
+}
+
+/* customize Bootstrap-table settings for td */
+.bootstrap-table .fixed-table-container .table tbody tr.no-records-found td {
+  text-align: center;
+  overflow-wrap: word-wrap !important; /* added new variable and value */
+  word-wrap: break-all !important; /* added new variable and value */
+  word-break: break-all !important; /* added new variable and value */
+}
+

--- a/static/css/bootstrap_table_cus2.css
+++ b/static/css/bootstrap_table_cus2.css
@@ -32,4 +32,3 @@ body::-webkit-scrollbar {
   word-wrap: break-all !important; /* added new variable and value */
   word-break: break-all !important; /* added new variable and value */
 }
-


### PR DESCRIPTION
<!-- markdownlint-disable-next-line first-line-heading -->
## Summary Change Description

- Made changes to the following templates to solve issues with table height and two vertical scrollbars, using the same strategy implemented in [PR602 ](https://github.com/Princeton-LSI-ResearchComputing/tracebase/pull/602) for study, animal, and sample pages.
 
  - list of tissues
  - peak group sets
  - list of compounds
  - list of infusates

## Affected Issue Numbers

- Resolves #613
- Resolves #614
- Resolves #615
- Resolves #616 

## Code Review Notes

- Used two css files to set table header variables (for tables with long header text to wrap  or  tables with a few columns). Mainly set different height for `<th>` for Bootstrap-table plugin. Will re-visit the css files in the future to see if they can be re-organized.  
-  Would like to get the changes merged into main this week, since the list pages would look better for demo next week.

## Checklist

- [x] Changes have been added to the *Unreleased* section in the [`changelog.md`](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/changelog.md).
- [x] All issue requirements satisfied (or no linked issues)
- [x] [Linting passes](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#linting).
- [x] [Migrations created & committed *(or no model changes)*](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#migration-process)
- Tests
  - [x] [Tests implemented *(or no code changes)*](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#test-implementation)
  - [x] [All tests pass](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#quality-control)
  - [x] All example load tests pass (remotely) *(or their failures predated and are unrelated to this branch)*
