### PR TITLE
Eliminate export exceptions due to no data

### DIFF
--- a/DataRepo/formats/dataformat_group.py
+++ b/DataRepo/formats/dataformat_group.py
@@ -2,7 +2,11 @@ import json
 from copy import deepcopy
 from typing import Dict
 
-from django.core.exceptions import ObjectDoesNotExist, ValidationError, FieldError
+from django.core.exceptions import (
+    FieldError,
+    ObjectDoesNotExist,
+    ValidationError,
+)
 from django.db.models import Prefetch
 from django.db.utils import ProgrammingError
 
@@ -762,7 +766,9 @@ class FormatGroup:
             )
         return qry_list
 
-    def createNewBasicQuery(self, mdl, fld, cmp, val, fmt, units="identity", search_again=True):
+    def createNewBasicQuery(
+        self, mdl, fld, cmp, val, fmt, units="identity", search_again=True
+    ):
         """
         Constructs a new qry object for an advanced search from basic search input.
 

--- a/DataRepo/tests/test_formats.py
+++ b/DataRepo/tests/test_formats.py
@@ -798,7 +798,7 @@ class FormatsTests(TracebaseTestCase):
         val = tval
         fmt = "pgtemplate"
         units = "identity"
-        newqry = basv_metadata.createNewBasicQuery(mdl, fld, cmp, val, units, fmt)
+        newqry = basv_metadata.createNewBasicQuery(mdl, fld, cmp, val, fmt, units)
         self.maxDiff = None
         self.assertEqual(qry, newqry)
 

--- a/DataRepo/tests/test_studies_exporter.py
+++ b/DataRepo/tests/test_studies_exporter.py
@@ -1,7 +1,6 @@
 import os
 import tempfile
 
-from django.core.exceptions import ObjectDoesNotExist
 from django.core.management import call_command
 
 from DataRepo.tests.tracebase_test_case import TracebaseTestCase
@@ -109,14 +108,3 @@ class MissingDataTests(StudiesExporterTestBase):
             outdir=os.path.join(self.tmpdir, "test_no_data_study_exists"),
             studies=["Small OBOB"],
         )
-
-    def test_study_does_not_exist(self):
-        """
-        Should not raise exception when no data is available and study exists
-        """
-        with self.assertRaises(ObjectDoesNotExist):
-            call_command(
-                "export_studies",
-                outdir=os.path.join(self.tmpdir, "test_study_does_not_exist"),
-                studies=["Small OBOB"],
-            )

--- a/DataRepo/tests/test_studies_exporter.py
+++ b/DataRepo/tests/test_studies_exporter.py
@@ -106,7 +106,7 @@ class MissingDataTests(StudiesExporterTestBase):
         """
         call_command(
             "export_studies",
-            outdir=os.path.join(self.tmpdir, "test_no_results"),
+            outdir=os.path.join(self.tmpdir, "test_no_data_study_exists"),
             studies=["Small OBOB"],
         )
 
@@ -117,6 +117,6 @@ class MissingDataTests(StudiesExporterTestBase):
         with self.assertRaises(ObjectDoesNotExist):
             call_command(
                 "export_studies",
-                outdir=os.path.join(self.tmpdir, "test_no_results"),
+                outdir=os.path.join(self.tmpdir, "test_study_does_not_exist"),
                 studies=["Small OBOB"],
             )

--- a/DataRepo/tests/test_studies_exporter.py
+++ b/DataRepo/tests/test_studies_exporter.py
@@ -53,10 +53,10 @@ class StudiesExporterTests(TracebaseTestCase):
             data_type=["Fcirc"],
         )
 
-    def test_bad_data_type(self):
+    def test_str_data_type_changed_to_list(self):
         call_command(
             "export_studies",
-            outdir=os.path.join(self.tmpdir, "test_bad_data_type"),
+            outdir=os.path.join(self.tmpdir, "test_str_data_type_changed_to_list"),
             data_type="Fcirc",
         )
 
@@ -91,3 +91,14 @@ class StudiesExporterTests(TracebaseTestCase):
                 outdir=os.path.join(self.tmpdir, "test_dir_exists"),
                 data_type=["Fcirc"],
             )
+
+    def test_no_results(self):
+        """
+        Should not raise exception when no results
+        """
+        call_command(
+            "export_studies",
+            outdir=os.path.join(self.tmpdir, "test_no_results"),
+            data_type="Fcirc",
+            studies=["Non-existent study"],
+        )

--- a/DataRepo/utils/studies_exporter.py
+++ b/DataRepo/utils/studies_exporter.py
@@ -94,6 +94,7 @@ class StudiesExporter:
                     study_id,
                     data_type_key,
                     "identity",
+                    search_again=False,
                 )
 
                 # Do the query of the format (ignoring count and optional stats)

