### PR TITLE
Use default admin interface for all models

### DIFF
--- a/DataRepo/admin.py
+++ b/DataRepo/admin.py
@@ -1,8 +1,19 @@
+from django.apps import apps
 from django.contrib import admin
 
-from .models import Compound
+from DataRepo.models import Compound
 
 
 @admin.register(Compound)
 class CompoundAdmin(admin.ModelAdmin):
     list_display = ["name", "formula", "hmdb_id"]
+
+
+# Use default ModelAdmin for remaining DataRepo models
+datarepo_models = apps.get_app_config("DataRepo").get_models()
+
+for model in datarepo_models:
+    try:
+        admin.site.register(model)
+    except admin.sites.AlreadyRegistered:
+        pass

--- a/changelog.md
+++ b/changelog.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Added an ArchiveFile class with associated DataType and DataFormat classes
 - LCMethod model and tests
+- Default view of all models in the admin interface
 
 ### Changed
 


### PR DESCRIPTION
<!-- markdownlint-disable-next-line first-line-heading -->
## Summary Change Description

The admin interface can be very useful when looking through the values in the database. Having a default view for each model makes it much more usable.

## Affected Issue Numbers

## Code Review Notes

## Checklist

- [x] Changes have been added to the *Unreleased* section in the [`changelog.md`](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/changelog.md).
- [x] All issue requirements satisfied (or no linked issues)
- [x] [Linting passes](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#linting).
- [x] [Migrations created & committed *(or no model changes)*](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#migration-process)
- Tests
  - [x] [Tests implemented *(or no code changes)*](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#test-implementation)
  - [x] [All tests pass](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#quality-control)
  - [x] All example load tests pass (remotely) *(or their failures predated and are unrelated to this branch)*
