### PR TITLE
Sequence load 1a (read a defaults sheet)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -135,3 +135,6 @@ dmypy.json
 # Pyre type checker
 .pyre/
 archive
+
+# Robs custom ignores - I use the following file that I haven't made into an "app" yet
+DataRepo/management/commands/list_tests.py

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -114,8 +114,8 @@ Set up the project's postgres database:
 ### (Optional) Load Some Example Data
 
     python manage.py loaddata data_types data_formats lc_methods
-    python manage.py load_compounds --compounds DataRepo/data/examples/compounds/consolidated_tracebase_compound_list.tsv
-    python manage.py load_tissues --tissues DataRepo/data/examples/tissues/tissues.tsv
+    python manage.py load_compounds --infile DataRepo/data/examples/compounds/consolidated_tracebase_compound_list.tsv
+    python manage.py load_tissues --infile DataRepo/data/examples/tissues/tissues.tsv
     python manage.py load_animals_and_samples --sample-table-filename DataRepo/data/examples/obob_fasted/obob_samples_table.tsv --animal-table-filename DataRepo/data/examples/obob_fasted/obob_animals_table.tsv --table-headers DataRepo/data/examples/obob_fasted/sample_and_animal_tables_headers.yaml
     python manage.py load_accucor_msruns --lc-protocol-name "unknown" --instrument "unknown" --polarity "unknown" --accucor-file DataRepo/data/examples/obob_fasted/obob_maven_6eaas_inf.xlsx --date 2021-04-29 --researcher "Anon" --new-researcher
 

--- a/DataRepo/management/commands/load_compounds.py
+++ b/DataRepo/management/commands/load_compounds.py
@@ -7,7 +7,7 @@ class Command(LoadFromTableCommand):
 
     help = "Loads data from a compound table into the database"
     loader_class = CompoundsLoader
-    sheet_default = "Compounds"
+    data_sheet_default = "Compounds"
 
     def add_arguments(self, parser):
         """Adds command line options.

--- a/DataRepo/management/commands/load_sequences.py
+++ b/DataRepo/management/commands/load_sequences.py
@@ -1,18 +1,13 @@
 from DataRepo.management.commands.load_table import LoadFromTableCommand
-from DataRepo.utils import ProtocolsLoader
-from DataRepo.utils.file_utils import is_excel
+from DataRepo.utils import SequencesLoader
 
 
 class Command(LoadFromTableCommand):
-    """Command to load the Protocol model from a table-like file."""
+    """Command to load the Sequence model from a table-like file."""
 
-    help = "Loads data from a protocol table into the database"
-    loader_class = ProtocolsLoader
-    data_sheet_default = "Treatments"
-
-    # default XLXS template headers
-    TREATMENTS_NAME_HEADER = "Animal Treatment"
-    TREATMENTS_DESC_HEADER = "Treatment Description"
+    help = "Loads data from a sequence table into the database"
+    loader_class = SequencesLoader
+    data_sheet_default = "Sequences"
 
     def handle(self, *args, **options):
         """Code to run when the command is called from the command line.
@@ -33,14 +28,4 @@ class Command(LoadFromTableCommand):
         Returns:
             Nothing
         """
-        # Different headers if an excel file is provided
-        if is_excel(self.get_infile()):
-            # An excel sheet is assumed to be for treatment protocols
-            self.set_headers(
-                custom_headers={
-                    ProtocolsLoader.NAME_KEY: self.TREATMENTS_NAME_HEADER,
-                    ProtocolsLoader.DESC_KEY: self.TREATMENTS_DESC_HEADER,
-                }
-            )
-
         self.load_data()

--- a/DataRepo/management/commands/load_study_table.py
+++ b/DataRepo/management/commands/load_study_table.py
@@ -7,7 +7,7 @@ class Command(LoadFromTableCommand):
 
     help = "Loads data from a study table (e.g. study code, name, and description) into the database."
     loader_class = StudyTableLoader
-    sheet_default = "Study"
+    data_sheet_default = "Study"
 
     def handle(self, *args, **options):
         """Code to run when the command is called from the command line.

--- a/DataRepo/management/commands/load_tissues.py
+++ b/DataRepo/management/commands/load_tissues.py
@@ -7,7 +7,7 @@ class Command(LoadFromTableCommand):
 
     help = "Loads data from a tissue table into the database"
     loader_class = TissuesLoader
