### PR TITLE
Update to Django 4.2, with necessary changes due to changes in behavior of `save()`

### DIFF
--- a/.github/workflows/tracebase-tests.yml
+++ b/.github/workflows/tracebase-tests.yml
@@ -32,10 +32,10 @@ jobs:
       VALIDATION_ENABLED: true
     steps:
       - uses: actions/checkout@v1
-      - name: Set up Python 3.8
+      - name: Set up Python 3.9
         uses: actions/setup-python@v1
         with:
-          python-version: 3.8
+          python-version: 3.9
       - name: psycopg2 prerequisites
         run: |
           sudo apt-get update

--- a/.github/workflows/tracebase-tests.yml
+++ b/.github/workflows/tracebase-tests.yml
@@ -10,7 +10,7 @@ jobs:
 
     services:
       postgres:
-        image: postgres:10.8
+        image: postgres:13.4
         env:
           POSTGRES_USER: postgres
           POSTGRES_PASSWORD: postgres

--- a/DataRepo/models/hier_cached_model.py
+++ b/DataRepo/models/hier_cached_model.py
@@ -220,9 +220,18 @@ class HierCachedModel(Model):
         # For every child model for which we have a related name
         for child_rel_name in self.child_related_key_names:
             child_instance = getattr(self, child_rel_name)
-            # For every child record, call its delete_descendant_caches()
-            for rec in child_instance.all():
-                rec.delete_descendant_caches()
+            try:
+                # For every child record, call its delete_descendant_caches()
+                for rec in child_instance.all():
+                    rec.delete_descendant_caches()
+            except ValueError as ve:
+                if (
+                    "instance needs to have a primary key value before this relationship can be used."
+                    not in str(ve)
+                ):
+                    raise ve
+                # The ValueError happens when child records don't exist (inferred from no primary key), so there cannot
+                # exist descendant caches to delete and this can be ignored
 
     @classmethod
     def get_my_cached_method_names(cls):

--- a/requirements/common.txt
+++ b/requirements/common.txt
@@ -1,4 +1,4 @@
-Django==3.2.20
+Django==4.2.4
 psycopg2-binary==2.9.6
 django-environ==0.10.0
 django-validators==1.0.1


### PR DESCRIPTION
## Summary Change Description

This PR catches an handles exceptions thrown in Django 4.2 that previously were not thrown in 3.2.  There are potentially multiple possible fixes for this issue, but I believe this fix is the least complex and most effective fix, though it does have a caveat.

Here's the difference between 3.2 and 4.2 in a nutshell:

In Django 3.2, if you're creating an Animal object, it will have a null `samples` "related name" because `Sample` has a foreign key into `Animal`.  In Django 3.2, you could override `save` in a superclass and traverse this relation, e.g. `self.samples.count()` or `self.samples.filter(...)` and it would return either `0` or and empty queryset, respectively.

Django 4.2 disallows traversal of these un-set-up relations (probably due to some new functionality, who knows) and throws a `ValueError` exception. But it does this indirectly (inferred from the existence of `self.pk`).

However, 4.2 *DOES* still allow traversals of relations that are direct members of the object being created.  E.g. you can query `self.animal...` in the `Sample` class's `save` override.

This PR solves the issue by making an assumption: if the updater method in the derived class traverses a disallowed relation, then there does not exist a valid value to make an update with.  The update is simply skipped.  In all cases, this is equivalent to the behavior in 3.2, where it was auto-updating field values to null/`None`.  In this case, it is simply leaving the field as `None` instead of explicitly setting it as `None`.

The **caveat** is that an updater method in the derived class **could** be a composite value with a "valid" component and an "invalid" component.  In 3.2, the value would get created and the "invalid" component would just not be included in the final value, e.g. if it loops on related records to append a value (or values).

An alternative solution would be to re-package the exception to explain that an updater must check the existence of `self.pk` and decide what to do when it is `None`.  Or I could add a warning to the log that explains it, but doesn't halt execution.

There are other places where the exception is ignored: (triggering auto-updates through relations in `MaintainedModel` and deleting descendant record caches in `HierCachedModel`, but in both of those cases, there is no caveat.  If there are no relations, there's nothing to do.

## Affected Issue Numbers

- Resolves #721
- Resolved #738 
- Cannot be merged until issue #729 is implemented

## Code Review Notes

Note, if you wish to test this, you will need to execute:
```
python -m pip install -r requirements/dev.txt
```

## Checklist

- [ ] Changes have been added to the *Unreleased* section in the [`changelog.md`](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/changelog.md).
- [x] All issue requirements satisfied (or no linked issues)
- [x] [Linting passes](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#linting).
- [x] [Migrations created & committed *(or no model changes)*](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#migration-process)
- Tests
  - [ ] [Tests implemented *(or no code changes)*](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#test-implementation)
  - [x] [All tests pass](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#quality-control)
  - [x] All example load tests pass (remotely) *(or their failures predated and are unrelated to this branch)*
