### PR TITLE
Sequence load 2 (renames and code moves)

### DIFF
--- a/DataRepo/management/commands/load_compounds.py
+++ b/DataRepo/management/commands/load_compounds.py
@@ -7,7 +7,6 @@ class Command(LoadFromTableCommand):
 
     help = "Loads data from a compound table into the database"
     loader_class = CompoundsLoader
-    data_sheet_default = "Compounds"
 
     def add_arguments(self, parser):
         # Add the options provided by the superclass
@@ -18,7 +17,7 @@ class Command(LoadFromTableCommand):
             "--synonym-separator",
             type=str,
             help="Character separating multiple synonyms in 'Synonyms' column (default '%(default)s')",
-            default=";",
+            default=self.loader_class.SYNOMYM_SEPARATOR,
             required=False,
         )
 

--- a/DataRepo/management/commands/load_protocols.py
+++ b/DataRepo/management/commands/load_protocols.py
@@ -1,6 +1,5 @@
 from DataRepo.management.commands.load_table import LoadFromTableCommand
 from DataRepo.utils import ProtocolsLoader
-from DataRepo.utils.file_utils import is_excel
 
 
 class Command(LoadFromTableCommand):
@@ -8,49 +7,20 @@ class Command(LoadFromTableCommand):
 
     help = "Loads data from a protocol table into the database"
     loader_class = ProtocolsLoader
-    data_sheet_default = "Treatments"
-
-    # default XLXS template headers
-    TREATMENTS_NAME_HEADER = "Animal Treatment"
-    TREATMENTS_DESC_HEADER = "Treatment Description"
-
-    def set_headers(self, custom_headers=None):
-        """Override of the base class to conditionally change the headers based on infile type.
-
-        Args:
-            custom_headers (namedtupe of loader_class.TableHeaders): Header names by header key
-
-        Raises:
-            Nothing
-
-        Returns:
-            headers (namedtupe of loader_class.TableHeaders): Header names by header key
-        """
-        if custom_headers is not None:
-            # This is only needed if called from elsewhere (e.g. another derived class of this class)
-            return super().set_headers(custom_headers=custom_headers)
-        # Different headers if an excel file is provided
-        if is_excel(self.get_infile()):
-            # An excel sheet is assumed to be for treatment protocols
-            excel_headers = {
-                ProtocolsLoader.NAME_KEY: self.TREATMENTS_NAME_HEADER,
-                ProtocolsLoader.DESC_KEY: self.TREATMENTS_DESC_HEADER,
-            }
-            return super().set_headers(custom_headers=excel_headers)
-        return super().set_headers()
 
     def handle(self, *args, **options):
         """Code to run when the command is called from the command line.
 
         This code is automatically wrapped by LoadFromTableCommand._handler, which handles:
-            - Retrieving the base-class-provided option values (and fills in the defaults provided by the loader_class)
-            - Atomic transactions with optionally deferred rollback
-            - Exception handling:
-                - DryRun Exceptions
-                - Contextualization of exceptions to the associated input in the file
-            - Validation
-                - Header and data type
-                - Unique file constraints
+
+        - Retrieving the base-class-provided option values (and fills in the defaults provided by the loader_class)
+        - Atomic transactions with optionally deferred rollback
+        - Exception handling:
+            - DryRun Exceptions
+            - Contextualization of exceptions to the associated input in the file
+        - Validation
+            - Header and data type
+            - Unique file constraints
 
         Args:
             options (dict of strings): String values provided on the command line by option name.
@@ -61,7 +31,4 @@ class Command(LoadFromTableCommand):
         Returns:
             Nothing
         """
-        # Force a re-evaluation of the header names.  They can change based on the options, given the custom code above.
-        # When the object is instantiated, they are set based on defaults, and will not reset automatically.
-        self.set_headers()
         self.load_data()

--- a/DataRepo/management/commands/load_sequences.py
+++ b/DataRepo/management/commands/load_sequences.py
@@ -7,7 +7,6 @@ class Command(LoadFromTableCommand):
 
     help = "Loads data from a sequence table into the database"
     loader_class = SequencesLoader
-    data_sheet_default = "Sequences"
 
     def handle(self, *args, **options):
         """Code to run when the command is called from the command line.

--- a/DataRepo/management/commands/load_study_table.py
+++ b/DataRepo/management/commands/load_study_table.py
@@ -7,7 +7,6 @@ class Command(LoadFromTableCommand):
 
     help = "Loads data from a study table (e.g. study code, name, and description) into the database."
     loader_class = StudyTableLoader
-    data_sheet_default = "Study"
 
     def handle(self, *args, **options):
         """Code to run when the command is called from the command line.

