### PR TITLE
Made row keys optional in the unique column constraint check

### DIFF
--- a/DataRepo/utils/file_utils.py
+++ b/DataRepo/utils/file_utils.py
@@ -505,7 +505,7 @@ def get_column_dupes(data, unique_col_keys, ignore_row_idxs=None):
         # Ignore empty combos
         empty_combo = True
         for ck in unique_col_keys:
-            val = row[ck]
+            val = row.get(ck, None)
             if val is not None or not isinstance(val, str) or val == "":
                 empty_combo = False
                 break
@@ -513,7 +513,7 @@ def get_column_dupes(data, unique_col_keys, ignore_row_idxs=None):
             continue
 
         composite_val = ", ".join(
-            list(map(lambda ck: f"{ck}: [{str(row[ck])}]", unique_col_keys))
+            list(map(lambda ck: f"{ck}: [{str(row.get(ck, 'None'))}]", unique_col_keys))
         )
 
         if len(val_locations[composite_val].keys()) > 0:
@@ -522,7 +522,7 @@ def get_column_dupes(data, unique_col_keys, ignore_row_idxs=None):
             val_locations[composite_val]["rowidxs"] = [rowidx]
             val_locations[composite_val]["vals"] = {}
             for ck in unique_col_keys:
-                val_locations[composite_val]["vals"][ck] = row[ck]
+                val_locations[composite_val]["vals"][ck] = row.get(ck, None)
 
     # Now create the dupe dict to contain values encountered more than once
     for val in val_locations.keys():


### PR DESCRIPTION
## Summary Change Description

Made the presence of the row keys optional in get_column_dupes in order to avoid KeyErrors.  This was the original intention, but the presence of the key wasn't checked before indexing.

## Affected Issues/Pull Requests

- Resolves no issue
- Next PR: #896

## Review Notes

I still have not yet figured out how to break up large-ish efforts into a series of PRs.  I just finished an effort and am going about breaking it up into separate PRs.  I'm doing it a bit differently this time, to avoid reviewing rewritten code.  It is slightly complicated by the solution I arrived at to resolve a circular import (another file re-arrangement).

The work in this very small PR addresses KeyErrors that arose because of the way the unique column constraints traversed the row data.  The new load script utilized mutually optional/required columns that had not been implemented at the same time as the unique column constraint code.  Once the 2 solutions collided, it revealed `KeyErrors` that are easily avoided just by accessing the column values using a different means.  Note, this solution means that `None == None`, i.e. the defined columns in a "unique combo" must be unique when one or more columns in the combo is not defined.  However, in this instance, values parsed from the tracer name are used to populate missing values.  (Also note, that that code is yet to be reviewed/submitted-in-a-PR.)

## Checklist
<!--
If any of the checkbox requirements are not met, uncheck them and add an
explanation. E.g. Linting errors pre-date this PR.
-->
This pull request will be merged once the following requirements are met.  The
author and/or reviewers should uncheck any unmet requirements:

- Review requirements
  - Minimum approvals: 1 <!-- Edit as desired (e.g. based on complexity) -->
  - No changes requested
  - All blocking issues resolved by reviewers
  - Specific reviewers: @__add_username_here__
    <!--
    Require reviewers with specific expertise to be included among the minimum
    number of reviewers by tagging them.  Also please send them a message.
    -->
  - Review period: 2 days <!-- Edit as desired (e.g. based on complexity) -->
- Associated issue/pull request requirements:
  <!--
  Assert that all requirements in issues marked "resolved" are done and that
  all required pull requests are merged.  If any are not done, either edit or
  split the issue or explain the unmerged affected pull requests.
  -->
  - [x] All requirements in affected issues marked "resolved" are satisfied
  - [x] All required pull requests are merged *(or none)*
- Basic requirements
  <!--
  Uncheck items to acknowledge failures/conflicts you intend to address.
  Add an explanation if any won't be addressed before merge.
  -->
  - [x] [All linters pass](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#linting)
  - [x] [All tests pass](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#quality-control)
  - [x] All conflicts resolved
- Overhead requirements
  <!--
  These are additional requirements that are not directly associated with
  resolving the affected issue(s).
  -->
  - [x] [New/changed method tests implemented/updated *(or no change)*](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#test-implementation)
  - [ ] [Updated *Unreleased* section of `changelog.md` *(or no change)*](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/changelog.md)
  - [x] [Migrations created & committed *(or no change)*](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#migration-process)