-    sheet_default = "Tissues"
+    data_sheet_default = "Tissues"
 
     def handle(self, *args, **options):
         """Code to run when the command is called from the command line.

--- a/DataRepo/tests/loading/test_load_table.py
+++ b/DataRepo/tests/loading/test_load_table.py
@@ -28,7 +28,7 @@ class TestLoader(TraceBaseLoader):
 # Class used for testing
 class TestCommand(LoadFromTableCommand):
     loader_class = TestLoader
-    sheet_default = "test"
+    data_sheet_default = "test"
 
     def handle(self, *args, **options):
         return self.load_data()
@@ -49,7 +49,7 @@ class LoadFromTableCommandSuperclassUnitTests(TracebaseTestCase):
         This tests that all required class attributes:
 
             loader_class
-            sheet_default
+            data_sheet_default
 
         are enforced.  We will do so by creating a class that does not have any of the required class attributes defined
         and catching the expected exception.
@@ -65,7 +65,7 @@ class LoadFromTableCommandSuperclassUnitTests(TracebaseTestCase):
             MyCommand()
             # pylint: enable=abstract-class-instantiated
         self.assertIn(
-            "Can't instantiate abstract class MyCommand with abstract methods loader_class, sheet_default",
+            "Can't instantiate abstract class MyCommand with abstract methods data_sheet_default, loader_class",
             str(ar.exception),
         )
 
@@ -100,19 +100,18 @@ class LoadFromTableCommandSuperclassUnitTests(TracebaseTestCase):
 
         class TestTypeCommand(LoadFromTableCommand):
             loader_class = NotATraceBaseLoaderClass
-            sheet_default = 1
+            data_sheet_default = 1
 
             def handle(self, *args, **options):
                 self.load_data()
 
-        ttc = TestTypeCommand()
         with self.assertRaises(AggregatedErrors) as ar:
-            ttc.check_class_attributes()
+            TestTypeCommand()
         aes = ar.exception
         self.assertEqual((1, 0), (aes.num_errors, aes.num_warnings))
         self.assertEqual(TypeError, type(aes.exceptions[0]))
         self.assertIn("loader_class", str(aes.exceptions[0]))
-        self.assertIn("sheet_default", str(aes.exceptions[0]))
+        self.assertIn("data_sheet_default", str(aes.exceptions[0]))
 
     def test_load_data(self):
         """

--- a/DataRepo/tests/loading/test_loading_protocols.py
+++ b/DataRepo/tests/loading/test_loading_protocols.py
@@ -41,7 +41,7 @@ class ProtocolLoadingTests(TracebaseTestCase):
 
     def load_dataframe_as_animal_treatment(self, df, dry_run=False):
         """Load a working dataframe to protocols table"""
