### PR TITLE
Defer rollback for protocols, tissues, and compounds

### DIFF
--- a/DataRepo/management/commands/load_animals_and_samples.py
+++ b/DataRepo/management/commands/load_animals_and_samples.py
@@ -64,7 +64,7 @@ class Command(BaseCommand):
         )
         # Used internally by the DataValidationView
         parser.add_argument(
-            "--validate",  # DO NOT USE MANUALLY - THIS WILL NOT ROLL BACK UPON ERROR (handle in outer atomic transact)
+            "--validate",  # Only affects what is/isn't a warning
             required=False,
             action="store_true",
             default=False,
@@ -77,10 +77,10 @@ class Command(BaseCommand):
             action="store_true",
             help=argparse.SUPPRESS,
         )
-        # Intended for use by load_study to prevent individual loader autoupdates and buffer clearing, then perform all
-        # mass autoupdates/buffer-clearings after all load scripts are complete
+        # Intended for use by load_study to prevent rollback of changes in the event of an error so that for example,
+        # subsequent loading scripts can validate with all necessary data present
         parser.add_argument(
-            "--defer-rollback",
+            "--defer-rollback",  # DO NOT USE MANUALLY - THIS WILL NOT ROLL BACK (handle in outer atomic transact)
             action="store_true",
             help=argparse.SUPPRESS,
         )

--- a/DataRepo/management/commands/load_compounds.py
+++ b/DataRepo/management/commands/load_compounds.py
@@ -42,7 +42,7 @@ class Command(BaseCommand):
         # Intended for use by load_study to prevent rollback of changes in the event of an error so that for example,
         # subsequent loading scripts can validate with all necessary data present
         parser.add_argument(
-            "--defer-rollback",
+            "--defer-rollback",  # DO NOT USE MANUALLY - THIS WILL NOT ROLL BACK (handle in outer atomic transact)
             action="store_true",
             help=argparse.SUPPRESS,
         )

--- a/DataRepo/management/commands/load_compounds.py
+++ b/DataRepo/management/commands/load_compounds.py
@@ -28,6 +28,7 @@ class Command(BaseCommand):
             default=";",
             required=False,
         )
+
         parser.add_argument(
             "--dry-run",
             action="store_true",
@@ -37,12 +38,12 @@ class Command(BaseCommand):
                 "but simply report back potential work or issues."
             ),
         )
-        # Used internally by the DataValidationView
+
+        # Intended for use by load_study to prevent rollback of changes in the event of an error so that for example,
+        # subsequent loading scripts can validate with all necessary data present
         parser.add_argument(
-            "--validate",
-            required=False,
+            "--defer-rollback",
             action="store_true",
-            default=False,
             help=argparse.SUPPRESS,
         )
 
@@ -58,12 +59,12 @@ class Command(BaseCommand):
         loader = CompoundsLoader(
             compounds_df=self.compounds_df,
             synonym_separator=options["synonym_separator"],
-            validate=options["validate"],
             dry_run=options["dry_run"],
+            defer_rollback=options["defer_rollback"],
         )
 
         try:
-            loader.load_compounds()
+            loader.load_compound_data()
         except DryRun:
             pass
 

--- a/DataRepo/management/commands/load_study.py
+++ b/DataRepo/management/commands/load_study.py
@@ -157,7 +157,8 @@ class Command(BaseCommand):
                     call_command(
                         "load_compounds",
                         compounds=compounds_file,
-                        validate=self.validate,
+                        defer_rollback=True,  # Until after we exit THIS atomic block
+                        # Validate is not needed - it changes nothing
                     )
                 except Exception as e:
                     self.package_group_exceptions(e, compounds_file)
@@ -178,8 +179,9 @@ class Command(BaseCommand):
                     call_command(
                         "load_protocols",
                         protocols=protocols_file,
-                        validate=self.validate,
                         verbosity=self.verbosity,
+                        defer_rollback=True,  # Until after we exit THIS atomic block
+                        # Validate is not needed - it changes nothing
                     )
                 except Exception as e:
                     self.package_group_exceptions(e, protocols_file)
