### PR TITLE
Speed debugging

### DIFF
--- a/DataRepo/tests/loading/test_load_accucor_msruns.py
+++ b/DataRepo/tests/loading/test_load_accucor_msruns.py
@@ -916,10 +916,31 @@ class IsoCorrDataLoadingTests(TracebaseTestCase):
 
         self.assertEqual(pg.count(), 2)
 
-        from django.db import connection
-        with connection.cursor() as cursor:
-            cursor.execute("EXPLAIN (ANALYZE) SELECT COUNT(*) FROM (SELECT DISTINCT ON (\"DataRepo_peakgroup\".\"id\", \"DataRepo_peakdatalabel\".\"element\") \"DataRepo_peakgroup\".\"id\" AS \"col1\", \"DataRepo_peakgroup\".\"name\" AS \"col2\", \"DataRepo_peakgroup\".\"formula\" AS \"col3\", \"DataRepo_peakgroup\".\"msrun_id\" AS \"col4\", \"DataRepo_peakgroup\".\"peak_annotation_file_id\" AS \"col5\" FROM \"DataRepo_peakgroup\" INNER JOIN \"DataRepo_msrun\" ON (\"DataRepo_peakgroup\".\"msrun_id\" = \"DataRepo_msrun\".\"id\") INNER JOIN \"DataRepo_sample\" ON (\"DataRepo_msrun\".\"sample_id\" = \"DataRepo_sample\".\"id\") INNER JOIN \"DataRepo_archivefile\" ON (\"DataRepo_peakgroup\".\"peak_annotation_file_id\" = \"DataRepo_archivefile\".\"id\") INNER JOIN \"DataRepo_peakdata\" ON (\"DataRepo_peakgroup\".\"id\" = \"DataRepo_peakdata\".\"peak_group_id\") INNER JOIN \"DataRepo_peakdatalabel\" ON (\"DataRepo_peakdata\".\"id\" = \"DataRepo_peakdatalabel\".\"peak_data_id\") WHERE (\"DataRepo_sample\".\"name\" = 'xzl5_panc' AND \"DataRepo_peakgroup\".\"name\" = 'serine' AND \"DataRepo_archivefile\".\"filename\" = 'alafasted_cor.xlsx' AND \"DataRepo_peakdatalabel\".\"element\" = 'C') ORDER BY \"DataRepo_peakgroup\".\"id\" ASC, \"DataRepo_peakdatalabel\".\"element\" ASC) subquery;")  # args=('xzl5_panc', 'serine', 'alafasted_cor.xlsx', 'C')")
-            print(cursor.fetchone())
+        # # Without the `VACUUM FULL ANALYZE` added in TracebaseTestCase, this is the sql query that is constructed from
+        # # the first count query below and this analyze shows that the heuristic that builds the SQL is based on stale
+        # # data in the postgres stats table from the destruction of the data in the previous test class.
+        # from django.db import connection
+        # with connection.cursor() as cursor:
+        #     cursor.execute(
+        #         "EXPLAIN (ANALYZE) SELECT COUNT(*) FROM (SELECT DISTINCT ON (\"DataRepo_peakgroup\".\"id\", "
+        #         "\"DataRepo_peakdatalabel\".\"element\") \"DataRepo_peakgroup\".\"id\" AS \"col1\", "
+        #         "\"DataRepo_peakgroup\".\"name\" AS \"col2\", \"DataRepo_peakgroup\".\"formula\" AS \"col3\", "
+        #         "\"DataRepo_peakgroup\".\"msrun_id\" AS \"col4\", "
+        #         "\"DataRepo_peakgroup\".\"peak_annotation_file_id\" AS \"col5\" FROM \"DataRepo_peakgroup\" "
+        #         "INNER JOIN \"DataRepo_msrun\" ON (\"DataRepo_peakgroup\".\"msrun_id\" = \"DataRepo_msrun\".\"id\") "
+        #         "INNER JOIN \"DataRepo_sample\" ON (\"DataRepo_msrun\".\"sample_id\" = \"DataRepo_sample\".\"id\") "
+        #         "INNER JOIN \"DataRepo_archivefile\" "
+        #         "ON (\"DataRepo_peakgroup\".\"peak_annotation_file_id\" = \"DataRepo_archivefile\".\"id\") "
+        #         "INNER JOIN \"DataRepo_peakdata\" "
+        #         "ON (\"DataRepo_peakgroup\".\"id\" = \"DataRepo_peakdata\".\"peak_group_id\") "
+        #         "INNER JOIN \"DataRepo_peakdatalabel\" "
+        #         "ON (\"DataRepo_peakdata\".\"id\" = \"DataRepo_peakdatalabel\".\"peak_data_id\") "
+        #         "WHERE (\"DataRepo_sample\".\"name\" = 'xzl5_panc' AND \"DataRepo_peakgroup\".\"name\" = 'serine' "
+        #         "AND \"DataRepo_archivefile\".\"filename\" = 'alafasted_cor.xlsx' "
+        #         "AND \"DataRepo_peakdatalabel\".\"element\" = 'C') "
+        #         "ORDER BY \"DataRepo_peakgroup\".\"id\" ASC, \"DataRepo_peakdatalabel\".\"element\" ASC) subquery;")
+        #     for l in cursor.fetchall():
+        #         print(l)
 
