### PR TITLE
Update handling of multiple file uploads

### DIFF
--- a/DataRepo/forms.py
+++ b/DataRepo/forms.py
@@ -289,6 +289,28 @@ class AdvSearchPageForm(forms.Form):
         return True
 
 
+class MultipleFileInput(forms.ClearableFileInput):
+    """Subclass of ClearableFileInput that specifically allows multiple selected files"""
+
+    allow_multiple_selected = True
+
+
+class MultipleFileField(forms.FileField):
+    """Subclass of FileField that validates multiple files submitted in a single form field"""
+
+    def __init__(self, *args, **kwargs):
+        kwargs.setdefault("widget", MultipleFileInput())
+        super().__init__(*args, **kwargs)
+
+    def clean(self, data, initial=None):
+        single_file_clean = super().clean
+        if isinstance(data, (list, tuple)):
+            result = [single_file_clean(d, initial) for d in data]
+        else:
+            result = single_file_clean(data, initial)
+        return result
+
+
 class DataSubmissionValidationForm(forms.Form):
     """
     Form for users to validate their Animal and Sample Table with Accucor and/or Isocorr files
@@ -302,9 +324,9 @@ class DataSubmissionValidationForm(forms.Form):
     animal_sample_table = forms.FileField(
         required=True, widget=forms.ClearableFileInput(attrs={"multiple": False})
     )
-    accucor_files = forms.FileField(
-        required=False, widget=forms.ClearableFileInput(attrs={"multiple": True})
+    accucor_files = MultipleFileField(
+        required=False, widget=MultipleFileInput(attrs={"multiple": True})
     )
-    isocorr_files = forms.FileField(
-        required=False, widget=forms.ClearableFileInput(attrs={"multiple": True})
+    isocorr_files = MultipleFileField(
+        required=False, widget=MultipleFileInput(attrs={"multiple": True})
     )

--- a/requirements/common.txt
+++ b/requirements/common.txt
@@ -1,4 +1,4 @@
-Django==3.2.18
+Django==3.2.19
 psycopg2-binary==2.8.6
 django-environ==0.4.5
 django-validators==1.0.1


### PR DESCRIPTION
Django <= 3.2.18 allowed multiple files to be uploaded using a `ClearableFileInput`. However, this presented a security risk since only the first file was validated. This PR extends the `forms.FileField` to properly validate multiple submitted files.

<!-- markdownlint-disable-next-line first-line-heading -->
## Summary Change Description

Django <= 3.2.18 allowed multiple files to be uploaded using a `ClearableFileInput`. However, this presented a security risk since only the first file was validated. This PR extends the `forms.FileField` to properly validate multiple submitted files.

Source: https://docs.djangoproject.com/en/3.2/topics/http/file-uploads/#uploading-multiple-files

## Affected Issue Numbers

- Resolves #680

## Code Review Notes

## Checklist

- [x] Changes have been added to the *Unreleased* section in the [`changelog.md`](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/changelog.md).
- [x] All issue requirements satisfied (or no linked issues)
- [x] [Linting passes](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#linting).
- [x] [Migrations created & committed *(or no model changes)*](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#migration-process)
- Tests
  - [x] [Tests implemented *(or no code changes)*](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#test-implementation)
  - [x] [All tests pass](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#quality-control)
  - [x] All example load tests pass (remotely) *(or their failures predated and are unrelated to this branch)*
