### PR TITLE
Employed threading.local() to make the mutable class attributes threa…

### DIFF
--- a/DataRepo/tests/loading/test_loading_autoupdates.py
+++ b/DataRepo/tests/loading/test_loading_autoupdates.py
@@ -39,7 +39,7 @@ class AutoupdateLoadingTests(TracebaseTestCase):
         self.assert_names_are_unupdated()
         bs1 = MaintainedModel.buffer_size()
         self.assertGreater(bs1, 0)
-        first_buffered_model_object = MaintainedModel.update_buffer[0]
+        first_buffered_model_object = MaintainedModel.data.update_buffer[0]
 
         self.assert_fcirc_data_is_unupdated()
 
@@ -60,7 +60,9 @@ class AutoupdateLoadingTests(TracebaseTestCase):
         self.assertGreater(MaintainedModel.buffer_size(), bs1)
         # The first buffered object from the first load script should be the same.  I.e. Running a second load script
         # without clearing the buffer should just append to the buffer.
-        self.assertEqual(first_buffered_model_object, MaintainedModel.update_buffer[0])
+        self.assertEqual(
+            first_buffered_model_object, MaintainedModel.data.update_buffer[0]
+        )
 
     def test_defer_autoupdates_sample(self):
         self.assert_no_names_to_start()


### PR DESCRIPTION
## Summary Change Description

I changed the class attributes to be stored in a `threading.local()`-created variable/class attribute.  If the web server is ever configured to use threading with shared memory, now requests won't change each other's class attributes.

## Affected Issues/Pull Requests

- Partially addresses #734
- Merges into PR: #735

## Review Notes

The change is very simple.  The only thing to be aware of is that linters do not support type hints if the variable is not a direct member of a class, so I had to remove the type hints.

Other than `maintained_model.py`, the only other file that changed was a test file that directly accesses one of the class attributes.  Maybe I will change that to use a getter before I request review, now that I think about it...

## Checklist

This pull request will be merged once the following requirements are met.  The
author and/or reviewers should uncheck any unmet requirements:

- Review requirements
  - Minimum approvals: 1
  - No changes requested
  - All blocking issues resolved by reviewers
  - Specific reviewers: none
  - Review period: 2 days
- Associated issue/pull request requirements:
  - [x] All requirements in the affected "resolved" issues are satisfied
  - [x] All required pull requests are merged *(or none)*
- Basic requirements
  - [x] [All linters pass](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#linting).
  - [x] [All tests pass](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#quality-control)
  - [x] All conflicts resolved
- Overhead requirements
  - [x] [New/changed method tests implemented/updated *(or no change)*](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#test-implementation)
  - [ ] Added changes to *Unreleased* section of [`changelog.md`](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/changelog.md).
    - No changes in behavior
  - [x] [Migrations created & committed *(or no change)*](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#migration-process)
