### PR TITLE
Renamed delimiter option for consistency

### DIFF
--- a/DataRepo/loaders/compounds_loader.py
+++ b/DataRepo/loaders/compounds_loader.py
@@ -24,7 +24,7 @@ class CompoundsLoader(TableLoader):
     FORMULA_KEY = "FORMULA"
     SYNONYMS_KEY = "SYNONYMS"
 
-    SYNOMYM_SEPARATOR = ";"
+    SYNONYMS_DELIMITER = ";"
 
     DataSheetName = "Compounds"
 
@@ -95,7 +95,7 @@ class CompoundsLoader(TableLoader):
                 sheet (Optional[str]) [None]: Sheet name (for error reporting).
                 file (Optional[str]) [None]: File name (for error reporting).
             Derived (this) class Args:
-                synonym_separator (Optional[str]) [;]: Synonym string delimiter.
+                synonyms_delimiter (Optional[str]) [;]: Synonym string delimiter.
 
         Raises:
             Nothing
@@ -103,7 +103,9 @@ class CompoundsLoader(TableLoader):
         Returns:
             Nothing
         """
-        self.synonym_separator = kwargs.pop("synonym_separator", self.SYNOMYM_SEPARATOR)
+        self.synonyms_delimiter = kwargs.pop(
+            "synonyms_delimiter", self.SYNONYMS_DELIMITER
+        )
         super().__init__(*args, **kwargs)
 
     def load_data(self):
@@ -158,6 +160,17 @@ class CompoundsLoader(TableLoader):
 
     @transaction.atomic
     def get_or_create_compound(self, row):
+        """Get or create a compound record.
+
+        Args:
+            row (pandas dataframe row)
+
+        Raises:
+            Nothing (explicitly)
+
+        Returns:
+            rec (Optional[Compound])
+        """
         rec_dict = None
         rec = None
 
@@ -207,6 +220,18 @@ class CompoundsLoader(TableLoader):
 
     @transaction.atomic
     def get_or_create_synonym(self, synonym, cmpd_rec):
+        """Get or create a compound synonym record.
+
+        Args:
+            synonym (string)
+            cmpd_rec (Compound)
+
+        Raises:
+            Nothing (explicitly)
+
+        Returns:
+            Nothing
+        """
         rec_dict = None
         try:
             rec_dict = {
@@ -232,7 +257,7 @@ class CompoundsLoader(TableLoader):
             raise e
 
     def parse_synonyms(self, synonyms_string: Optional[str]) -> list:
-        """Parse the synonyms column value using the self.synonym_separator.
+        """Parse the synonyms column value using the self.synonyms_delimiter.
 
         Args:
             synonyms_string (Optional[str]): String of delimited synonyms
@@ -249,7 +274,7 @@ class CompoundsLoader(TableLoader):
         if synonyms_string:
             synonyms = [
                 synonym.strip()
-                for synonym in synonyms_string.split(self.synonym_separator)
+                for synonym in synonyms_string.split(self.synonyms_delimiter)
                 if synonym.strip() != ""
             ]
         return synonyms

--- a/DataRepo/management/commands/load_compounds.py
+++ b/DataRepo/management/commands/load_compounds.py
@@ -14,10 +14,10 @@ class Command(LoadTableCommand):
 
         # Add additional options for this specific script
         parser.add_argument(
-            "--synonym-separator",
+            "--synonyms-delimiter",
             type=str,
-            help="Character separating multiple synonyms in 'Synonyms' column (default '%(default)s')",
-            default=self.loader_class.SYNOMYM_SEPARATOR,
+            help="Character delimiting multiple synonyms in the synonyms column (default '%(default)s')",
+            default=self.loader_class.SYNONYMS_DELIMITER,
             required=False,
         )
 
@@ -45,5 +45,5 @@ class Command(LoadTableCommand):
         """
         # The CompoundsLoader class constructor has 1 custom argument
         # The TableLoader superclass arguments are controlled by the LoadTableCommand superclass
-        self.init_loader(synonym_separator=options["synonym_separator"])
+        self.init_loader(synonyms_delimiter=options["synonyms_delimiter"])
         self.load_data()