-        # self.assertEqual(pg.filter(peak_data__labels__element__exact="C").count(), 1)
-        # self.assertEqual(pg.filter(peak_data__labels__element__exact="N").count(), 1)
+        self.assertEqual(pg.filter(peak_data__labels__element__exact="C").count(), 1)
+        self.assertEqual(pg.filter(peak_data__labels__element__exact="N").count(), 1)

--- a/DataRepo/tests/loading/test_load_accucor_msruns.py
+++ b/DataRepo/tests/loading/test_load_accucor_msruns.py
@@ -915,5 +915,11 @@ class IsoCorrDataLoadingTests(TracebaseTestCase):
         )
 
         self.assertEqual(pg.count(), 2)
-        self.assertEqual(pg.filter(peak_data__labels__element__exact="C").count(), 1)
-        self.assertEqual(pg.filter(peak_data__labels__element__exact="N").count(), 1)
+
+        from django.db import connection
+        with connection.cursor() as cursor:
+            cursor.execute("EXPLAIN (ANALYZE) SELECT COUNT(*) FROM (SELECT DISTINCT ON (\"DataRepo_peakgroup\".\"id\", \"DataRepo_peakdatalabel\".\"element\") \"DataRepo_peakgroup\".\"id\" AS \"col1\", \"DataRepo_peakgroup\".\"name\" AS \"col2\", \"DataRepo_peakgroup\".\"formula\" AS \"col3\", \"DataRepo_peakgroup\".\"msrun_id\" AS \"col4\", \"DataRepo_peakgroup\".\"peak_annotation_file_id\" AS \"col5\" FROM \"DataRepo_peakgroup\" INNER JOIN \"DataRepo_msrun\" ON (\"DataRepo_peakgroup\".\"msrun_id\" = \"DataRepo_msrun\".\"id\") INNER JOIN \"DataRepo_sample\" ON (\"DataRepo_msrun\".\"sample_id\" = \"DataRepo_sample\".\"id\") INNER JOIN \"DataRepo_archivefile\" ON (\"DataRepo_peakgroup\".\"peak_annotation_file_id\" = \"DataRepo_archivefile\".\"id\") INNER JOIN \"DataRepo_peakdata\" ON (\"DataRepo_peakgroup\".\"id\" = \"DataRepo_peakdata\".\"peak_group_id\") INNER JOIN \"DataRepo_peakdatalabel\" ON (\"DataRepo_peakdata\".\"id\" = \"DataRepo_peakdatalabel\".\"peak_data_id\") WHERE (\"DataRepo_sample\".\"name\" = 'xzl5_panc' AND \"DataRepo_peakgroup\".\"name\" = 'serine' AND \"DataRepo_archivefile\".\"filename\" = 'alafasted_cor.xlsx' AND \"DataRepo_peakdatalabel\".\"element\" = 'C') ORDER BY \"DataRepo_peakgroup\".\"id\" ASC, \"DataRepo_peakdatalabel\".\"element\" ASC) subquery;")  # args=('xzl5_panc', 'serine', 'alafasted_cor.xlsx', 'C')")
+            print(cursor.fetchone())
+
+        # self.assertEqual(pg.filter(peak_data__labels__element__exact="C").count(), 1)
+        # self.assertEqual(pg.filter(peak_data__labels__element__exact="N").count(), 1)

--- a/DataRepo/tests/loading/test_load_accucor_msruns.py
+++ b/DataRepo/tests/loading/test_load_accucor_msruns.py
@@ -602,9 +602,9 @@ class IsoCorrDataLoadingTests(TracebaseTestCase):
             skip_cache_updates=True,
         )
 
-        # Postgres performance tweak (to address slowness with this test in version 13).  Django furum folks recommended
-        # doing it after data updates.
-        self.vacuum_postgres_stats_table()
+        # # Postgres performance tweak (to address slowness with this test in version 13).  Django furum folks recommended
+        # # doing it after data updates.
+        # self.vacuum_postgres_stats_table()
 
         (
             post_samples,
@@ -674,9 +674,9 @@ class IsoCorrDataLoadingTests(TracebaseTestCase):
             skip_cache_updates=True,
         )
 
-        # Postgres performance tweak (to address slowness with this test in version 13).  Django furum folks recommended
-        # doing it after data updates.
-        self.vacuum_postgres_stats_table()
+        # # Postgres performance tweak (to address slowness with this test in version 13).  Django furum folks recommended
+        # # doing it after data updates.
+        # self.vacuum_postgres_stats_table()
 
         post_load_group_count = PeakGroup.objects.count()
         # The number of samples in the isocorr xlsx file (not the samples file)
@@ -712,9 +712,9 @@ class IsoCorrDataLoadingTests(TracebaseTestCase):
             skip_cache_updates=True,
         )
 
-        # Postgres performance tweak (to address slowness with this test in version 13).  Django furum folks recommended
-        # doing it after data updates.
-        self.vacuum_postgres_stats_table()
+        # # Postgres performance tweak (to address slowness with this test in version 13).  Django furum folks recommended
+        # # doing it after data updates.
+        # self.vacuum_postgres_stats_table()
 
         post_load_group_count = PeakGroup.objects.count()
         # The number of samples in the isocorr xlsx file (not the samples file)