--- a/DataRepo/management/commands/load_tissues.py
+++ b/DataRepo/management/commands/load_tissues.py
@@ -7,7 +7,6 @@ class Command(LoadFromTableCommand):
 
     help = "Loads data from a tissue table into the database"
     loader_class = TissuesLoader
-    data_sheet_default = "Tissues"
 
     def handle(self, *args, **options):
         """Code to run when the command is called from the command line.

--- a/DataRepo/tests/loading/test_load_table.py
+++ b/DataRepo/tests/loading/test_load_table.py
@@ -9,14 +9,15 @@ from DataRepo.utils.loader import TraceBaseLoader
 
 # Class used for testing
 class TestLoader(TraceBaseLoader):
-    TableHeaders = namedtuple("TableHeaders", ["TEST"])
-    DefaultHeaders = TableHeaders(TEST="Test")
-    RequiredHeaders = TableHeaders(TEST=True)
-    RequiredValues = RequiredHeaders
-    ColumnTypes = {"TEST": str}
-    DefaultValues = TableHeaders(TEST=5)
-    UniqueColumnConstraints = [["TEST"]]
-    FieldToHeaderKey = {"Tissue": {"name": "TEST"}}
+    DataSheetName = "test"
+    DataTableHeaders = namedtuple("DataTableHeaders", ["TEST"])
+    DataHeaders = DataTableHeaders(TEST="Test")
+    DataRequiredHeaders = DataTableHeaders(TEST=True)
+    DataRequiredValues = DataRequiredHeaders
+    DataColumnTypes = {"TEST": str}
+    DataDefaultValues = DataTableHeaders(TEST=5)
+    DataUniqueColumnConstraints = [["TEST"]]
+    FieldToDataHeaderKey = {"Tissue": {"name": "TEST"}}
     # TODO: Create a TestModel to use instead of Tissue (and change/rename TraceBaseLoader to not depend on TraceBase)
     Models = [Tissue]
 
@@ -28,7 +29,6 @@ class TestLoader(TraceBaseLoader):
 # Class used for testing
 class TestCommand(LoadFromTableCommand):
     loader_class = TestLoader
-    data_sheet_default = "test"
 
     def handle(self, *args, **options):
         return self.load_data()
@@ -50,7 +50,6 @@ class LoadFromTableCommandSuperclassUnitTests(TracebaseTestCase):
         This tests that all required class attributes:
 
             loader_class
-            data_sheet_default
 
         are enforced.  We will do so by creating a class that does not have any of the required class attributes defined
         and catching the expected exception.
@@ -66,7 +65,7 @@ class LoadFromTableCommandSuperclassUnitTests(TracebaseTestCase):
             MyCommand()
             # pylint: enable=abstract-class-instantiated
         self.assertIn(
-            "Can't instantiate abstract class MyCommand with abstract methods data_sheet_default, loader_class",
+            "Can't instantiate abstract class MyCommand with abstract method loader_class",
             str(ar.exception),
         )
 
@@ -101,7 +100,6 @@ class LoadFromTableCommandSuperclassUnitTests(TracebaseTestCase):
 
         class TestTypeCommand(LoadFromTableCommand):
             loader_class = NotATraceBaseLoaderClass
-            data_sheet_default = 1
 
             def handle(self, *args, **options):
                 self.load_data()
@@ -112,7 +110,6 @@ class LoadFromTableCommandSuperclassUnitTests(TracebaseTestCase):
         self.assertEqual((1, 0), (aes.num_errors, aes.num_warnings))
         self.assertEqual(TypeError, type(aes.exceptions[0]))
         self.assertIn("loader_class", str(aes.exceptions[0]))
-        self.assertIn("data_sheet_default", str(aes.exceptions[0]))
 
     def test_load_data(self):
         """
@@ -137,23 +134,23 @@ class LoadFromTableCommandSuperclassUnitTests(TracebaseTestCase):
 
     def test_get_defaults(self):
         """
-        Tests the return of get_defaults is what was set in TestLoader.DefaultValues
+        Tests the return of get_defaults is what was set in TestLoader.DataDefaultValues
         """
         tc = TestCommand()
         tc.handle(**self.TEST_OPTIONS)
-        self.assertEqual(TestLoader.DefaultValues, tc.get_defaults())
+        self.assertEqual(TestLoader.DataDefaultValues, tc.get_defaults())
 
     def test_get_headers(self):
         """
-        Tests the return of get_defaults is what was set in TestLoader.DefaultHeaders
+        Tests the return of get_defaults is what was set in TestLoader.DataHeaders
         """
         tc = TestCommand()
         tc.handle(**self.TEST_OPTIONS)