-        defaults = ProtocolsLoader.get_defaults(
+        defaults = ProtocolsLoader.get_class_defaults(
             custom_default_data={
                 ProtocolsLoader.CAT_KEY: Protocol.ANIMAL_TREATMENT,
             }
@@ -75,7 +75,7 @@ class ProtocolLoadingTests(TracebaseTestCase):
         """Test the ProtocolsLoader with dataframe missing category"""
         # The DefaultValues namedtuple in ProtocolsLoader sets a category default of Protocol.ANIMAL_TREATMENT, so in
         # order to make the error occur, we must set that default to None
-        defaults = ProtocolsLoader.get_defaults(
+        defaults = ProtocolsLoader.get_class_defaults(
             custom_default_data={
                 ProtocolsLoader.CAT_KEY: None,
             }
@@ -107,15 +107,17 @@ class ProtocolLoadingTests(TracebaseTestCase):
 
     def test_protocols_loader_with_bad_category_error(self):
         """Test the ProtocolsLoader with an improper category"""
-        defaults = ProtocolsLoader.get_defaults(
+        defaults = ProtocolsLoader.get_class_defaults(
             custom_default_data={
                 ProtocolsLoader.CAT_KEY: "Some Nonsense Category",
             }
         )
+        print(f"defaults: {defaults}")
         protocol_loader = ProtocolsLoader(
             self.working_df,
             defaults=defaults,
         )
+        print(f"SAVED DEFAULTS BY HEADER: {protocol_loader.defaults_by_header}")
         with self.assertRaises(AggregatedErrors) as ar:
             protocol_loader.load_data()
         aes = ar.exception

--- a/DataRepo/utils/compounds_loader.py
+++ b/DataRepo/utils/compounds_loader.py
@@ -102,7 +102,7 @@ class CompoundsLoader(TraceBaseLoader):
         # it explicitly in this derived class.
         self.check_for_cross_column_name_duplicates()
 
-        for index, row in self.df.iterrows():
+        for _, row in self.df.iterrows():
             if self.is_skip_row():
                 continue
 
@@ -155,7 +155,7 @@ class CompoundsLoader(TraceBaseLoader):
             synonyms = self.parse_synonyms(self.get_row_val(row, self.headers.SYNONYMS))
 
             # get_row_val can add to skip_row_indexes when there is a missing required value
-            if index in self.get_skip_row_indexes():
+            if self.is_skip_row():
                 continue
 
             for synonym in synonyms:

--- a/DataRepo/utils/protocols_loader.py
+++ b/DataRepo/utils/protocols_loader.py
@@ -56,27 +56,6 @@ class ProtocolsLoader(TraceBaseLoader):
     }
     Models = [Protocol]
 
-    def __init__(self, *args, **kwargs):
-        """Constructor.
-
-        Args:
-            df (pandas dataframe): Data, e.g. as parsed from a table-like file.
-            headers (Optional[Tableheaders namedtuple]) [DefaultHeaders]: Header names by header key.
-            defaults (Optional[Tableheaders namedtuple]) [DefaultValues]: Default values by header key.
-            dry_run (Optional[boolean]) [False]: Dry run mode.
-            defer_rollback (Optional[boolean]) [False]: Defer rollback mode.  DO NOT USE MANUALLY - A PARENT SCRIPT MUST
-                HANDLE THE ROLLBACK.
-            sheet (Optional[str]) [None]: Sheet name (for error reporting).
-            file (Optional[str]) [None]: File name (for error reporting).
-
-        Raises:
-            Nothing
-
-        Returns:
-            Nothing
-        """
-        super().__init__(*args, **kwargs)
-
     def load_data(self):
         """Loads the tissue table from the dataframe.
 
@@ -91,14 +70,14 @@ class ProtocolsLoader(TraceBaseLoader):
             Nothing (see TraceBaseLoader._loader() wrapper for return value from the automatically applied wrapping
                 method)
         """
-        for index, row in self.df.iterrows():
+        for _, row in self.df.iterrows():
             rec_dict = None
 
             try:
                 name = self.get_row_val(row, self.headers.NAME)
                 category = self.get_row_val(row, self.headers.CATEGORY)
                 description = self.get_row_val(row, self.headers.DESCRIPTION)
-
+                print(f"category: {category}")
                 rec_dict = {
                     "name": name,
                     "category": category,

--- a/DataRepo/utils/study_table_loader.py
+++ b/DataRepo/utils/study_table_loader.py
@@ -40,27 +40,6 @@ class StudyTableLoader(TraceBaseLoader):
     }
     Models = [Study]
 
-    def __init__(self, *args, **kwargs):
-        """Constructor.
-
-        Args:
-            df (pandas dataframe): Data, e.g. as parsed from a table-like file.
-            headers (Optional[Tableheaders namedtuple]) [DefaultHeaders]: Header names by header key.
-            defaults (Optional[Tableheaders namedtuple]) [DefaultValues]: Default values by header key.
-            dry_run (Optional[boolean]) [False]: Dry run mode.
-            defer_rollback (Optional[boolean]) [False]: Defer rollback mode.  DO NOT USE MANUALLY - A PARENT SCRIPT MUST
-                HANDLE THE ROLLBACK.
-            sheet (Optional[str]) [None]: Sheet name (for error reporting).
-            file (Optional[str]) [None]: File name (for error reporting).
-
-        Raises:
-            Nothing
-
-        Returns:
-            Nothing
-        """
-        super().__init__(*args, **kwargs)
-
     def load_data(self):
         """Loads the study table from the dataframe.
 
@@ -75,7 +54,7 @@ class StudyTableLoader(TraceBaseLoader):
             Nothing (see TraceBaseLoader._loader() wrapper for return value from the automatically applied wrapping
                 method)
         """
-        for index, row in self.df.iterrows():
+        for _, row in self.df.iterrows():
             rec_dict = None
 
             try:

--- a/DataRepo/utils/tissues_loader.py
+++ b/DataRepo/utils/tissues_loader.py
@@ -38,27 +38,6 @@ class TissuesLoader(TraceBaseLoader):
     }
     Models = [Tissue]
 
-    def __init__(self, *args, **kwargs):
-        """Constructor.
-
-        Args:
-            df (pandas dataframe): Data, e.g. as parsed from a table-like file.
-            headers (Optional[Tableheaders namedtuple]) [DefaultHeaders]: Header names by header key.
-            defaults (Optional[Tableheaders namedtuple]) [DefaultValues]: Default values by header key.
-            dry_run (Optional[boolean]) [False]: Dry run mode.
-            defer_rollback (Optional[boolean]) [False]: Defer rollback mode.  DO NOT USE MANUALLY - A PARENT SCRIPT MUST
-                HANDLE THE ROLLBACK.
-            sheet (Optional[str]) [None]: Sheet name (for error reporting).
-            file (Optional[str]) [None]: File name (for error reporting).
-
-        Raises:
-            Nothing
-
-        Returns:
-            Nothing
-        """
-        super().__init__(*args, **kwargs)
-
     def load_data(self):
         """Loads the tissue table from the dataframe.
 
@@ -73,7 +52,7 @@ class TissuesLoader(TraceBaseLoader):
             Nothing (see TraceBaseLoader._loader() wrapper for return value from the automatically applied wrapping
                 method)
         """
-        for index, row in self.df.iterrows():
+        for _, row in self.df.iterrows():
             rec_dict = None
 
             try:


### PR DESCRIPTION
## Summary Change Description

Added the ability to read default values from an excel sheet.

Details and miscellaneous updates:

- Replaced unused variables with underscores
- Removed pointless constructors in derived classes
- Made load_wrapper pass along arguments (if any).  (Note, there is commented code that needs to be removed in there.)
- There are some debug prints that need to be removed.
- Added method get_user_defaults to TraceBaseLoader
- Made df an optional argument to the traceBaseLoader constructor in order to be able to optionally supply it to load_data and make it easier to set defaults via the constructor.  (Headers need to be set before that dataframe could be used anyway - it just makes sense to hold off on setting it until it's ready to be processed.  And if it's supplied, it potentially could be re-used with different dataframes, though it's not set up that way right now.)
- Created TraceBaseLoader setters for headers and defaults.
- Made the TraceBaseLoader getters for headers and defaults into instance methods and added separate methods to retrieve (and optionally modify) class default headers and defaults).  This should be simplified more, but it's getting there.
- Created read_headers_from_file in file_utils.py and made the file type determination into its own method so that read_headers_from_file and read_from_file could both use it.
- Added exceptions: InvalidHeaderCrossReferenceError and ExcelSheetsNotFound to exceptions.py
- Moved summarize_int_list to the bottom of exceptions.py so that it could be co-located with the similar purpose method: generate_file_location_string
- Changed the load_table class variable sheet_default to data_sheet_default
- Added methods to load_table: get_user_defaults, set_defaults, set_headers, get_class_defaults, and get_class_headers, and changed get_headers and get)defaults into instance methods.
- Updated the CONTRIB doc
- Added list_tests.py (my own "app") to .gitignore, used for making running tests faster when debugging.

Note, I need to add more unit tests for the added methods, I have some refactors planned (mentioned above and in a comment in the issue), and there are debug prints and commented code that need to be removed.

## Affected Issues/Pull Requests

- Partially addresses #824

## Review Notes

This is not a working branch.  This was my initial draft (the initial commit) on the `sequence_load` branch.  I decided to break up that PR.  Initially, I did it at commits that passed all checks, but the first commit that could do that was the fourth one in, and that PR was too big, so I decided to break it up even further to make the reviews easier.  Just note that there are code changes in here that end up getting changed.  I will do my best to note those places in comments for the review.

## Checklist
<!--
If any of the checkbox requirements are not met, uncheck them and add an
explanation. E.g. Linting errors pre-date this PR.
-->
This pull request will be merged once the following requirements are met.  The
author and/or reviewers should uncheck any unmet requirements:

- Review requirements
  - Minimum approvals: 1 <!-- Edit as desired (e.g. based on complexity) -->
  - No changes requested
  - All blocking issues resolved by reviewers
  - Specific reviewers: @__add_username_here__
    <!--
    Require reviewers with specific expertise to be included among the minimum
    number of reviewers by tagging them.  Also please send them a message.
    -->
  - Review period: 2 days <!-- Edit as desired (e.g. based on complexity) -->
- Associated issue/pull request requirements:
  <!--
  Assert that all requirements in issues marked "resolved" are done and that
  all required pull requests are merged.  If any are not done, either edit or
  split the issue or explain the unmerged affected pull requests.
  -->
  - [x] All requirements in affected issues marked "resolved" are satisfied
  - [x] All required pull requests are merged *(or none)*
- Basic requirements
  <!--
  Uncheck items to acknowledge failures/conflicts you intend to address.
  Add an explanation if any won't be addressed before merge.
  -->
  - [x] [All linters pass](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#linting)
  - [x] [All tests pass](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#quality-control)
  - [x] All conflicts resolved
- Overhead requirements
  <!--
  These are additional requirements that are not directly associated with
  resolving the affected issue(s).
  -->
  - [x] [New/changed method tests implemented/updated *(or no change)*](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#test-implementation)
  - [ ] [Updated *Unreleased* section of `changelog.md` *(or no change)*](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/changelog.md)
  - [x] [Migrations created & committed *(or no change)*](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#migration-process)