@@ -750,9 +750,9 @@ class IsoCorrDataLoadingTests(TracebaseTestCase):
             skip_cache_updates=True,
         )
 
-        # Postgres performance tweak (to address slowness with this test in version 13).  Django furum folks recommended
-        # doing it after data updates.
-        self.vacuum_postgres_stats_table()
+        # # Postgres performance tweak (to address slowness with this test in version 13).  Django furum folks recommended
+        # # doing it after data updates.
+        # self.vacuum_postgres_stats_table()
 
         post_load_group_count = PeakGroup.objects.count()
         # The number of samples in the isocorr xlsx file (not the samples file)
@@ -797,9 +797,9 @@ class IsoCorrDataLoadingTests(TracebaseTestCase):
             skip_cache_updates=True,
         )
 
-        # Postgres performance tweak (to address slowness with this test in version 13).  Django furum folks recommended
-        # doing it after data updates.
-        self.vacuum_postgres_stats_table()
+        # # Postgres performance tweak (to address slowness with this test in version 13).  Django furum folks recommended
+        # # doing it after data updates.
+        # self.vacuum_postgres_stats_table()
 
         (
             post_samples,
@@ -844,9 +844,9 @@ class IsoCorrDataLoadingTests(TracebaseTestCase):
             skip_cache_updates=True,
         )
 
-        # Postgres performance tweak (to address slowness with this test in version 13).  Django furum folks recommended
-        # doing it after data updates.
-        self.vacuum_postgres_stats_table()
+        # # Postgres performance tweak (to address slowness with this test in version 13).  Django furum folks recommended
+        # # doing it after data updates.
+        # self.vacuum_postgres_stats_table()
 
         post_load_group_count = PeakGroup.objects.count()
 
@@ -869,9 +869,9 @@ class IsoCorrDataLoadingTests(TracebaseTestCase):
             skip_cache_updates=True,
         )
 
-        # Postgres performance tweak (to address slowness with this test in version 13).  Django furum folks recommended
-        # doing it after data updates.
-        self.vacuum_postgres_stats_table()
+        # # Postgres performance tweak (to address slowness with this test in version 13).  Django furum folks recommended
+        # # doing it after data updates.
+        # self.vacuum_postgres_stats_table()
 
         post_load_group_count = PeakGroup.objects.count()
 
@@ -895,9 +895,9 @@ class IsoCorrDataLoadingTests(TracebaseTestCase):
             skip_cache_updates=True,
         )
 
-        # Postgres performance tweak (to address slowness with this test in version 13).  Django furum folks recommended
-        # doing it after data updates.
-        self.vacuum_postgres_stats_table()
+        # # Postgres performance tweak (to address slowness with this test in version 13).  Django furum folks recommended
+        # # doing it after data updates.
+        # self.vacuum_postgres_stats_table()
 
         post_load_group_count = PeakGroup.objects.count()
 
@@ -945,8 +945,9 @@ class IsoCorrDataLoadingTests(TracebaseTestCase):
 
         # Postgres performance tweak (to address slowness with this test in version 13).  Django furum folks recommended
         # doing it after data updates.
-        self.vacuum_postgres_stats_table()
-
+        # self.vacuum_postgres_stats_table()
+        import time
+        startTime = time.time()
         pg = (
             PeakGroup.objects.filter(msrun__sample__name="xzl5_panc")
             .filter(name__exact="serine")
@@ -956,8 +957,14 @@ class IsoCorrDataLoadingTests(TracebaseTestCase):
             .order_by("id", "peak_data__labels__element")
             .distinct("id", "peak_data__labels__element")
         )
+        t = time.time()
+        print("pg query time: %.3f" % (t - startTime))
+        startTime = t
 
         self.assertEqual(pg.count(), 2)
+        t = time.time()
+        print("pg count time: %.3f" % (t - startTime))
+        startTime = t
 
         # # Without the `VACUUM FULL ANALYZE` added in TracebaseTestCase, this is the sql query that is constructed from
         # # the first count query below and this analyze shows that the heuristic that builds the SQL is based on stale
@@ -986,4 +993,10 @@ class IsoCorrDataLoadingTests(TracebaseTestCase):
         #         print(l)
 
         self.assertEqual(pg.filter(peak_data__labels__element__exact="C").count(), 1)
+        t = time.time()
+        print("carbon count time: %.3f" % (t - startTime))
+        startTime = t
         self.assertEqual(pg.filter(peak_data__labels__element__exact="N").count(), 1)
+        t = time.time()
+        print("nitrogen count time: %.3f" % (t - startTime))
+        startTime = t

--- a/DataRepo/tests/loading/test_load_accucor_msruns.py
+++ b/DataRepo/tests/loading/test_load_accucor_msruns.py
@@ -602,10 +602,6 @@ class IsoCorrDataLoadingTests(TracebaseTestCase):
             skip_cache_updates=True,
         )
 
-        # # Postgres performance tweak (to address slowness with this test in version 13).  Django furum folks recommended
-        # # doing it after data updates.
-        # self.vacuum_postgres_stats_table()
-
         (
             post_samples,
             post_infusates,
@@ -674,10 +670,6 @@ class IsoCorrDataLoadingTests(TracebaseTestCase):
             skip_cache_updates=True,
         )
 
