### PR TITLE
Use human readable str methods for ArchiveFile

### DIFF
--- a/DataRepo/models/archive_file.py
+++ b/DataRepo/models/archive_file.py
@@ -34,6 +34,9 @@ class DataType(models.Model):
         Must return a tuple."""
         return (self.code,)
 
+    def __str__(self):
+        return f"{self.code}:{self.name}"
+
 
 class DataFormatManager(models.Manager):
     def get_by_natural_key(self, code):
@@ -69,6 +72,9 @@ class DataFormat(models.Model):
 
         Must return a tuple."""
         return (self.code,)
+
+    def __str__(self):
+        return f"{self.code}:{self.name}"
 
 
 def data_type_path(instance, filename):
@@ -113,3 +119,6 @@ class ArchiveFile(models.Model):
     data_type = models.ForeignKey(DataType, on_delete=models.PROTECT)
 
     data_format = models.ForeignKey(DataFormat, on_delete=models.PROTECT)
+
+    def __str__(self):
+        return f"{self.filename} ({self.checksum})"

--- a/changelog.md
+++ b/changelog.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Updated dependencies
+- Use human readable string methods for ArchiveFile, DataType, and DataFormat (affects admin interface, other default templates)
 
 ## [2.0.3] - 2023-07-07
 


### PR DESCRIPTION
<!-- markdownlint-disable-next-line first-line-heading -->
## Summary Change Description

Having human readable default string representations for model classes makes the default admin interface much easier to read.

## Affected Issue Numbers

## Code Review Notes

## Checklist

- [x] Changes have been added to the *Unreleased* section in the [`changelog.md`](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/changelog.md).
- [x] All issue requirements satisfied (or no linked issues)
- [x] [Linting passes](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#linting).
- [x] [Migrations created & committed *(or no model changes)*](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#migration-process)
- Tests
  - [x] [Tests implemented *(or no code changes)*](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#test-implementation)
  - [x] [All tests pass](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#quality-control)
  - [x] All example load tests pass (remotely) *(or their failures predated and are unrelated to this branch)*
