### PR TITLE
Fix URL for sample table template on upload page

### DIFF
--- a/DataRepo/templates/upload.html
+++ b/DataRepo/templates/upload.html
@@ -13,7 +13,7 @@
         <ol>
             <h5 id="create-a-sample-sheet"><li>Create a Sample Sheet</li></h5>
             <ol>
-                <li><a href="https://docs.google.com/spreadsheets/d/1ywj9BvwX76ygRc5iXHwmzBcg1CWc5eFjLGOC6NtSHo8/copy?copyComments=true">Copy</a> the TraceBase Animal and Sample Table Template.
+                <li><a href="https://docs.google.com/spreadsheets/d/1To3495KxJkAtnAD9KVdzc162zKbNiYuPEVyPseQPjMQ/copy?copyComments=true">Copy</a> the TraceBase Animal and Sample Table Template.
                 </li>
                 <li>Fill in the <em>Animals</em> sheet <a class="badge text-light bg-secondary" data-bs-toggle="collapse" data-bs-target="#fill-animals">more</a>
                     <div id="fill-animals" class="collapse">


### PR DESCRIPTION
<!-- markdownlint-disable-next-line first-line-heading -->
## Summary Change Description

Fix the link to the sample table template on the upload page

## Affected Issue Numbers

- Resolves #639

## Code Review Notes

## Checklist

- [ ] Changes have been added to the *Unreleased* section in the [`changelog.md`](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/changelog.md).
- [ ] All issue requirements satisfied (or no linked issues)
- [ ] [Linting passes](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#linting).
- [ ] [Migrations created & committed *(or no model changes)*](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#migration-process)
- Tests
  - [ ] [Tests implemented *(or no code changes)*](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#test-implementation)
  - [ ] [All tests pass](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#quality-control)
  - [ ] All example load tests pass (remotely) *(or their failures predated and are unrelated to this branch)*
