### PR TITLE
Comprehensive initialization of thread-local data in `MaintainedModel` for auto-update mode tracking

### DIFF
--- a/DataRepo/models/maintained_model.py
+++ b/DataRepo/models/maintained_model.py
@@ -25,27 +25,6 @@ class MaintainedModelCoordinator:
     autoupdates are performed at all.
     """
 
-    # Track whether the fields from the decorators have been validated
-    # This is only ever initialized once, the first time every derived class is ever instantiated, so it's loosely an
-    # immutable class attribute (though technically mutable), as it would only ever change if new models are added and
-    # is only used to decide when a derived class's usage of MaintainedModel is invalid
-    maintained_model_initialized: Dict[str, bool] = {}
-
-    # Track the metadata recorded by each derived model class's setter and relation decorators
-    # Similar to maintained_model_initialized, this is loosely an immutable class attribute (though technically
-    # mutable), as it is only ever set when the setter and relation decorators are created, which only ever happens once
-    # This does not need to be thread-safe because it will not ever change after all the decorators have been registered
-    updater_list: Dict[str, List] = defaultdict(list)
-
-    # A dict of class name keys and class values used by get_classes needed for rebuild_maintained_fields. This is
-    # initialized via MaintainedModel's decorators as a way to avoid needing the module path of all the models as was
-    # formerly done.
-    model_classes: Dict[str, Model] = defaultdict(Model)
-
-    # A dict saving the package (referenced elsewhere as "model_path") that holds each model so that it's class can be
-    # retrieved when needed.
-    model_packages: Dict[str, str] = defaultdict(str)
-
     def __init__(self, auto_update_mode="immediate", **kwargs):
         self.auto_update_mode = auto_update_mode
         if auto_update_mode == "immediate":
@@ -125,58 +104,14 @@ class MaintainedModelCoordinator:
             filter_in = True
         cnt = 0
         for buffered_item in self.update_buffer:
-            updaters_list = self._filter_updaters(
-                self.get_updater_dicts_by_model_name(buffered_item.__class__.__name__),
+            updaters_list = buffered_item._filter_updaters(
+                buffered_item.get_my_updaters(),
                 generation=generation,
                 label_filters=label_filters,
                 filter_in=filter_in,
             )
             cnt += 1 if len(updaters_list) else 0
         return cnt
-
-    @classmethod
-    def _filter_updaters(
-        cls,
-        updaters_list,
-        generation,
-        label_filters,
-        filter_in,
-    ):
-        """
-        This method was made private, because it has no access to instance values for generation, label_filters, or
-        filter_in.  Users are not expected to supply these.  All instance methods that internally call these must pass
-        them.
-
-        Returns a sublist of the supplied updaters_list that meets both the filter criteria (generation matches and
-        update_label is in the label_filters), if those filters were supplied.
-        """
-        # This will be the new buffer (in case we're being selective)
-        new_updaters_list = []
-
-        # Convenience variables to make the conditional easier to read
-        no_filters = label_filters is None or len(label_filters) == 0
-        no_generation = generation is None
-
-        for updater_dict in updaters_list:
-            gen = updater_dict["generation"]
-            label = updater_dict["update_label"]
-            has_label = label is not None
-            if (
-                filter_in
-                and (
-                    (no_generation or generation == gen)
-                    and (no_filters or (has_label and label in label_filters))
-                )
-            ) or (
-                not filter_in
-                and (
-                    (no_generation or generation != gen)
-                    and (no_filters or not has_label or label not in label_filters)
-                )
-            ):
-                new_updaters_list.append(updater_dict)
-
-        return new_updaters_list
 
     def clear_update_buffer(self, generation=None, label_filters=None, filter_in=None):
         """
@@ -220,8 +155,8 @@ class MaintainedModelCoordinator:
             # supplied label_filters is ["name"] and filter_in is True, then the matching updater WILL be returned by
             # this filter operation and the buffered item will be left out of the new_buffer.  If a model object in the
             # buffer does NOT have the "name" label in any of its updaters, it will be added to the new_buffer.