@@ -200,8 +202,9 @@ class Command(BaseCommand):
                     call_command(
                         "load_tissues",
                         tissues=tissues_file,
-                        validate=self.validate,
                         verbosity=self.verbosity,
+                        defer_rollback=True,  # Until after we exit THIS atomic block
+                        # Validate is not needed - it changes nothing
                     )
                 except Exception as e:
                     self.package_group_exceptions(e, tissues_file)
@@ -242,9 +245,11 @@ class Command(BaseCommand):
                         table_headers=headers_file,
                         skip_researcher_check=skip_researcher_check,
                         verbosity=self.verbosity,
+                        # Validate mode affects what is or isn't a warning. It essentially represents "end user context"
+                        # and changes errors to warnings when the user has no means to fix it themselves.
                         validate=self.validate,
                         defer_autoupdates=True,
-                        defer_rollback=True,
+                        defer_rollback=True,  # Until after we exit THIS atomic block
                     )
                 except Exception as e:
                     self.package_group_exceptions(e, animals_samples_table_file)

--- a/DataRepo/management/commands/load_tissues.py
+++ b/DataRepo/management/commands/load_tissues.py
@@ -33,7 +33,7 @@ class Command(BaseCommand):
         # Intended for use by load_study to prevent rollback of changes in the event of an error so that for example,
         # subsequent loading scripts can validate with all necessary data present
         parser.add_argument(
-            "--defer-rollback",
+            "--defer-rollback",  # DO NOT USE MANUALLY - THIS WILL NOT ROLL BACK (handle in outer atomic transact)
             action="store_true",
             help=argparse.SUPPRESS,
         )

--- a/DataRepo/management/commands/load_tissues.py
+++ b/DataRepo/management/commands/load_tissues.py
@@ -30,12 +30,11 @@ class Command(BaseCommand):
             help=("Dry-run. If specified, nothing will be saved to the database. "),
         )
 
-        # Used internally by the DataValidationView
+        # Intended for use by load_study to prevent rollback of changes in the event of an error so that for example,
+        # subsequent loading scripts can validate with all necessary data present
         parser.add_argument(
-            "--validate",
-            required=False,
+            "--defer-rollback",
             action="store_true",
-            default=False,
             help=argparse.SUPPRESS,
         )
 
@@ -47,11 +46,11 @@ class Command(BaseCommand):
         self.tissue_loader = TissuesLoader(
             tissues=new_tissues,
             dry_run=options["dry_run"],
-            validate=options["validate"],
+            defer_rollback=options["defer_rollback"],
         )
 
         try:
-            self.tissue_loader.load()
+            self.tissue_loader.load_tissue_data()
         except DryRun:
             pass
 

--- a/DataRepo/tests/loading/test_loading_compounds.py
+++ b/DataRepo/tests/loading/test_loading_compounds.py
@@ -133,7 +133,7 @@ class CompoundLoadingTests(TracebaseTestCase):
                 }
             )
         )
-        cl.load_compounds()
+        cl.load_compound_data()
         self.assertEqual(
             1,
             cl.num_existing_compounds,
@@ -221,7 +221,7 @@ class CompoundLoadingTests(TracebaseTestCase):
             )
         )
         with self.assertRaises(AggregatedErrors) as ar:
-            cl.load_compounds()
+            cl.load_compound_data()
         aes = ar.exception
         self.assertEqual(2, aes.num_errors)
         self.assertEqual(
@@ -292,7 +292,7 @@ class CompoundLoadingTests(TracebaseTestCase):
             )
         )
         with self.assertRaises(AggregatedErrors) as ar:
-            cl.load_compounds()
+            cl.load_compound_data()
         aes = ar.exception
         self.assertEqual(2, aes.num_errors)
         self.assertEqual(SynonymExistsAsMismatchedCompound, type(aes.exceptions[0]))
@@ -311,9 +311,9 @@ class CompoundsLoaderTests(TracebaseTestCase):
     def test_compound_exists_skipped(self):
         df = self.get_dataframe()
         cl = CompoundsLoader(df)
