### PR TITLE
Fixed minor bugs in stats reporting and conflicting value error summarization (mainly for compounds)

### DIFF
--- a/DataRepo/management/commands/load_table.py
+++ b/DataRepo/management/commands/load_table.py
@@ -434,8 +434,8 @@ class LoadFromTableCommand(ABC, BaseCommand):
     def report_status(self):
         """Prints load status per model.
 
-        Reports counts of loaded, existed and errored records.  Includes a note about dry run mode, if active.  Respects
-        the verbosity option.
+        Reports counts of loaded, existed, skipped, and errored records.  Includes a note about dry run mode, if active.
+        Respects the verbosity option.
 
         Args:
             None
@@ -446,6 +446,8 @@ class LoadFromTableCommand(ABC, BaseCommand):
         Returns:
             Nothing
         """
+        if self.options["verbosity"] == 0:
+            return
         msg = "Done.\n"
         if self.options["dry_run"]:
             msg = "Dry-run complete.  The following would occur during a real load:\n"
@@ -454,11 +456,15 @@ class LoadFromTableCommand(ABC, BaseCommand):
         for mdl in self.loader_class.get_models():
             mdl_name = mdl.__name__
             if mdl_name in load_stats.keys():
-                msg += "%s records loaded: [%i], skipped: [%i], and errored: [%i]." % (
-                    mdl_name,
-                    load_stats[mdl_name]["created"],
-                    load_stats[mdl_name]["skipped"],
-                    load_stats[mdl_name]["errored"],
+                msg += (
+                    "%s records created: [%i], existed: [%i], skipped [%i], and errored: [%i]."
+                    % (
+                        mdl_name,
+                        load_stats[mdl_name]["created"],
+                        load_stats[mdl_name]["existed"],
+                        load_stats[mdl_name]["skipped"],
+                        load_stats[mdl_name]["errored"],
+                    )
                 )
 
         if self.saved_aes is not None and self.saved_aes.get_num_errors() > 0:
@@ -468,5 +474,4 @@ class LoadFromTableCommand(ABC, BaseCommand):
         else:
             status = self.style.SUCCESS(msg)
 
-        if self.options["verbosity"] > 0:
-            self.stdout.write(status)
+        self.stdout.write(status)

--- a/DataRepo/utils/exceptions.py
+++ b/DataRepo/utils/exceptions.py
@@ -1112,9 +1112,7 @@ class ConflictingValueErrors(Exception):
         )
         for cve in conflicting_value_errors:
             # Create a new location string that excludes the column
-            cve_loc = generate_file_location_string(
-                rownum=cve.rownum, sheet=cve.sheet, file=cve.file
-            )
+            cve_loc = generate_file_location_string(sheet=cve.sheet, file=cve.file)
             if cve.rec is None:
                 conflict_data[cve_loc]["No record provided"][
                     "No file data provided"
@@ -1128,7 +1126,17 @@ class ConflictingValueErrors(Exception):
             for mdl in conflict_data[cve_loc].keys():
                 message += f"\tCreation of the following {mdl} record(s) encountered conflicts:\n"
                 for file_rec_str in conflict_data[cve_loc][mdl].keys():
-                    message += f"\t\tFile record:     {file_rec_str}\n"
+                    rowstr = ", ".join(
+                        summarize_int_list(
+                            [
+                                cve.rownum
+                                for cve in conflict_data[cve_loc][mdl][file_rec_str]
+                            ]
+                        )
+                    )
+                    message += (
+                        f"\t\tFile record:     {file_rec_str} (on rows: {rowstr})\n"
+                    )
                     for cve in conflict_data[cve_loc][mdl][file_rec_str]:
                         recstr = "Database record not provided"
                         if cve.rec is not None:

--- a/DataRepo/utils/protocols_loader.py
+++ b/DataRepo/utils/protocols_loader.py
@@ -107,6 +107,7 @@ class ProtocolsLoader(TraceBaseLoader):
 
                 # get_row_val can add to skip_row_indexes when there is a missing required value
                 if self.is_skip_row():
+                    self.errored()
                     continue
 
                 # Try and get the protocol

--- a/DataRepo/utils/study_table_loader.py
+++ b/DataRepo/utils/study_table_loader.py
@@ -91,6 +91,7 @@ class StudyTableLoader(TraceBaseLoader):
 
                 # get_row_val can add to skip_row_indexes when there is a missing required value
                 if self.is_skip_row():
+                    self.errored()
                     continue
 
                 study_rec, created = Study.objects.get_or_create(**rec_dict)

--- a/DataRepo/utils/tissues_loader.py
+++ b/DataRepo/utils/tissues_loader.py
@@ -87,6 +87,7 @@ class TissuesLoader(TraceBaseLoader):
 
                 # get_row_val can add to skip_row_indexes when there is a missing required value
                 if self.is_skip_row():
+                    self.errored()
                     continue
 
                 tissue, created = Tissue.objects.get_or_create(**rec_dict)


### PR DESCRIPTION
## Summary Change Description

- Added calls to self.errored() wherever there is a continue due to the return of is_skip_row()
- Added a skipped() method and stat (for when a record is not attempted to have been loaded because data for a previous model record had an issue
- Added a num argument to the incrementors, specifically for incrementing all synonyms parsed from a line when skipped.
- Buffered RequiredColumnValue from inside get_row_val because it was unintentionally stopping the loop.
- Fixed the summarization code in ConflictingValueErrors.
- Improved the summarization code to group by file and list associated row numbers.

## Affected Issues/Pull Requests

- Resolves #863

## Review Notes
<!--
For added context for reviewers, add comments to relevant lines of code.  Use
this space to describe any general areas of concern not linked to a specific
line of code that reviewers should pay particular attention to, e.g. please
make sure I have accounted for all possible inputs.
-->
See comments in-line.

## Checklist
<!--
If any of the checkbox requirements are not met, uncheck them and add an
explanation. E.g. Linting errors pre-date this PR.
-->
This pull request will be merged once the following requirements are met.  The
author and/or reviewers should uncheck any unmet requirements:

- Review requirements
  - Minimum approvals: 1 <!-- Edit as desired (e.g. based on complexity) -->
  - No changes requested
  - All blocking issues resolved by reviewers
  - Specific reviewers: @__add_username_here__
    <!--
    Require reviewers with specific expertise to be included among the minimum
    number of reviewers by tagging them.  Also please send them a message.
    -->
  - Review period: 2 days <!-- Edit as desired (e.g. based on complexity) -->
- Associated issue/pull request requirements:
  <!--
  Assert that all requirements in issues marked "resolved" are done and that
  all required pull requests are merged.  If any are not done, either edit or
  split the issue or explain the unmerged affected pull requests.
  -->
  - [x] All requirements in affected issues marked "resolved" are satisfied
  - [x] All required pull requests are merged *(or none)*
- Basic requirements
  <!--
  Uncheck items to acknowledge failures/conflicts you intend to address.
  Add an explanation if any won't be addressed before merge.
  -->
  - [x] [All linters pass](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#linting)
  - [x] [All tests pass](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#quality-control)
  - [x] All conflicts resolved
- Overhead requirements
  <!--
  These are additional requirements that are not directly associated with
  resolving the affected issue(s).
  -->
  - [x] [New/changed method tests implemented/updated *(or no change)*](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#test-implementation)
  - [ ] [Updated *Unreleased* section of `changelog.md` *(or no change)*](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/changelog.md)
  - [x] [Migrations created & committed *(or no change)*](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#migration-process)