-        # # Postgres performance tweak (to address slowness with this test in version 13).  Django furum folks recommended
-        # # doing it after data updates.
-        # self.vacuum_postgres_stats_table()
-
         post_load_group_count = PeakGroup.objects.count()
         # The number of samples in the isocorr xlsx file (not the samples file)
         SAMPLES_COUNT = 30
@@ -712,10 +704,6 @@ class IsoCorrDataLoadingTests(TracebaseTestCase):
             skip_cache_updates=True,
         )
 
-        # # Postgres performance tweak (to address slowness with this test in version 13).  Django furum folks recommended
-        # # doing it after data updates.
-        # self.vacuum_postgres_stats_table()
-
         post_load_group_count = PeakGroup.objects.count()
         # The number of samples in the isocorr xlsx file (not the samples file)
         SAMPLES_COUNT = 30
@@ -749,10 +737,6 @@ class IsoCorrDataLoadingTests(TracebaseTestCase):
             isocorr_format=True,
             skip_cache_updates=True,
         )
-
-        # # Postgres performance tweak (to address slowness with this test in version 13).  Django furum folks recommended
-        # # doing it after data updates.
-        # self.vacuum_postgres_stats_table()
 
         post_load_group_count = PeakGroup.objects.count()
         # The number of samples in the isocorr xlsx file (not the samples file)
@@ -797,10 +781,6 @@ class IsoCorrDataLoadingTests(TracebaseTestCase):
             skip_cache_updates=True,
         )
 
-        # # Postgres performance tweak (to address slowness with this test in version 13).  Django furum folks recommended
-        # # doing it after data updates.
-        # self.vacuum_postgres_stats_table()
-
         (
             post_samples,
             post_infusates,
@@ -844,10 +824,6 @@ class IsoCorrDataLoadingTests(TracebaseTestCase):
             skip_cache_updates=True,
         )
 
-        # # Postgres performance tweak (to address slowness with this test in version 13).  Django furum folks recommended
-        # # doing it after data updates.
-        # self.vacuum_postgres_stats_table()
-
         post_load_group_count = PeakGroup.objects.count()
 
         self.assert_peak_group_counts(
@@ -868,10 +844,6 @@ class IsoCorrDataLoadingTests(TracebaseTestCase):
             isocorr_format=True,
             skip_cache_updates=True,
         )
-
-        # # Postgres performance tweak (to address slowness with this test in version 13).  Django furum folks recommended
-        # # doing it after data updates.
-        # self.vacuum_postgres_stats_table()
 
         post_load_group_count = PeakGroup.objects.count()
 
@@ -894,10 +866,6 @@ class IsoCorrDataLoadingTests(TracebaseTestCase):
             skip_samples=("bk",),
             skip_cache_updates=True,
         )
-
-        # # Postgres performance tweak (to address slowness with this test in version 13).  Django furum folks recommended
-        # # doing it after data updates.
-        # self.vacuum_postgres_stats_table()
 
         post_load_group_count = PeakGroup.objects.count()
 
@@ -943,12 +911,6 @@ class IsoCorrDataLoadingTests(TracebaseTestCase):
             skip_cache_updates=True,
         )
 
-        # # Postgres performance tweak (to address slowness with this test in version 13).  Django furum folks recommended
-        # # doing it after data updates.
-        # self.vacuum_postgres_stats_table()
-
-        import time
-        startTime = time.time()
         pg = (
             PeakGroup.objects.filter(msrun__sample__name="xzl5_panc")
             .filter(name__exact="serine")
@@ -958,50 +920,8 @@ class IsoCorrDataLoadingTests(TracebaseTestCase):
             .order_by("id", "peak_data__labels__element")
             .distinct("id", "peak_data__labels__element")
         )
-        # self.vacuum_postgres_stats_table()
-        t = time.time()
-        print("pg query time: %.3f" % (t - startTime))
-        startTime = t
 
         self.assertEqual(pg.count(), 2)