-        self.assertEqual(TestLoader.DefaultHeaders, tc.get_headers())
+        self.assertEqual(TestLoader.DataHeaders, tc.get_headers())
 
     def test_get_dataframe(self):
         """
-        Tests the return of get_defaults is what was set in TestLoader.DefaultHeaders
+        Tests the return of get_defaults is what was set in TestLoader.DataHeaders
         """
         tc = TestCommand()
         tc.handle(**self.TEST_OPTIONS)

--- a/DataRepo/tests/loading/test_loading_protocols.py
+++ b/DataRepo/tests/loading/test_loading_protocols.py
@@ -72,8 +72,8 @@ class ProtocolLoadingTests(TracebaseTestCase):
 
     def test_protocols_loader_without_category_error(self):
         """Test the ProtocolsLoader with dataframe missing category"""
-        # The DefaultValues namedtuple in ProtocolsLoader sets a category default of Protocol.ANIMAL_TREATMENT, so in
-        # order to make the error occur, we must set that default to None
+        # The DataDefaultValues namedtuple in ProtocolsLoader sets a category default of Protocol.ANIMAL_TREATMENT, so
+        # in order to make the error occur, we must set that default to None
         protocol_loader = ProtocolsLoader(self.working_df)
         protocol_loader.set_defaults(
             custom_defaults={

--- a/DataRepo/tests/utils/test_loader.py
+++ b/DataRepo/tests/utils/test_loader.py
@@ -61,12 +61,13 @@ class TraceBaseLoaderTests(TracebaseTestCase):
     @classmethod
     def generate_test_loader(cls, mdl):
         class TestLoader(TraceBaseLoader):
-            TableHeaders = namedtuple("TableHeaders", ["NAME", "CHOICE"])
-            DefaultHeaders = TableHeaders(NAME="Name", CHOICE="Choice")
-            RequiredHeaders = TableHeaders(NAME=True, CHOICE=False)
-            RequiredValues = RequiredHeaders
-            UniqueColumnConstraints = [["NAME"]]
-            FieldToHeaderKey = {mdl.__name__: {"name": "NAME", "choice": "CHOICE"}}
+            DataSheetName = "test"
+            DataTableHeaders = namedtuple("DataTableHeaders", ["NAME", "CHOICE"])
+            DataHeaders = DataTableHeaders(NAME="Name", CHOICE="Choice")
+            DataRequiredHeaders = DataTableHeaders(NAME=True, CHOICE=False)
+            DataRequiredValues = DataRequiredHeaders
+            DataUniqueColumnConstraints = [["NAME"]]
+            FieldToDataHeaderKey = {mdl.__name__: {"name": "NAME", "choice": "CHOICE"}}
             Models = [mdl]
 
             def load_data(self):
@@ -77,13 +78,16 @@ class TraceBaseLoaderTests(TracebaseTestCase):
     @classmethod
     def generate_uc_test_loader(cls, mdl):
         class TestUCLoader(TraceBaseLoader):
-            TableHeaders = namedtuple("TableHeaders", ["NAME", "UFONE", "UFTWO"])
-            DefaultHeaders = TableHeaders(NAME="Name", UFONE="uf1", UFTWO="uf2")
-            RequiredHeaders = TableHeaders(NAME=True, UFONE=False, UFTWO=False)
-            RequiredValues = RequiredHeaders
-            UniqueColumnConstraints = [["NAME"], ["UFONE", "UFTWO"]]
-            ColumnTypes = {"NAME": str, "UFONE": str, "UFTWO": str}
-            FieldToHeaderKey = {
+            DataSheetName = "test"
+            DataTableHeaders = namedtuple(
+                "DataTableHeaders", ["NAME", "UFONE", "UFTWO"]
+            )
+            DataHeaders = DataTableHeaders(NAME="Name", UFONE="uf1", UFTWO="uf2")
+            DataRequiredHeaders = DataTableHeaders(NAME=True, UFONE=False, UFTWO=False)
+            DataRequiredValues = DataRequiredHeaders
+            DataUniqueColumnConstraints = [["NAME"], ["UFONE", "UFTWO"]]
+            DataColumnTypes = {"NAME": str, "UFONE": str, "UFTWO": str}
+            FieldToDataHeaderKey = {
                 "TestUCModel": {"name": "NAME", "uf1": "UFONE", "uf2": "UFTWO"}
             }
             Models = [mdl]
@@ -330,13 +334,14 @@ class TraceBaseLoaderTests(TracebaseTestCase):
 
     def test_get_defaults_dict_by_header_name(self):
         class TestDefaultsLoader(TraceBaseLoader):
-            TableHeaders = namedtuple("TableHeaders", ["NAME", "CHOICE"])
-            DefaultHeaders = TableHeaders(NAME="Name", CHOICE="Choice")
-            RequiredHeaders = TableHeaders(NAME=True, CHOICE=False)
-            RequiredValues = RequiredHeaders
-            DefaultValues = TableHeaders(NAME="test", CHOICE="1")
-            UniqueColumnConstraints = [["NAME"]]
-            FieldToHeaderKey = {"TestModel": {"name": "NAME", "choice": "CHOICE"}}
+            DataSheetName = "test"
+            DataTableHeaders = namedtuple("DataTableHeaders", ["NAME", "CHOICE"])
+            DataHeaders = DataTableHeaders(NAME="Name", CHOICE="Choice")
+            DataRequiredHeaders = DataTableHeaders(NAME=True, CHOICE=False)
+            DataRequiredValues = DataRequiredHeaders
+            DataDefaultValues = DataTableHeaders(NAME="test", CHOICE="1")
+            DataUniqueColumnConstraints = [["NAME"]]
+            FieldToDataHeaderKey = {"TestModel": {"name": "NAME", "choice": "CHOICE"}}
             Models = [self.TestModel]
 
             def load_data(self):
@@ -385,12 +390,13 @@ class TraceBaseLoaderTests(TracebaseTestCase):
 
     def test_check_header_names(self):
         class TestDoubleHeaderLoader(TraceBaseLoader):
-            TableHeaders = namedtuple("TableHeaders", ["NAME", "CHOICE"])
-            DefaultHeaders = TableHeaders(NAME="Choice", CHOICE="Choice")
-            RequiredHeaders = TableHeaders(NAME=True, CHOICE=False)
-            RequiredValues = RequiredHeaders
-            UniqueColumnConstraints = [["NAME"]]
-            FieldToHeaderKey = {"TestModel": {"name": "NAME", "choice": "CHOICE"}}
+            DataSheetName = "test"
+            DataTableHeaders = namedtuple("DataTableHeaders", ["NAME", "CHOICE"])
+            DataHeaders = DataTableHeaders(NAME="Choice", CHOICE="Choice")
+            DataRequiredHeaders = DataTableHeaders(NAME=True, CHOICE=False)
+            DataRequiredValues = DataRequiredHeaders
+            DataUniqueColumnConstraints = [["NAME"]]
+            FieldToDataHeaderKey = {"TestModel": {"name": "NAME", "choice": "CHOICE"}}
             Models = [self.TestModel]
 
             def load_data(self):
@@ -463,7 +469,7 @@ class TraceBaseLoaderTests(TracebaseTestCase):
         self.assertEqual(expected, td)
 
     def test_isnamedtuple(self):
-        nt = self.TestLoader.TableHeaders(
+        nt = self.TestLoader.DataTableHeaders(
             NAME=True,
             CHOICE=True,
         )
@@ -482,13 +488,14 @@ class TraceBaseLoaderTests(TracebaseTestCase):
 
     def test_check_class_attributes(self):
         class TestInvalidLoader(TraceBaseLoader):
-            TableHeaders = namedtuple("TableHeaders", ["NAME", "CHOICE"])
-            DefaultHeaders = None
-            RequiredHeaders = None
-            RequiredValues = None
-            DefaultValues = None
-            UniqueColumnConstraints = None
-            FieldToHeaderKey = None
+            DataSheetName = "test"
+            DataTableHeaders = namedtuple("DataTableHeaders", ["NAME", "CHOICE"])
+            DataHeaders = None
+            DataRequiredHeaders = None
+            DataRequiredValues = None
+            DataDefaultValues = None
+            DataUniqueColumnConstraints = None
+            FieldToDataHeaderKey = None
             Models = None
 
             def load_data(self):
@@ -503,11 +510,11 @@ class TraceBaseLoaderTests(TracebaseTestCase):
         self.assertEqual(
             (
                 "Invalid attributes:\n"
-                "\tattribute [TestInvalidLoader.DefaultHeaders] namedtuple required, <class 'NoneType'> set\n"
-                "\tattribute [TestInvalidLoader.RequiredHeaders] namedtuple required, <class 'NoneType'> set\n"
-                "\tattribute [TestInvalidLoader.RequiredValues] namedtuple required, <class 'NoneType'> set\n"
-                "\tattribute [TestInvalidLoader.UniqueColumnConstraints] list required, <class 'NoneType'> set\n"
-                "\tattribute [TestInvalidLoader.FieldToHeaderKey] dict required, <class 'NoneType'> set"
+                "\tattribute [TestInvalidLoader.DataHeaders] namedtuple required, <class 'NoneType'> set\n"
+                "\tattribute [TestInvalidLoader.DataRequiredHeaders] namedtuple required, <class 'NoneType'> set\n"
+                "\tattribute [TestInvalidLoader.DataRequiredValues] namedtuple required, <class 'NoneType'> set\n"
+                "\tattribute [TestInvalidLoader.DataUniqueColumnConstraints] list required, <class 'NoneType'> set\n"
+                "\tattribute [TestInvalidLoader.FieldToDataHeaderKey] dict required, <class 'NoneType'> set"
             ),
             str(aes.exceptions[0]),
         )
@@ -515,11 +522,11 @@ class TraceBaseLoaderTests(TracebaseTestCase):
     def test_get_defaults(self):
         tl = self.TestLoader(None)
         # initialize_metadata is called in the constructor
-        self.assertEqual(tl.DefaultValues, tl.get_defaults())
+        self.assertEqual(tl.DefaultDataValues, tl.get_defaults())
 
     def test_get_header_keys(self):
         tl = self.TestLoader(None)
-        self.assertEqual(list(tl.DefaultHeaders._asdict().keys()), tl.get_header_keys())
+        self.assertEqual(list(tl.DataHeaders._asdict().keys()), tl.get_header_keys())
 
     def test_get_pretty_headers(self):
         tl = self.TestLoader(None)
@@ -529,7 +536,7 @@ class TraceBaseLoaderTests(TracebaseTestCase):
 
     def test_get_headers(self):
         tl = self.TestLoader(None)
-        self.assertEqual(tl.DefaultHeaders, tl.get_headers())
+        self.assertEqual(tl.DataHeaders, tl.get_headers())
 
     def test_set_row_index(self):
         tl = self.TestLoader(None)
@@ -594,9 +601,9 @@ class TraceBaseLoaderTests(TracebaseTestCase):
             TestEmptyLoader()
         self.assertEqual(
             (
-                "Can't instantiate abstract class TestEmptyLoader with abstract methods DefaultHeaders, "
-                "FieldToHeaderKey, Models, RequiredHeaders, RequiredValues, TableHeaders, UniqueColumnConstraints, "
-                "load_data"
+                "Can't instantiate abstract class TestEmptyLoader with abstract methods DataHeaders, "
+                "FieldToDataHeaderKey, Models, DataRequiredHeaders, DataRequiredValues, DataTableHeaders, "
+                "DataUniqueColumnConstraints, load_data"
             ),
             str(ar.exception),
         )
@@ -608,7 +615,7 @@ class TraceBaseLoaderTests(TracebaseTestCase):
         self.assertFalse(tl.is_skip_row(0))
 
     def test_tableheaders_to_dict_by_header_name(self):
-        nt = self.TestLoader.TableHeaders(
+        nt = self.TestLoader.DataTableHeaders(
             NAME=True,
             CHOICE=True,
         )

--- a/DataRepo/utils/compounds_loader.py
+++ b/DataRepo/utils/compounds_loader.py
@@ -23,9 +23,13 @@ class CompoundsLoader(TraceBaseLoader):
     FORMULA_KEY = "FORMULA"
     SYNONYMS_KEY = "SYNONYMS"
 
+    SYNOMYM_SEPARATOR = ";"
+
+    DataSheetName = "Compounds"
+
     # The tuple used to store different kinds of data per column at the class level
-    TableHeaders = namedtuple(
-        "TableHeaders",
+    DataTableHeaders = namedtuple(
+        "DataTableHeaders",
         [
             "NAME",
             "HMDB_ID",
@@ -35,7 +39,7 @@ class CompoundsLoader(TraceBaseLoader):
     )
 
     # The default header names (which can be customized via yaml file via the corresponding load script)
-    DefaultHeaders = TableHeaders(
+    DataHeaders = DataTableHeaders(
         NAME="Compound",
         HMDB_ID="HMDB ID",
         FORMULA="Formula",
@@ -43,24 +47,24 @@ class CompoundsLoader(TraceBaseLoader):
     )
 
     # Whether each column is required to be present of not
-    RequiredHeaders = TableHeaders(
+    DataRequiredHeaders = DataTableHeaders(
         NAME=True,
         HMDB_ID=True,
         FORMULA=True,
         SYNONYMS=False,
     )
 
-    # Whether a value for an row in a column is required or not (note that defined DefaultValues will satisfy this)
-    RequiredValues = RequiredHeaders
+    # Whether a value for an row in a column is required or not (note that defined DataDefaultValues will satisfy this)
+    DataRequiredValues = DataRequiredHeaders
 
-    # No DefaultValues needed
-    # No ColumnTypes needed
+    # No DataDefaultValues needed
+    # No DataColumnTypes needed
 
     # Combinations of columns whose values must be unique in the file
-    UniqueColumnConstraints = [[NAME_KEY], [HMDBID_KEY]]
+    DataUniqueColumnConstraints = [[NAME_KEY], [HMDBID_KEY]]
 
     # A mapping of database field to column.  Only set when the mapping is 1:1.  Omit others.
-    FieldToHeaderKey = {
+    FieldToDataHeaderKey = {
         "Compound": {
             "name": NAME_KEY,
             "hmdb_id": HMDBID_KEY,
@@ -82,8 +86,8 @@ class CompoundsLoader(TraceBaseLoader):
         Args:
             Superclass Args:
                 df (pandas dataframe): Data, e.g. as parsed from a table-like file.
-                headers (Optional[Tableheaders namedtuple]) [DefaultHeaders]: Header names by header key.
-                defaults (Optional[Tableheaders namedtuple]) [DefaultValues]: Default values by header key.
+                headers (Optional[Tableheaders namedtuple]) [DataHeaders]: Header names by header key.
+                defaults (Optional[Tableheaders namedtuple]) [DataDefaultValues]: Default values by header key.
                 dry_run (Optional[boolean]) [False]: Dry run mode.
                 defer_rollback (Optional[boolean]) [False]: Defer rollback mode.  DO NOT USE MANUALLY - A PARENT SCRIPT
                     MUST HANDLE THE ROLLBACK.
@@ -98,7 +102,7 @@ class CompoundsLoader(TraceBaseLoader):
         Returns:
             Nothing
         """
-        self.synonym_separator = kwargs.pop("synonym_separator", ";")
+        self.synonym_separator = kwargs.pop("synonym_separator", self.SYNOMYM_SEPARATOR)
         super().__init__(*args, **kwargs)
 
     def load_data(self):

--- a/DataRepo/utils/sequences_loader.py
+++ b/DataRepo/utils/sequences_loader.py
@@ -22,9 +22,11 @@ class SequencesLoader(TraceBaseLoader):
     LC_DESC_KEY = "LC_DESC"
     NOTES_KEY = "NOTES"
 
+    DataSheetName = "Sequences"
+
     # The tuple used to store different kinds of data per column at the class level
-    TableHeaders = namedtuple(
-        "TableHeaders",
+    DataTableHeaders = namedtuple(
+        "DataTableHeaders",
         [
             "STUDY_CODE",  # See TODO 1 above
             "ID",  # See TODO 1 above
@@ -39,7 +41,7 @@ class SequencesLoader(TraceBaseLoader):
     )
 
     # The default header names (which can be customized via yaml file via the corresponding load script)
-    DefaultHeaders = TableHeaders(
+    DataHeaders = DataTableHeaders(
         STUDY_CODE="Study Code",  # See TODO 1 above
         ID="Sequence Number",  # See TODO 1 above
         OPERATOR="Operator",
@@ -52,7 +54,7 @@ class SequencesLoader(TraceBaseLoader):
     )
 
     # Whether each column is required to be present of not
-    RequiredHeaders = TableHeaders(
+    DataRequiredHeaders = DataTableHeaders(
         STUDY_CODE=False,  # See TODO 1 above
         ID=True,  # See TODO 1 above
         OPERATOR=True,
@@ -64,8 +66,8 @@ class SequencesLoader(TraceBaseLoader):
         NOTES=False,
     )
 
-    # Whether a value for an row in a column is required or not (note that defined DefaultValues will satisfy this)
-    RequiredValues = TableHeaders(
+    # Whether a value for an row in a column is required or not (note that defined DataDefaultValues will satisfy this)
+    DataRequiredValues = DataTableHeaders(
         STUDY_CODE=True,  # Study code and ID combined are an "accession number" for a Sequence
         ID=True,  # See TODO 1 above
         OPERATOR=True,
@@ -77,9 +79,9 @@ class SequencesLoader(TraceBaseLoader):
         NOTES=False,
     )
 
-    # No DefaultValues needed
+    # No DataDefaultValues needed
 
-    ColumnTypes: Dict[str, type] = {
+    DataColumnTypes: Dict[str, type] = {
         STUDY_CODE_KEY: str,  # See TODO 1 above
         ID_KEY: int,  # See TODO 1 above
         OPERATOR_KEY: str,
@@ -92,13 +94,13 @@ class SequencesLoader(TraceBaseLoader):
     }
 
     # Combinations of columns whose values must be unique in the file  # See TODO 1 above
-    UniqueColumnConstraints = [
+    DataUniqueColumnConstraints = [
         [STUDY_CODE_KEY, ID_KEY],
         [OPERATOR_KEY, DATE_KEY, INSTRUMENT_KEY, LC_PROTOCOL_KEY, LC_RUNLEN_KEY],
     ]
 
     # A mapping of database field to column.  Only set when the mapping is 1:1.  Omit others.
-    FieldToHeaderKey = {
+    FieldToDataHeaderKey = {
         "MSRunSequence": {
             "researcher": OPERATOR_KEY,
             "date": DATE_KEY,

--- a/DataRepo/utils/study_table_loader.py
+++ b/DataRepo/utils/study_table_loader.py
@@ -10,9 +10,11 @@ class StudyTableLoader(TraceBaseLoader):
     NAME_KEY = "NAME"
     DESC_KEY = "DESCRIPTION"
 
+    DataSheetName = "Study"
+
     # The tuple used to store different kinds of data per column at the class level
-    TableHeaders = namedtuple(
-        "TableHeaders",
+    DataTableHeaders = namedtuple(
+        "DataTableHeaders",
         [
             "CODE",
             "NAME",
@@ -21,30 +23,30 @@ class StudyTableLoader(TraceBaseLoader):
     )
 
     # The default header names (which can be customized via yaml file via the corresponding load script)
-    DefaultHeaders = TableHeaders(
+    DataHeaders = DataTableHeaders(
         CODE="Study ID",
         NAME="Name",
         DESCRIPTION="Description",
     )
 
     # Whether each column is required to be present of not
-    RequiredHeaders = TableHeaders(
+    DataRequiredHeaders = DataTableHeaders(
         CODE=True,
         NAME=True,
         DESCRIPTION=True,
     )
 
-    # Whether a value for an row in a column is required or not (note that defined DefaultValues will satisfy this)
-    RequiredValues = RequiredHeaders
+    # Whether a value for an row in a column is required or not (note that defined DataDefaultValues will satisfy this)
+    DataRequiredValues = DataRequiredHeaders
 
-    # No DefaultValues needed
-    # No ColumnTypes needed
+    # No DataDefaultValues needed
+    # No DataColumnTypes needed
 
     # Combinations of columns whose values must be unique in the file
-    UniqueColumnConstraints = [[CODE_KEY], [NAME_KEY]]
+    DataUniqueColumnConstraints = [[CODE_KEY], [NAME_KEY]]
 
     # A mapping of database field to column.  Only set when the mapping is 1:1.  Omit others.
-    FieldToHeaderKey = {
+    FieldToDataHeaderKey = {
         "Study": {
             "code": CODE_KEY,
             "name": NAME_KEY,

--- a/DataRepo/utils/tissues_loader.py
+++ b/DataRepo/utils/tissues_loader.py
@@ -9,9 +9,11 @@ class TissuesLoader(TraceBaseLoader):
     NAME_KEY = "NAME"
     DESC_KEY = "DESCRIPTION"
 
+    DataSheetName = "Tissues"
+
     # The tuple used to store different kinds of data per column at the class level
-    TableHeaders = namedtuple(
-        "TableHeaders",
+    DataTableHeaders = namedtuple(
+        "DataTableHeaders",
         [
             "NAME",
             "DESCRIPTION",
@@ -19,33 +21,33 @@ class TissuesLoader(TraceBaseLoader):
     )
 
     # The default header names (which can be customized via yaml file via the corresponding load script)
-    DefaultHeaders = TableHeaders(
+    DataHeaders = DataTableHeaders(
         NAME="Tissue",
         DESCRIPTION="Description",
     )
 
     # Whether each column is required to be present of not
-    RequiredHeaders = TableHeaders(
+    DataRequiredHeaders = DataTableHeaders(
         NAME=True,
         DESCRIPTION=True,
     )
 
-    # Whether a value for an row in a column is required or not (note that defined DefaultValues will satisfy this)
-    RequiredValues = RequiredHeaders
+    # Whether a value for an row in a column is required or not (note that defined DataDefaultValues will satisfy this)
+    DataRequiredValues = DataRequiredHeaders
 
     # The type of data in each column (used by pandas to not, for example, turn "1" into an integer then str is set)
-    ColumnTypes = {
+    DataColumnTypes = {
         NAME_KEY: str,
         DESC_KEY: str,
     }
 
-    # No DefaultValues needed
+    # No DataDefaultValues needed
 
     # Combinations of columns whose values must be unique in the file
-    UniqueColumnConstraints = [[NAME_KEY]]
+    DataUniqueColumnConstraints = [[NAME_KEY]]
 
     # A mapping of database field to column.  Only set when the mapping is 1:1.  Omit others.
-    FieldToHeaderKey = {
+    FieldToDataHeaderKey = {
         "Tissue": {
             "name": NAME_KEY,
             "description": DESC_KEY,


### PR DESCRIPTION
## Summary Change Description

Renamed most of the (abstract) class attributes and moved class attributes from LoadFromTableCommand to TraceBaseLoader.

The class attribute names became somewhat ambiguous when the defaults sheet was introduced, so not all attributes that are about the input data sheet start with "Data" and all the ones for the defaults sheet start with "Defaults".

I also realized that details of the files (e.g. headers) were a part of the loader class(es), so I decided that the sheet names should live there as well.  Now the only class attribute in LoadFromTableCommand is loader_class.

As such, I also moved the protocol alternate excel file headers definition to the ProtocolsLoader and adjusted the logic for set_headers in the superclass when the loader object is recreated so that "saved" headers would get the right hierarchical setting, by treating the saved headers as "developer" headers, then treating the potentially changed developer headers as a layer on top of that.  I'm not entirely sure that's the optimal way to do it, but it works as intended for the current use cases.

Details:

- Renamed (and new) class attributes in TraceBaseLoader
  - LoadFromTableCommand.data_sheet_default -> TraceBaseLoader.DataSheetName
  - LoadFromTableCommand.defaults_sheet_default -> TraceBaseLoader.DefaultsSheetName
  - TableHeaders -> DataTableHeaders
  - DefaultHeaders -> DataHeaders
  - RequiredHeaders -> DataRequiredHeaders
  - RequiredValues -> DataRequiredValues
  - UniqueColumnConstraints -> DataUniqueColumnConstraints
  - FieldToHeaderKey -> FieldToDataHeaderKey
  - DefaultValues -> DataDefaultValues
  - ColumnTypes -> DataColumnTypes
  - DefaultsSheetHeaders -> DefaultsHeaders
- Added an override of get_pretty_headers in ProtocolsLoader and changed the return type to string (from a tuple of list and string)
- Changed the default for --synonym-separator from a static string to self.loader_class.SYNOMYM_SEPARATOR
- Added type checks to check_class_attributes, including for the namedtuple type and the new defaults attributes.

## Affected Issues/Pull Requests

- Partially addresses #824
- Merges into #882
- Next PR: #870

## Review Notes

Not going to comment in-line on this one.  Only simple code changes.

## Checklist
<!--
If any of the checkbox requirements are not met, uncheck them and add an
explanation. E.g. Linting errors pre-date this PR.
-->
This pull request will be merged once the following requirements are met.  The
author and/or reviewers should uncheck any unmet requirements:

- Review requirements
  - Minimum approvals: 1 <!-- Edit as desired (e.g. based on complexity) -->
  - No changes requested
  - All blocking issues resolved by reviewers
  - Specific reviewers: @__add_username_here__
    <!--
    Require reviewers with specific expertise to be included among the minimum
    number of reviewers by tagging them.  Also please send them a message.
    -->
  - Review period: 2 days <!-- Edit as desired (e.g. based on complexity) -->
- Associated issue/pull request requirements:
  <!--
  Assert that all requirements in issues marked "resolved" are done and that
  all required pull requests are merged.  If any are not done, either edit or
  split the issue or explain the unmerged affected pull requests.
  -->
  - [x] All requirements in affected issues marked "resolved" are satisfied
  - [x] All required pull requests are merged *(or none)*
- Basic requirements
  <!--
  Uncheck items to acknowledge failures/conflicts you intend to address.
  Add an explanation if any won't be addressed before merge.
  -->
  - [x] [All linters pass](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#linting)
  - [x] [All tests pass](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#quality-control)
  - [x] All conflicts resolved
- Overhead requirements
  <!--
  These are additional requirements that are not directly associated with
  resolving the affected issue(s).
  -->
  - [x] [New/changed method tests implemented/updated *(or no change)*](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#test-implementation)
  - [x] [Updated *Unreleased* section of `changelog.md` *(or no change)*](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/changelog.md)
  - [x] [Migrations created & committed *(or no change)*](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#migration-process)
