### PR TITLE
Superlinter v5

### DIFF
--- a/.github/workflows/superlinter.yml
+++ b/.github/workflows/superlinter.yml
@@ -2,7 +2,7 @@
 name: Super-Linter
 
 # Run this workflow every time a new commit is pushed to your repository
-on: push
+"on": push
 
 jobs:
   # Set the job key. The key is displayed as the job name
@@ -20,7 +20,7 @@ jobs:
 
       # Runs the Super-Linter action
       - name: Run Super-Linter
-        uses: github/super-linter/slim@v4
+        uses: github/super-linter/slim@v5
         env:
           DEFAULT_BRANCH: main
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/DataRepo/formats/dataformat.py
+++ b/DataRepo/formats/dataformat.py
@@ -1043,7 +1043,6 @@ class Format:
 
             # If the split_all override in false and there exist custom distinct fields defined
             if not split_all and custom_distinct_fields_exist:
-
                 for distinct_fld_nm in self.model_instances[mdl_inst_nm][
                     "fields"
                 ].keys():
@@ -1080,7 +1079,6 @@ class Format:
                 # expressions`
                 tmp_distincts = self.getOrderByFields(mdl_inst_nm)
                 for fld_nm in tmp_distincts:
-
                     # Remove potential loop added to the path when ordering_fields are dereferenced
                     # E.g. This changes "peak_data__labels__peak_data__peak_group__name" to
                     # "peak_data__peak_group__name"

--- a/DataRepo/formats/dataformat_group.py
+++ b/DataRepo/formats/dataformat_group.py
@@ -232,7 +232,7 @@ class FormatGroup:
         all_fld_choices = ()
         seen = []
         for fmtid in self.modeldata.keys():
-            for (fld_val, fld_name) in self.getSearchFieldChoices(fmtid):
+            for fld_val, fld_name in self.getSearchFieldChoices(fmtid):
                 if fld_val not in seen:
                     seen.append(fld_val)
                     all_fld_choices = all_fld_choices + ((fld_val, fld_name),)
@@ -647,7 +647,6 @@ class FormatGroup:
 
                 # For each stats category defined for this format
                 for params in params_arrays:
-
                     if "delimiter" in params:
                         delim = params["delimiter"]
                     else:

--- a/DataRepo/formats/dataformat_group_query.py
+++ b/DataRepo/formats/dataformat_group_query.py
@@ -229,7 +229,6 @@ def formsetToDict(rawformset, form_classes):
         formset = rawformset
 
     for rawform in formset:
-
         if isRaw:
             form = rawform.saved_data
         else:

--- a/DataRepo/management/commands/build_caches.py
+++ b/DataRepo/management/commands/build_caches.py
@@ -41,7 +41,6 @@ def cached_function_call(cls, cfunc_name):
 
 
 class Command(BaseCommand):
-
     # Show this when the user types help
     help = "Builds cache values for all cached_functions"
 

--- a/DataRepo/management/commands/load_accucor_msruns.py
+++ b/DataRepo/management/commands/load_accucor_msruns.py
@@ -143,7 +143,6 @@ class Command(BaseCommand):
         print(f"Done loading {fmt} data into MsRun, PeakGroups, and PeakData")
 
     def extract_dataframes_from_accucor_xlsx(self, options):
-
         if not options["isocorr_format"]:
             # Note, setting `mangle_dupe_cols=False` would overwrite duplicates instead of raise an exception, so we're
             # checking for duplicate headers manually here.
@@ -189,7 +188,6 @@ class Command(BaseCommand):
         ).dropna(axis=0, how="all")
 
     def extract_dataframes_from_csv(self, options):
-
         corr_heads = pd.read_csv(
             options["accucor_file"],
             nrows=1,

--- a/DataRepo/management/commands/load_animals_and_samples.py
+++ b/DataRepo/management/commands/load_animals_and_samples.py
@@ -9,7 +9,6 @@ from DataRepo.utils import SampleTableLoader
 
 
 class Command(BaseCommand):
-
     examples_dir = "DataRepo/example_data/"
     example_animals = examples_dir + "obob_animals_table.tsv"
     example_samples = examples_dir + "obob_samples_table.tsv"
@@ -87,7 +86,6 @@ class Command(BaseCommand):
         )
 
     def handle(self, *args, **options):