-        # self.vacuum_postgres_stats_table()
-        t = time.time()
-        print("pg count time: %.3f" % (t - startTime))
-        startTime = t
-
-        # # Without the `VACUUM FULL ANALYZE` added in TracebaseTestCase, this is the sql query that is constructed from
-        # # the first count query below and this analyze shows that the heuristic that builds the SQL is based on stale
-        # # data in the postgres stats table from the destruction of the data in the previous test class.
-        # from django.db import connection
-        # with connection.cursor() as cursor:
-        #     cursor.execute(
-        #         "EXPLAIN (ANALYZE) SELECT COUNT(*) FROM (SELECT DISTINCT ON (\"DataRepo_peakgroup\".\"id\", "
-        #         "\"DataRepo_peakdatalabel\".\"element\") \"DataRepo_peakgroup\".\"id\" AS \"col1\", "
-        #         "\"DataRepo_peakgroup\".\"name\" AS \"col2\", \"DataRepo_peakgroup\".\"formula\" AS \"col3\", "
-        #         "\"DataRepo_peakgroup\".\"msrun_id\" AS \"col4\", "
-        #         "\"DataRepo_peakgroup\".\"peak_annotation_file_id\" AS \"col5\" FROM \"DataRepo_peakgroup\" "
-        #         "INNER JOIN \"DataRepo_msrun\" ON (\"DataRepo_peakgroup\".\"msrun_id\" = \"DataRepo_msrun\".\"id\") "
-        #         "INNER JOIN \"DataRepo_sample\" ON (\"DataRepo_msrun\".\"sample_id\" = \"DataRepo_sample\".\"id\") "
-        #         "INNER JOIN \"DataRepo_archivefile\" "
-        #         "ON (\"DataRepo_peakgroup\".\"peak_annotation_file_id\" = \"DataRepo_archivefile\".\"id\") "
-        #         "INNER JOIN \"DataRepo_peakdata\" "
-        #         "ON (\"DataRepo_peakgroup\".\"id\" = \"DataRepo_peakdata\".\"peak_group_id\") "
-        #         "INNER JOIN \"DataRepo_peakdatalabel\" "
-        #         "ON (\"DataRepo_peakdata\".\"id\" = \"DataRepo_peakdatalabel\".\"peak_data_id\") "
-        #         "WHERE (\"DataRepo_sample\".\"name\" = 'xzl5_panc' AND \"DataRepo_peakgroup\".\"name\" = 'serine' "
-        #         "AND \"DataRepo_archivefile\".\"filename\" = 'alafasted_cor.xlsx' "
-        #         "AND \"DataRepo_peakdatalabel\".\"element\" = 'C') "
-        #         "ORDER BY \"DataRepo_peakgroup\".\"id\" ASC, \"DataRepo_peakdatalabel\".\"element\" ASC) subquery;")
-        #     for l in cursor.fetchall():
-        #         print(l)
 
         self.assertEqual(pg.filter(peak_data__labels__element__exact="C").count(), 1)
-        # self.vacuum_postgres_stats_table()
-        t = time.time()
-        print("carbon count time: %.3f" % (t - startTime))
-        startTime = t
         self.assertEqual(pg.filter(peak_data__labels__element__exact="N").count(), 1)
-        # self.vacuum_postgres_stats_table()
-        t = time.time()
-        print("nitrogen count time: %.3f" % (t - startTime))
-        startTime = t

--- a/DataRepo/tests/loading/test_load_accucor_msruns.py
+++ b/DataRepo/tests/loading/test_load_accucor_msruns.py
@@ -943,9 +943,9 @@ class IsoCorrDataLoadingTests(TracebaseTestCase):
             skip_cache_updates=True,
         )
 
-        # Postgres performance tweak (to address slowness with this test in version 13).  Django furum folks recommended
-        # doing it after data updates.
-        self.vacuum_postgres_stats_table()
+        # # Postgres performance tweak (to address slowness with this test in version 13).  Django furum folks recommended
+        # # doing it after data updates.
+        # self.vacuum_postgres_stats_table()
 
         import time
         startTime = time.time()

--- a/DataRepo/tests/loading/test_load_accucor_msruns.py
+++ b/DataRepo/tests/loading/test_load_accucor_msruns.py
@@ -602,6 +602,10 @@ class IsoCorrDataLoadingTests(TracebaseTestCase):
             skip_cache_updates=True,
         )
 
+        # Postgres performance tweak (to address slowness with this test in version 13).  Django furum folks recommended
+        # doing it after data updates.
+        self.vacuum_postgres_stats_table()
+
         (
             post_samples,
             post_infusates,
@@ -669,6 +673,11 @@ class IsoCorrDataLoadingTests(TracebaseTestCase):
             isocorr_format=True,
             skip_cache_updates=True,
         )
+
+        # Postgres performance tweak (to address slowness with this test in version 13).  Django furum folks recommended
+        # doing it after data updates.
+        self.vacuum_postgres_stats_table()
+
         post_load_group_count = PeakGroup.objects.count()
         # The number of samples in the isocorr xlsx file (not the samples file)
         SAMPLES_COUNT = 30
@@ -702,6 +711,11 @@ class IsoCorrDataLoadingTests(TracebaseTestCase):
             isocorr_format=True,
             skip_cache_updates=True,
         )
+
+        # Postgres performance tweak (to address slowness with this test in version 13).  Django furum folks recommended
+        # doing it after data updates.
+        self.vacuum_postgres_stats_table()
+
         post_load_group_count = PeakGroup.objects.count()
         # The number of samples in the isocorr xlsx file (not the samples file)
         SAMPLES_COUNT = 30
@@ -735,6 +749,11 @@ class IsoCorrDataLoadingTests(TracebaseTestCase):
             isocorr_format=True,
             skip_cache_updates=True,
         )
+
+        # Postgres performance tweak (to address slowness with this test in version 13).  Django furum folks recommended
+        # doing it after data updates.
+        self.vacuum_postgres_stats_table()
+
         post_load_group_count = PeakGroup.objects.count()
         # The number of samples in the isocorr xlsx file (not the samples file)
         SAMPLES_COUNT = 60
@@ -778,6 +797,10 @@ class IsoCorrDataLoadingTests(TracebaseTestCase):
             skip_cache_updates=True,
         )
 
+        # Postgres performance tweak (to address slowness with this test in version 13).  Django furum folks recommended
+        # doing it after data updates.
+        self.vacuum_postgres_stats_table()
+
         (
             post_samples,
             post_infusates,
@@ -820,6 +843,11 @@ class IsoCorrDataLoadingTests(TracebaseTestCase):
             isocorr_format=True,
             skip_cache_updates=True,
         )
