### PR TITLE
Include ArchiveFile information in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -275,3 +275,36 @@ Check for unapplied migrations:
 Apply migrations to the postgres database:
 
     python manage.py migrate
+
+### Archive Files
+
+TraceBase has an `ArchiveFile` class that is used to [store data files on the
+file system](https://docs.djangoproject.com/en/3.2/topics/files/). The files
+are stored locally using the
+[`MEDIA_ROOT`](https://docs.djangoproject.com/en/3.2/ref/settings/#std-setting-MEDIA_ROOT)
+and
+[`MEDIA_URL`](https://docs.djangoproject.com/en/3.2/ref/settings/#std-setting-MEDIA_URL)
+settings. A
+[`FileField`](https://docs.djangoproject.com/en/3.2/ref/models/fields/#django.db.models.FileField)
+is used to manage store the files and to track the storage location in the
+database.
+
+Archived files are stored in
+`{MEDIA_ROOT}/archive_files/{YYYY-MM}/{DATA_TYPE}/{FILENAME}"`. Duplicate file
+names are made unique by Django's
+[`Storage.save()`](https://docs.djangoproject.com/en/3.2/ref/files/storage/#django.core.files.storage.Storage.save)
+method.
+
+When running tests, it is desirable that the file stored do not remain on the
+file system after testing is complete. This is accomplished in TraceBase by
+using a custom test runner `Tracebase/runner.py`. The test runner changes the
+`MEDIA_ROOT` and `DEFAULT_FILE_STORAGE` settings during test runs to use a
+temporary location on local file storage.
+
+Per the
+[`FileField.delete()`](https://docs.djangoproject.com/en/4.2/ref/models/fields/#django.db.models.fields.files.FieldFile.delete)
+documentation, when a model is deleted, related files are not deleted. If you
+need to cleanup orphaned files, you’ll need to handle it yourself (for
+instance, with a custom management command that can be run manually or
+scheduled to run periodically via e.g. cron). See [Management command to list
+orphaned files in `MEDIA_ROOT` #718](https://github.com/Princeton-LSI-ResearchComputing/tracebase/issues/718).


### PR DESCRIPTION
<!-- markdownlint-disable-next-line first-line-heading -->
## Summary Change Description

Include documentation about `ArchiveFile` in the `CONTRIBUTING.md` file.

## Affected Issue Numbers

- Resolves #719 

## Code Review Notes


## Checklist

- [x] Changes have been added to the *Unreleased* section in the [`changelog.md`](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/changelog.md).
- [x] All issue requirements satisfied (or no linked issues)
- [x] [Linting passes](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#linting).
- [x] [Migrations created & committed *(or no model changes)*](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#migration-process)
- Tests
  - [x] [Tests implemented *(or no code changes)*](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#test-implementation)
  - [x] [All tests pass](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#quality-control)
  - [x] All example load tests pass (remotely) *(or their failures predated and are unrelated to this branch)*
