### PR TITLE
Display None when enrichment values are missing

### DIFF
--- a/DataRepo/templates/DataRepo/search/results/peakgroups.html
+++ b/DataRepo/templates/DataRepo/search/results/peakgroups.html
@@ -338,12 +338,26 @@
 
                     <!-- Enrichment Fraction -->
                     <td class="text-end">
-                        {% for label_rec in label_recs %}{% if not forloop.first %}, {% endif %}<p title="{{ label_rec.enrichment_fraction|floatformat:15 }}">{{ label_rec.enrichment_fraction|floatformat:4 }}</p>{% endfor %}
+                        {% for label_rec in label_recs %}
+                            {% if not forloop.first %}, {% endif %}
+                            {% if label_rec.enrichment_fraction is None %}
+                                <p>None</p>
+                            {% else %}
+                                <p title="{{ label_rec.enrichment_fraction|floatformat:15 }}">{{ label_rec.enrichment_fraction|floatformat:4 }}</p>
+                            {% endif %}
+                        {% endfor %}
                     </td>
 
                     <!-- Enrichment Abundance -->
                     <td class="text-end">
-                        {% for label_rec in label_recs %}{% if not forloop.first %}, {% endif %}<p title="{{ label_rec.enrichment_abundance|floatformat:10 }}">{{ label_rec.enrichment_abundance|floatformat:4 }}</p>{% endfor %}
+                        {% for label_rec in label_recs %}
+                            {% if not forloop.first %}, {% endif %}
+                            {% if label_rec.enrichment_abundance is None %}
+                                <p>None</p>
+                            {% else %}
+                                <p title="{{ label_rec.enrichment_abundance|floatformat:10 }}">{{ label_rec.enrichment_abundance|floatformat:4 }}</p>
+                            {% endif %}
+                        {% endfor %}
                     </td>
 
                     <!-- Normalized Labeling -->

--- a/changelog.md
+++ b/changelog.md
@@ -13,6 +13,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Sample table loading now checks in-file sample name uniqueness
 - Added the ability for the accucor loading code to deal with infusates with multiple labeled elements when there is only 1 isotopic version of it among the tracers.
 
+
+### Fixed
+
+- PeakGroups table now displays "None" when erichment fraction or enrichment
+  abundance cannot be calculated. Previously was blank. (Issue #611).
+
 ### Changed
 
 - Stripped units in the sample table loader now generate an error if the units are deemed to be incorrect.


### PR DESCRIPTION


<!-- markdownlint-disable-next-line first-line-heading -->
## Summary Change Description

Templates now check enrichment fraction and enrichment abundance and display "None" if no value can be calculated.

## Affected Issue Numbers

- Resolves #611

## Code Review Notes

Describe any areas of concern that code reviewers should pay particular
attention to.  E.g. There are significant logic changes in function X.

## Checklist

- [x] Changes have been added to the *Unreleased* section in the [`changelog.md`](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/changelog.md).
- [x] All issue requirements satisfied (or no linked issues)
- [x] [Linting passes](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#linting).
- [x] [Migrations created & committed *(or no model changes)*](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#migration-process)
- Tests
  - [x] [Tests implemented *(or no code changes)*](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#test-implementation)
  - [x] [All tests pass](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#quality-control)
  - [x] All example load tests pass (remotely) *(or their failures predated and are unrelated to this branch)*