+
+        # Postgres performance tweak (to address slowness with this test in version 13).  Django furum folks recommended
+        # doing it after data updates.
+        self.vacuum_postgres_stats_table()
+
         post_load_group_count = PeakGroup.objects.count()
 
         self.assert_peak_group_counts(
@@ -840,6 +868,11 @@ class IsoCorrDataLoadingTests(TracebaseTestCase):
             isocorr_format=True,
             skip_cache_updates=True,
         )
+
+        # Postgres performance tweak (to address slowness with this test in version 13).  Django furum folks recommended
+        # doing it after data updates.
+        self.vacuum_postgres_stats_table()
+
         post_load_group_count = PeakGroup.objects.count()
 
         self.assert_peak_group_counts(
@@ -861,6 +894,11 @@ class IsoCorrDataLoadingTests(TracebaseTestCase):
             skip_samples=("bk",),
             skip_cache_updates=True,
         )
+
+        # Postgres performance tweak (to address slowness with this test in version 13).  Django furum folks recommended
+        # doing it after data updates.
+        self.vacuum_postgres_stats_table()
+
         post_load_group_count = PeakGroup.objects.count()
 
         self.assert_peak_group_counts(
@@ -904,6 +942,11 @@ class IsoCorrDataLoadingTests(TracebaseTestCase):
             isocorr_format=True,
             skip_cache_updates=True,
         )