--- a/DataRepo/management/commands/load_table.py
+++ b/DataRepo/management/commands/load_table.py
@@ -3,7 +3,7 @@ from abc import ABC, abstractmethod
 
 from django.core.management import BaseCommand
 
-from DataRepo.loaders.table_loader import TableLoader
+from DataRepo.loaders import TableLoader
 from DataRepo.utils import (
     AggregatedErrors,
     DryRun,
@@ -36,10 +36,10 @@ class LoadTableCommand(ABC, BaseCommand):
 
             def add_arguments(self, parser):
                 super().add_arguments(parser)
-                parser.add_argument("--synonym-separator", type=str)
+                parser.add_argument("--synonyms-delimiter", type=str)
 
             def handle(self, *args, **options):
-                self.load_data(synonym_separator=options["synonym_separator"])
+                self.load_data(synonyms_delimiter=options["synonyms_delimiter"])
 
     Attributes:
         help (str): Default help string to be printed when the CLI is used with the help command.
@@ -86,6 +86,7 @@ class LoadTableCommand(ABC, BaseCommand):
             saved_headers = self.get_headers()
             saved_defaults = self.get_defaults()
 
+        # TODO: Move the disallowed_args up above the if self.options conditional and add headers and defaults to it.
         kwargs["headers"] = saved_headers
         kwargs["defaults"] = saved_defaults
 
@@ -344,7 +345,7 @@ class LoadTableCommand(ABC, BaseCommand):
             defer_rollback (boolean): Defer rollback mode.   DO NOT USE MANUALLY.  A PARENT SCRIPT MUST HANDLE ROLLBACK.
             sheet (str): Name of the sheet to load (for error reporting only).
             file (str): Name of the file to load (for error reporting only).
-            **kwargs (key/value pairs): Any custom args for the derived loader class, e.g. compound synonyms separator
+            **kwargs (key/value pairs): Any custom args for the derived loader class, e.g. compound synonyms delimiter
 
         Raises:
             Nothing


### PR DESCRIPTION
## Summary Change Description

Renamed the synonym delimiter option for consistency.  This should not affect any scripts, as they all use the default value.  Also added a TODO comment and a couple doc strings.

## Affected Issues/Pull Requests

- Resolves no issue
- Merges into #896

## Review Notes
<!--
For added context for reviewers, add comments to relevant lines of code.  Use
this space to describe any general areas of concern not linked to a specific
line of code that reviewers should pay particular attention to, e.g. please
make sure I have accounted for all possible inputs.
-->
See comments in-line.

## Checklist
<!--
If any of the checkbox requirements are not met, uncheck them and add an
explanation. E.g. Linting errors pre-date this PR.
-->
This pull request will be merged once the following requirements are met.  The
author and/or reviewers should uncheck any unmet requirements:

- Review requirements
  - Minimum approvals: 1 <!-- Edit as desired (e.g. based on complexity) -->
  - No changes requested
  - All blocking issues resolved by reviewers
  - Specific reviewers: @__add_username_here__
    <!--
    Require reviewers with specific expertise to be included among the minimum
    number of reviewers by tagging them.  Also please send them a message.
    -->
  - Review period: 2 days <!-- Edit as desired (e.g. based on complexity) -->
- Associated issue/pull request requirements:
  <!--
  Assert that all requirements in issues marked "resolved" are done and that
  all required pull requests are merged.  If any are not done, either edit or
  split the issue or explain the unmerged affected pull requests.
  -->
  - [x] All requirements in affected issues marked "resolved" are satisfied
  - [x] All required pull requests are merged *(or none)*
- Basic requirements
  <!--
  Uncheck items to acknowledge failures/conflicts you intend to address.
  Add an explanation if any won't be addressed before merge.
  -->
  - [x] [All linters pass](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#linting)
  - [x] [All tests pass](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#quality-control)
  - [x] All conflicts resolved
- Overhead requirements
  <!--
  These are additional requirements that are not directly associated with
  resolving the affected issue(s).
  -->
  - [x] [New/changed method tests implemented/updated *(or no change)*](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#test-implementation)
  - [x] [Updated *Unreleased* section of `changelog.md` *(or no change)*](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/changelog.md)
  - [x] [Migrations created & committed *(or no change)*](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#migration-process)
