### PR TITLE
Fixed an issue with DetailViews relating to MaintainedModel's threading.local data

### DIFF
--- a/DataRepo/models/maintained_model.py
+++ b/DataRepo/models/maintained_model.py
@@ -656,6 +656,13 @@ class MaintainedModel(Model):
         called both from __init__() and save().
         """
 
+        # Make sure the class has been fulling initialized
+        # Without this, you get an AttributeError: '_thread._local' object has no attribute 'coordinator_stack'
+        # from django.db.models.base's from_db class method when a model's DetailView is created.
+        if not hasattr(self.data, "default_coordinator"):
+            self.data.__setattr__("default_coordinator", MaintainedModelCoordinator())
+            self.data.__setattr__("coordinator_stack", [])
+
         # The coordinator keeps track of the running mode, buffer and filters in use
         coordinator = self.get_coordinator()
 


### PR DESCRIPTION
## Summary Change Description

Added a check and set of the class's attributes if not set.

## Affected Issues/Pull Requests

- Resolves an [issue](https://tracebase.slack.com/archives/C01LFSYQHN3/p1697049043747259) Lance encountered on main

## Review Notes

This might not be the best or only way to fix this issue.  According to [this stack post](https://stackoverflow.com/a/20643172/2057516), it suggests I might be setting the `threading.local` values in an unsupported way, but I'm pretty sure I'd looked it up.

This PR fixes this error when you try to look at any model's `DetailView`:
```
Traceback (most recent call last):
  File "/home/lparsons/mambaforge/envs/tracebase/lib/python3.8/site-packages/django/core/handlers/exception.py", line 47, in inner
    response = get_response(request)
  File "/home/lparsons/mambaforge/envs/tracebase/lib/python3.8/site-packages/django/core/handlers/base.py", line 181, in _get_response
    response = wrapped_callback(request, *callback_args, **callback_kwargs)
  File "/home/lparsons/mambaforge/envs/tracebase/lib/python3.8/site-packages/django/views/generic/base.py", line 70, in view
    return self.dispatch(request, *args, **kwargs)
  File "/home/lparsons/mambaforge/envs/tracebase/lib/python3.8/site-packages/django/views/generic/base.py", line 98, in dispatch
    return handler(request, *args, **kwargs)
  File "/home/lparsons/mambaforge/envs/tracebase/lib/python3.8/site-packages/django/views/generic/detail.py", line 106, in get
    self.object = self.get_object()
  File "/home/lparsons/mambaforge/envs/tracebase/lib/python3.8/site-packages/django/views/generic/detail.py", line 52, in get_object
    obj = queryset.get()
  File "/home/lparsons/mambaforge/envs/tracebase/lib/python3.8/site-packages/django/db/models/query.py", line 431, in get
    num = len(clone)
  File "/home/lparsons/mambaforge/envs/tracebase/lib/python3.8/site-packages/django/db/models/query.py", line 262, in __len__
    self._fetch_all()
  File "/home/lparsons/mambaforge/envs/tracebase/lib/python3.8/site-packages/django/db/models/query.py", line 1324, in _fetch_all
    self._result_cache = list(self._iterable_class(self))
  File "/home/lparsons/mambaforge/envs/tracebase/lib/python3.8/site-packages/django/db/models/query.py", line 69, in __iter__
    obj = model_cls.from_db(db, init_list, row[model_fields_start:model_fields_end])
  File "/home/lparsons/mambaforge/envs/tracebase/lib/python3.8/site-packages/django/db/models/base.py", line 515, in from_db
    new = cls(*values)
  File "/home/lparsons/Documents/projects/tracebase/DataRepo/models/maintained_model.py", line 650, in __init__
    self._maintained_model_setup(**kwargs)
  File "/home/lparsons/Documents/projects/tracebase/DataRepo/models/maintained_model.py", line 660, in _maintained_model_setup
    coordinator = self.get_coordinator()
  File "/home/lparsons/Documents/projects/tracebase/DataRepo/models/maintained_model.py", line 1119, in get_coordinator
    return cls._get_current_coordinator()
  File "/home/lparsons/Documents/projects/tracebase/DataRepo/models/maintained_model.py", line 1123, in _get_current_coordinator
    if len(cls.data.coordinator_stack) > 0:

Exception Type: AttributeError at /DataRepo/samples/1/
Exception Value: '_thread._local' object has no attribute 'coordinator_stack'
```

## Checklist
<!--
If any of the checkbox requirements are not met, uncheck them and add an
explanation. E.g. Linting errors pre-date this PR.
-->
This pull request will be merged once the following requirements are met.  The
author and/or reviewers should uncheck any unmet requirements:

- Review requirements
  - Minimum approvals: 1 <!-- Edit as desired (e.g. based on complexity) -->
  - No changes requested
  - All blocking issues resolved by reviewers
  - Specific reviewers: @__add_username_here__
    <!--
    Require reviewers with specific expertise to be included among the minimum
    number of reviewers by tagging them.  Also please send them a message.
    -->
  - Review period: 2 days <!-- Edit as desired (e.g. based on complexity) -->
- Associated issue/pull request requirements:
  <!--
  Assert that all requirements in issues marked "resolved" are done and that
  all required pull requests are merged.  If any are not done, either edit or
  split the issue or explain the unmerged affected pull requests.
  -->
  - [x] All requirements in affected issues marked "resolved" are satisfied
  - [x] All required pull requests are merged *(or none)*
- Basic requirements
  <!--
  Uncheck items to acknowledge failures/conflicts you intend to address.
  Add an explanation if any won't be addressed before merge.
  -->
  - [x] [All linters pass](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#linting)
  - [x] [All tests pass](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#quality-control)
  - [x] All conflicts resolved
- Overhead requirements
  <!--
  These are additional requirements that are not directly associated with
  resolving the affected issue(s).
  -->
  - [ ] [New/changed method tests implemented/updated *(or no change)*](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#test-implementation)
  - [ ] Added changes to *Unreleased* section of [`changelog.md`](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/changelog.md)
  - [x] [Migrations created & committed *(or no change)*](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#migration-process)