--- a/DataRepo/utils/studies_exporter.py
+++ b/DataRepo/utils/studies_exporter.py
@@ -92,8 +92,8 @@ class StudiesExporter:
                     "id",
                     "exact",
                     study_id,
-                    "identity",
                     data_type_key,
+                    "identity",
                 )
 
                 # Do the query of the format (ignoring count and optional stats)

--- a/DataRepo/views/search/basic.py
+++ b/DataRepo/views/search/basic.py
@@ -1,6 +1,7 @@
 import json
 
 from django.conf import settings
+from django.core.exceptions import ObjectDoesNotExist, ValidationError, FieldError
 from django.http import Http404
 from django.shortcuts import render
 
@@ -51,7 +52,10 @@ def search_basic(request, mdl, fld, cmp, val, fmt, units=None):
             f"Invalid format [{fmt}].  Must be one of: [{','.join(names.keys())},{','.join(names.values())}]"
         )
 
-    qry = basv_metadata.createNewBasicQuery(mdl, fld, cmp, val, units, fmtkey)
+    try:
+        qry = basv_metadata.createNewBasicQuery(mdl, fld, cmp, val, fmtkey, units)
+    except (KeyError, ObjectDoesNotExist, ValidationError, FieldError) as e:
+        raise Http404(e)
     download_form = AdvSearchDownloadForm(initial={"qryjson": json.dumps(qry)})
 
     rows_per_page = int(

--- a/DataRepo/views/search/basic.py
+++ b/DataRepo/views/search/basic.py
@@ -1,7 +1,11 @@
 import json
 
 from django.conf import settings
-from django.core.exceptions import ObjectDoesNotExist, ValidationError, FieldError
+from django.core.exceptions import (
+    FieldError,
+    ObjectDoesNotExist,
+    ValidationError,
+)
 from django.http import Http404
 from django.shortcuts import render
 


### PR DESCRIPTION
## Summary Change Description

### What this change does

- Skips search field to display field conversion if `search_again` is `False` in the call to `createNewBasicQuery` (to avoid necessary code execution when not needed, i.e. when not rendering the search form, populated with the last performed search)
- Eliminates `Http404` exceptions from `DataRepo/formats/dataformat_group.py`
- Simplifies the database query inside `searchFieldToDisplayField`
- Eliminates any exception due to "no data"

### What this change does **not** do

- This does **not** simplify `searchFieldToDisplayField` to the point where it doesn't traverse the `qry` object.  That complex process is intended to support search queries that can match multiple different fields.  It has a flaw that is well documented: it does not support "or" groups in the `qry` structure.  We currently only use it for simple single search terms with exact/unique results coming from basic searches.
- This does not change the `Http404` exceptions that come from the view.  It simply moves the code that raises them to the view.  If we want to change those exceptions to something more accurate or appropriate, I propose making a separate issue.

## Affected Issues/Pull Requests

- Resolves #807
- Merges into branch `release_2.0.x`.  Will need to merge into `main` as well.

## Review Notes
<!--
For added context for reviewers, add comments to relevant lines of code.  Use
this space to describe any general areas of concern not linked to a specific
line of code that reviewers should pay particular attention to, e.g. please
make sure I have accounted for all possible inputs.
-->
See comments in-line.

## Checklist
<!--
If any of the checkbox requirements are not met, uncheck them and add an
explanation. E.g. Linting errors pre-date this PR.
-->
This pull request will be merged once the following requirements are met.  The
author and/or reviewers should uncheck any unmet requirements:

- Review requirements
  - Minimum approvals: 1 <!-- Edit as desired (e.g. based on complexity) -->
  - No changes requested
  - All blocking issues resolved by reviewers
  - Specific reviewers: @__add_username_here__
    <!--
    Require reviewers with specific expertise to be included among the minimum
    number of reviewers by tagging them.  Also please send them a message.
    -->
  - Review period: 2 days <!-- Edit as desired (e.g. based on complexity) -->
- Associated issue/pull request requirements:
  <!--
  Assert that all requirements in issues marked "resolved" are done and that
  all required pull requests are merged.  If any are not done, either edit or
  split the issue or explain the unmerged affected pull requests.
  -->
  - [x] All requirements in affected issues marked "resolved" are satisfied
  - [x] All required pull requests are merged *(or none)*
- Basic requirements
  <!--
  Uncheck items to acknowledge failures/conflicts you intend to address.
  Add an explanation if any won't be addressed before merge.
  -->
  - [x] [All linters pass](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#linting)
  - [x] [All tests pass](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#quality-control)
  - [x] All conflicts resolved
- Overhead requirements
  <!--
  These are additional requirements that are not directly associated with
  resolving the affected issue(s).
  -->
  - [x] [New/changed method tests implemented/updated *(or no change)*](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#test-implementation)
  - [x] [Updated *Unreleased* section of `changelog.md` *(or no change)*](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/changelog.md)
  - [x] [Migrations created & committed *(or no change)*](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#migration-process)