+
+        # Postgres performance tweak (to address slowness with this test in version 13).  Django furum folks recommended
+        # doing it after data updates.
+        self.vacuum_postgres_stats_table()
+
         pg = (
             PeakGroup.objects.filter(msrun__sample__name="xzl5_panc")
             .filter(name__exact="serine")

--- a/DataRepo/tests/loading/test_load_accucor_msruns.py
+++ b/DataRepo/tests/loading/test_load_accucor_msruns.py
@@ -945,7 +945,8 @@ class IsoCorrDataLoadingTests(TracebaseTestCase):
 
         # Postgres performance tweak (to address slowness with this test in version 13).  Django furum folks recommended
         # doing it after data updates.
-        # self.vacuum_postgres_stats_table()
+        self.vacuum_postgres_stats_table()
+
         import time
         startTime = time.time()
         pg = (
@@ -957,11 +958,13 @@ class IsoCorrDataLoadingTests(TracebaseTestCase):
             .order_by("id", "peak_data__labels__element")
             .distinct("id", "peak_data__labels__element")
         )
+        # self.vacuum_postgres_stats_table()
         t = time.time()
         print("pg query time: %.3f" % (t - startTime))
         startTime = t
 
         self.assertEqual(pg.count(), 2)
+        # self.vacuum_postgres_stats_table()
         t = time.time()
         print("pg count time: %.3f" % (t - startTime))
         startTime = t
@@ -993,10 +996,12 @@ class IsoCorrDataLoadingTests(TracebaseTestCase):
         #         print(l)
 
         self.assertEqual(pg.filter(peak_data__labels__element__exact="C").count(), 1)
+        # self.vacuum_postgres_stats_table()
         t = time.time()
         print("carbon count time: %.3f" % (t - startTime))
         startTime = t
         self.assertEqual(pg.filter(peak_data__labels__element__exact="N").count(), 1)
+        # self.vacuum_postgres_stats_table()
         t = time.time()
         print("nitrogen count time: %.3f" % (t - startTime))
         startTime = t

--- a/DataRepo/tests/tracebase_test_case.py
+++ b/DataRepo/tests/tracebase_test_case.py
@@ -1,6 +1,8 @@
 import psycopg2
 import time
 
+from django.conf import settings
+from django.db import connection
 from django.test import TestCase, TransactionTestCase
 
 from DataRepo.models.utilities import get_all_models
@@ -82,16 +84,27 @@ def test_case_class_factory(base_class):
 
         @classmethod
         def vacuum_postgres_stats_table(cls):
-            print("Clearing out postgres statistics tables")
+            print(f"Connecting to postgres DB ({settings.DATABASES['default']['NAME']}) to clear out stats table")
             vacuumStartTime = time.time()
-            conn = psycopg2.connect()
-            conn.autocommit = True
-            with conn.cursor() as cursor:
-                cursor.execute("VACUUM FULL ANALYZE")
-                # cursor.execute("select * from pg_stat_user_tables where relid = \"DataRepo_peakdata\"::regclass;")
-                # for l in cursor.fetchall():
-                #     print(l)
-            conn.close()
+            # conn = psycopg2.connect(
+            #     "dbname=%s host=%s port=%s user=%s password=%s" % (
+            #         settings.DATABASES["default"]["NAME"],
+            #         settings.DATABASES["default"]["HOST"],
+            #         settings.DATABASES["default"]["PORT"],
+            #         settings.DATABASES["default"]["USER"],
+            #         settings.DATABASES["default"]["PASSWORD"],
+            #     )
+            # )
+            # conn.autocommit = True
+            print("Clearing out postgres statistics table")
+            # with conn.cursor() as cursor:
+            with connection.cursor() as cursor:
+                # cursor.execute("VACUUM FULL ANALYZE")
+                # cursor.execute("pg_relation_size('DataRepo_peakdata_peak_group_id_4dd87f4a');")
+                cursor.execute("select * from pg_stat_user_tables where relid = '\"DataRepo_peakdata\"'::regclass;")
+                for l in cursor.fetchall():
+                    print(l)
+            # conn.close()
             print("vacuum time: %.3f" % (time.time() - vacuumStartTime))
 
         class Meta:

--- a/DataRepo/tests/tracebase_test_case.py
+++ b/DataRepo/tests/tracebase_test_case.py
@@ -1,8 +1,6 @@
-import psycopg2
 import time
 
 from django.conf import settings
-from django.db import connection
 from django.test import TestCase, TransactionTestCase
 
 from DataRepo.models.utilities import get_all_models
@@ -49,7 +47,7 @@ def test_case_class_factory(base_class):
             This method in the superclass is intended to record the setUpTestData start time so that the setup run time
             can be reported in setUpTestData.
             """
-            cls.set_autovac()
+            cls.set_postgres_autovac()
             cls.setupStartTime = time.time()
             print(
                 "SETTING UP TEST CLASS: %s.%s at %s"
@@ -59,7 +57,6 @@ def test_case_class_factory(base_class):
 
         @classmethod
         def tearDownClass(cls):
-            # cls.vacuum_postgres_stats_table()
             super().tearDownClass()
 
         @classmethod
@@ -68,7 +65,6 @@ def test_case_class_factory(base_class):
             This method in the superclass is intended to provide run time information for the setUpTestData method.
             """
             super().setUpTestData()
-            # cls.vacuum_postgres_stats_table()
             reportRunTime(
                 f"{cls.__module__}.{cls.__name__}.setUpTestData", cls.setupStartTime
             )
@@ -84,50 +80,46 @@ def test_case_class_factory(base_class):
             return record_counts
 
         @classmethod
-        def vacuum_postgres_stats_table(cls):
-            print(f"Connecting to postgres DB ({settings.DATABASES['default']['NAME']}) to clear out stats table")
-            vacuumStartTime = time.time()
-            conn = psycopg2.connect(
-                database=settings.DATABASES["default"]["NAME"],
-                host=settings.DATABASES["default"]["HOST"],
-                port=settings.DATABASES["default"]["PORT"],
-                user=settings.DATABASES["default"]["USER"],
-                password=settings.DATABASES["default"]["PASSWORD"],
-            )
-            conn.autocommit = True
-            print("Clearing out postgres statistics table")
-            # with connection.cursor() as cursor:
-            with conn.cursor() as cursor:
-                # cursor.execute("VACUUM FULL")
-                cursor.execute("VACUUM FULL ANALYZE")
-                # cursor.execute("pg_relation_size('DataRepo_peakdata_peak_group_id_4dd87f4a');")
-                # cursor.execute("select * from pg_stat_user_tables where relid = '\"DataRepo_peakdata\"'::regclass;")
-                # for l in cursor.fetchall():
-                #     print(l)
-            conn.close()
-            print("vacuum time: %.3f" % (time.time() - vacuumStartTime))
+        def set_postgres_autovac(cls):
+            """
+            The update to postgres 13 caused a doubling in time to run the test suite.  The following changes to the
+            autovacuum settings brings the time time down to on-par with before the update.  See:
 
-        @classmethod
-        def set_autovac(cls):
-            print(f"Connecting to postgres DB ({settings.DATABASES['default']['NAME']}) to set autovacuum")
-            vacuumStartTime = time.time()
-            conn = psycopg2.connect(
-                database=settings.DATABASES["default"]["NAME"],
-                host=settings.DATABASES["default"]["HOST"],
-                port=settings.DATABASES["default"]["PORT"],
-                user=settings.DATABASES["default"]["USER"],
-                password=settings.DATABASES["default"]["PASSWORD"],
-            )
-            conn.autocommit = True
-            print("Setting autovacuum")
-            with conn.cursor() as cursor:
-                # cursor.execute("VACUUM FULL")
-                cursor.execute("ALTER TABLE \"DataRepo_peakdata\" SET (autovacuum_vacuum_scale_factor = 0.0);")
-                cursor.execute("ALTER TABLE \"DataRepo_peakdata\" SET (autovacuum_vacuum_threshold = 5000);")
-                cursor.execute("ALTER TABLE \"DataRepo_peakdata\" SET (autovacuum_analyze_scale_factor = 0.0);")
-                cursor.execute("ALTER TABLE \"DataRepo_peakdata\" SET (autovacuum_analyze_threshold = 5000);")
-            conn.close()
-            print("vacuum time: %.3f" % (time.time() - vacuumStartTime))
+            https://forum.djangoproject.com/t/test-time-doubled-after-django-3-2-4-2-and-postgres-10-13-update/24843
+            https://www.postgresql.org/message-id/18177-a282c2eaaf791f21%40postgresql.org
+            """
+            # The conditional keeps our code base somewhat database-independent
+            if "postgresql" in settings.DATABASES["default"]["ENGINE"]:
+                import psycopg2
+
+                print(
+                    f"Connecting to postgres DB ({settings.DATABASES['default']['NAME']}) to set autovacuum"
+                )
+                vacuumStartTime = time.time()
+                conn = psycopg2.connect(
+                    database=settings.DATABASES["default"]["NAME"],
+                    host=settings.DATABASES["default"]["HOST"],
+                    port=settings.DATABASES["default"]["PORT"],
+                    user=settings.DATABASES["default"]["USER"],
+                    password=settings.DATABASES["default"]["PASSWORD"],
+                )
+                conn.autocommit = True
+                with conn.cursor() as cursor:
+                    # cursor.execute("VACUUM FULL")
+                    cursor.execute(
+                        'ALTER TABLE "DataRepo_peakdata" SET (autovacuum_vacuum_scale_factor = 0.0);'
+                    )
+                    cursor.execute(
+                        'ALTER TABLE "DataRepo_peakdata" SET (autovacuum_vacuum_threshold = 5000);'
+                    )
+                    cursor.execute(
+                        'ALTER TABLE "DataRepo_peakdata" SET (autovacuum_analyze_scale_factor = 0.0);'
+                    )
+                    cursor.execute(
+                        'ALTER TABLE "DataRepo_peakdata" SET (autovacuum_analyze_threshold = 5000);'
+                    )
+                conn.close()
+                print("vacuum time: %.3f" % (time.time() - vacuumStartTime))
 
         class Meta:
             abstract = True

--- a/DataRepo/tests/tracebase_test_case.py
+++ b/DataRepo/tests/tracebase_test_case.py
@@ -56,10 +56,6 @@ def test_case_class_factory(base_class):
             super().setUpClass()
 
         @classmethod
-        def tearDownClass(cls):
-            super().tearDownClass()
-
-        @classmethod
         def setUpTestData(cls):
             """
             This method in the superclass is intended to provide run time information for the setUpTestData method.

--- a/DataRepo/tests/tracebase_test_case.py
+++ b/DataRepo/tests/tracebase_test_case.py
@@ -1,5 +1,6 @@
 import time
 
+import psycopg2
 from django.test import TestCase, TransactionTestCase
 
 from DataRepo.models.utilities import get_all_models
@@ -51,6 +52,20 @@ def test_case_class_factory(base_class):
                 "SETTING UP TEST CLASS: %s.%s at %s"
                 % (cls.__module__, cls.__name__, time.strftime("%m/%d/%Y, %H:%M:%S"))
             )
+            super().setUpClass()
+
+        @classmethod
+        def tearDownClass(cls):
+            """
+            This method in the superclass is intended to clear out the postgres 13 statistics tables to address
+            performance issues that have more than doubled test time.
+            """
+            print("Clearing out postgres statistics tables")
+            conn = psycopg2.connect()
+            conn.autocommit = True
+            with conn.cursor() as cursor:
+                cursor.execute("VACUUM FULL ANALYZE")
+            conn.close()
             super().setUpClass()
 
         @classmethod

--- a/DataRepo/tests/tracebase_test_case.py
+++ b/DataRepo/tests/tracebase_test_case.py
@@ -55,6 +55,11 @@ def test_case_class_factory(base_class):
             super().setUpClass()
 
         @classmethod
+        def tearDownClass(cls):
+            # cls.vacuum_postgres_stats_table()
+            super().tearDownClass()
+
+        @classmethod
         def setUpTestData(cls):
             """
             This method in the superclass is intended to provide run time information for the setUpTestData method.
@@ -78,11 +83,16 @@ def test_case_class_factory(base_class):
         @classmethod
         def vacuum_postgres_stats_table(cls):
             print("Clearing out postgres statistics tables")
+            vacuumStartTime = time.time()
             conn = psycopg2.connect()
             conn.autocommit = True
             with conn.cursor() as cursor:
                 cursor.execute("VACUUM FULL ANALYZE")
+                # cursor.execute("select * from pg_stat_user_tables where relid = \"DataRepo_peakdata\"::regclass;")
+                # for l in cursor.fetchall():
+                #     print(l)
             conn.close()
+            print("vacuum time: %.3f" % (time.time() - vacuumStartTime))
 
         class Meta:
             abstract = True


### PR DESCRIPTION
## Summary Change Description

Edited the postgres autovacuum settings, as suggested by the postgres bugs mailing list folks.  The entire test suite now runs in a speed on par with before the postgres 13 update.

## Affected Issues/Pull Requests

- Resolves #775

## Review Notes

See comments in-line.

## Checklist

This pull request will be merged once the following requirements are met.  The
author and/or reviewers should uncheck any unmet requirements:

- Review requirements
  - Minimum approvals: 1
  - No changes requested
  - All blocking issues resolved by reviewers
  - Specific reviewers: none
  - Review period: 2 days <!-- Edit as desired (e.g. based on complexity) -->
- Associated issue/pull request requirements:
  - [x] All requirements in affected issues marked "resolved" are satisfied
  - [x] All required pull requests are merged *(or none)*
- Basic requirements
  - [x] [All linters pass](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#linting)
  - [x] [All tests pass](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#quality-control)
  - [x] All conflicts resolved
- Overhead requirements
  - [x] [New/changed method tests implemented/updated *(or no change)*](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#test-implementation)
  - [ ] Added changes to *Unreleased* section of [`changelog.md`](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/changelog.md)
  - [x] [Migrations created & committed *(or no change)*](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#migration-process)