-
         self.stdout.write(self.style.MIGRATE_HEADING("Reading header definition..."))
         if options["table_headers"]:
             with open(options["table_headers"]) as headers_file:

--- a/DataRepo/management/commands/load_compounds.py
+++ b/DataRepo/management/commands/load_compounds.py
@@ -70,7 +70,6 @@ class Command(BaseCommand):
         self.stdout.write(self.style.SUCCESS(f"{action} compound data completed"))
 
     def extract_compounds_from_tsv(self, options):
-
         self.compounds_df = pd.read_csv(
             options["compounds"], sep="\t", keep_default_na=False
         )

--- a/DataRepo/management/commands/load_protocols.py
+++ b/DataRepo/management/commands/load_protocols.py
@@ -125,7 +125,6 @@ class Command(BaseCommand):
         return protocols_df, batch_category
 
     def read_protocols_tsv(self, protocols_tsv):
-
         # Keeping `na` to differentiate between intentional empty descriptions and spaces in the first column that were
         # intended to be tab characters
         protocols_df = pd.read_table(

--- a/DataRepo/management/commands/load_study.py
+++ b/DataRepo/management/commands/load_study.py
@@ -34,7 +34,6 @@ from DataRepo.utils.exceptions import (
 
 
 class Command(BaseCommand):
-
     # Path to example config file
     example_configfile = os.path.relpath(
         os.path.join(
@@ -108,7 +107,6 @@ class Command(BaseCommand):
         )
 
     def handle(self, *args, **options):
-
         self.missing_samples = defaultdict(list)
         self.missing_tissues = defaultdict(dict)
         self.missing_compounds = defaultdict(dict)
@@ -148,7 +146,6 @@ class Command(BaseCommand):
 
         with transaction.atomic():
             if "compounds" in study_params:
-
                 compound_file_basename = study_params["compounds"]
                 compounds_file = os.path.join(study_dir, compound_file_basename)
                 self.load_statuses.init_load(compounds_file)
@@ -170,7 +167,6 @@ class Command(BaseCommand):
                     self.package_group_exceptions(e, compounds_file)
 
             if "protocols" in study_params:
-
                 protocol_file_basename = study_params["protocols"]
                 protocols_file = os.path.join(study_dir, protocol_file_basename)
                 self.load_statuses.init_load(protocols_file)
@@ -193,7 +189,6 @@ class Command(BaseCommand):
                     self.package_group_exceptions(e, protocols_file)
 
             if "tissues" in study_params:
-
                 tissue_file_basename = study_params["tissues"]
                 tissues_file = os.path.join(study_dir, tissue_file_basename)
                 self.load_statuses.init_load(tissues_file)
@@ -216,7 +211,6 @@ class Command(BaseCommand):
                     self.package_group_exceptions(e, tissues_file)
 
             if "animals_samples_treatments" in study_params:
-
                 # Read in animals and samples file
                 sample_file_basename = study_params["animals_samples_treatments"][
                     "table"
@@ -260,7 +254,6 @@ class Command(BaseCommand):
                     self.package_group_exceptions(e, animals_samples_table_file)
 
             if "accucor_data" in study_params:
-
                 # Get parameters for all accucor files
                 study_protocol = study_params["accucor_data"]["msrun_protocol"]
                 study_date = study_params["accucor_data"]["date"]
@@ -275,7 +268,6 @@ class Command(BaseCommand):
 
                 # Read in accucor data files
                 for accucor_info_dict in study_params["accucor_data"]["accucor_files"]:
-
                     # Get parameters specific to each accucor file
                     accucor_file_basename = accucor_info_dict["name"]
                     accucor_file = os.path.join(study_dir, accucor_file_basename)
@@ -373,7 +365,6 @@ class Command(BaseCommand):
         # representation will be the "fatal error" and the errors in the files will be kept to cross-reference with the
         # group level error.  See handle_exceptions.
         if isinstance(exception, AggregatedErrors):
-
             # Consolidate related cross-file exceptions, like missing samples
             # Note, this can change whether the AggregatedErrors for this file are fatal or not
             missing_sample_exceptions = exception.get_exception_type(

--- a/DataRepo/management/commands/load_study_set.py
+++ b/DataRepo/management/commands/load_study_set.py
@@ -15,7 +15,6 @@ from DataRepo.utils.exceptions import AggregatedErrorsSet
 
 
 class Command(BaseCommand):
-
     # Show this when the user types help
     help = (
         "Loads a set of studies using the load_study command. Input is a file of "
@@ -39,7 +38,6 @@ class Command(BaseCommand):
         )
 
     def handle(self, *args, **options):
-
         # The buffer can only exist as long as the existence of the process, but since this method can be called from
         # code, who knows what has been done before.  So the clear_buffer option allows the load_study_set method to be
         # called in code with an option to explicitly clean the buffer.

--- a/DataRepo/management/commands/load_tissues.py
+++ b/DataRepo/management/commands/load_tissues.py
@@ -40,7 +40,6 @@ class Command(BaseCommand):
         )
 
     def handle(self, *args, **options):
-
         # Keeping `na` to differentiate between intentional empty descriptions and spaces in the first column that were
         # intended to be tab characters
         new_tissues = pd.read_csv(options["tissues"], sep="\t", keep_default_na=True)
@@ -61,7 +60,6 @@ class Command(BaseCommand):
         )
 
     def print_notices(self, stats, opt, verbosity):
-
         if verbosity >= 2:
             for stat in stats["created"]:
                 self.stdout.write(

--- a/DataRepo/management/commands/rebuild_maintained_fields.py
+++ b/DataRepo/management/commands/rebuild_maintained_fields.py
@@ -30,7 +30,6 @@ def rebuild_maintained_fields(label_filters=[]):
 
     # For every generation from the youngest leaves/children to root/parent
     for gen in sorted(range(youngest_generation + 1), reverse=True):
-
         # For every MaintainedModel derived class with decorated functions
         for cls in get_classes("DataRepo.models", gen, label_filters):
             class_name = cls.__name__
@@ -82,7 +81,6 @@ def rebuild_maintained_fields(label_filters=[]):
 
 
 class Command(BaseCommand):
-
     # Show this when the user types help
     help = "Update all maintained fields for every record in the database containing maintained fields."
 

--- a/DataRepo/models/animal_label.py
+++ b/DataRepo/models/animal_label.py
@@ -106,7 +106,6 @@ class AnimalLabel(HierCachedModel):
             last_serum_tracers_enrichment_sum = 0.0
             total_atom_count = 0
             for pg in self.last_serum_tracer_label_peak_groups.all():
-
                 # Count the total number of this element among all the tracer compounds (via the single peakgroup
                 # formula).   This may be called on formulas that do not have self.element, but those just return 0 and
                 # that's OK.

--- a/DataRepo/models/compound.py
+++ b/DataRepo/models/compound.py
@@ -117,7 +117,6 @@ class Compound(models.Model):
 
 
 class CompoundSynonym(models.Model):
-
     # Instance / model fields
     name = models.CharField(
         primary_key=True,

--- a/DataRepo/models/element_label.py
+++ b/DataRepo/models/element_label.py
@@ -3,7 +3,6 @@
 # (https://docs.djangoproject.com/en/3.2/topics/db/models/#abstract-base-classes).
 # This simply shares some configured variables/values.
 class ElementLabel:
-
     # choice specifications
     CARBON = "C"
     NITROGEN = "N"

--- a/DataRepo/models/maintained_model.py
+++ b/DataRepo/models/maintained_model.py
@@ -234,7 +234,6 @@ def maintained_model_relation(
         )
 
     def decorator(cls):
-
         func_dict = {
             "update_function": None,
             "update_field": None,
@@ -442,7 +441,6 @@ class MaintainedModel(Model):
 
         class_name = self.__class__.__name__
         for updater_dict in updater_list[class_name]:
-
             # Ensure the field being set is not a maintained field
 
             update_fld = updater_dict["update_field"]
@@ -470,7 +468,6 @@ class MaintainedModel(Model):
                 ]
             )
             if decorator_signature not in self.maintained_model_initialized:
-
                 if settings.DEBUG:
                     print(
                         f"Validating {self.__class__.__name__} updater: {updater_dict}"
@@ -696,7 +693,6 @@ class MaintainedModel(Model):
             # update we're about to trigger
             parent_sig = f"{parent_inst.__class__.__name__}.{parent_inst.id}"
             if parent_sig not in updated:
-
                 if settings.DEBUG:
                     self_sig = f"{self.__class__.__name__}.{self.pk}"
                     print(
@@ -733,17 +729,14 @@ class MaintainedModel(Model):
 
             # If there is a parent that should update based on this change
             if parent_fld is not None:
-
                 # Get the parent instance
                 tmp_parent_inst = getattr(self, parent_fld)
 
                 # if a parent record exists
                 if tmp_parent_inst is not None:
-
                     try:
                         # Make sure that the (direct) parnet (or M:M related parent) *isa* MaintainedModel
                         if isinstance(tmp_parent_inst, MaintainedModel):
-
                             parent_inst = tmp_parent_inst
                             if parent_inst not in parents:
                                 parents.append(parent_inst)
@@ -752,12 +745,10 @@ class MaintainedModel(Model):
                             tmp_parent_inst.__class__.__name__ == "ManyRelatedManager"
                             or tmp_parent_inst.__class__.__name__ == "RelatedManager"
                         ):
-
                             # NOTE: This is where the `through` model is skipped
                             if tmp_parent_inst.count() > 0 and isinstance(
                                 tmp_parent_inst.first(), MaintainedModel
                             ):
-
                                 for mm_parent_inst in tmp_parent_inst.all():
                                     if mm_parent_inst not in parents:
                                         parents.append(mm_parent_inst)
@@ -788,12 +779,10 @@ class MaintainedModel(Model):
         """
         children = self.get_child_instances()
         for child_inst in children:
-
             # If the current instance's update was triggered - and was triggered by the same child instance whose
             # update we're about to trigger
             child_sig = f"{child_inst.__class__.__name__}.{child_inst.id}"
             if child_sig not in updated:
-
                 if settings.DEBUG:
                     self_sig = f"{self.__class__.__name__}.{self.pk}"
                     print(
@@ -829,16 +818,13 @@ class MaintainedModel(Model):
 
             # If there is a child that should update based on this change
             for child_fld in child_flds:
-
                 # Get the child instance
                 tmp_child_inst = getattr(self, child_fld)
 
                 # if a child record exists
                 if tmp_child_inst is not None:
-
                     # Make sure that the (direct) parnet (or M:M related child) *isa* MaintainedModel
                     if isinstance(tmp_child_inst, MaintainedModel):
-
                         child_inst = tmp_child_inst
                         if child_inst not in children:
                             children.append(child_inst)
@@ -847,15 +833,12 @@ class MaintainedModel(Model):
                         tmp_child_inst.__class__.__name__ == "ManyRelatedManager"
                         or tmp_child_inst.__class__.__name__ == "RelatedManager"
                     ):
-
                         try:
                             # NOTE: This is where the `through` model is skipped
                             if tmp_child_inst.count() > 0 and isinstance(
                                 tmp_child_inst.first(), MaintainedModel
                             ):
-
                                 for mm_child_inst in tmp_child_inst.all():
-
                                     if mm_child_inst not in children:
                                         children.append(mm_child_inst)
 
@@ -1203,7 +1186,6 @@ def perform_buffered_updates(label_filters=None, filter_in=None):
                 updated = buffer_item.call_dfs_related_updaters(updated=updated)
 
             elif key not in updated and buffer_item not in new_buffer:
-
                 new_buffer.append(buffer_item)
 
         except Exception as e:

--- a/DataRepo/models/peak_group.py
+++ b/DataRepo/models/peak_group.py
@@ -16,7 +16,6 @@ from DataRepo.models.utilities import atom_count_in_formula
     update_label="fcirc_calcs",
 )
 class PeakGroup(HierCachedModel, MaintainedModel):
-
     parent_related_key_name = "msrun"
     child_related_key_names = ["labels"]
 

--- a/DataRepo/models/peak_group_label.py
+++ b/DataRepo/models/peak_group_label.py
@@ -11,7 +11,6 @@ from DataRepo.models.utilities import atom_count_in_formula
 
 
 class PeakGroupLabel(HierCachedModel):
-
     parent_related_key_name = "peak_group"
     # Leaf
 

--- a/DataRepo/models/protocol.py
+++ b/DataRepo/models/protocol.py
@@ -2,7 +2,6 @@ from django.db import models
 
 
 class Protocol(models.Model):
-
     MSRUN_PROTOCOL = "msrun_protocol"
     ANIMAL_TREATMENT = "animal_treatment"
     CATEGORY_CHOICES = [

--- a/DataRepo/models/tracer.py
+++ b/DataRepo/models/tracer.py
@@ -63,7 +63,6 @@ class TracerQuerySet(models.QuerySet):
 
 
 class Tracer(MaintainedModel, ElementLabel):
-
     objects = TracerQuerySet().as_manager()
 
     id = models.AutoField(primary_key=True)

--- a/DataRepo/models/tracer_label.py
+++ b/DataRepo/models/tracer_label.py
@@ -15,7 +15,6 @@ from DataRepo.utils.infusate_name_parser import IsotopeData
 
 class TracerLabelQuerySet(models.QuerySet):
     def create_tracer_label(self, tracer: Tracer, isotope_data: IsotopeData):
-
         tracer_label = self.create(
             tracer=tracer,
             element=isotope_data["element"],
@@ -29,7 +28,6 @@ class TracerLabelQuerySet(models.QuerySet):
 
 
 class TracerLabel(MaintainedModel, ElementLabel):
-
     objects = TracerLabelQuerySet().as_manager()
 
     id = models.AutoField(primary_key=True)

--- a/DataRepo/tests/loading/test_load_accucor_msruns.py
+++ b/DataRepo/tests/loading/test_load_accucor_msruns.py
@@ -121,7 +121,6 @@ class AccuCorDataLoadingTests(TracebaseTestCase):
         self.assertTrue(isinstance(aes.exceptions[0], NoSamplesError))
 
     def test_accucor_load_in_debug(self):
-
         pre_load_counts = self.get_record_counts()
         pre_load_maintained_values = get_all_maintained_field_values("DataRepo.models")
         self.assertGreater(

--- a/DataRepo/tests/loading/test_loading_compounds.py
+++ b/DataRepo/tests/loading/test_loading_compounds.py
@@ -54,7 +54,6 @@ class LoadCompoundsTests(TracebaseTestCase):
 class CompoundLoadingTests(TracebaseTestCase):
     @classmethod
     def setUpTestData(cls):
-
         primary_compound_file = (
             "DataRepo/example_data/consolidated_tracebase_compound_list.tsv"
         )

--- a/DataRepo/tests/loading/test_loading_protocols.py
+++ b/DataRepo/tests/loading/test_loading_protocols.py
@@ -23,7 +23,6 @@ class ProtocolLoadingTests(TracebaseTestCase):
 
     @classmethod
     def setUpTestData(cls):
-
         # initialize list of lists
         data = [
             ["no treatment", "No treatment was applied to the animal."],
@@ -171,7 +170,6 @@ class ProtocolLoadingTests(TracebaseTestCase):
         self.assertEqual(Protocol.objects.count(), 0)
 
     def test_protocol_load_in_debug(self):
-
         pre_load_counts = self.get_record_counts()
         self.assertEqual(0, buffer_size(), msg="Autoupdate buffer is empty to start.")
 

--- a/DataRepo/tests/test_models.py
+++ b/DataRepo/tests/test_models.py
@@ -60,7 +60,6 @@ from DataRepo.utils import (
 
 class ExampleDataConsumer:
     def get_sample_test_dataframe(self):
-
         # making this a dataframe, if more rows are need for future tests, or we
         # switch to a file based test
         test_df = pd.DataFrame(
@@ -82,7 +81,6 @@ class ExampleDataConsumer:
         return test_df
 
     def get_peak_group_test_dataframe(self):
-
         peak_data_df = pd.DataFrame(
             {
                 "labeled_element": ["C", "C"],
@@ -448,7 +446,6 @@ class DataLoadingTests(TracebaseTestCase):
         self.assertFalse(nonserum.is_serum_sample)
 
     def test_peak_groups_set_loaded(self):
-
         # 2 peak group sets , 1 for each call to load_accucor_msruns
         self.assertEqual(
             PeakGroupSet.objects.all().count(), self.ALL_PEAKGROUPSETS_COUNT
@@ -1836,7 +1833,6 @@ class AnimalAndSampleLoadingTests(TracebaseTestCase):
         super().setUpTestData()
 
     def test_animal_and_sample_load_xlsx(self):
-
         # initialize some sample-table-dependent counters
         SAMPLES_COUNT = 16
         ANIMALS_COUNT = 1
@@ -1859,7 +1855,6 @@ class AnimalAndSampleLoadingTests(TracebaseTestCase):
         self.assertEqual(study.animals.count(), ANIMALS_COUNT)
 
     def test_animal_and_sample_load_in_dry_run(self):
-
         # Load some data to ensure that none of it changes during the actual test
         call_command(
             "load_animals_and_samples",
@@ -2131,7 +2126,6 @@ class StudyLoadingTests(TracebaseTestCase):
         )
 
     def test_leaderboards(self):
-
         expected_leaderboard = {
             "studies_leaderboard": [
                 (Researcher(name="Xianfeng Zeng"), 1),

--- a/DataRepo/utils/accucor_data_loader.py
+++ b/DataRepo/utils/accucor_data_loader.py
@@ -259,7 +259,6 @@ class AccuCorDataLoader:
                 )
 
     def initialize_sample_names(self):
-
         minimum_sample_index = self.get_first_sample_column_index(
             self.accucor_corrected_df
         )
@@ -355,7 +354,6 @@ class AccuCorDataLoader:
                 )
 
     def validate_compounds(self):
-
         # In case validate_compounds is ever called more than once...
         # These are used to skip duplicated data in the load
         self.dupe_isotope_compounds["original"] = defaultdict(dict)
@@ -417,7 +415,6 @@ class AccuCorDataLoader:
             )
 
     def initialize_db_samples_dict(self):
-
         self.missing_samples = []
 
         if self.verbosity >= 1:
@@ -570,7 +567,6 @@ class AccuCorDataLoader:
             if peak_group_formula_key:
                 peak_group_formula = row[peak_group_formula_key]
             if peak_group_name not in self.peak_group_dict:
-
                 # cache it for later; note, if the first row encountered
                 # is missing a formula, there will be issues later
                 self.peak_group_dict[peak_group_name] = {
@@ -691,7 +687,6 @@ class AccuCorDataLoader:
 
         # Each sample gets its own msrun
         for sample_name in self.db_samples_dict.keys():
-
             # each msrun/sample has its own set of peak groups
             inserted_peak_group_dict = {}
 
@@ -762,12 +757,10 @@ class AccuCorDataLoader:
 
         # Create all PeakGroups
         for sample_name in sample_msrun_dict.keys():
-
             msrun = sample_msrun_dict[sample_name]
 
             # Pass through the rows once to identify the PeakGroups
             for index, corr_row in self.accucor_corrected_df.iterrows():
-
                 try:
                     obs_isotopes = self.get_observed_isotopes(corr_row)
                     peak_group_name = corr_row[self.compound_header]
@@ -792,7 +785,6 @@ class AccuCorDataLoader:
                         and obs_isotopes[0]["parent"]
                         and peak_group_name in self.peak_group_dict
                     ):
-
                         """
                         Here we insert PeakGroup, by name (only once per file).
                         NOTE: If the C12 PARENT/0-Labeled row encountered has any issues (for example, a null formula),
@@ -854,12 +846,10 @@ class AccuCorDataLoader:
 
             # For each PeakGroup, create PeakData rows
             for peak_group_name in inserted_peak_group_dict:
-
                 # we should have a cached PeakGroup and its labeled element now
                 peak_group = inserted_peak_group_dict[peak_group_name]
 
                 if self.accucor_original_df is not None:
-
                     peak_group_original_data = self.accucor_original_df.loc[
                         self.accucor_original_df["compound"] == peak_group_name
                     ]
@@ -874,7 +864,6 @@ class AccuCorDataLoader:
                         0, peak_group_label_rec.atom_count() + 1
                     ):
                         try:
-
                             raw_abundance = 0
                             med_mz = 0
                             med_rt = 0
@@ -971,7 +960,6 @@ class AccuCorDataLoader:
                     ]
 
                     for _index, corr_row in peak_group_corrected_df.iterrows():
-
                         try:
                             corrected_abundance_for_sample = corr_row[sample_name]
                             # No original dataframe, no raw_abundance, med_mz, or med_rt
@@ -1005,7 +993,6 @@ class AccuCorDataLoader:
                             )
 
                             for isotope in corr_isotopes:
-
                                 if self.verbosity >= 1:
                                     print(
                                         f"\t\t\tInserting peak data label [{isotope['mass_number']}{isotope['element']}"
@@ -1119,7 +1106,6 @@ class AccuCorDataLoader:
                 )
 
         else:
-
             # Get the mass number(s) from the associated tracers
             mns = [
                 x["mass_number"]
@@ -1199,7 +1185,6 @@ class AccuCorDataLoader:
         return isotope_observations
 
     def load_accucor_data(self):
-
         self.pre_load_setup()
 
         # Data validation and loading

--- a/DataRepo/utils/exceptions.py
+++ b/DataRepo/utils/exceptions.py
@@ -297,7 +297,6 @@ class MultiLoadStatus(Exception):
     """
 
     def __init__(self, load_keys=None):
-
         self.state = "PASSED"
         self.is_valid = True
         self.num_errors = 0
@@ -379,7 +378,6 @@ class MultiLoadStatus(Exception):
         return self.is_valid
 
     def get_final_exception(self, message=None):
-
         # If success, return None
         if self.get_success_status():
             return None
@@ -403,7 +401,6 @@ class MultiLoadStatus(Exception):
         return AggregatedErrorsSet(aggregated_errors_dict, message=message)
 
     def get_status_message(self):
-
         # Overall status message
         message = f"Load {self.state}"
         if self.num_warnings > 0:
@@ -414,7 +411,6 @@ class MultiLoadStatus(Exception):
         return message, self.state
 
     def get_status_messages(self):
-
         messages = []
         for load_key in self.get_ordered_status_keys(reverse=False):
             messages.append(

--- a/DataRepo/utils/infusate_name_parser.py
+++ b/DataRepo/utils/infusate_name_parser.py
@@ -97,7 +97,7 @@ def parse_infusate_name(
             f"\tTracers: {tracer_strings}\n"
             f"\tConcentration values: {concentrations}"
         )
-    for (tracer_string, concentration) in zip_longest(tracer_strings, concentrations):
+    for tracer_string, concentration in zip_longest(tracer_strings, concentrations):
         infusate_tracer: InfusateTracer = {
             "tracer": parse_tracer_string(tracer_string),
             "concentration": concentration,
@@ -113,7 +113,6 @@ def split_encoded_tracers_string(tracers_string: str) -> List[str]:
 
 
 def parse_tracer_string(tracer: str) -> TracerData:
-
     tracer_data: TracerData = {
         "unparsed_string": tracer,
         "compound_name": "",
@@ -139,7 +138,6 @@ def parse_tracer_string(tracer: str) -> TracerData:
 
 
 def parse_isotope_string(isotopes_string: str) -> List[IsotopeData]:
-
     if not isotopes_string:
         raise IsotopeParsingError("parse_isotope_string requires a defined string.")
 
@@ -152,7 +150,6 @@ def parse_isotope_string(isotopes_string: str) -> List[IsotopeData]:
 
     parsed_string = None
     for isotope in ISOTOPE_ENCODING_PATTERN.finditer(isotopes_string):
-
         mass_number = int(isotope.group("mass_number"))
         element = isotope.group("element")
         count = int(isotope.group("count"))

--- a/DataRepo/utils/sample_table_loader.py
+++ b/DataRepo/utils/sample_table_loader.py
@@ -207,7 +207,6 @@ class SampleTableLoader:
         }
 
     def load_sample_table(self, data):
-
         disable_autoupdates()
         disable_caching_updates()
         # Only auto-update fields whose update_label in the decorator is "name"
@@ -716,7 +715,6 @@ class SampleTableLoader:
                     print(f"SKIPPING existing Sample record: {sample_name}")
 
             except Sample.DoesNotExist:
-
                 try:
                     sample_rec, sample_created = Sample.objects.get_or_create(
                         name=sample_name,

--- a/DataRepo/views/loading/validation.py
+++ b/DataRepo/views/loading/validation.py
@@ -256,7 +256,6 @@ class DataValidationView(FormView):
 
     def add_ms_data(self, basic_loading_data, tmpdir, files, filenames, is_isocorr):
         for i, form_file_path in enumerate(files):
-
             if len(files) == len(filenames):
                 fn = filenames[i]
             else:

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -1,13 +1,17 @@
 # Specifies only dev-specific requirements
 # But imports the common ones too
 -r common.txt
-flake8==4.0.1
-black==22.3.0
-isort==5.10.1
-pylint==2.13.4
-mypy==0.942
-mypy-extensions==0.4.3
-yamllint==1.26.3
+flake8==6.0.0
+mccabe==0.7.0
+pycodestyle==2.10.0
+pyflakes==3.0.1
+black==23.3.0
+isort==5.12.0
+pylint==2.17.4
+mypy==1.2.0
+mypy-extensions==1.0.0
+tomli==2.0.1
+typing_extensions==4.5.0
+yamllint==1.31.0
 mkdocs>=1.4.2
 mkdocs-roamlinks-plugin>=0.1.3
-

--- a/static/css/sidebar.css
+++ b/static/css/sidebar.css
@@ -2,6 +2,6 @@
   width: 9rem;
 }
 
-@media (min-width: 768px) {
+@media (width >= 768px) {
   #sidebar-wrapper { margin-left: 0; }
 }


### PR DESCRIPTION
<!-- markdownlint-disable-next-line first-line-heading -->
## Summary Change Description

Update Super-Linter to v5
    
Update Super-Linter to version 5
Update various linter versions in requirements/dev.txt to match
Reformat some files (mostly just whitespace change in black)

## Affected Issue Numbers

## Code Review Notes

This is a minor update, just happened to notice that super-linter had a new version which required a few formatting changes. This handles it all in one PR.

## Checklist

- [x] Changes have been added to the *Unreleased* section in the [`changelog.md`](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/changelog.md).
- [x] All issue requirements satisfied (or no linked issues)
- [x] [Linting passes](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#linting).
- [x] [Migrations created & committed *(or no model changes)*](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#migration-process)
- Tests
  - [x] [Tests implemented *(or no code changes)*](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#test-implementation)
  - [x] [All tests pass](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#quality-control)
  - [x] All example load tests pass (remotely) *(or their failures predated and are unrelated to this branch)*
