### PR TITLE
Fixed a minor bug with units lookups when there are no units setup for a particular field

### DIFF
--- a/DataRepo/formats/dataformat.py
+++ b/DataRepo/formats/dataformat.py
@@ -1170,7 +1170,10 @@ class Format:
         """
         units_lookup = self.getFieldUnitsLookup()
         if fld in units_lookup.keys():
-            if units in units_lookup[fld].keys():
+            print(
+                f"Inspecting units data for field {fld} in units_lookup: {units_lookup}"
+            )
+            if units_lookup[fld] is not None and units in units_lookup[fld].keys():
                 try:
                     return units_lookup[fld][units]["pyconvert"](val)
                 except Exception as e:
@@ -1180,12 +1183,16 @@ class Format:
                         f"[{self.name}] failed with an exception: {str(e)}.  Returning original value.  Fix the "
                         "[pyconvert] function in Format.unit_options to better handle this value."
                     )
+            elif units != "identity":
+                # We can ignore "identity" - for which we just return val as-is, but if it's something other than
+                # identity and it wasn't present in the lookup, issue a warning.
+                warnings.warn(
+                    f"Units [{units}] dict for field [{fld}] not found for format [{self.name}]."
+                )
+        else:
             warnings.warn(
-                f"Units [{units}] dict for field [{fld}] not found for format [{self.name}]."
+                f"Units lookup is missing field key [{fld}] not found for format [{self.name}]."
             )
-        warnings.warn(
-            f"Units lookup is missing field key [{fld}] not found for format [{self.name}]."
-        )
         return val
 
     def meetsCondition(self, recval, condition, searchterm):


### PR DESCRIPTION
## Summary Change Description

Checked for `None` before calling `.keys()` and return identity (`val`) if so.  I also changed the warnings to only warn in the event that the `units` value is not `identity`.

## Affected Issues/Pull Requests

- Resolves #742

## Review Notes

Pretty small and straight-forward.

## Checklist
<!--
If any of the checkbox requirements are not met, uncheck them and add an
explanation. E.g. Linting errors pre-date this PR.
-->
This pull request will be merged once the following requirements are met.  The
author and/or reviewers should uncheck any unmet requirements:

- Review requirements
  - Minimum approvals: 1 <!-- Edit as desired (e.g. based on complexity) -->
  - No changes requested
  - All blocking issues resolved by reviewers
  - Specific reviewers: @__add_username_here__
    <!--
    Require reviewers with specific expertise to be included among the minimum
    number of reviewers by tagging them.  Also please send them a message.
    -->
  - Review period: 2 days <!-- Edit as desired (e.g. based on complexity) -->
- Associated issue/pull request requirements:
  <!--
  Assert that all requirements in issues marked "resolved" are done and that
  all required pull requests are merged.  If any are not done, either edit or
  split the issue or explain the unmerged affected pull requests.
  -->
  - [x] All requirements in affected issues marked "resolved" are satisfied
  - [x] All required pull requests are merged *(or none)*
- Basic requirements
  <!--
  Uncheck items to acknowledge failures/conflicts you intend to address.
  Add an explanation if any won't be addressed before merge.
  -->
  - [x] [All linters pass](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#linting)
  - [x] [All tests pass](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#quality-control)
  - [x] All conflicts resolved
- Overhead requirements
  <!--
  These are additional requirements that are not directly associated with
  resolving the affected issue(s).
  -->
  - [x] [New/changed method tests implemented/updated *(or no change)*](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#test-implementation)
  - [x] Added changes to *Unreleased* section of [`changelog.md`](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/changelog.md)
  - [x] [Migrations created & committed *(or no change)*](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#migration-process)