-        cl.load_compounds()
+        cl.load_compound_data()
         cl2 = CompoundsLoader(df)
-        cl2.load_compounds()
+        cl2.load_compound_data()
         self.assertEqual(0, cl2.num_inserted_compounds)
         self.assertEqual(0, cl2.num_erroneous_compounds)
         self.assertEqual(1, cl2.num_existing_compounds)
@@ -340,7 +340,7 @@ class CompoundsLoaderTests(TracebaseTestCase):
                 }
             )
         )
-        cl.load_compounds()
+        cl.load_compound_data()
 
         # The fact these 2 gets don't raise an exception is a test that the load worked
         ncpd = Compound.objects.get(name__exact="my new compound")

--- a/DataRepo/tests/loading/test_loading_protocols.py
+++ b/DataRepo/tests/loading/test_loading_protocols.py
@@ -46,7 +46,7 @@ class ProtocolLoadingTests(TracebaseTestCase):
             category=Protocol.ANIMAL_TREATMENT,
             dry_run=dry_run,
         )
-        protocol_loader.load()
+        protocol_loader.load_protocol_data()
 
     def test_protocols_loader(self):
         """Test the ProtocolsLoader class"""
@@ -72,7 +72,7 @@ class ProtocolLoadingTests(TracebaseTestCase):
         protocol_loader = ProtocolsLoader(protocols=self.working_df)
 
         with self.assertRaises(AggregatedErrors) as ar:
-            protocol_loader.load()
+            protocol_loader.load_protocol_data()
         aes = ar.exception
         self.assertEqual(1, aes.num_errors)
         self.assertEqual(0, aes.num_warnings)
@@ -88,7 +88,7 @@ class ProtocolLoadingTests(TracebaseTestCase):
             category="Some Nonsense Category",
         )
         with self.assertRaises(AggregatedErrors) as ar:
-            protocol_loader.load()
+            protocol_loader.load_protocol_data()
         aes = ar.exception
         self.assertEqual(1, aes.num_errors)
         self.assertEqual(0, aes.num_warnings)

--- a/DataRepo/utils/protocols_loader.py
+++ b/DataRepo/utils/protocols_loader.py
@@ -57,7 +57,6 @@ class ProtocolsLoader:
         self.aggregated_errors_object = AggregatedErrors()
 
     def load_protocol_data(self):
-
         saved_aes = None
 
         with transaction.atomic():

--- a/DataRepo/utils/sample_table_loader.py
+++ b/DataRepo/utils/sample_table_loader.py
@@ -142,11 +142,11 @@ class SampleTableLoader:
     def __init__(
         self,
         sample_table_headers=DefaultSampleTableHeaders,
-        validate=False,  # DO NOT USE MANUALLY - THIS WILL NOT ROLL BACK UPON ERROR (handle in outer atomic transact)
+        validate=False,  # Only affects what is/isn't a warning
         verbosity=1,
         skip_researcher_check=False,
         defer_autoupdates=False,
-        defer_rollback=False,
+        defer_rollback=False,  # DO NOT USE MANUALLY - THIS WILL NOT ROLL BACK (handle in atomic transact in caller)
         dry_run=False,
     ):
         # Header config
@@ -157,11 +157,9 @@ class SampleTableLoader:
         self.verbosity = verbosity
         self.dry_run = dry_run
         self.validate = validate
-
         # How to handle mass autoupdates
         self.defer_autoupdates = defer_autoupdates
-
-        # Whether to rollback upon error or defer it to the caller
+        # Whether to rollback upon error or keep the changes and defer rollback to the caller
         self.defer_rollback = defer_rollback
 
         # Caching overhead
@@ -210,20 +208,23 @@ class SampleTableLoader:
         MaintainedModel.init_autoupdate_label_filters(label_filters=["name"])
 
         try:
+
             saved_aes = None
+
             with transaction.atomic():
                 try:
-                    self.load_data(data)
+                    self._load_data(data)
                 except AggregatedErrors as aes:
