### PR TITLE
Made it possible to define conditionally required columns and column values

### DIFF
--- a/DataRepo/loaders/sequences_loader.py
+++ b/DataRepo/loaders/sequences_loader.py
@@ -51,29 +51,18 @@ class SequencesLoader(TableLoader):
         NOTES="Notes",
     )
 
-    # Whether each column is required to be present or not
-    DataRequiredHeaders = DataTableHeaders(
-        ID=True,  # See TODO 1 above
-        OPERATOR=True,
-        DATE=True,
-        INSTRUMENT=True,
-        LC_PROTOCOL=True,
-        LC_RUNLEN=True,
-        LC_DESC=False,
-        NOTES=False,
-    )
+    # List of required header keys
+    DataRequiredHeaders = [
+        ID_KEY,  # See TODO 1 above
+        OPERATOR_KEY,
+        DATE_KEY,
+        INSTRUMENT_KEY,
+        LC_PROTOCOL_KEY,
+        LC_RUNLEN_KEY,
+    ]
 
-    # Whether a value for an row in a column is required or not (note that defined DataDefaultValues will satisfy this)
-    DataRequiredValues = DataTableHeaders(
-        ID=True,  # See TODO 1 above
-        OPERATOR=True,
-        DATE=True,
-        INSTRUMENT=True,
-        LC_PROTOCOL=True,
-        LC_RUNLEN=True,
-        LC_DESC=False,  # Required if LCMethod record doesn't exist
-        NOTES=False,
-    )
+    # List of header keys for columns that require a value
+    DataRequiredValues = DataRequiredHeaders
 
     # No DataDefaultValues needed
 
@@ -98,13 +87,13 @@ class SequencesLoader(TableLoader):
 
     # A mapping of database field to column.  Only set when the mapping is 1:1.  Omit others.
     FieldToDataHeaderKey = {
-        "MSRunSequence": {
+        MSRunSequence.__name__: {
             "researcher": OPERATOR_KEY,
             "date": DATE_KEY,
             "instrument": INSTRUMENT_KEY,
             "notes": NOTES_KEY,
         },
-        "LCMethod": {
+        LCMethod.__name__: {
             "type": LC_PROTOCOL_KEY,
             "runlength": LC_RUNLEN_KEY,
             "description": LC_DESC_KEY,
@@ -130,7 +119,7 @@ class SequencesLoader(TableLoader):
             try:
                 lc_rec, _ = self.get_or_create_lc_method(row)
             except Exception:
-                # Exception handling was handled in get_or_create_protocol
+                # Exception handling was handled in get_or_create_*
                 # Continue processing rows to find more errors
                 lc_rec = None
 
@@ -141,7 +130,7 @@ class SequencesLoader(TableLoader):
             try:
                 self.get_or_create_sequence(row, lc_rec)
             except Exception:
-                # Exception handling was handled in get_or_create_protocol
+                # Exception handling was handled in get_or_create_*
                 # Continue processing rows to find more errors
                 pass
 
@@ -172,7 +161,7 @@ class SequencesLoader(TableLoader):
             raw_run_length = self.get_row_val(row, self.headers.LC_RUNLEN)
             description = self.get_row_val(row, self.headers.LC_DESC)
 
-            # In case run_lengths was None, let's prevent an exception at the timedelta
+            # In case run_length was None, let's prevent an exception at the timedelta
             if self.is_skip_row():
                 self.errored(LCMethod.__name__)
                 return rec, created

--- a/DataRepo/tests/loaders/test_protocols_loader.py
+++ b/DataRepo/tests/loaders/test_protocols_loader.py
@@ -9,7 +9,7 @@ class ProtocolsLoaderTests(TracebaseTestCase):
         pl = ProtocolsLoader()
         self.assertEqual(
             (
-                "[Name*, Category, Description*] (or, if the input file is an excel file: [Animal Treatment*, "
+                "[Name*, Description*, Category] (or, if the input file is an excel file: [Animal Treatment*, "
                 "Treatment Description*]) (* = Required)"
             ),
             pl.get_pretty_headers(),

--- a/DataRepo/tests/management/test_load_table.py
+++ b/DataRepo/tests/management/test_load_table.py
@@ -27,7 +27,7 @@ class TestLoader(TableLoader):
     DataSheetName = "Test"
     DataTableHeaders = namedtuple("DataTableHeaders", ["TEST"])
     DataHeaders = DataTableHeaders(TEST="Test")
-    DataRequiredHeaders = DataTableHeaders(TEST=True)
+    DataRequiredHeaders = ["TEST"]
     DataRequiredValues = DataRequiredHeaders
     DataColumnTypes = {"TEST": str}
     DataDefaultValues = DataTableHeaders(TEST="five")


### PR DESCRIPTION
## Summary Change Description

This code change is used in the tracers loader that will be in the next PR.

Basically, I changed:

- `TableLoader.DataRequiredHeaders`
- `TableLoader.DataRequiredValues`

from `namedtuple`s to (N-dimensional) lists of required header keys.

The simplest example:

```
[a, b, [c, d]]
```

This means a, b, and (either c or d) are required.

The methods which handle these data structures are recursive and each iteration alternates between "all required" (i.e. "and'ed" groups) and "any required" (i.e. "or'ed" groups).  So, for example:

```
[a, [b, [c, d]]]
```
means "a and (either b or (c and d)) are required".

This makes checking required headers and/or values as simple as just creating the nested list in the derived loader class.

## Affected Issues/Pull Requests

- Resolves no issue
- Merges into PR #898
- Next PR: #900

## Review Notes

I documented all the methods fairly well, but this is a more involved PR than the previous ones in this series, so I will go through and comment on any changes that could benefit from additional context.

## Checklist
<!--
If any of the checkbox requirements are not met, uncheck them and add an
explanation. E.g. Linting errors pre-date this PR.
-->
This pull request will be merged once the following requirements are met.  The
author and/or reviewers should uncheck any unmet requirements:

- Review requirements
  - Minimum approvals: 1 <!-- Edit as desired (e.g. based on complexity) -->
  - No changes requested
  - All blocking issues resolved by reviewers
  - Specific reviewers: @__add_username_here__
    <!--
    Require reviewers with specific expertise to be included among the minimum
    number of reviewers by tagging them.  Also please send them a message.
    -->
  - Review period: 2 days <!-- Edit as desired (e.g. based on complexity) -->
- Associated issue/pull request requirements:
  <!--
  Assert that all requirements in issues marked "resolved" are done and that
  all required pull requests are merged.  If any are not done, either edit or
  split the issue or explain the unmerged affected pull requests.
  -->
  - [x] All requirements in affected issues marked "resolved" are satisfied
  - [x] All required pull requests are merged *(or none)*
- Basic requirements
  <!--
  Uncheck items to acknowledge failures/conflicts you intend to address.
  Add an explanation if any won't be addressed before merge.
  -->
  - [x] [All linters pass](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#linting)
  - [x] [All tests pass](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#quality-control)
  - [x] All conflicts resolved
- Overhead requirements
  <!--
  These are additional requirements that are not directly associated with
  resolving the affected issue(s).
  -->
  - [x] [New/changed method tests implemented/updated *(or no change)*](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#test-implementation)
  - [ ] [Updated *Unreleased* section of `changelog.md` *(or no change)*](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/changelog.md)
  - [x] [Migrations created & committed *(or no change)*](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#migration-process)