-            matching_updaters = self._filter_updaters(
-                self.get_updater_dicts_by_model_name(buffered_item.__class__.__name__),
+            matching_updaters = buffered_item._filter_updaters(
+                buffered_item.get_my_updaters(),
                 generation=generation,
                 label_filters=label_filters,
                 filter_in=filter_in,
@@ -232,7 +167,7 @@ class MaintainedModelCoordinator:
             # because updates and buffer clears should happen from leaf to root.  And we should only check those which
             # have a target label.
             if generation is not None:
-                max_gen = self.get_max_generation(
+                max_gen = buffered_item.get_max_generation(
                     matching_updaters, label_filters, filter_in
                 )
 
@@ -258,77 +193,8 @@ class MaintainedModelCoordinator:
         # populate the buffer with what's left
         self.update_buffer = new_buffer
 
-    def get_max_generation(self, updaters_list, label_filters=None, filter_in=None):
-        """
-        Takes a list of updaters and a list of label filters and returns the max generation found in the updaters list.
-        """
-        if filter_in is None:
-            filter_in = True
-        if label_filters is None:
-            label_filters = (
-                []
-            )  # Include everything by default, regardless of default filters
-            filter_in = True
-        max_gen = None
-        for updater_dict in sorted(
-            self._filter_updaters(
-                updaters_list,
-                generation=None,
-                label_filters=label_filters,
-                filter_in=filter_in,
-            ),
-            key=lambda x: x["generation"],
-            reverse=True,
-        ):
-            gen = updater_dict["generation"]
-            if max_gen is None or gen > max_gen:
-                max_gen = gen
-                break
-        return max_gen
-
     def _peek_update_buffer(self, index=0):
         return self.update_buffer[index]
-
-    def get_max_buffer_generation(self, label_filters=None, filter_in=None):
-        """
-        Takes a list of label filters and searches the buffered records to return the max generation found among the
-        decorated functions (matching the filter criteria) associated with the buffered model object's class.
-
-        The purpose is so that records can be updated breadth first (from leaves to root).
-        """
-        if filter_in is None:
-            filter_in = True
-        if label_filters is None:
-            label_filters = (
-                []
-            )  # Include everything by default, regardless of default filters
-            filter_in = True
-        exploded_updater_dicts = []
-        for buffered_item in self.update_buffer:
-            exploded_updater_dicts += self._filter_updaters(
-                self.get_updater_dicts_by_model_name(buffered_item.__class__.__name__),
-                generation=None,
-                label_filters=label_filters,
-                filter_in=filter_in,
-            )
-        return self.get_max_generation(
-            exploded_updater_dicts, label_filters=label_filters, filter_in=filter_in
-        )
-
-    def updater_list_has_matching_labels(self, updaters_list, label_filters, filter_in):
-        """
-        Returns True if any updater dict in updaters_list passes the label filtering criteria.
-        """
-        for updater_dict in updaters_list:
-            label = updater_dict["update_label"]
-            has_a_label = label is not None
-            if filter_in:
-                if has_a_label and label in label_filters:
-                    return True
-            elif not has_a_label or label not in label_filters:
-                return True
-
-        return False
 
     def buffer_update(self, mdl_obj):
         """
@@ -344,8 +210,8 @@ class MaintainedModelCoordinator:
         if (
             mdl_obj.label_filters is not None
             and len(mdl_obj.label_filters) > 0
-            and not self.updater_list_has_matching_labels(
-                self.get_updater_dicts_by_model_name(mdl_obj.__class__.__name__),
+            and not mdl_obj.updater_list_has_matching_labels(
+                mdl_obj.get_my_updaters(),
                 mdl_obj.label_filters,
                 mdl_obj.filter_in,
             )
@@ -422,9 +288,7 @@ class MaintainedModelCoordinator:
 
         # For each record in the buffer
         for buffer_item in self.update_buffer:
-            updater_dicts = self.get_updater_dicts_by_model_name(
-                buffer_item.__class__.__name__
-            )
+            updater_dicts = buffer_item.get_my_updaters()
 
             if use_object_label_filters:
                 label_filters = buffer_item.label_filters
@@ -440,7 +304,7 @@ class MaintainedModelCoordinator:
             try:
                 if key not in updated and (
                     no_filters
-                    or self.updater_list_has_matching_labels(
+                    or buffer_item.updater_list_has_matching_labels(
                         updater_dicts, label_filters, filter_in
                     )
                 ):
@@ -468,162 +332,6 @@ class MaintainedModelCoordinator:
         # Eliminate the updated items from the buffer
         self.update_buffer = new_buffer
 
-    @classmethod
-    def get_all_updaters(cls):
-        """
-        Retrieve a flattened list of all updater dicts.
-        Used by rebuild_maintained_fields.
-        """
-        all_updaters = []
-        for class_name in cls.updater_list:
-            all_updaters += cls.updater_list[class_name]
-        return all_updaters
-
-    @classmethod
-    def _get_classes(
-        cls,
-        generation,
-        label_filters,
-        filter_in,
-        models_path=None,
-    ):
-        """
-        This method was made private, because it has no access to instance values for generation, label_filters, or
-        filter_in.  Users are not expected to supply these.  All instance methods that internally call these must pass
-        them.
-
-        Retrieve a list of classes containing maintained fields that match the given criteria.
-        Used by rebuild_maintained_fields and get_maintained_fields.
-
-        models_path is optional and must be a string like "DataRepo.models".  It's only required if called before any of
-        the model classes have been instantiated and after the decorators have registered.
-        """
-        class_list = []
-        for model_class_name in cls.updater_list.keys():
-            if (
-                len(
-                    cls._filter_updaters(
-                        updaters_list=cls.updater_list[model_class_name],
-                        generation=generation,
-                        label_filters=label_filters,
-                        filter_in=filter_in,
-                    )
-                )
-                > 0
-            ):
-                class_list.append(cls.get_model_class(model_class_name, models_path))
-        return class_list
-
-    @classmethod
-    def get_model_class(cls, model_class_name, models_path=None):
-        """
-        models_path is optional and must be a string like "DataRepo.models".  It's only required if called before any of
-        the model classes have been instantiated and after the decorators have registered.
-        """
-        if model_class_name in cls.model_classes.keys():
-            return cls.model_classes[model_class_name]
-        access_method = "determiend by the decorator(s)"
-        try:
-            if models_path is None:
-                # The decorators *try* to record the models_path for each model.  If that was successful, we can use
-                # that, otherwise, the models_path is required.
-                if (
-                    cls.model_packages
-                    and model_class_name in cls.model_packages
-                    and cls.model_packages[model_class_name] is not None
-                ):
-                    models_path = cls.model_packages[model_class_name]
-                    module = importlib.import_module(models_path)
-                else:
-                    raise ValueError(
-                        f"models_path is required because the class {model_class_name} hasn't been instantiated as a "
-                        "MaintainedModel yet."
-                    )
-            else:
-                access_method = "supplied"
-                module = importlib.import_module(models_path)
-            mdl_cls = getattr(module, model_class_name)
-        except Exception as e:
-            raise ValueError(
-                f"The models_path {access_method} [{models_path}] resulted in an error when trying to retrieve the "
-                f"class type [{model_class_name}].  Supply a different models_path.  Error encountered: "
-                f"{type(e).__name__}: {e}"
-            )
-        return mdl_cls
-
-    @classmethod
-    def get_maintained_fields(cls, models_path=None):
-        """
-        Returns all of the model classes that have maintained fields and the names of those fields in a dict where the
-        class name is the key and each value is a dict containing, for example:
-
-        {"class": <model class reference>, "fields": [list of field names]}
-
-        models_path is optional and must be a string like "DataRepo.models".  It's only required if called before any of
-        the model classes have been instantiated and after the decorators have registered.
-        """
-        maintained_fields = defaultdict(lambda: defaultdict(list))
-        for mdl in cls._get_classes(None, None, None, models_path=models_path):
-            mdl_name = mdl.__name__
-            mdl_update_flds = cls.get_update_fields_by_model_name(mdl_name)
-            if issubclass(mdl, MaintainedModel) and len(mdl_update_flds) > 0:
-                maintained_fields[mdl_name]["class"] = mdl
-                maintained_fields[mdl_name]["fields"] = mdl_update_flds
-        return maintained_fields
-
-    @classmethod
-    def get_update_fields_by_model_name(cls, model_name):
-        """
-        Returns a list of update_fields of the current model that are marked via the MaintainedModel.setter
-        decorators in the model.  Returns an empty list if there are none (e.g. if the only decorator in the model is
-        the relation decorator on the class).
-        """
-        update_fields = []
-        if model_name in cls.updater_list:
-            for updater_dict in cls.updater_list[model_name]:
-                if (
-                    "update_field" in updater_dict.keys()
-                    and updater_dict["update_field"]
-                ):
-                    update_fields.append(updater_dict["update_field"])
-        else:
-            raise NoDecorators(model_name)
-
-        return update_fields
-
-    @classmethod
-    def get_updater_dicts_by_model_name(cls, model_name):
-        """
-        Retrieves all the updater information of each decorated function of the calling model from the global
-        updater_list variable.
-        """
-        updaters = []
-        if model_name in cls.updater_list:
-            updaters = cls.updater_list[model_name]
-        else:
-            raise NoDecorators(model_name)
-
-        return updaters
-
-    @classmethod
-    def get_all_maintained_field_values(cls, models_path=None):
-        """
-        This method can be used to obtain every value of a maintained field before and after a load that raises an
-        exception to ensure that the failed load has no side-effects.  Results are stored in a list for each model in a
-        dict keyed on model.
-
-        models_path is optional and must be a string like "DataRepo.models".  It's only required if called before any of
-        the model classes have been instantiated and after the decorators have registered.
-        """
-        all_values = {}
-        maintained_fields = cls.get_maintained_fields(models_path)
-
-        for key in maintained_fields.keys():
-            mdl = maintained_fields[key]["class"]
-            flds = maintained_fields[key]["fields"]
-            all_values[mdl.__name__] = list(mdl.objects.values_list(*flds, flat=True))
-        return all_values
-
 
 class MaintainedModel(Model):
     """
@@ -637,6 +345,27 @@ class MaintainedModel(Model):
 
     # Thread-safe mutable class attributes.  Thread data is initialized via _check_set_coordinator_thread_data
     data = local()
+
+    # Track whether the fields from the decorators have been validated
+    # This is only ever initialized once, the first time every derived class is ever instantiated, so it's loosely an
+    # immutable class attribute (though technically mutable), as it would only ever change if new models are added and
+    # is only used to decide when a derived class's usage of MaintainedModel is invalid
+    maintained_model_initialized: Dict[str, bool] = {}
+
+    # Track the metadata recorded by each derived model class's setter and relation decorators
+    # Similar to maintained_model_initialized, this is loosely an immutable class attribute (though technically
+    # mutable), as it is only ever set when the setter and relation decorators are created, which only ever happens once
+    # This does not need to be thread-safe because it will not ever change after all the decorators have been registered
+    updater_list: Dict[str, List] = defaultdict(list)
+
+    # A dict of class name keys and class values used by get_classes needed for rebuild_maintained_fields. This is
+    # initialized via MaintainedModel's decorators as a way to avoid needing the module path of all the models as was
+    # formerly done.
+    model_classes: Dict[str, Model] = defaultdict(Model)
+
+    # A dict saving the package (referenced elsewhere as "model_path") that holds each model so that it's class can be
+    # retrieved when needed.
+    model_packages: Dict[str, str] = defaultdict(str)
 
     def __init__(self, *args, **kwargs):
         """
@@ -669,16 +398,14 @@ class MaintainedModel(Model):
         class_name = self.__class__.__name__
 
         # Register the class with the coordinator if not already registered
-        if class_name not in coordinator.model_classes.keys():
+        if class_name not in MaintainedModel.model_classes.keys():
             print(
                 f"Registering class {class_name} as a MaintainedModel from _maintained_model_setup: {type(self)}"
             )
-            MaintainedModelCoordinator.model_classes[class_name] = type(self)
-            MaintainedModelCoordinator.model_packages[class_name] = type(
-                self
-            ).__module__
+            MaintainedModel.model_classes[class_name] = type(self)
+            MaintainedModel.model_packages[class_name] = type(self).__module__
 
-        for updater_dict in coordinator.updater_list[class_name]:
+        for updater_dict in MaintainedModel.updater_list[class_name]:
             # Ensure the field being set is not a maintained field
 
             update_fld = updater_dict["update_field"]
@@ -705,13 +432,13 @@ class MaintainedModel(Model):
                     ]
                 ]
             )
-            if decorator_signature not in coordinator.maintained_model_initialized:
+            if decorator_signature not in MaintainedModel.maintained_model_initialized:
                 if settings.DEBUG:
                     print(
                         f"Validating {self.__class__.__name__} updater: {updater_dict}"
                     )
 
-                coordinator.maintained_model_initialized[decorator_signature] = True
+                MaintainedModel.maintained_model_initialized[decorator_signature] = True
                 # Now we can validate the fields
                 flds = {}
                 if updater_dict["update_field"]:
@@ -932,15 +659,15 @@ class MaintainedModel(Model):
             class_name = cls.__name__
 
             # Register the class (and the module) with the coordinator if not already registered
-            if class_name not in MaintainedModelCoordinator.model_classes.keys():
+            if class_name not in MaintainedModel.model_classes.keys():
                 print(
                     f"Registering class {class_name} as a MaintainedModel from the relation decorator: {cls}"
                 )
-                MaintainedModelCoordinator.model_classes[class_name] = cls
-                MaintainedModelCoordinator.model_packages[class_name] = cls.__module__
+                MaintainedModel.model_classes[class_name] = cls
+                MaintainedModel.model_packages[class_name] = cls.__module__
 
             # Register the updater with the coordinator
-            MaintainedModelCoordinator.updater_list[class_name].append(func_dict)
+            MaintainedModel.updater_list[class_name].append(func_dict)
 
             # No way to ensure supplied fields exist because the models aren't actually loaded yet, so while that would
             # be nice to handle here, it will have to be handled in MaintanedModel when objects are created
@@ -1027,19 +754,19 @@ class MaintainedModel(Model):
             }
 
             # Try to register the model class.  If this fails, fallback methods will be used when it is needed later.
-            if class_name not in MaintainedModelCoordinator.model_packages.keys():
+            if class_name not in MaintainedModel.model_packages.keys():
                 models_path = (
                     MaintainedModel.get_model_package_name_from_member_function(fn)
                 )
                 # Register the class with the coordinator if not already registered
                 if models_path is not None:
-                    MaintainedModelCoordinator.model_packages[class_name] = models_path
+                    MaintainedModel.model_packages[class_name] = models_path
 
             # No way to ensure supplied fields exist because the models aren't actually loaded yet, so while that would
             # be nice to handle here, it will have to be handled in MaintanedModel when objects are created
 
             # Add this info to our global updater_list
-            MaintainedModelCoordinator.updater_list[class_name].append(func_dict)
+            MaintainedModel.updater_list[class_name].append(func_dict)
             # It would be nice if we could register the class here, but getting the surrounding class from the function
             # is tricky and fragile.  The class will be registered when its first instance is created.
 
@@ -1387,6 +1114,232 @@ class MaintainedModel(Model):
         return decorator
 
     @classmethod
+    def get_all_updaters(cls):
+        """
+        Retrieve a flattened list of all updater dicts.
+        Used by rebuild_maintained_fields.
+        """
+        all_updaters = []
+        for class_name in cls.updater_list:
+            all_updaters += cls.updater_list[class_name]
+        return all_updaters
+
+    @classmethod
+    def _get_classes(
+        cls,
+        generation,
+        label_filters,
+        filter_in,
+        models_path=None,
+    ):
+        """
+        This method was made private, because it has no access to instance values for generation, label_filters, or
+        filter_in.  Users are not expected to supply these.  All instance methods that internally call these must pass
+        them.
+
+        Retrieve a list of classes containing maintained fields that match the given criteria.
+        Used by rebuild_maintained_fields and get_maintained_fields_query_dict.
+
+        models_path is optional and must be a string like "DataRepo.models".  It's only required if called before any of
+        the model classes have been instantiated and after the decorators have registered.
+        """
+        class_list = []
+        for model_class_name in cls.updater_list.keys():
+            if (
+                len(
+                    cls._filter_updaters(
+                        updaters_list=cls.updater_list[model_class_name],
+                        generation=generation,
+                        label_filters=label_filters,
+                        filter_in=filter_in,
+                    )
+                )
+                > 0
+            ):
+                class_list.append(cls.get_model_class(model_class_name, models_path))
+        return class_list
+
+    @classmethod
+    def get_model_class(cls, model_class_name, models_path=None):
+        """
+        models_path is optional and must be a string like "DataRepo.models".  It's only required if called before any of
+        the model classes have been instantiated and after the decorators have registered.
+        """
+        if model_class_name in cls.model_classes.keys():
+            return cls.model_classes[model_class_name]
+        access_method = "determiend by the decorator(s)"
+        try:
+            if models_path is None:
+                # The decorators *try* to record the models_path for each model.  If that was successful, we can use
+                # that, otherwise, the models_path is required.
+                if (
+                    cls.model_packages
+                    and model_class_name in cls.model_packages
+                    and cls.model_packages[model_class_name] is not None
+                ):
+                    models_path = cls.model_packages[model_class_name]
+                    module = importlib.import_module(models_path)
+                else:
+                    raise ValueError(
+                        f"models_path is required because the class {model_class_name} hasn't been instantiated as a "
+                        "MaintainedModel yet."
+                    )
+            else:
+                access_method = "supplied"
+                module = importlib.import_module(models_path)
+            mdl_cls = getattr(module, model_class_name)
+        except Exception as e:
+            raise ValueError(
+                f"The models_path {access_method} [{models_path}] resulted in an error when trying to retrieve the "
+                f"class type [{model_class_name}].  Supply a different models_path.  Error encountered: "
+                f"{type(e).__name__}: {e}"
+            )
+        return mdl_cls
+
+    @classmethod
+    def get_all_maintained_field_values(cls, models_path=None):
+        """
+        This method can be used to obtain every value of a maintained field before and after a load that raises an
+        exception to ensure that the failed load has no side-effects.  Results are stored in a list for each model in a
+        dict keyed on model.
+
+        models_path is optional and must be a string like "DataRepo.models".  It's only required if called before any of
+        the model classes have been instantiated and after the decorators have registered.
+        """
+        all_values = {}
+        maintained_fields = cls.get_maintained_fields_query_dict(models_path)
+
+        for key in maintained_fields.keys():
+            mdl = maintained_fields[key]["class"]
+            flds = maintained_fields[key]["fields"]
+            all_values[mdl.__name__] = list(mdl.objects.values_list(*flds, flat=True))
+
+        return all_values
+
+    @classmethod
+    def get_maintained_fields_query_dict(cls, models_path=None):
+        """
+        Returns all of the model classes that have maintained fields and the names of those fields in a dict where the
+        class name is the key and each value is a dict containing, for example:
+
+        {"class": <model class reference>, "fields": [list of field names]}
+
+        models_path is optional and must be a string like "DataRepo.models".  It's only required if called before any of
+        the model classes have been instantiated and after the decorators have registered.
+        """
+        maintained_fields = defaultdict(lambda: defaultdict(list))
+
+        # For each model class
+        for mdl in cls._get_classes(None, None, None, models_path=models_path):
+            mdl_name = mdl.__name__
+            mdl_update_flds = []
+
+            if mdl_name not in cls.updater_list:
+                raise NoDecorators(mdl_name)
+
+            for updater_dict in cls.updater_list[mdl_name]:
+                if (
+                    "update_field" in updater_dict.keys()
+                    and updater_dict["update_field"]
+                ):
+                    mdl_update_flds.append(updater_dict["update_field"])
+
+            if issubclass(mdl, MaintainedModel) and len(mdl_update_flds) > 0:
+                maintained_fields[mdl_name]["class"] = mdl
+                maintained_fields[mdl_name]["fields"] = mdl_update_flds
+
+        return maintained_fields
+
+    @classmethod
+    def _filter_updaters(
+        cls,
+        updaters_list,
+        generation,
+        label_filters,
+        filter_in,
+    ):
+        """
+        This method was made private, because it has no access to instance values for generation, label_filters, or
+        filter_in.  Users are not expected to supply these.  All instance methods that internally call these must pass
+        them.
+
+        Returns a sublist of the supplied updaters_list that meets both the filter criteria (generation matches and
+        update_label is in the label_filters), if those filters were supplied.
+        """
+        # This will be the new buffer (in case we're being selective)
+        new_updaters_list = []
+
+        # Convenience variables to make the conditional easier to read
+        no_filters = label_filters is None or len(label_filters) == 0
+        no_generation = generation is None
+
+        for updater_dict in updaters_list:
+            gen = updater_dict["generation"]
+            label = updater_dict["update_label"]
+            has_label = label is not None
+            if (
+                filter_in
+                and (
+                    (no_generation or generation == gen)
+                    and (no_filters or (has_label and label in label_filters))
+                )
+            ) or (
+                not filter_in
+                and (
+                    (no_generation or generation != gen)
+                    and (no_filters or not has_label or label not in label_filters)
+                )
+            ):
+                new_updaters_list.append(updater_dict)
+
+        return new_updaters_list
+
+    @classmethod
+    def updater_list_has_matching_labels(cls, updaters_list, label_filters, filter_in):
+        """
+        Returns True if any updater dict in updaters_list passes the label filtering criteria.
+        """
+        for updater_dict in updaters_list:
+            label = updater_dict["update_label"]
+            has_a_label = label is not None
+            if filter_in:
+                if has_a_label and label in label_filters:
+                    return True
+            elif not has_a_label or label not in label_filters:
+                return True
+
+        return False
+
+    @classmethod
+    def get_max_generation(cls, updaters_list, label_filters=None, filter_in=None):
+        """
+        Takes a list of updaters and a list of label filters and returns the max generation found in the updaters list.
+        """
+        if filter_in is None:
+            filter_in = True
+        if label_filters is None:
+            label_filters = (
+                []
+            )  # Include everything by default, regardless of default filters
+            filter_in = True
+        max_gen = None
+        for updater_dict in sorted(
+            cls._filter_updaters(
+                updaters_list,
+                generation=None,
+                label_filters=label_filters,
+                filter_in=filter_in,
+            ),
+            key=lambda x: x["generation"],
+            reverse=True,
+        ):
+            gen = updater_dict["generation"]
+            if max_gen is None or gen > max_gen:
+                max_gen = gen
+                break
+        return max_gen
+
+    @classmethod
     def rebuild_maintained_fields(
         cls,
         models_path=None,
@@ -1419,8 +1372,8 @@ class MaintainedModel(Model):
 
         with cls.custom_coordinator(coordinator):
             # Get the largest generation value
-            youngest_generation = coordinator.get_max_generation(
-                coordinator.get_all_updaters(),
+            youngest_generation = cls.get_max_generation(
+                cls.get_all_updaters(),
                 label_filters=label_filters,
                 filter_in=filter_in,
             )
@@ -1431,7 +1384,7 @@ class MaintainedModel(Model):
             # For every generation from the youngest leaves/children to root/parent
             for gen in sorted(range(youngest_generation + 1), reverse=True):
                 # For every MaintainedModel derived class with decorated functions
-                for mdl_cls in coordinator._get_classes(
+                for mdl_cls in cls._get_classes(
                     gen,
                     label_filters,
                     filter_in,
@@ -1446,7 +1399,7 @@ class MaintainedModel(Model):
 
                     # Leave the loop when the max generation present changes so that we can update the updated buffer
                     # with the parent-triggered updates that were locally buffered during the execution of this loop
-                    max_gen = coordinator.get_max_generation(
+                    max_gen = cls.get_max_generation(
                         updater_dicts,
                         label_filters=label_filters,
                         filter_in=filter_in,
@@ -1455,11 +1408,8 @@ class MaintainedModel(Model):
                         break
 
                     # No need to perform updates if none of the updaters match the label filters
-                    if (
-                        has_filters
-                        and not coordinator.updater_list_has_matching_labels(
-                            updater_dicts, label_filters, filter_in
-                        )
+                    if has_filters and not cls.updater_list_has_matching_labels(
+                        updater_dicts, label_filters, filter_in
                     ):
                         break
 
@@ -1792,7 +1742,13 @@ class MaintainedModel(Model):
         Retrieves all the updater information of each decorated function of the calling model from the global
         updater_list variable.
         """
-        return MaintainedModelCoordinator.get_updater_dicts_by_model_name(cls.__name__)
+        updaters = []
+        if cls.__name__ in cls.updater_list:
+            updaters = cls.updater_list[cls.__name__]
+        else:
+            raise NoDecorators(cls.__name__)
+
+        return updaters
 
     def transaction_management_warning(
         self,

--- a/DataRepo/tests/loading/test_load_accucor_msruns.py
+++ b/DataRepo/tests/loading/test_load_accucor_msruns.py
@@ -160,8 +160,7 @@ class AccuCorDataLoadingTests(TracebaseTestCase):
 
     def test_accucor_load_in_debug(self):
         pre_load_counts = self.get_record_counts()
-        coordinator = MaintainedModel._get_default_coordinator()
-        pre_load_maintained_values = coordinator.get_all_maintained_field_values()
+        pre_load_maintained_values = MaintainedModel.get_all_maintained_field_values()
         self.assertGreater(
             len(pre_load_maintained_values.keys()),
             0,
@@ -182,7 +181,7 @@ class AccuCorDataLoadingTests(TracebaseTestCase):
                 dry_run=True,
             )
 
-        post_load_maintained_values = coordinator.get_all_maintained_field_values()
+        post_load_maintained_values = MaintainedModel.get_all_maintained_field_values()
         post_load_counts = self.get_record_counts()
 
         self.assertEqual(

--- a/DataRepo/tests/models/test_maintained_model.py
+++ b/DataRepo/tests/models/test_maintained_model.py
@@ -1,0 +1,161 @@
+import queue
+import sys
+import threading
+import time
+
+from DataRepo.models import Compound, MaintainedModel, Tracer
+from DataRepo.models.maintained_model import MaintainedModelCoordinator
+from DataRepo.tests.tracebase_test_case import TracebaseTransactionTestCase
+from DataRepo.tests.tracebase_thread_test import (
+    ChildException,
+    run_child_during_parent_thread,
+    run_in_child_thread,
+    run_parent_during_child_thread,
+)
+
+excs = []
+
+
+class MaintainedModelThreadTests(TracebaseTransactionTestCase):
+    def create_tracer(self):
+        cmpd = Compound.objects.create(name="glucose", formula="C6H12O6", hmdb_id="1")
+        return Tracer.objects.create(compound=cmpd)
+
+    def test_TestThreadRunner_raises_exceptions_from_child(self):
+        """
+        This is a meta-test sanity check to ensure that exceptions in the child are raised in the parent as a
+        ChildException
+        """
+
+        def child_func():
+            time.sleep(0.2)
+            raise Exception("Sanity check")
+
+        def parent_func():
+            return None
+
+        with self.assertRaises(ChildException):
+            run_parent_during_child_thread(parent_func, child_func)
+
+    def create_tracer_in_disabled_coordinator_works_in_child_thread(self):
+        def child_func():
+            disabled = MaintainedModelCoordinator("disabled")
+            with MaintainedModel.custom_coordinator(disabled):
+                cmpd = Compound.objects.create(
+                    name="lysine", formula="C6H14N2O2", hmdb_id="2"
+                )
+                _ = Tracer.objects.create(compound=cmpd)
+                # Make sure the child runs long enough for any exceptions it raises to be collected by the parent
+                time.sleep(0.25)
+
+        # Just test that there are no exceptions
+        run_in_child_thread(child_func)
+
+    def test_failure_when_coordinator_access_shortcut_taken(self):
+        """
+        This tests the negative case.  This proves that thread-local data is not setup if you circumvent the accessors.
+        """
+        with self.assertRaises(AttributeError) as ar:
+            t1_trcr = self.create_tracer()
+            _ = t1_trcr.default_coordinator
+        # Assert the exception mentions the default coordinator
+        self.assertIn("default_coordinator", str(ar.exception))
+
+    def test_failure_when_coordinator_access_shortcut_taken_in_thread(self):
+        """
+        This tests the negative case.  This proves that thread-local data is not setup if you circumvent the accessors.
+        """
+
+        def child_func():
+            t2_trcr = self.create_tracer()
+            _ = t2_trcr.default_coordinator
+
+        with self.assertRaises(ChildException) as ar:
+            run_in_child_thread(child_func)
+        # Assert the exception mentions the default coordinator
+        self.assertIn("default_coordinator", str(ar.exception))
+
+    def test_success_when_coordinator_accessed_via_getter(self):
+        """
+        This tests the main thread case.  This proves that thread-local data is correctly set up in the main thread.
+        """
+        t1_trcr = self.create_tracer()
+        _ = t1_trcr._get_default_coordinator()
+
+    def test_success_when_coordinator_accessed_via_getter_in_thread(self):
+        """
+        This tests an alternate thread case.  This proves that thread-local data is correctly set up in new threads.
+        """
+
+        def child_func():
+            t2_trcr = self.create_tracer()
+            _ = t2_trcr._get_default_coordinator()
+            # Allow time to let the parent be assured there was no exception
+            time.sleep(0.2)
+
+        # Just test that there are no exceptions
+        run_in_child_thread(child_func)
+
+    def test_coordinator_stack(self):
+        """
+        This tests the main thread case.  This proves that thread-local data is correctly set up in the main thread.
+        """
+        disabled = MaintainedModelCoordinator("disabled")
+        with MaintainedModel.custom_coordinator(disabled):
+            t1_trcr = self.create_tracer()
+            self.assertEqual(
+                "disabled", t1_trcr._get_current_coordinator().auto_update_mode
+            )
+        self.assertEqual(
+            "immediate", t1_trcr._get_current_coordinator().auto_update_mode
+        )
+
+    def test_parent_thread_coordinator_unaffected_by_custom_child_coordinator(self):
+        def child_func():
+            """
+            Child thread puts a disabled coordinator on the coordinator stack
+            """
+            disabled = MaintainedModelCoordinator("disabled")
+            with MaintainedModel.custom_coordinator(disabled):
+                # Sleep to give parent time to check its auto-update mode
+                time.sleep(0.25)
+
+        def parent_func():
+            """
+            Assert that the current coordinator is still the default when the child adds a disabled coordinator to its
+            own coordinator_stack
+            """
+            parent_coordinator = MaintainedModel._get_current_coordinator()
+            self.assertEqual("immediate", parent_coordinator.auto_update_mode)
+
+        run_parent_during_child_thread(parent_func, child_func)
+
+    def test_child_thread_coordinator_unaffected_by_custom_parent_coordinator(self):
+        def child_func():
+            """
+            The child thread will sleep a bit, then obtain the current coordinator (run during a time when the parent
+            has added a disabled coordinator to the coordinator stack)
+            """
+            # Sleep 0.1 seconds so that the parent's coordinator context is active
+            time.sleep(0.1)
+            child_coordinator = MaintainedModel._get_current_coordinator()
+            # Wasn't sure if I could use self.assertEqual()
+            if "immediate" != child_coordinator.auto_update_mode:
+                raise Exception(
+                    "The child thread's default coordinator should be 'immediate', but it is "
+                    f"{child_coordinator.auto_update_mode}"
+                )
+            # Allow time to let the parent be assured there was no exception
+            time.sleep(0.4)
+
+        def parent_func():
+            """
+            The parent thread will run  after the child starts, but the child will wait a bit, so that the parent, run
+            after, will establish a new context, so we can check if the child's context has changed.
+            """
+            disabled = MaintainedModelCoordinator("disabled")
+            with MaintainedModel.custom_coordinator(disabled):
+                # Sleep to give parent time to check its auto-update mode
+                time.sleep(0.2)
+
+        run_child_during_parent_thread(parent_func, child_func)

--- a/DataRepo/tests/models/test_maintained_model.py
+++ b/DataRepo/tests/models/test_maintained_model.py
@@ -1,6 +1,3 @@
-import queue
-import sys
-import threading
 import time
 
 from DataRepo.models import Compound, MaintainedModel, Tracer
@@ -12,8 +9,6 @@ from DataRepo.tests.tracebase_thread_test import (
     run_in_child_thread,
     run_parent_during_child_thread,
 )
-
-excs = []
 
 
 class MaintainedModelThreadTests(TracebaseTransactionTestCase):

--- a/DataRepo/tests/test_models.py
+++ b/DataRepo/tests/test_models.py
@@ -1915,8 +1915,7 @@ class AnimalAndSampleLoadingTests(TracebaseTestCase):
         )
 
         pre_load_counts = self.get_record_counts()
-        coordinator = MaintainedModel._get_current_coordinator()
-        pre_load_maintained_values = coordinator.get_all_maintained_field_values(
+        pre_load_maintained_values = MaintainedModel.get_all_maintained_field_values(
             "DataRepo.models"
         )
         self.assertGreater(
@@ -1936,7 +1935,7 @@ class AnimalAndSampleLoadingTests(TracebaseTestCase):
                 dry_run=True,
             )
 
-        post_load_maintained_values = coordinator.get_all_maintained_field_values(
+        post_load_maintained_values = MaintainedModel.get_all_maintained_field_values(
             "DataRepo.models"
         )
         post_load_counts = self.get_record_counts()

--- a/DataRepo/tests/test_views.py
+++ b/DataRepo/tests/test_views.py
@@ -814,8 +814,7 @@ class ValidationViewTests(TracebaseTransactionTestCase):
 
         # Get initial record counts for all models
         tb_init_counts = self.get_record_counts()
-        coordinator = MaintainedModel._get_current_coordinator()
-        pre_load_maintained_values = coordinator.get_all_maintained_field_values(
+        pre_load_maintained_values = MaintainedModel.get_all_maintained_field_values(
             "DataRepo.models"
         )
 
@@ -831,7 +830,7 @@ class ValidationViewTests(TracebaseTransactionTestCase):
 
         # Get record counts for all models
         tb_post_counts = self.get_record_counts()
-        post_load_maintained_values = coordinator.get_all_maintained_field_values(
+        post_load_maintained_values = MaintainedModel.get_all_maintained_field_values(
             "DataRepo.models"
         )
 

--- a/DataRepo/tests/tracebase_thread_test.py
+++ b/DataRepo/tests/tracebase_thread_test.py
@@ -1,0 +1,174 @@
+import queue
+import threading
+import time
+
+
+class TestThreadRunner(threading.Thread):
+    """
+    This class allows you to start a child thread to run a function, and also specify a queue.Queue object into which
+    exceptions should be queued and a time to wait after queuing an axception to allow the parent time to collect it.
+    Note that the child function must give the parent time to run any tests while the child is running.
+    """
+
+    def __init__(self, exc_queue, child_func, exc_delay=0.2):
+        threading.Thread.__init__(self)
+        self.exc_queue = exc_queue
+        self.child_func = child_func
+        self.exc_delay = exc_delay
+
+    def run(self):
+        try:
+            self.child_func()
+        except Exception as e:
+            self.exc_queue.put(e)
+            # Sleep to allow the parent time to collect the queue contents
+            time.sleep(self.exc_delay)
+
+
+def run_in_child_thread(child_func, check_interval=0.1):
+    exc_queue = queue.Queue()
+    thread_runner = TestThreadRunner(
+        exc_queue, child_func, exc_delay=2 * check_interval
+    )
+    thread_runner.start()
+
+    # Collect possible exception
+    check_times = 0
+    exc = None
+    while True:
+        try:
+            check_times += 1
+            # Try to retrieve an exception from the child
+            exc = exc_queue.get(block=False)
+        except queue.Empty:
+            # Skip down to check if the child is still alive
+            pass
+
+        # Attempt to collect the child thread with a 0.1 second timeout
+        thread_runner.join(check_interval)
+        # Now check if the child thread is still running
+        if thread_runner.is_alive():
+            continue
+        else:
+            # The child is done, so let's break out of this loop
+            break
+
+    if exc is not None:
+        raise ChildException(exc)
+    elif check_times == 1:
+        raise PossiblePrematureChildDeath(check_interval)
+
+
+def run_parent_during_child_thread(
+    parent_func, child_func, parent_start_delay=0.1, check_interval=0.1
+):
+    """
+    This method allows you to run some code in the parent thread while a child thread is running.  It reports exceptions
+    from the child as well as the parent, in the parent(/current) thread.
+    """
+    exc_queue = queue.Queue()
+    thread_runner = TestThreadRunner(
+        exc_queue, child_func, exc_delay=2 * check_interval
+    )
+    thread_runner.start()
+
+    if parent_start_delay and parent_start_delay > 0.0:
+        time.sleep(parent_start_delay)
+
+    # Run the parent function while the child runs
+    parent_func()
+
+    # Collect possible exception
+    check_times = 0
+    exc = None
+    while True:
+        try:
+            check_times += 1
+            # Try to retrieve an exception from the child
+            exc = exc_queue.get(block=False)
+        except queue.Empty:
+            # Skip down to check if the child is still alive
+            pass
+
+        # Attempt to collect the child thread with a 0.1 second timeout
+        thread_runner.join(check_interval)
+        # Now check if the child thread is still running
+        if thread_runner.is_alive():
+            continue
+        else:
+            # The child is done, so let's break out of this loop
+            break
+
+    if exc is not None:
+        raise ChildException(exc)
+    elif check_times == 1:
+        raise PossibleChildDeathBeforeParent(parent_start_delay, check_interval)
+
+
+def run_child_during_parent_thread(parent_func, child_func, check_interval=0.1):
+    """
+    This method allows you to run some code in a child thread while the parent is running.  The child is started first,
+    so it must sleep a biut so that the parent can start, and then the child resumes during the parent.  The parent must
+    run long enough for the child to execute during the run of the parent.  It reports exceptions from the child as well
+    as the parent, in the parent(/current) thread.
+    """
+    exc_queue = queue.Queue()
+    thread_runner = TestThreadRunner(
+        exc_queue, child_func, exc_delay=2 * check_interval
+    )
+    thread_runner.start()
+
+    # Run the parent function while the child runs
+    parent_func()
+
+    # Collect possible exception
+    check_times = 0
+    exc = None
+    while True:
+        try:
+            check_times += 1
+            # Try to retrieve an exception from the child
+            exc = exc_queue.get(block=False)
+        except queue.Empty:
+            # Skip down to check if the child is still alive
+            pass
+
+        # Attempt to collect the child thread with a 0.1 second timeout
+        thread_runner.join(check_interval)
+        # Now check if the child thread is still running
+        if thread_runner.is_alive():
+            continue
+        else:
+            # The child is done, so let's break out of this loop
+            break
+
+    if exc is not None:
+        raise ChildException(exc)
+    elif check_times == 1:
+        raise PossiblePrematureChildDeath(check_interval)
+
+
+class ChildException(Exception):
+    def __init__(self, exc):
+        message = f"Exception occurred in child thread: {exc}"
+        super().__init__(message)
+
+
+class PossibleChildDeathBeforeParent(Exception):
+    def __init__(self, psd, ci):
+        message = (
+            "The child process may have exited with an exception before the parent had a chance to collect it.  "
+            f"Please ensure that the child runs longer than the parent_start_delay ({psd}) and 2 * check_interval "
+            f"({ci}) to ensure that exceptions are caught by the parent."
+        )
+        super().__init__(message)
+
+
+class PossiblePrematureChildDeath(Exception):
+    def __init__(self, ci):
+        message = (
+            "The child process may have exited with an exception before the parent had a chance to collect it.  "
+            f"Please ensure that the child runs longer than 2 * check_interval ({ci}) to ensure that exceptions are "
+            "caught by the parent."
+        )
+        super().__init__(message)


### PR DESCRIPTION
## Summary Change Description

This is the planned follow-up to PR #766, to more formalize that quick fix.  The fix was easy, but I wanted to write some decent tests involving threads, which took the better part of a work-day equivalent.

There are 2 main changes:

1. The `MaintainedModel.data` class attribute for storing thread-local data (the `coordinator_stack` and `default_coordinator` for tracking the current coordinator context), is now comprehensively initialized in each thread, as-needed, and all access to that data was routed through getters that check and perform the initialization if needed.
2. The class attributes (and associated methods) of `MaintainedModelCoordinator` were moved to the `MaintainedModel` class, because since they don't have anything to do with coordinator context, and can be accessed via the objects in the buffer that the coordinator maintains, it made more sense that they be in the class associated with the models.

Initially, I'd thought that the second change was necessary as a part of this effort, but I later realized that those class attributes were already in thread-shared memory, so that change mainly amounts to some better encapsulation / conceptual organization of the code.

## Affected Issues/Pull Requests

- Resolves #769

## Review Notes

See comments in-line.

## Checklist

This pull request will be merged once the following requirements are met.  The
author and/or reviewers should uncheck any unmet requirements:

- Review requirements
  - Minimum approvals: 1
  - No changes requested
  - All blocking issues resolved by reviewers
  - Specific reviewers: none
  - Review period: 2 days
- Associated issue/pull request requirements:
  - [x] All requirements in affected issues marked "resolved" are satisfied
  - [x] All required pull requests are merged *(or none)*
- Basic requirements
  - [x] [All linters pass](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#linting)
  - [x] [All tests pass](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#quality-control)
  - [x] All conflicts resolved
- Overhead requirements
  - [x] [New/changed method tests implemented/updated *(or no change)*](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#test-implementation)
  - [x] Added changes to *Unreleased* section of [`changelog.md`](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/changelog.md)
  - [x] [Migrations created & committed *(or no change)*](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#migration-process)
