### PR TITLE
Improved exception inheritance

### DIFF
--- a/DataRepo/loaders/accucor_data_loader.py
+++ b/DataRepo/loaders/accucor_data_loader.py
@@ -1527,7 +1527,7 @@ class AccuCorDataLoader:
                         pg_rec=existing_peak_group,
                         peak_annot1=existing_peak_group.peak_annotation_file.filename,
                         peak_annot2=peak_annotation_file.filename,
-                        col=col,
+                        column=col,
                         rownum=rownum,
                         sheet="absolte" if self.isocorr_format else "Corrected",
                     )
@@ -1536,7 +1536,7 @@ class AccuCorDataLoader:
                     differences=differences,
                     file=peak_annotation_file.filename,
                     rownum=rownum,
-                    col=col,
+                    column=col,
                     sheet="absolte" if self.isocorr_format else "Corrected",
                 )
 

--- a/DataRepo/loaders/table_loader.py
+++ b/DataRepo/loaders/table_loader.py
@@ -1344,8 +1344,8 @@ class TableLoader(ABC):
                     ExcelSheetsNotFound(
                         unknown_sheets,
                         all_sheet_names,
-                        file=self.defaults_file,
-                        column=self.DefaultsHeaders.SHEET_NAME,
+                        source_file=self.defaults_file,
+                        source_column=self.DefaultsHeaders.SHEET_NAME,
                         source_sheet=self.defaults_sheet,
                     )
                 )


### PR DESCRIPTION
## Summary Change Description

A lot of the exception code was repetitive.  All of the exceptions that were using `generate_file_location_string` and `summarize_int_list` were modified to inherit from a new base exception class named `InfileError`.

A feature was added to the base class to be able to manually specify where location information should be incorporated into a supplied message.  This is achieved with an "order" argument that corresponds to what information should be placed where formatting "" characters are in the supplied message.

I also noted that a number of the exception tests were put in the wrong test class, so I rearranged them to be in the appropriate classes.

I also created a new exception class named CompoundDoesNotExist in order to provide file context to the exception.

## Affected Issues/Pull Requests

- Resolves no issue
- Merges into #897
- Next PR: #899

## Review Notes
<!--
For added context for reviewers, add comments to relevant lines of code.  Use
this space to describe any general areas of concern not linked to a specific
line of code that reviewers should pay particular attention to, e.g. please
make sure I have accounted for all possible inputs.
-->
See comments in-line.

## Checklist
<!--
If any of the checkbox requirements are not met, uncheck them and add an
explanation. E.g. Linting errors pre-date this PR.
-->
This pull request will be merged once the following requirements are met.  The
author and/or reviewers should uncheck any unmet requirements:

- Review requirements
  - Minimum approvals: 1 <!-- Edit as desired (e.g. based on complexity) -->
  - No changes requested
  - All blocking issues resolved by reviewers
  - Specific reviewers: @__add_username_here__
    <!--
    Require reviewers with specific expertise to be included among the minimum
    number of reviewers by tagging them.  Also please send them a message.
    -->
  - Review period: 2 days <!-- Edit as desired (e.g. based on complexity) -->
- Associated issue/pull request requirements:
  <!--
  Assert that all requirements in issues marked "resolved" are done and that
  all required pull requests are merged.  If any are not done, either edit or
  split the issue or explain the unmerged affected pull requests.
  -->
  - [x] All requirements in affected issues marked "resolved" are satisfied
  - [x] All required pull requests are merged *(or none)*
- Basic requirements
  <!--
  Uncheck items to acknowledge failures/conflicts you intend to address.
  Add an explanation if any won't be addressed before merge.
  -->
  - [x] [All linters pass](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#linting)
  - [x] [All tests pass](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#quality-control)
  - [x] All conflicts resolved
- Overhead requirements
  <!--
  These are additional requirements that are not directly associated with
  resolving the affected issue(s).
  -->
  - [x] [New/changed method tests implemented/updated *(or no change)*](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#test-implementation)
  - [ ] [Updated *Unreleased* section of `changelog.md` *(or no change)*](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/changelog.md)
  - [x] [Migrations created & committed *(or no change)*](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#migration-process)
