### PR TITLE
Added a disable of caching updates to the LCMethod record migration

### DIFF
--- a/DataRepo/migrations/0016_protocols_to_lcmethods.py
+++ b/DataRepo/migrations/0016_protocols_to_lcmethods.py
@@ -2,6 +2,11 @@ import re
 
 from django.db import migrations
 
+from DataRepo.models.hier_cached_model import (
+    disable_caching_updates,
+    enable_caching_updates,
+)
+
 # Matches 25mins, 25min, 25minutes, 25minute, 25-mins, ...
 RUNLEN_PAT = re.compile(r"(?P<mins_digits>\d+)[^0-9a-zA-Z]?(?:min|minute)s?")
 HILIC_PAT = re.compile(r"(?i)(?:hilic|lc-ms|^default$)")
@@ -101,6 +106,7 @@ def msrunprotocol_to_lcmethod(apps, _):
         # When none of the above match:
         default_lc_method = LCMethod.objects.get(name__exact="unknown")
 
+        disable_caching_updates()
         for msrun_rec in MSRun.objects.all():
             protocol_name = str(msrun_rec.protocol)
             lcm_rec = msrunprotocol_name_to_lcmethod_rec(
@@ -109,6 +115,7 @@ def msrunprotocol_to_lcmethod(apps, _):
 
             msrun_rec.lc_method = lcm_rec
             msrun_rec.save()
+        enable_caching_updates()
     # Else - nothing to migrate
 
 


### PR DESCRIPTION
## Summary Change Description

This makes the migration MUCH faster.  I discovered the slowness because after my initial migration, I loaded new data on a different branch that was causing me errors, so I had to copy the method into the shell and run it manually.  It was taking forever and there were a lot of caching update messages, so I stopped it and added the caching update disable call and it finished in short order.

## Affected Issues/Pull Requests

- Resolves no issue

## Review Notes

Straight-forward.

## Checklist
<!--
If any of the checkbox requirements are not met, uncheck them and add an
explanation. E.g. Linting errors pre-date this PR.
-->
This pull request will be merged once the following requirements are met.  The
author and/or reviewers should uncheck any unmet requirements:

- Review requirements
  - Minimum approvals: 1 <!-- Edit as desired (e.g. based on complexity) -->
  - No changes requested
  - All blocking issues resolved by reviewers
  - Specific reviewers: @__add_username_here__
    <!--
    Require reviewers with specific expertise to be included among the minimum
    number of reviewers by tagging them.  Also please send them a message.
    -->
  - Review period: 2 days <!-- Edit as desired (e.g. based on complexity) -->
- Associated issue/pull request requirements:
  <!--
  Assert that all requirements in issues marked "resolved" are done and that
  all required pull requests are merged.  If any are not done, either edit or
  split the issue or explain the unmerged affected pull requests.
  -->
  - [x] All requirements in affected issues marked "resolved" are satisfied
  - [x] All required pull requests are merged *(or none)*
- Basic requirements
  <!--
  Uncheck items to acknowledge failures/conflicts you intend to address.
  Add an explanation if any won't be addressed before merge.
  -->
  - [x] [All linters pass](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#linting)
  - [x] [All tests pass](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#quality-control)
  - [x] All conflicts resolved
- Overhead requirements
  <!--
  These are additional requirements that are not directly associated with
  resolving the affected issue(s).
  -->
  - [x] [New/changed method tests implemented/updated *(or no change)*](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#test-implementation)
  - [x] Added changes to *Unreleased* section of [`changelog.md`](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/changelog.md)
  - [x] [Migrations created & committed *(or no change)*](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#migration-process)
