### PR TITLE
Atomic transactions added to new loaders

### DIFF
--- a/DataRepo/utils/__init__.py
+++ b/DataRepo/utils/__init__.py
@@ -63,7 +63,6 @@ from DataRepo.utils.infusate_name_parser import (
     parse_infusate_name,
     parse_tracer_concentrations,
 )
-from DataRepo.utils.table_loader import TraceBaseLoader
 from DataRepo.utils.protocols_loader import ProtocolsLoader
 from DataRepo.utils.queryset_to_pandas_dataframe import (
     QuerysetToPandasDataFrame,
@@ -74,6 +73,7 @@ from DataRepo.utils.sample_table_loader import (
 )
 from DataRepo.utils.sequences_loader import SequencesLoader
 from DataRepo.utils.study_table_loader import StudyTableLoader
+from DataRepo.utils.table_loader import TraceBaseLoader
 from DataRepo.utils.tissues_loader import TissuesLoader
 
 __all__ = [

--- a/DataRepo/utils/accucor_data_loader.py
+++ b/DataRepo/utils/accucor_data_loader.py
@@ -4,7 +4,7 @@ import re
 from collections import Counter, defaultdict
 from datetime import datetime
 from pathlib import Path
-from typing import Dict, List, TypedDict
+from typing import List, TypedDict
 
 import regex
 import xmltodict

--- a/DataRepo/utils/compounds_loader.py
+++ b/DataRepo/utils/compounds_loader.py
@@ -135,23 +135,27 @@ class CompoundsLoader(TraceBaseLoader):
 
                 cmpd_rec = self.get_or_create_compound(row)
 
-                synonyms = self.parse_synonyms(
-                    self.get_row_val(row, self.headers.SYNONYMS)
-                )
-
-                # get_row_val can add to skip_row_indexes when there is a missing required value
-                if self.is_skip_row() or cmpd_rec is None:
-                    # The count will be inaccurate.  If there was an error reading or parsing, we don't know how many
-                    # there are
-                    self.errored(CompoundSynonym.__name__)
-                    continue
-
-                for synonym in synonyms:
-                    self.get_or_create_synonym(synonym, cmpd_rec)
             except Exception:
                 # Exception handling was handled in get_or_create_*
                 # Continue processing rows to find more errors
                 pass
+
+            synonyms = self.parse_synonyms(self.get_row_val(row, self.headers.SYNONYMS))
+
+            # get_row_val can add to skip_row_indexes when there is a missing required value
+            if self.is_skip_row() or cmpd_rec is None:
+                # The count will be inaccurate.  If there was an error reading or parsing, we don't know how many
+                # there are
+                self.errored(CompoundSynonym.__name__)
+                continue
+
+            for synonym in synonyms:
+                try:
+                    self.get_or_create_synonym(synonym, cmpd_rec)
+                except Exception:
+                    # Exception handling was handled in get_or_create_*
+                    # Continue processing rows to find more errors
+                    pass
 
     @transaction.atomic
     def get_or_create_compound(self, row):

--- a/DataRepo/utils/compounds_loader.py
+++ b/DataRepo/utils/compounds_loader.py
@@ -1,6 +1,7 @@
 from collections import defaultdict, namedtuple
 from typing import Optional
 
+from django.db import transaction
 from django.db.utils import IntegrityError
 
 from DataRepo.models import Compound, CompoundSynonym
@@ -9,7 +10,7 @@ from DataRepo.utils.exceptions import (
     DuplicateValues,
     SynonymExistsAsMismatchedCompound,
 )
-from DataRepo.utils.loader import TraceBaseLoader
+from DataRepo.utils.table_loader import TraceBaseLoader
 
 
 class CompoundsLoader(TraceBaseLoader):
@@ -112,12 +113,10 @@ class CompoundsLoader(TraceBaseLoader):
             None
 
         Raises:
-            Nothing (see TraceBaseLoader._loader() wrapper for exceptions raised by the automatically applied wrapping
-                method)
+            Nothing
 
         Returns:
-            Nothing (see TraceBaseLoader._loader() wrapper for return value from the automatically applied wrapping
-                method)
+            Nothing
         """
         # TraceBaseLoader doesn't handle parsing column values like the delimited synonyms column, so we need to check
         # it explicitly in this derived class.
@@ -125,83 +124,102 @@ class CompoundsLoader(TraceBaseLoader):
 
         for _, row in self.df.iterrows():
             if self.is_skip_row():
-                continue
-
-            cmpd_recdict = None
-            syn_recdict = None
-
-            try:
-                name = self.get_row_val(row, self.headers.NAME)
-                formula = self.get_row_val(row, self.headers.FORMULA)
-                hmdb_id = self.get_row_val(row, self.headers.HMDB_ID)
-
-                cmpd_recdict = {
-                    "name": name,
-                    "formula": formula,
-                    "hmdb_id": hmdb_id,
-                }
-
-                # get_row_val can add to skip_row_indexes when there is a missing required value
-                if self.is_skip_row():
-                    continue
-
-                cmpd_rec, cmpd_created = Compound.objects.get_or_create(**cmpd_recdict)
-
-                if cmpd_created:
-                    cmpd_rec.full_clean()
-                    self.created(Compound.__name__)
-                else:
-                    self.existed(Compound.__name__)
-
-            except Exception as e:
-                if isinstance(
-                    e, IntegrityError
-                ) and "DataRepo_compoundsynonym_pkey" in str(e):
-                    # This is caused by trying to create a synonym that is already associated with a different compound
-                    # We want a better error to describe this situation than we would get from handle_load_db_errors
-                    self.aggregated_errors_object.buffer_error(
-                        CompoundExistsAsMismatchedSynonym(
-                            cmpd_recdict["name"],
-                            cmpd_recdict,
-                            CompoundSynonym.objects.get(
-                                name__exact=cmpd_recdict["name"]
-                            ),
-                        )
-                    )
-                else:
-                    self.handle_load_db_errors(e, Compound, cmpd_recdict)
+                # check_for_cross_column_name_duplicates can add to the skip row indexes
                 self.errored(Compound.__name__)
+                # The synonym errored count will be inaccurate.  If there was an error reading or parsing, we don't know
+                # how many there are
+                # TODO: Uncomment when main is merged in
+                # self.skipped(CompoundSynonym.__name__)
                 continue
+
+            cmpd_rec = self.get_or_create_compound(row)
 
             synonyms = self.parse_synonyms(self.get_row_val(row, self.headers.SYNONYMS))
 
             # get_row_val can add to skip_row_indexes when there is a missing required value
-            if self.is_skip_row():
+            if self.is_skip_row() or cmpd_rec is None:
+                # The count will be inaccurate.  If there was an error reading or parsing, we don't know how many there
+                # are
+                self.errored(CompoundSynonym.__name__)
                 continue
 
             for synonym in synonyms:
-                try:
-                    syn_recdict = {
-                        "name": synonym,
-                        "compound": cmpd_rec,
-                    }
+                self.get_or_create_synonym(synonym, cmpd_rec)
 
-                    syn_rec, syn_created = CompoundSynonym.objects.get_or_create(
-                        **syn_recdict
+    @transaction.atomic
+    def get_or_create_compound(self, row):
+        rec_dict = None
+        rec = None
+
+        try:
+            name = self.get_row_val(row, self.headers.NAME)
+            formula = self.get_row_val(row, self.headers.FORMULA)
+            hmdb_id = self.get_row_val(row, self.headers.HMDB_ID)
+
+            rec_dict = {
+                "name": name,
+                "formula": formula,
+                "hmdb_id": hmdb_id,
+            }
+
+            # get_row_val can add to skip_row_indexes when there is a missing required value
+            if self.is_skip_row():
+                self.errored(Compound.__name__)
+                return rec
+
+            rec, created = Compound.objects.get_or_create(**rec_dict)
+
+            if created:
+                rec.full_clean()
+                self.created(Compound.__name__)
+            else:
+                self.existed(Compound.__name__)
+
+        except Exception as e:
+            if isinstance(e, IntegrityError) and "DataRepo_compoundsynonym_pkey" in str(
+                e
+            ):
+                # This is caused by trying to create a synonym that is already associated with a different compound
+                # We want a better error to describe this situation than we would get from handle_load_db_errors
+                self.aggregated_errors_object.buffer_error(
+                    CompoundExistsAsMismatchedSynonym(
+                        rec_dict["name"],
+                        rec_dict,
+                        CompoundSynonym.objects.get(name__exact=rec_dict["name"]),
                     )
+                )
+            else:
+                self.handle_load_db_errors(e, Compound, rec_dict)
+            self.errored(Compound.__name__)
+            raise e
 
-                    if syn_created:
-                        syn_rec.full_clean()
-                        self.created(CompoundSynonym.__name__)
-                    else:
-                        self.existed(CompoundSynonym.__name__)
+        return rec
 
-                except SynonymExistsAsMismatchedCompound as seamc:
-                    self.aggregated_errors_object.buffer_error(seamc)
-                    self.errored(CompoundSynonym.__name__)
-                except Exception as e:
-                    self.handle_load_db_errors(e, CompoundSynonym, syn_recdict)
-                    self.errored(CompoundSynonym.__name__)
+    @transaction.atomic
+    def get_or_create_synonym(self, synonym, cmpd_rec):
+        rec_dict = None
+        try:
+            rec_dict = {
+                "name": synonym,
+                "compound": cmpd_rec,
+            }
+
+            syn_rec, created = CompoundSynonym.objects.get_or_create(**rec_dict)
+
+            if created:
+                syn_rec.full_clean()
+                self.created(CompoundSynonym.__name__)
+            else:
+                self.existed(CompoundSynonym.__name__)
+
+        except SynonymExistsAsMismatchedCompound as seamc:
+            self.aggregated_errors_object.buffer_error(seamc)
+            self.errored(CompoundSynonym.__name__)
+            raise seamc
+        except Exception as e:
+            self.handle_load_db_errors(e, CompoundSynonym, rec_dict)
+            self.errored(CompoundSynonym.__name__)
+            raise e
 
     def parse_synonyms(self, synonyms_string: Optional[str]) -> list:
         """Parse the synonyms column value using the self.synonym_separator.
@@ -213,7 +231,7 @@ class CompoundsLoader(TraceBaseLoader):
             Nothing
 
         Returns:
-            list of strings
+            synonyms (list of strings)
         """
         if synonyms_string is None:
             return []
@@ -232,8 +250,11 @@ class CompoundsLoader(TraceBaseLoader):
         Args:
             None
 
-        Exceptions Buffered:
-            DuplicateValues
+        Exceptions:
+            Raises:
+                Nothing
+            Buffered:
+                DuplicateValues
 
         Returns:
             Nothing

--- a/DataRepo/utils/protocols_loader.py
+++ b/DataRepo/utils/protocols_loader.py
@@ -1,8 +1,10 @@
 from collections import namedtuple
 
+from django.db import transaction
+
 from DataRepo.models import Protocol
 from DataRepo.utils.file_utils import is_excel
-from DataRepo.utils.loader import TraceBaseLoader
+from DataRepo.utils.table_loader import TraceBaseLoader
 
 
 class ProtocolsLoader(TraceBaseLoader):
@@ -153,42 +155,66 @@ class ProtocolsLoader(TraceBaseLoader):
             None
 
         Raises:
-            Nothing (see TraceBaseLoader._loader() wrapper for exceptions raised by the automatically applied wrapping
-                method)
+            Nothing
 
         Returns:
-            Nothing (see TraceBaseLoader._loader() wrapper for return value from the automatically applied wrapping
-                method)
+            Nothing
         """
         for _, row in self.df.iterrows():
-            rec_dict = None
-
             try:
-                name = self.get_row_val(row, self.headers.NAME)
-                category = self.get_row_val(row, self.headers.CATEGORY)
-                description = self.get_row_val(row, self.headers.DESCRIPTION)
+                self.get_or_create_protocol(row)
+            except Exception:
+                # Exception handling was handled in get_or_create_protocol
+                # Continue processing rows to find more errors
+                pass
 
-                rec_dict = {
-                    "name": name,
-                    "category": category,
-                    "description": description,
-                }
+    @transaction.atomic
+    def get_or_create_protocol(self, row):
+        """Get or create a protocol record and buffer exceptions before raising.
 
-                # get_row_val can add to skip_row_indexes when there is a missing required value
-                if self.is_skip_row():
-                    continue
+        Args:
+            row (pandas dataframe row)
 
-                # Try and get the protocol
-                rec, created = Protocol.objects.get_or_create(**rec_dict)
+        Raises:
+            Nothing (explicitly)
 
-                # If no protocol was found, create it
-                if created:
-                    rec.full_clean()
-                    self.created()
-                else:
-                    self.existed()
+        Returns:
+            Nothing
+        """
+        try:
+            rec_dict = None
+            rec = None
+            created = False
 
-            except Exception as e:
-                # Package errors (like IntegrityError and ValidationError) with relevant details
-                self.handle_load_db_errors(e, Protocol, rec_dict)
+            name = self.get_row_val(row, self.headers.NAME)
+            category = self.get_row_val(row, self.headers.CATEGORY)
+            description = self.get_row_val(row, self.headers.DESCRIPTION)
+
+            rec_dict = {
+                "name": name,
+                "category": category,
+                "description": description,
+            }
+
+            # get_row_val can add to skip_row_indexes when there is a missing required value
+            if self.is_skip_row():
                 self.errored()
+                return
+
+            # Try and get the protocol
+            rec, created = Protocol.objects.get_or_create(**rec_dict)
+
+            # If no protocol was found, create it
+            if created:
+                rec.full_clean()
+                self.created()
+            else:
+                self.existed()
+
+        except Exception as e:
+            # Package errors (like IntegrityError and ValidationError) with relevant details
+            # This also updates the skip row indexes
+            self.handle_load_db_errors(e, Protocol, rec_dict)
+            self.errored()
+            # Now that the exception has been handled, trigger a roolback of this record load attempt
+            raise e

--- a/DataRepo/utils/sequences_loader.py
+++ b/DataRepo/utils/sequences_loader.py
@@ -7,13 +7,12 @@ from django.db import transaction
 from DataRepo.models import LCMethod, MSRunSequence
 from DataRepo.utils.exceptions import RequiredColumnValueWhenNovel
 from DataRepo.utils.file_utils import string_to_datetime
-from DataRepo.utils.loader import TraceBaseLoader
+from DataRepo.utils.table_loader import TraceBaseLoader
 
 
 class SequencesLoader(TraceBaseLoader):
     # TODO: 1. Implement a sequence accession composed of study code and sequence number
     # Header keys (for convenience use only).  Note, they cannot be used in the namedtuple() call.  Literal required.
-    STUDY_CODE_KEY = "STUDY_CODE"  # See TODO 1 above
     ID_KEY = "ID"  # See TODO 1 above
     OPERATOR_KEY = "OPERATOR"
     DATE_KEY = "DATE"
@@ -29,7 +28,6 @@ class SequencesLoader(TraceBaseLoader):
     DataTableHeaders = namedtuple(
         "DataTableHeaders",
         [
-            "STUDY_CODE",  # See TODO 1 above
             "ID",  # See TODO 1 above
             "OPERATOR",
             "DATE",
@@ -43,7 +41,6 @@ class SequencesLoader(TraceBaseLoader):
 
     # The default header names (which can be customized via yaml file via the corresponding load script)
     DataHeaders = DataTableHeaders(
-        STUDY_CODE="Study Code",  # See TODO 1 above
         ID="Sequence Number",  # See TODO 1 above
         OPERATOR="Operator",
         DATE="Date",
@@ -54,9 +51,8 @@ class SequencesLoader(TraceBaseLoader):
         NOTES="Notes",
     )
 
-    # Whether each column is required to be present of not
+    # Whether each column is required to be present or not
     DataRequiredHeaders = DataTableHeaders(
-        STUDY_CODE=False,  # See TODO 1 above
         ID=True,  # See TODO 1 above
         OPERATOR=True,
         DATE=True,
@@ -69,7 +65,6 @@ class SequencesLoader(TraceBaseLoader):
 
     # Whether a value for an row in a column is required or not (note that defined DataDefaultValues will satisfy this)
     DataRequiredValues = DataTableHeaders(
-        STUDY_CODE=True,  # Study code and ID combined are an "accession number" for a Sequence
         ID=True,  # See TODO 1 above
         OPERATOR=True,
         DATE=True,
@@ -83,7 +78,6 @@ class SequencesLoader(TraceBaseLoader):
     # No DataDefaultValues needed
 
     DataColumnTypes: Dict[str, type] = {
-        STUDY_CODE_KEY: str,  # See TODO 1 above
         ID_KEY: int,  # See TODO 1 above
         OPERATOR_KEY: str,
         DATE_KEY: str,
@@ -127,25 +121,18 @@ class SequencesLoader(TraceBaseLoader):
             None
 
         Raises:
-            Nothing (see TraceBaseLoader._loader() wrapper for exceptions raised by the automatically applied wrapping
-                method)
+            Nothing
 
         Returns:
-            Nothing (see TraceBaseLoader._loader() wrapper for return value from the automatically applied wrapping
-                method)
+            Nothing
         """
         for _, row in self.df.iterrows():
             try:
                 lc_rec, _ = self.get_or_create_lc_method(row)
-            except Exception as e:
-                # get_or_create_lc_method raises database exceptions in order to roll back the 1 attempted record load
-                # We catch here so that we can proceed unencumbered
-                if self.aggregated_errors_object.exception_type_exists(type(e)):
-                    # TODO: Uncomment after main merge
-                    # self.skipped(MSRunSequence.__name__)
-                    continue
-                # If the exception wasn't buffered, this is a programming error, so raise immediately
-                raise e
+            except Exception:
+                # Exception handling was handled in get_or_create_protocol
+                # Continue processing rows to find more errors
+                pass
 
             if self.is_skip_row() or lc_rec is None:
                 # TODO: Uncomment after main merge
@@ -154,15 +141,11 @@ class SequencesLoader(TraceBaseLoader):
 
             try:
                 self.get_or_create_sequence(row, lc_rec)
-            except Exception as e:
-                # get_or_create_lc_method raises database exceptions in order to roll back the 1 attempted record load
-                # We catch here so that we can proceed unencumbered
-                if self.aggregated_errors_object.exception_type_exists(type(e)):
-                    continue
-                # If the exception wasn't buffered, this is a programming error, so raise immediately
-                raise e
+            except Exception:
+                # Exception handling was handled in get_or_create_protocol
+                # Continue processing rows to find more errors
+                pass
 
-    # TODO: Add atomic transactions inside the loops of all the loaders, like how it is done here
     @transaction.atomic
     def get_or_create_lc_method(self, row):
         """Gets or creates an LCMethod record from the supplied row.
@@ -175,14 +158,13 @@ class SequencesLoader(TraceBaseLoader):
             row (pandas dataframe row)
 
         Raises:
-            Nothing specific, but any database exception that is raised by the ORM:
-                IntegrityError
-                ValidationError
+            Nothing (explicitly)
 
         Returns:
-            lc_rec (LCMethod)
+            lc_rec (Optional[LCMethod])
         """
         rec_dict = None
+        rec = None
 
         try:
             type = self.get_row_val(row, self.headers.LC_PROTOCOL)
@@ -192,7 +174,7 @@ class SequencesLoader(TraceBaseLoader):
             # In case run_lengths was None, let's prevent an exception at the timedelta
             if self.is_skip_row():
                 self.errored(LCMethod.__name__)
-                return None, False
+                return rec
 
             # run_length is a required value (see DataRequiredValues), and is typed to be an int (see DataColumnTypes)
             run_length = timedelta(minutes=raw_run_length)
@@ -202,20 +184,14 @@ class SequencesLoader(TraceBaseLoader):
             # get_row_val can add to skip_row_indexes when there is a missing required value
             if self.is_skip_row():
                 self.errored(LCMethod.__name__)
-                return None, False
+                return rec
 
             rec_dict = {
                 "type": type,
                 "run_length": run_length,
                 "name": name,
             }
-        except Exception as e:
-            # Package errors with relevant details
-            self.handle_load_db_errors(e, LCMethod, rec_dict)
-            self.errored(LCMethod.__name__)
-            return None, False
 
-        try:
             # The LC_DESC column is optional WHEN the LC Method *exists*.  Required Otherwise.
             if description is None:
                 qs = LCMethod.objects.filter(**rec_dict)
@@ -226,7 +202,7 @@ class SequencesLoader(TraceBaseLoader):
                             column="description", model_name=LCMethod.__name__
                         )
                     )
-                    return None, False
+                    return rec
                 rec = qs.first()
                 created = False
             else:
@@ -241,15 +217,13 @@ class SequencesLoader(TraceBaseLoader):
 
         except Exception as e:
             # Package errors (like IntegrityError and ValidationError) with relevant details
+            # This also updates the skip row indexes
             self.handle_load_db_errors(e, LCMethod, rec_dict)
             self.errored(LCMethod.__name__)
-
-            # Any database exception should trigger a raise in order to roll back of just this record insertion attempt.
-            # This will be caught in the loop in load_data so that we can proceed.
-            # (We can proceed, because the exception was also buffered and the skip row indexes updated.)
+            # Now that the exception has been handled, trigger a roolback of this record load attempt
             raise e
 
-        return rec, created
+        return rec
 
     @transaction.atomic
     def get_or_create_sequence(self, row, lc_rec):
@@ -264,9 +238,7 @@ class SequencesLoader(TraceBaseLoader):
             lc_rec (LCMethod)
 
         Raises:
-            Nothing specific, but any database exception that is raised by the ORM:
-                IntegrityError
-                ValidationError
+            Nothing (explicitly)
 
         Returns:
             Nothing
@@ -274,9 +246,7 @@ class SequencesLoader(TraceBaseLoader):
         rec_dict = None
 
         try:
-            # See TODO 1 above
-            # study_code = self.get_row_val(row, self.headers.STUDY_CODE)
-            # seq_id = self.get_row_val(row, self.headers.ID)
+            # See TODO 1 above, and read in study_code and seq_id
             researcher = self.get_row_val(row, self.headers.OPERATOR)
             date_str = self.get_row_val(row, self.headers.DATE)
             date = string_to_datetime(
@@ -291,7 +261,8 @@ class SequencesLoader(TraceBaseLoader):
 
             # get_row_val can add to skip_row_indexes when there is a missing required value
             if self.is_skip_row():
-                return None, False
+                self.errored(MSRunSequence.__name__)
+                return
 
             rec_dict = {
                 "researcher": researcher,
@@ -300,14 +271,8 @@ class SequencesLoader(TraceBaseLoader):
                 "notes": notes,
                 "lc_method": lc_rec,
             }
-        except Exception as e:
-            # Package errors with relevant details
-            self.handle_load_db_errors(e, MSRunSequence, rec_dict)
-            self.errored(MSRunSequence.__name__)
-            return None, False
 
-        try:
-            rec, created = MSRunSequence.objects.get_or_create(**rec_dict)
+            _, created = MSRunSequence.objects.get_or_create(**rec_dict)
 
             if created:
                 lc_rec.full_clean()
@@ -317,12 +282,8 @@ class SequencesLoader(TraceBaseLoader):
 
         except Exception as e:
             # Package errors (like IntegrityError and ValidationError) with relevant details
+            # This also updates the skip row indexes
             self.handle_load_db_errors(e, MSRunSequence, rec_dict)
             self.errored(MSRunSequence.__name__)
-
-            # Any database exception should trigger a raise in order to roll back of just this record insertion attempt.
-            # This will be caught in the loop in load_data so that we can proceed.
-            # (We can proceed, because the exception was also buffered and the skip row indexes updated.)
+            # Now that the exception has been handled, trigger a roolback of this record load attempt
             raise e
-
-        return rec, created

--- a/DataRepo/utils/study_table_loader.py
+++ b/DataRepo/utils/study_table_loader.py
@@ -1,7 +1,9 @@
 from collections import namedtuple
 
+from django.db import transaction
+
 from DataRepo.models import Study
-from DataRepo.utils.loader import TraceBaseLoader
+from DataRepo.utils.table_loader import TraceBaseLoader
 
 
 class StudyTableLoader(TraceBaseLoader):
@@ -64,40 +66,62 @@ class StudyTableLoader(TraceBaseLoader):
             None
 
         Raises:
-            Nothing (see TraceBaseLoader._loader() wrapper for exceptions raised by the automatically applied wrapping
-                method)
+            Nothing (explicitly)
 
         Returns:
-            Nothing (see TraceBaseLoader._loader() wrapper for return value from the automatically applied wrapping
-                method)
+            Nothing
         """
         for _, row in self.df.iterrows():
-            rec_dict = None
-
             try:
-                code = self.get_row_val(row, self.headers.CODE)
-                name = self.get_row_val(row, self.headers.NAME)
-                description = self.get_row_val(row, self.headers.DESCRIPTION)
+                self.get_or_create_study(row)
+            except Exception:
+                # Exception handling was handled in get_or_create_protocol
+                # Continue processing rows to find more errors
+                pass
 
-                rec_dict = {
-                    "code": code,
-                    "name": name,
-                    "description": description,
-                }
+    @transaction.atomic
+    def get_or_create_study(self, row):
+        """Get or create a study record and buffer exceptions before raising.
 
-                # get_row_val can add to skip_row_indexes when there is a missing required value
-                if self.is_skip_row():
-                    continue
+        Args:
+            row (pandas dataframe row)
 
-                study_rec, created = Study.objects.get_or_create(**rec_dict)
+        Raises:
+            Nothing (explicitly)
 
-                if created:
-                    study_rec.full_clean()
-                    self.created()
-                else:
-                    self.existed()
+        Returns:
+            Nothing
+        """
+        rec_dict = None
 
-            except Exception as e:
-                # Package errors (like IntegrityError and ValidationError) with relevant details
-                self.handle_load_db_errors(e, Study, rec_dict)
+        try:
+            code = self.get_row_val(row, self.headers.CODE)
+            name = self.get_row_val(row, self.headers.NAME)
+            description = self.get_row_val(row, self.headers.DESCRIPTION)
+
+            rec_dict = {
+                "code": code,
+                "name": name,
+                "description": description,
+            }
+
+            # get_row_val can add to skip_row_indexes when there is a missing required value
+            if self.is_skip_row():
                 self.errored()
+                return
+
+            study_rec, created = Study.objects.get_or_create(**rec_dict)
+
+            if created:
+                study_rec.full_clean()
+                self.created()
+            else:
+                self.existed()
+
+        except Exception as e:
+            # Package errors (like IntegrityError and ValidationError) with relevant details
+            # This also updates the skip row indexes
+            self.handle_load_db_errors(e, Study, rec_dict)
+            self.errored()
+            # Now that the exception has been handled, trigger a roolback of this record load attempt
+            raise e

--- a/DataRepo/views/__init__.py
+++ b/DataRepo/views/__init__.py
@@ -1,4 +1,3 @@
-from .upload import DataValidationView, upload, validation_disabled
 from .models import (
     AnimalDetailView,
     AnimalListView,
@@ -34,6 +33,7 @@ from .search import (
     search_basic,
     view_search_results,
 )
+from .upload import DataValidationView, upload, validation_disabled
 
 __all__ = [
     "home",


### PR DESCRIPTION
## Summary Change Description

This implements the atomic transaction TODO item in the sequence load PR series.  This resolves an unrealized concern about the nature of the `AggregatedErrors` strategy, where exceptions are allowed to happen and processing of an input file is allowed to continue despite those exceptions (which are buffered and the code is allowed to proceed).

In a discussion I had on the django forum about a different but related issue, I realized that I had been mis-interpreting what I would consider ambiguous language in the django docs about what to do in the event of database-related exceptions.  I had interpreted the language about catching and rolling back in another try/except block to be referring to an *outer* block, when allowing the code to proceed, making things safe.  But I learned that what it meant to convey (implicitly) was that an *inner* try/except block should be used to roll back *just* the record that caused the exception, and once I realized that, it made total sense to me that that's how `AggregatedErrors` should have been used:

1. Catch inside the atomic block (and inside the loop iterating over the input) to buffer the exception
2. Then immediately *raise* the exception inside that inner atomic block and inside the loop
3. Then *catch* the exception *outside* the atomic block, so that the failed record gets rolled back (but still inside the loop) and ignore the exception to continue iterating

The basic design pattern I implemented in this change is:

```
def load_data(self):
    for row in df.iterrows:
        try:
            self.get_or_create_mymodel_rec(row)
        except Exception:
            pass

@transaction.atomic
def get_or_create_mymodel_rec(self, row):
    try:
        rec_dict = self.create_rec_dict(row)
        Model.objects.get_or_create(**rec_dict)
    except Exception as e:
        self.handle_exception(e, MyModel, rec_dict)  # This buffers the exception
        raise e
    return rec
```

Note, the only place where I had already implemented this design pattern was in the sequences loader, but that code had a couple mistakes and I also streamlined it a bit.

There are a couple other trivial changes, like typo fixes and linting.  Incidentally, the linting fixes were fixed in 2 branches (by mistake, due to retroactively splitting the TODO items into 2 PRs somewhat retroactively) and I will address those conflicts on merge.

Oh, and this also removes the **unused `STUDY_CODE`** references, due to concerns expressed over that strategy during a prior review.  I will implement that if/when I get around to it.

## Affected Issues/Pull Requests

- Resolves TODO item left during the sequence load PR series
- Merges into #883

## Review Notes
<!--
For added context for reviewers, add comments to relevant lines of code.  Use
this space to describe any general areas of concern not linked to a specific
line of code that reviewers should pay particular attention to, e.g. please
make sure I have accounted for all possible inputs.
-->
See comments in-line.

## Checklist
<!--
If any of the checkbox requirements are not met, uncheck them and add an
explanation. E.g. Linting errors pre-date this PR.
-->
This pull request will be merged once the following requirements are met.  The
author and/or reviewers should uncheck any unmet requirements:

- Review requirements
  - Minimum approvals: 1 <!-- Edit as desired (e.g. based on complexity) -->
  - No changes requested
  - All blocking issues resolved by reviewers
  - Specific reviewers: @__add_username_here__
    <!--
    Require reviewers with specific expertise to be included among the minimum
    number of reviewers by tagging them.  Also please send them a message.
    -->
  - Review period: 2 days <!-- Edit as desired (e.g. based on complexity) -->
- Associated issue/pull request requirements:
  <!--
  Assert that all requirements in issues marked "resolved" are done and that
  all required pull requests are merged.  If any are not done, either edit or
  split the issue or explain the unmerged affected pull requests.
  -->
  - [x] All requirements in affected issues marked "resolved" are satisfied
  - [x] All required pull requests are merged *(or none)*
- Basic requirements
  <!--
  Uncheck items to acknowledge failures/conflicts you intend to address.
  Add an explanation if any won't be addressed before merge.
  -->
  - [x] [All linters pass](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#linting)
  - [x] [All tests pass](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#quality-control)
  - [x] All conflicts resolved
- Overhead requirements
  <!--
  These are additional requirements that are not directly associated with
  resolving the affected issue(s).
  -->
  - [x] [New/changed method tests implemented/updated *(or no change)*](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#test-implementation)
  - [ ] [Updated *Unreleased* section of `changelog.md` *(or no change)*](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/changelog.md)
  - [x] [Migrations created & committed *(or no change)*](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#migration-process)