-                    if not self.validate and not self.defer_rollback:
+                    if self.defer_rollback:
+                        saved_aes = aes
+                    else:
                         # If we're not working for the validation interface, raise here to cause a rollback
                         raise aes
-                    else:
-                        saved_aes = aes
-            if (self.validate or self.defer_rollback) and saved_aes:
-                # If we're working for the validation interface, raise here to not cause a rollback (so that the
-                # accucor loader can be run to find more issues - samples must be loaded already to run the accucor
-                # loader), and provide the validation interface details on the exceptions.
+
+            # If we were directed to defer rollback in the event of an error, raise the exception here (outside of
+            # the atomic transaction block).  This assumes that the caller is handling rollback in their own atomic
+            # transaction blocl.
+            if saved_aes is not None:
                 raise saved_aes
 
         except Exception as e:
@@ -245,7 +246,7 @@ class SampleTableLoader:
         if self.dry_run:
             MaintainedModel.enable_buffering()
 
-    def load_data(self, data):
+    def _load_data(self, data):
         # Create a list to hold the csv reader data so that iterations from validating doesn't leave the csv reader
         # empty/at-the-end upon the import loop
         sample_table_data = list(data)

--- a/DataRepo/utils/sample_table_loader.py
+++ b/DataRepo/utils/sample_table_loader.py
@@ -208,7 +208,6 @@ class SampleTableLoader:
         MaintainedModel.init_autoupdate_label_filters(label_filters=["name"])
 
         try:
-
             saved_aes = None
 
             with transaction.atomic():

--- a/DataRepo/utils/tissues_loader.py
+++ b/DataRepo/utils/tissues_loader.py
@@ -37,12 +37,10 @@ class TissuesLoader:
             self.defer_rollback = defer_rollback
 
         except Exception as e:
-
             self.aggregated_errors_object.buffer_error(e)
             raise self.aggregated_errors_object
 
     def load_tissue_data(self):
-
         saved_aes = None
 
         with transaction.atomic():


### PR DESCRIPTION
## Summary Change Description

I updated issue #577 today, having to do with errors during load about novel protocols (and tissues and compounds).  Basically, I implemented the same strategy that was used to solve this same problem WRT accucor errors about missing samples - I deferred rollback of changes to be handled in `load_study`.

## Affected Issues/Pull Requests

- Resolves #577

## Review Notes

See comments in-line.

## Checklist
<!--
If any of the checkbox requirements are not met, uncheck them and add an
explanation. E.g. Linting errors pre-date this PR.
-->
This pull request will be merged once the following requirements are met.  The
author and/or reviewers should uncheck any unmet requirements:

- Review requirements
  - Minimum approvals: 1 <!-- Edit as desired (e.g. based on complexity) -->
  - No changes requested
  - All blocking issues resolved by reviewers
  - Specific reviewers: @__add_username_here__
    <!--
    Require reviewers with specific expertise to be included among the minimum
    number of reviewers by tagging them.  Also please send them a message.
    -->
  - Review period: 2 days <!-- Edit as desired (e.g. based on complexity) -->
- Associated issue/pull request requirements:
  <!--
  Assert that all requirements in issues marked "resolved" are done and that
  all required pull requests are merged.  If any are not done, either edit or
  split the issue or explain the unmerged affected pull requests.
  -->
  - [x] All requirements in affected issues marked "resolved" are satisfied
  - [x] All required pull requests are merged *(or none)*
- Basic requirements
  <!--
  Uncheck items to acknowledge failures/conflicts you intend to address.
  Add an explanation if any won't be addressed before merge.
  -->
  - [x] [All linters pass](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#linting)
  - [x] [All tests pass](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#quality-control)
  - [x] All conflicts resolved
- Overhead requirements
  <!--
  These are additional requirements that are not directly associated with
  resolving the affected issue(s).
  -->
  - [x] [New/changed method tests implemented/updated *(or no change)*](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#test-implementation)
  - [x] Added changes to *Unreleased* section of [`changelog.md`](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/changelog.md)
  - [x] [Migrations created & committed *(or no change)*](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#migration-process)
