### PR TITLE
TracersLoader

### DIFF
--- a/DataRepo/loaders/tracers_loader.py
+++ b/DataRepo/loaders/tracers_loader.py
@@ -1,0 +1,1008 @@
+from collections import defaultdict, namedtuple
+from typing import Dict
+
+from django.core.exceptions import ObjectDoesNotExist
+from django.db import ProgrammingError, transaction
+
+from DataRepo.loaders.table_loader import TableLoader
+from DataRepo.models import Compound, MaintainedModel, Tracer, TracerLabel
+from DataRepo.utils.exceptions import (
+    CompoundDoesNotExist,
+    InfileError,
+    summarize_int_list,
+)
+from DataRepo.utils.infusate_name_parser import (
+    IsotopeData,
+    TracerData,
+    parse_tracer_string,
+)
+
+
+class TracersLoader(TableLoader):
+    # Header keys (for convenience use only).  Note, they cannot be used in the namedtuple() call.  Literal required.
+    ID_KEY = "ID"
+    COMPOUND_KEY = "COMPOUND"
+    ELEMENT_KEY = "ELEMENT"
+    MASS_NUMBER_KEY = "MASSNUMBER"
+    LABEL_COUNT_KEY = "LABELCOUNT"
+    LABEL_POSITIONS_KEY = "LABELPOSITIONS"
+    NAME_KEY = "NAME"
+
+    POSITIONS_DELIMITER = ","
+
+    DataSheetName = "Tracers"
+
+    # The tuple used to store different kinds of data per column at the class level
+    DataTableHeaders = namedtuple(
+        "DataTableHeaders",
+        [
+            "ID",
+            "COMPOUND",
+            "ELEMENT",
+            "MASSNUMBER",
+            "LABELCOUNT",
+            "LABELPOSITIONS",
+            "NAME",
+        ],
+    )
+
+    # The default header names (which can be customized via yaml file via the corresponding load script)
+    DataHeaders = DataTableHeaders(
+        ID="Tracer Number",
+        COMPOUND="Compound Name",
+        ELEMENT="Element",
+        MASSNUMBER="Mass Number",
+        LABELCOUNT="Label Count",
+        LABELPOSITIONS="Label Positions",
+        NAME="Tracer Name",
+    )
+
+    # List of required header keys
+    DataRequiredHeaders = [
+        [
+            # Either tracer number, compound, element, mass, and count - or tracer name
+            [
+                ID_KEY,
+                COMPOUND_KEY,
+                ELEMENT_KEY,
+                MASS_NUMBER_KEY,
+                LABEL_COUNT_KEY,
+            ],
+            NAME_KEY,
+        ],
+    ]
+
+    # List of header keys for columns that require a value
+    DataRequiredValues = DataRequiredHeaders
+
+    # The type of data in each column (used by pandas to not, for example, turn "1" into an integer then str is set)
+    DataColumnTypes: Dict[str, type] = {
+        ID_KEY: int,
+        COMPOUND_KEY: str,
+        ELEMENT_KEY: str,
+        MASS_NUMBER_KEY: int,
+        LABEL_COUNT_KEY: int,
+        LABEL_POSITIONS_KEY: str,
+        NAME_KEY: str,
+    }
+
+    # No DataDefaultValues needed
+
+    # Combinations of columns whose values must be unique in the file
+    DataUniqueColumnConstraints = [
+        [
+            ID_KEY,
+            COMPOUND_KEY,
+            ELEMENT_KEY,
+            MASS_NUMBER_KEY,
+            LABEL_COUNT_KEY,
+            LABEL_POSITIONS_KEY,
+        ],
+        [
+            NAME_KEY,
+            COMPOUND_KEY,
+            ELEMENT_KEY,
+            MASS_NUMBER_KEY,
+            LABEL_COUNT_KEY,
+            LABEL_POSITIONS_KEY,
+        ],
+    ]
+
+    # A mapping of database field to column.  Only set when the mapping is 1:1.  Omit others.
+    # Notes:
+    # The purpose of FieldToDataHeaderKey is to interpret database errors that reference a field name and then associate
+    # it with a problematic column value.  The value types do not need to be the same.  It is just for reporting, so:
+    # - Tracer.compound is a foreign key, so even though the column value is a string, errors that reference the foreign
+    #   key are directly applicable to the value in the column.
+    # - Tracer.name is OK to have here for the future, but since it is both null=True and a Maintained Field, it is not
+    #   allowed to be included in an ORM create command, and thus cannot be referenced in a database error.
+    # - TracerLabel.positions is an ArrayField, not a string, so even though the column value is a delimited string,
+    #   errors that reference the array value are directly applicable to the value in the column.
+    # - TracerLabel.name is not mapped because it does not exist as a single column.  It is also a Maintained Field, so
+    #   it would not exist in an error from the database anyway.
+    FieldToDataHeaderKey = {
+        Tracer.__name__: {
+            "name": NAME_KEY,
+            "compound": COMPOUND_KEY,
+        },
+        TracerLabel.__name__: {
+            "element": ELEMENT_KEY,
+            "mass_number": MASS_NUMBER_KEY,
+            "count": LABEL_COUNT_KEY,
+            "positions": LABEL_POSITIONS_KEY,
+        },
+    }
+
+    # List of model classes that the loader enters records into.  Used for summarized results & some exception handling
+    Models = [Tracer, TracerLabel]
+
+    def __init__(self, *args, **kwargs):
+        """Constructor.
+
+        Args:
+            Superclass Args:
+                df (pandas dataframe): Data, e.g. as parsed from a table-like file.
+                headers (Optional[Tableheaders namedtuple]) [DataHeaders]: Header names by header key.
+                defaults (Optional[Tableheaders namedtuple]) [DataDefaultValues]: Default values by header key.
+                dry_run (Optional[boolean]) [False]: Dry run mode.
+                defer_rollback (Optional[boolean]) [False]: Defer rollback mode.  DO NOT USE MANUALLY - A PARENT SCRIPT
+                    MUST HANDLE THE ROLLBACK.
+                sheet (Optional[str]) [None]: Sheet name (for error reporting).
+                file (Optional[str]) [None]: File name (for error reporting).
+            Derived (this) class Args:
+                synonym_separator (Optional[str]) [;]: Synonym string delimiter.
+
+        Raises:
+            Nothing
+
+        Returns:
+            Nothing
+        """
+        self.positions_delimiter = kwargs.pop(
+            "positions_delimiter", self.POSITIONS_DELIMITER
+        )
+        super().__init__(*args, **kwargs)
+
+    def init_load(self):
+        """Initializes load-related metadata.  Called before any load occurs (in load_data().
+
+        Args:
+            None
+
+        Exceptions:
+            None
+
+        Returns:
+            Nothing
+        """
+        self.tracer_dict = defaultdict(dict)
+        self.tracer_name_to_number = defaultdict(lambda: defaultdict(list))
+        self.valid_tracers = {}
+
+        self.inconsistent_compounds = defaultdict(lambda: defaultdict(list))
+        self.inconsistent_names = defaultdict(lambda: defaultdict(list))
+        self.inconsistent_numbers = defaultdict(lambda: defaultdict(list))
+
+    @MaintainedModel.defer_autoupdates()
+    def load_data(self):
+        """Loads the Tracer and TracerLabel tables from the dataframe (self.df).
+
+        Args:
+            None
+
+        Exceptions:
+            None (explicitly)
+
+        Returns:
+            Nothing
+        """
+        # Gather all the data needed for the tracers (a tracer can span multiple rows)
+        self.build_tracer_dict()
+
+        # Check the self.tracer_dict to fill in missing values parsed from the name
+        self.check_extract_name_data()
+        self.buffer_consistency_issues()
+
+        # Now that all the tracer data has been collated and validated, load it
+        self.load_tracer_dict()
+
+    def build_tracer_dict(self):
+        """Iterate over the row data in self.df to populate self.tracer_dict and self.valid_tracers
+
+        Args:
+            None
+
+        Exceptions:
+            Raises:
+                Nothing
+            Buffers:
+                InfileError
+
+        Returns:
+            None
+        """
+        if not hasattr(self, "tracer_dict"):
+            self.init_load()
+
+        for _, row in self.df.iterrows():
+            try:
+                # missing required values update the skip_row_indexes before load_data is even called, and get_row_val
+                # sets the current row index
+                if self.is_skip_row(row.name):
+                    self.errored(Tracer.__name__)
+                    self.errored(TracerLabel.__name__)
+                    continue
+
+                (
+                    tracer_number,
+                    compound_name,
+                    tracer_name,
+                    element,
+                    mass_number,
+                    count,
+                    positions,
+                ) = self.get_row_data(row)
+
+                if tracer_number is None:
+                    self.aggregated_errors_object.buffer_error(
+                        InfileError(
+                            f"{self.headers.ID} undefined.",
+                            rownum=self.rownum,
+                            file=self.file,
+                            sheet=self.sheet,
+                        )
+                    )
+                    self.errored(Tracer.__name__)
+                    self.errored(TracerLabel.__name__)
+                    continue
+
+                if not self.valid_tracers[tracer_number]:
+                    continue
+
+                if tracer_number not in self.tracer_dict.keys():
+                    # Initialize the tracer dict
+                    self.tracer_dict[tracer_number] = {
+                        "compound_name": compound_name,
+                        "tracer_name": tracer_name,
+                        "isotopes": [],
+                        # Metadata for error reporting
+                        "rownum": self.rownum,
+                        "row_index": self.row_index,
+                    }
+
+                if (
+                    element is not None
+                    or mass_number is not None
+                    or count is not None
+                    or positions is not None
+                ):
+                    self.tracer_dict[tracer_number]["isotopes"].append(
+                        {
+                            "element": element,
+                            "mass_number": mass_number,
+                            "count": count,
+                            "positions": positions,
+                            # Metadata for error reporting
+                            "rownum": self.rownum,
+                            "row_index": self.row_index,
+                        }
+                    )
+
+            except Exception as e:
+                exc = InfileError(
+                    str(e), rownum=self.rownum, sheet=self.sheet, file=self.file
+                )
+                self.add_skip_row_index(row.name)
+                self.aggregated_errors_object.buffer_error(exc)
+                if tracer_number is not None:
+                    self.valid_tracers[tracer_number] = False
+
+    @transaction.atomic
+    @MaintainedModel.defer_autoupdates()
+    def load_tracer_dict(self):
+        """Iterate over the self.tracer_dict to get or create Tracer and TracerLabel database records
+
+        Args:
+            None
+
+        Exceptions:
+            None
+
+        Returns:
+            None
+        """
+        for tracer_number, entry in self.tracer_dict.items():
+            # We are iterating a dict independent of the file rows, so set the row index manually
+            self.set_row_index(entry["row_index"])
+
+            if self.is_skip_row():
+                # If the row the tracer name was first obtained from is a skip row, skip it
+                continue
+
+            num_labels = len(entry["isotopes"]) if len(entry["isotopes"]) > 0 else 1
+
+            if not self.valid_tracers[tracer_number] or self.is_skip_row():
+                # This happens if there was an error in the file processing, like missing required columns, unique
+                # column constraint violations, or name parsing issues
+                self.errored(Tracer.__name__)
+                self.errored(TracerLabel.__name__, num=num_labels)
+                continue
+
+            try:
+                # We want to roll back everything related to the current tracer record in here if there was an exception
+                # We do that by catching outside the atomic block, below.  Note that this method has an atomic
+                # transaction decorator that is just for good measure (because the automatically applied wrapper around
+                # load_data will roll back everything if any exception occurs - but the decorator on this method is just
+                # in case it's every called from anywhere other than load_data)
+                with transaction.atomic():
+                    tracer_rec, tracer_created = self.get_or_create_tracer(entry)
+
+                    # If the tracer rec is None, skip the synonyms
+                    if tracer_rec is None:
+                        # Assume the compound didn't exist and mark as skipped
+                        self.skipped(Tracer.__name__)
+                        self.skipped(TracerLabel.__name__, num=num_labels)
+                        continue
+                    elif not tracer_created:
+                        # Note: tracer_rec has already been checked by check_tracer_name_consistent when it existed
+                        self.existed(Tracer.__name__)
+                        # Refresh the count with the actual existing records (i.e. in case isotope data wasn't provided)
+                        num_labels = tracer_rec.labels.count()
+                        self.existed(TracerLabel.__name__, num=num_labels)
+                        continue
+
+                    # Now, get or create the labels
+                    for isotope_dict in self.tracer_dict[tracer_number]["isotopes"]:
+                        # We are iterating a dict independent of the file rows, so set the row index manually
+                        self.set_row_index(isotope_dict["row_index"])
+
+                        if self.is_skip_row():
+                            self.skipped(TracerLabel.__name__)
+                            continue
+
+                        self.get_or_create_tracer_label(isotope_dict, tracer_rec)
+
+                    # Only mark as created after this final check (which raises an exception)
+                    self.check_tracer_name_consistent(tracer_rec, entry)
+
+                    # Refresh the count with the actual existing records (i.e. in case isotope data wasn't provided)
+                    num_labels = tracer_rec.labels.count()
+
+                    self.created(Tracer.__name__)
+                    self.created(TracerLabel.__name__, num=num_labels)
+            except Exception as e:
+                if not self.aggregated_errors_object.exception_type_exists(type(e)):
+                    self.aggregated_errors_object.buffer_error(e)
+                # All exceptions are buffered in their respective functions, so just update the stats
+                self.errored(Tracer.__name__)
+                self.errored(TracerLabel.__name__, num=num_labels)
+
+    def get_row_data(self, row):
+        """Retrieve and validate the row data.
+
+        Updates:
+            self.tracer_name_to_number
+
+        Args:
+            row (pandas dataframe row)
+            tracer_number (integer): Number used to associate multiple rows of label data to a distinct tracer.
+
+        Exceptions:
+            None
+
+        Returns:
+            compound_name (string)
+            tracer_name (string)
+            element (string)
+            mass_number (integer)
+            count (integer)
+            positions (list of integers)
+        """
+        tracer_number = self.get_row_val(row, self.headers.ID)
+        compound_name = self.get_row_val(row, self.headers.COMPOUND)
+        tracer_name = self.get_row_val(row, self.headers.NAME)
+        element = self.get_row_val(row, self.headers.ELEMENT)
+        mass_number = self.get_row_val(row, self.headers.MASSNUMBER)
+        count = self.get_row_val(row, self.headers.LABELCOUNT)
+        raw_positions = self.get_row_val(row, self.headers.LABELPOSITIONS)
+        positions = self.parse_label_positions(raw_positions)
+
+        if tracer_number is None:
+            # Automatically populate the tracer number
+            # Index from 1
+            tracer_number = row.name + 1
+
+        retval = (
+            tracer_number,
+            compound_name,
+            tracer_name,
+            element,
+            mass_number,
+            count,
+            positions,
+        )
+
+        if tracer_number not in self.tracer_dict.keys():
+            # Check for tracer names that map to multiple different tracer numbers
+            if tracer_name not in self.tracer_name_to_number.keys():
+                # The normal case: 1 name, 1 number
+                self.tracer_name_to_number[tracer_name][tracer_number] = self.rownum
+            elif tracer_number not in self.tracer_name_to_number[tracer_name].keys():
+                # An inconsistency: 1 name associated with a new number
+                existing_num = list(self.tracer_name_to_number[tracer_name].keys())[0]
+                self.inconsistent_numbers[tracer_name][existing_num].append(
+                    self.tracer_name_to_number[tracer_name][existing_num]
+                )
+                self.inconsistent_numbers[tracer_name][tracer_number].append(
+                    self.rownum
+                )
+            elif len(self.tracer_name_to_number[tracer_name].keys()) > 1:
+                # This is already in an inconsistent state because there are multiple numbers, so append new rows
+                self.inconsistent_numbers[tracer_name][tracer_number].append(
+                    self.rownum
+                )
+
+            # If this is the first time we've seen this number, start out as valid
+            if tracer_number not in self.valid_tracers.keys():
+                self.valid_tracers[tracer_number] = True
+        else:
+            # Make sure the compound, tracer name, and number are consistent (even though we're not going to use
+            # them on this row - we only use the first occurrence of a tracer name, but we should sanity check the rest)
+            self.check_data_is_consistent(
+                tracer_number,
+                compound_name,
+                tracer_name,
+            )
+
+        return retval
+
+    def check_extract_name_data(self):
+        """Fill in missing data in self.tracer_dict using data parsed from the tracer name, and check for
+        inconsistencies.
+
+        Args:
+            None
+
+        Exceptions:
+            Raises:
+                Nothing
+            Buffers:
+                InfileError
+
+        Returns:
+            Nothing
+        """
+        for tracer_number in self.tracer_dict.keys():
+            table_tracer = self.tracer_dict[tracer_number]
+            table_tracer_name = table_tracer["tracer_name"]
+
+            if table_tracer_name is None:
+                continue
+
+            compound_name = table_tracer["compound_name"]
+            parsed_tracer = parse_tracer_string(table_tracer_name)
+            parsed_compound_name = parsed_tracer["compound_name"]
+
+            if compound_name is None:
+                table_tracer["compound_name"] = parsed_compound_name
+            elif compound_name != parsed_compound_name:
+                self.aggregated_errors_object.buffer_error(
+                    InfileError(
+                        (
+                            f"Compound name from column [{compound_name}] does not match the name parsed from the "
+                            f"tracer name ({table_tracer_name}): [{parsed_compound_name}]: %s"
+                        ),
+                        file=self.file,
+                        sheet=self.sheet,
+                        rownum=table_tracer["rownum"],
+                        column=self.headers.COMPOUND,
+                    )
+                )
+
+            fill_in = len(table_tracer["isotopes"]) == 0
+            for table_isotope in table_tracer["isotopes"]:
+                match = False
+                for parsed_isotope in parsed_tracer["isotopes"]:
+                    match = False
+                    for key in ["element", "mass_number", "count", "positions"]:
+                        if table_isotope[key] is None:
+                            fill_in = True
+                        elif parsed_isotope[key] == table_isotope[key]:
+                            match = True
+                        elif parsed_isotope[key] != table_isotope[key]:
+                            match = False
+                            break
+                    if match is True:
+                        break
+                if match is False:
+                    cols = ", ".join(
+                        [
+                            f"{self.headers.ELEMENT}: {table_isotope['element']}",
+                            f"{self.headers.MASSNUMBER}: {table_isotope['mass_number']}",
+                            f"{self.headers.LABELCOUNT}: {table_isotope['count']}",
+                            f"{self.headers.LABELPOSITIONS}: {table_isotope['positions']}",
+                        ]
+                    )
+                    irows = [ir["rownum"] for ir in table_tracer["isotopes"]]
+                    self.aggregated_errors_object.buffer_error(
+                        InfileError(
+                            (
+                                f"Isotope data from columns [{cols}] on row(s) {irows} does not match any of the "
+                                f"isotopes parsed from the {self.headers.NAME} [{table_tracer_name}] on %s."
+                            ),
+                            file=self.file,
+                            sheet=self.sheet,
+                            rownum=table_tracer["rownum"],
+                        )
+                    )
+
+            if len(table_tracer["isotopes"]) != len(parsed_tracer["isotopes"]):
+                fill_in = True
+                irows = [ir["rownum"] for ir in table_tracer["isotopes"]]
+                self.aggregated_errors_object.buffer_warning(
+                    InfileError(
+                        (
+                            f"There are [{len(table_tracer['isotopes'])}] rows {irows} of data defining isotopes for "
+                            f"{self.headers.NAME} [{table_tracer_name}] in %s, but the number of labels parsed from "
+                            f"the {self.headers.NAME} [{len(parsed_tracer['isotopes'])}] does not match the number of "
+                            f"rows for {self.headers.ID} {tracer_number}.  Perhaps {self.headers.ID} {tracer_number} "
+                            "is on the wrong number of rows?"
+                        ),
+                        file=self.file,
+                        sheet=self.sheet,
+                    )
+                )
+
+            # If anything was missing, we're going to just recreate the data from the names
+            if fill_in is True:
+                table_tracer["isotopes"] = []
+                for parsed_isotope in parsed_tracer["isotopes"]:
+                    table_tracer["isotopes"].append(
+                        {
+                            "element": parsed_isotope["element"],
+                            "mass_number": parsed_isotope["mass_number"],
+                            "count": parsed_isotope["count"],
+                            "positions": parsed_isotope["positions"],
+                            # The row info where the tracer name was obtained
+                            "rownum": table_tracer["rownum"],
+                            "row_index": table_tracer["row_index"],
+                        }
+                    )
+
+    def get_or_create_tracer(self, entry):
+        """Get or create a Tracer record.
+
+        Also counts skipped records (when the compound doesn't exist).
+
+        Args:
+            id (integer)
+            entry (dict)
+
+        Exceptions:
+            None
+
+        Returns:
+            rec (Tracer)
+            created (boolean)
+        """
+        created = False
+        rec = None
+
+        # See if we can retrieve an existing record
+        rec = self.get_tracer(entry)
+
+        if rec is not None:
+            self.check_tracer_name_consistent(rec, entry)
+            return rec, created
+
+        # If we got here, we are creating, so first, try to retrieve the compound
+        compound_rec = self.get_compound(entry["compound_name"])
+
+        if compound_rec is None:
+            return rec, created
+
+        rec = self.create_tracer(compound_rec)
+        created = True
+
+        return rec, created
+
+    def get_tracer(self, entry):
+        """Get a Tracer record.
+
+        Also counts existing or errored records.
+
+        Args:
+            id (integer)
+            entry (dict)
+
+        Exceptions:
+            Raises:
+                Nothing (explicitly)
+            Buffers:
+                InfileError (repackages other exceptions)
+
+        Returns:
+            rec (Optional[Tracer])
+        """
+        rec = None
+
+        # See if we can retrieve an existing record
+        try:
+            # First, we will try to see if we can retrieve the precise tracer, using a TracerData object
+            tracer_data = TracerData(
+                unparsed_string=entry["tracer_name"],
+                compound_name=entry["compound_name"],
+                isotopes=[
+                    IsotopeData(
+                        element=ido["element"],
+                        mass_number=ido["mass_number"],
+                        count=ido["count"],
+                        positions=ido["positions"],
+                    )
+                    for ido in entry["isotopes"]
+                ],
+            )
+
+            rec = Tracer.objects.get_tracer(tracer_data)
+
+        except Exception as e:
+            exc = InfileError(
+                str(e), rownum=self.rownum, sheet=self.sheet, file=self.file
+            )
+            # Package errors (like IntegrityError and ValidationError) with relevant details
+            # This also updates the skip row indexes
+            self.aggregated_errors_object.buffer_error(exc)
+            # Now that the exception has been handled, trigger a rollback of this record load attempt
+            raise e
+
+        return rec
+
+    def get_compound(self, compound_name):
+        """Retrieves a Compound record whose name or synonym matches the supplied name.
+
+        Args:
+            compound_name (string)
+
+        Exceptions:
+            Raises:
+                Nothing
+            Buffers:
+                CompoundDoesNotExist
+                InfileError
+
+        Returns:
+            rec (Optional[Tracer])
+        """
+        rec = None
+
+        # If we got here, we are creating, so first, try to retrieve the compound
+        try:
+            rec = Compound.compound_matching_name_or_synonym(compound_name)
+
+            if rec is None:
+                raise ProgrammingError(
+                    "The assumption that compound_matching_name_or_synonym either returns a real record or else raises "
+                    "an exception was incorrect."
+                )
+
+        except ObjectDoesNotExist:
+            self.aggregated_errors_object.buffer_error(
+                CompoundDoesNotExist(
+                    name=compound_name,
+                    rownum=self.rownum,
+                    column=self.headers.COMPOUND,
+                    file=self.file,
+                    sheet=self.sheet,
+                )
+            )
+        except Exception as e:
+            # Package errors (like IntegrityError and ValidationError) with relevant details
+            # This also updates the skip row indexes
+            self.aggregated_errors_object.buffer_error(
+                InfileError(
+                    str(e), rownum=self.rownum, sheet=self.sheet, file=self.file
+                )
+            )
+
+        return rec
+
+    @transaction.atomic
+    def create_tracer(self, compound_rec):
+        """Creates a Tracer record.
+
+        Also counts created or errored records.
+
+        Args:
+            compound_rec (Compound)
+
+        Exceptions:
+            Raises:
+                Nothing (explicitly)
+            Buffers:
+                Nothing (explicitly)
+
+        Returns:
+            rec (Tracer)
+        """
+        rec = None
+        rec_dict = {"compound": compound_rec}
+
+        try:
+            rec = Tracer.objects.create(**rec_dict)
+        except Exception as e:
+            # Package errors (like IntegrityError and ValidationError) with relevant details
+            # This also updates the skip row indexes
+            self.handle_load_db_errors(e, Tracer, rec_dict)
+            # Now that the exception has been handled, trigger a rollback of this record load attempt
+            raise e
+
+        return rec
+
+    def get_or_create_tracer_label(self, isotope_dict, tracer_rec):
+        """Get or create a TracerLabel record.
+
+        Also counts created, existed, or errored records.
+
+        Args:
+            row (pandas dataframe row)
+            tracer_rec (Tracer)
+
+        Raises:
+            Nothing (explicitly)
+
+        Returns:
+            rec (Optional[TracerLabel])
+            created (boolean)
+        """
+        rec = None
+        rec_dict = None
+        created = False
+
+        try:
+            element = isotope_dict["element"]
+            mass_number = isotope_dict["mass_number"]
+            count = isotope_dict["count"]
+            positions = isotope_dict["positions"]
+
+            rec_dict = {
+                "element": element,
+                "mass_number": mass_number,
+                "count": count,
+                "positions": positions,
+                "tracer": tracer_rec,
+            }
+
+            rec, created = TracerLabel.objects.get_or_create(**rec_dict)
+
+            if created:
+                rec.full_clean()
+
+        except Exception as e:
+            # Package errors (like IntegrityError and ValidationError) with relevant details
+            # This also updates the skip row indexes
+            self.handle_load_db_errors(e, TracerLabel, rec_dict)
+            # Now that the exception has been handled, trigger a rollback of this record load attempt
+            raise e
+
+        return rec, created
+
+    def parse_label_positions(self, positions_str):
+        """Create a list of integers from a delimited string of integers.
+
+        Args:
+            positions_str (string): delimited string of integers
+
+        Raises:
+            Nothing
+
+        Returns:
+            positions (Optional[list of integers])
+        """
+        positions = None
+        if positions_str is None:
+            return positions
+        if positions_str:
+            try:
+                positions = [
+                    int(pos.strip())
+                    for pos in positions_str.split(self.positions_delimiter)
+                    if pos.strip() != ""
+                ]
+            except Exception as e:
+                self.add_skip_row_index()
+                exc = InfileError(
+                    str(e), rownum=self.rownum, sheet=self.sheet, file=self.file
+                )
+                # Package errors (like IntegrityError and ValidationError) with relevant details
+                # This also updates the skip row indexes
+                self.aggregated_errors_object.buffer_error(exc)
+
+        return positions
+
+    def check_data_is_consistent(
+        self,
+        tracer_number,
+        compound_name,
+        tracer_name,
+    ):
+        """Ensures that each tracer number is associated with the same compound and tracer name.
+
+        Accesses:
+            self.tracer_dict
+            self.tracer_name_to_number
+
+        Adds inconsistencies to:
+            self.inconsistent_compounds
+            self.inconsistent_names
+            self.inconsistent_numbers
+
+        Args:
+            tracer_number (integer)
+            compound_str (string)
+            tracer_str (string)
+
+        Exceptions:
+            None
+
+        Returns:
+            None
+        """
+        # Make sure that each tracer number is always associated with the same compound
+        if self.tracer_dict[tracer_number]["compound_name"] != compound_name:
+            if tracer_number not in self.inconsistent_compounds.keys():
+                self.inconsistent_compounds[tracer_number][
+                    self.tracer_dict[tracer_number]["compound_name"]
+                ] = [self.tracer_dict[tracer_number]["rownum"]]
+            self.inconsistent_compounds[tracer_number][compound_name].append(
+                self.rownum
+            )
+
+        # Make sure that each tracer number is always associated with the same tracer name
+        if self.tracer_dict[tracer_number]["tracer_name"] != tracer_name:
+            if tracer_number not in self.inconsistent_names.keys():
+                self.inconsistent_names[tracer_number][
+                    self.tracer_dict[tracer_number]["tracer_name"]
+                ] = [self.tracer_dict[tracer_number]["rownum"]]
+            self.inconsistent_names[tracer_number][tracer_name].append(self.rownum)
+
+        if (
+            tracer_name in self.tracer_name_to_number.keys()
+            and tracer_number not in self.tracer_name_to_number[tracer_name].keys()
+        ):
+            self.inconsistent_numbers[tracer_name][tracer_number].append(self.rownum)
+
+    def buffer_consistency_issues(self):
+        """Buffers consistency errors.
+
+        - When a tracer number is associated with multiple compounds
+        - When a tracer number is associated with multiple tracer names
+        - When a tracer name is associated with multiple tracer numbers
+
+        Args:
+            None
+
+        Exceptions:
+            Raises:
+                None
+            Buffers:
+                InfileError
+
+        Returns:
+            None
+        """
+        # TODO: While all these errors are accurate, it would probably be better to organize them differently and reword
+        #       them to be easier to follow.
+        for tracer_number in self.inconsistent_compounds.keys():
+            msg = (
+                f"%s:\n\t{self.headers.ID} {tracer_number} is associated with multiple {self.headers.COMPOUND}s on the "
+                f"indicated rows.  Only one {self.headers.COMPOUND} is allowed per {self.headers.ID}.\n\t\t"
+            )
+            msg += "\n\t\t".join(
+                [
+                    f"{c} (on rows: {self.inconsistent_compounds[tracer_number][c]})"
+                    for c in self.inconsistent_compounds[tracer_number].keys()
+                ]
+            )
+            self.aggregated_errors_object.buffer_error(
+                InfileError(
+                    msg,
+                    column=f"{self.headers.ID} and {self.headers.COMPOUND}",
+                    file=self.file,
+                    sheet=self.sheet,
+                )
+            )
+            for nk in self.inconsistent_compounds[tracer_number].keys():
+                self.add_skip_row_index(
+                    index_list=self.inconsistent_compounds[tracer_number][nk]
+                )
+
+        for tracer_number in self.inconsistent_names.keys():
+            msg = (
+                f"%s:\n\t{self.headers.ID} {tracer_number} is associated with multiple {self.headers.NAME}s on the "
+                f"indicated rows.  Only one {self.headers.NAME} is allowed per {self.headers.ID}.\n\t\t"
+            )
+            msg += "\n\t\t".join(
+                [
+                    f"{n} (on rows: {self.inconsistent_names[tracer_number][n]})"
+                    for n in self.inconsistent_names[tracer_number].keys()
+                ]
+            )
+            self.aggregated_errors_object.buffer_error(
+                InfileError(
+                    msg,
+                    column=f"{self.headers.NAME} and {self.headers.ID}",
+                    file=self.file,
+                    sheet=self.sheet,
+                )
+            )
+            for nk in self.inconsistent_names[tracer_number].keys():
+                self.add_skip_row_index(
+                    index_list=self.inconsistent_names[tracer_number][nk]
+                )
+
+        for tracer_name in self.inconsistent_numbers.keys():
+            msg = (
+                f"%s:\n\t{self.headers.NAME} {tracer_name} is associated with multiple {self.headers.ID}s on the "
+                f"indicated rows.  Only one {self.headers.ID} is allowed per {self.headers.NAME}.\n\t\t"
+            )
+            msg += "\n\t\t".join(
+                [
+                    f"{n} (on rows: {self.inconsistent_numbers[tracer_name][n]})"
+                    for n in self.inconsistent_numbers[tracer_name].keys()
+                ]
+            )
+            self.aggregated_errors_object.buffer_error(
+                InfileError(
+                    msg,
+                    column=f"{self.headers.ID} and {self.headers.NAME}",
+                    file=self.file,
+                    sheet=self.sheet,
+                )
+            )
+            for nk in self.inconsistent_numbers[tracer_name].keys():
+                self.add_skip_row_index(
+                    index_list=self.inconsistent_numbers[tracer_name][nk]
+                )
+
+    def check_tracer_name_consistent(self, rec, entry):
+        """Checks for consistency between a dynamically generated tracer name and the one supplied in the file.
+
+        Args:
+            rec (Tracer): A Tracer model object
+            entry (dict): Data parsed from potentially multiple rows relating to a single Tracer
+
+        Exceptions:
+            Raises:
+                InfileError
+            Buffers:
+                InfileError
+
+        Returns:
+            None
+        """
+        supplied_name = entry["tracer_name"]
+
+        if supplied_name is None:
+            # Nothing to check
+            return
+
+        # We have to generate it instead of simply access it in the model object, because this is a maintained field,
+        # and if the record was created, auto-update will not happen until the load is complete
+        generated_name = rec._name()
+
+        if supplied_name != generated_name:
+            data_rownums = summarize_int_list(
+                [rd["rownum"] for rd in entry["isotopes"]]
+            )
+            exc = InfileError(
+                (
+                    f"The supplied tracer name [{supplied_name}] from row %s does not match the automatically "
+                    f"generated name [{generated_name}] using the data on rows {data_rownums}."
+                ),
+                file=self.file,
+                sheet=self.sheet,
+                column=self.headers.NAME,
+                rownum=entry["rownum"],
+            )
+            self.aggregated_errors_object.buffer_error(exc)
+            raise exc

--- a/DataRepo/tests/loaders/test_tracers_loader.py
+++ b/DataRepo/tests/loaders/test_tracers_loader.py
@@ -1,0 +1,426 @@
+from collections import defaultdict
+
+import pandas as pd
+
+from DataRepo.loaders.tracers_loader import TracersLoader
+from DataRepo.models import Compound, Tracer, TracerLabel
+from DataRepo.tests.tracebase_test_case import TracebaseTestCase
+from DataRepo.utils.exceptions import InfileError
+from DataRepo.utils.infusate_name_parser import IsotopeData, TracerData
+
+
+class TracersLoaderTests(TracebaseTestCase):
+    fixtures = ["lc_methods.yaml", "data_types.yaml", "data_formats.yaml"]
+
+    LYSINE_TRACER_DATA = TracerData(
+        unparsed_string="lysine-[13C6]",
+        compound_name="lysine",
+        isotopes=[
+            IsotopeData(
+                element="C",
+                mass_number=13,
+                count=6,
+                positions=None,
+            )
+        ],
+    )
+
+    LYSINE_TRACER_DATAFRAME = pd.DataFrame.from_dict(
+        {
+            "Tracer Number": [1],
+            "Compound Name": ["lysine"],
+            "Element": ["C"],
+            "Mass Number": [13],
+            "Label Count": [6],
+            "Label Positions": [None],
+            "Tracer Name": ["lysine-[13C6]"],
+        },
+    )
+
+    TRACER_DICT = {
+        1: {
+            "compound_name": "lysine",
+            "isotopes": [
+                {
+                    "count": 6,
+                    "element": "C",
+                    "mass_number": 13,
+                    "positions": None,
+                    "row_index": 0,
+                    "rownum": 2,
+                },
+            ],
+            "row_index": 0,
+            "rownum": 2,
+            "tracer_name": "lysine-[13C6]",
+        },
+    }
+
+    @classmethod
+    def setUpTestData(cls):
+        cls.LYSINE = Compound.objects.create(
+            name="lysine", formula="C6H14N2O2", hmdb_id="HMDB0000182"
+        )
+        super().setUpTestData()
+
+    def test_init_load(self):
+        tl = TracersLoader()
+
+        tl.init_load()
+
+        self.assertTrue(hasattr(tl, "tracer_dict"))
+        self.assertTrue(hasattr(tl, "tracer_name_to_number"))
+        self.assertTrue(hasattr(tl, "valid_tracers"))
+        self.assertTrue(hasattr(tl, "inconsistent_compounds"))
+        self.assertTrue(hasattr(tl, "inconsistent_names"))
+        self.assertTrue(hasattr(tl, "inconsistent_numbers"))
+
+        self.assertEqual(defaultdict, type(tl.tracer_dict))
+        self.assertEqual(defaultdict, type(tl.tracer_name_to_number))
+        self.assertEqual(dict, type(tl.valid_tracers))
+        self.assertEqual(defaultdict, type(tl.inconsistent_compounds))
+        self.assertEqual(defaultdict, type(tl.inconsistent_names))
+        self.assertEqual(defaultdict, type(tl.inconsistent_numbers))
+
+        self.assertEqual(0, len(tl.tracer_dict.keys()))
+        self.assertEqual(0, len(tl.tracer_name_to_number.keys()))
+        self.assertEqual(0, len(tl.valid_tracers.keys()))
+        self.assertEqual(0, len(tl.inconsistent_compounds.keys()))
+        self.assertEqual(0, len(tl.inconsistent_names.keys()))
+        self.assertEqual(0, len(tl.inconsistent_numbers.keys()))
+
+    def test_tracer_loader_load_data(self):
+        # Establish that the tracer does not exist at first
+        self.assertIsNone(Tracer.objects.get_tracer(self.LYSINE_TRACER_DATA))
+
+        tl = TracersLoader(df=self.LYSINE_TRACER_DATAFRAME)
+        tl.load_data()
+
+        self.assertEqual(1, Tracer.objects.count())
+        self.assertEqual(1, TracerLabel.objects.count())
+        self.assertIsNotNone(Tracer.objects.get_tracer(self.LYSINE_TRACER_DATA))
+
+    def test_build_tracer_dict(self):
+        tl = TracersLoader(df=self.LYSINE_TRACER_DATAFRAME)
+        tl.build_tracer_dict()
+        self.assertDictEqual(
+            self.TRACER_DICT,
+            tl.tracer_dict,
+        )
+
+    def test_load_tracer_dict(self):
+        # Establish that the tracer does not exist at first
+        self.assertIsNone(Tracer.objects.get_tracer(self.LYSINE_TRACER_DATA))
+
+        tl = TracersLoader(df=self.LYSINE_TRACER_DATAFRAME)
+        tl.build_tracer_dict()
+        tl.load_tracer_dict()
+
+        self.assertIsNotNone(Tracer.objects.get_tracer(self.LYSINE_TRACER_DATA))
+
+    def test_get_row_data(self):
+        tl = TracersLoader(df=self.LYSINE_TRACER_DATAFRAME)
+        tl.init_load()
+        for _, row in self.LYSINE_TRACER_DATAFRAME.iterrows():
+            break
+
+        (
+            tracer_number,
+            compound_name,
+            tracer_name,
+            element,
+            mass_number,
+            count,
+            positions,
+        ) = tl.get_row_data(row)
+
+        self.assertEqual(1, tracer_number)
+        self.assertEqual("lysine", compound_name)
+        self.assertEqual("lysine-[13C6]", tracer_name)
+        self.assertEqual("C", element)
+        self.assertEqual(13, mass_number)
+        self.assertEqual(6, count)
+        self.assertIsNone(positions)
+
+    def test_check_extract_name_data(self):
+        tl = TracersLoader(df=self.LYSINE_TRACER_DATAFRAME)
+        tl.init_load()
+        tl.tracer_dict = {
+            1: {
+                "compound_name": None,
+                "isotopes": [],
+                "row_index": 0,
+                "rownum": 2,
+                "tracer_name": "lysine-[13C6]",
+            },
+        }
+        tl.check_extract_name_data()
+        self.assertDictEqual(self.TRACER_DICT, tl.tracer_dict)
+
+    def test_tracer_loader_get_or_create_tracer(self):
+        # Establish that the tracer does not exist at first
+        self.assertIsNone(Tracer.objects.get_tracer(self.LYSINE_TRACER_DATA))
+
+        tl = TracersLoader(df=self.LYSINE_TRACER_DATAFRAME)
+        rec, created = tl.get_or_create_tracer(self.TRACER_DICT[1])
+
+        self.assertIsNotNone(rec)
+        self.assertTrue(created)
+        self.assertIsNotNone(Tracer.objects.get(compound=self.LYSINE))
+
+    def test_tracer_loader_get_tracer(self):
+        Tracer.objects.get_or_create_tracer(self.LYSINE_TRACER_DATA)
+        # Establish that the tracer does not exist at first
+        self.assertIsNotNone(Tracer.objects.get_tracer(self.LYSINE_TRACER_DATA))
+
+        tl = TracersLoader(df=self.LYSINE_TRACER_DATAFRAME)
+        rec = tl.get_tracer(self.TRACER_DICT[1])
+
+        self.assertIsNotNone(rec)
+
+    def test_tracer_loader_get_compound(self):
+        tl = TracersLoader()
+        rec = tl.get_compound("lysine")
+        self.assertEqual(Compound, type(rec))
+        self.assertIsNotNone(rec)
+        self.assertEqual("lysine", rec.name)
+
+    def test_tracer_loader_create_tracer(self):
+        tl = TracersLoader()
+        rec = tl.create_tracer(self.LYSINE)
+        self.assertEqual(Tracer, type(rec))
+        self.assertIsNotNone(rec)
+
+    def test_tracer_loader_get_or_create_tracer_label(self):
+        self.assertEqual(0, TracerLabel.objects.count())
+        tl = TracersLoader()
+        tracer_rec = tl.create_tracer(self.LYSINE)
+        irec, created = tl.get_or_create_tracer_label(
+            self.TRACER_DICT[1]["isotopes"][0], tracer_rec
+        )
+        self.assertIsNotNone(irec)
+        self.assertEqual(TracerLabel, type(irec))
+        self.assertTrue(created)
+        self.assertEqual(1, TracerLabel.objects.count())
+
+    def test_parse_label_positions(self):
+        tl = TracersLoader()
+        positions = tl.parse_label_positions("1,2,3,4,5")
+        self.assertEqual([1, 2, 3, 4, 5], positions)
+
+    def test_tracer_loader_check_data_is_consistent(self):
+        """Assert that tracer name, number, or compound inconsistencies are logged in their respective lists."""
+
+        tl = TracersLoader()
+        tl.init_load()
+        tl.tracer_dict = {
+            1: {
+                "compound_name": "lysine",
+                "isotopes": [
+                    {
+                        "count": None,
+                        "element": None,
+                        "mass_number": None,
+                        "positions": None,
+                        "row_index": 0,
+                        "rownum": 2,
+                    },
+                ],
+                "row_index": 0,
+                "rownum": 2,
+                "tracer_name": "lysine-[13C6]",
+            },
+            2: {
+                "compound_name": "threonine",
+                "isotopes": [
+                    {
+                        "count": None,
+                        "element": None,
+                        "mass_number": None,
+                        "positions": None,
+                        "row_index": 0,
+                        "rownum": 3,
+                    },
+                ],
+                "row_index": 0,
+                "rownum": 3,
+                "tracer_name": "threonine-[13C6]",
+            },
+            3: {
+                "compound_name": "aspartame",
+                "isotopes": [
+                    {
+                        "count": None,
+                        "element": None,
+                        "mass_number": None,
+                        "positions": None,
+                        "row_index": 0,
+                        "rownum": 4,
+                    },
+                ],
+                "row_index": 0,
+                "rownum": 4,
+                "tracer_name": "aspartame-[13C6]",
+            },
+            4: {
+                "compound_name": "aspartame",
+                "isotopes": [
+                    {
+                        "count": None,
+                        "element": None,
+                        "mass_number": None,
+                        "positions": None,
+                        "row_index": 0,
+                        "rownum": 5,
+                    },
+                ],
+                "row_index": 0,
+                "rownum": 5,
+                "tracer_name": "aspartame-[13C6]",
+            },
+        }
+
+        tl.tracer_name_to_number = {
+            "lysine-[13C6]": {1: 2},
+            "threonine-[13C6]": {2: 3},
+            "aspartame-[13C6]": {3: 4},  # Note: see comment below
+        }
+
+        self.assertEqual(0, len(tl.inconsistent_compounds))
+        self.assertEqual(0, len(tl.inconsistent_names))
+        self.assertEqual(0, len(tl.inconsistent_numbers))
+
+        # Check multiple compound names per number
+        tl.rownum = 2  # check_data_is_consistent uses self.rownum
+        tl.check_data_is_consistent(1, "lysine", "lysine-[13C6]")
+        tl.rownum += 1
+        tl.check_data_is_consistent(1, "asparagine", "lysine-[13C6]")
+        self.assertEqual(1, len(tl.inconsistent_compounds))
+
+        # Check multiple tracer names per number
+        tl.rownum += 1
+        tl.check_data_is_consistent(2, "threonine", "threonine-[13C6]")
+        tl.rownum += 1
+        tl.check_data_is_consistent(2, "threonine", "threonine-[14C6]")
+        self.assertEqual(1, len(tl.inconsistent_names))
+
+        # Check multiple tracer numbers per name
+        # Note: check_data_is_consistent is not the only method that updates inconsistent_numbers, so tracer number 4
+        # was intentionally left out of the tracer_name_to_number dict above
+        tl.rownum += 1
+        tl.check_data_is_consistent(3, "aspartame", "aspartame-[13C6]")
+        tl.rownum += 1
+        tl.check_data_is_consistent(4, "aspartame", "aspartame-[13C6]")
+        self.assertEqual(1, len(tl.inconsistent_numbers))
+
+    def test_tracer_loader_buffer_consistency_issues(self):
+        """Assert that an exception is buffered when the tracer name, number, or compound are inconsistent."""
+
+        tl = TracersLoader()
+        tl.init_load()
+
+        # 2 different compound names associated with 1 tracer number
+        tl.inconsistent_compounds[1]["lysine"] = [2]
+        tl.inconsistent_compounds[1]["asparagine"] = [3]
+
+        # 2 different tracer names associated with 1 tracer number
+        tl.inconsistent_names[2]["threonine-[13C6]"] = [4]
+        tl.inconsistent_names[2]["threonine-[14C6]"] = [5]
+
+        # 2 different tracer numbers associated with 1 tracer name
+        tl.inconsistent_numbers["aspartame-[13C6]"][3] = [6]
+        tl.inconsistent_numbers["aspartame-[13C6]"][4] = [7]
+
+        tl.buffer_consistency_issues()
+
+        self.assertEqual(3, len(tl.aggregated_errors_object.exceptions))
+        self.assertEqual(InfileError, type(tl.aggregated_errors_object.exceptions[0]))
+        self.assertEqual(InfileError, type(tl.aggregated_errors_object.exceptions[1]))
+        self.assertEqual(InfileError, type(tl.aggregated_errors_object.exceptions[2]))
+
+        self.assertIn(
+            "Tracer Number and Compound Name",
+            str(tl.aggregated_errors_object.exceptions[0]),
+        )
+        self.assertIn(
+            "Tracer Number 1 ", str(tl.aggregated_errors_object.exceptions[0])
+        )
+        self.assertIn(
+            "one Compound Name is allowed per Tracer Number",
+            str(tl.aggregated_errors_object.exceptions[0]),
+        )
+        self.assertIn(
+            "lysine (on rows: [2])", str(tl.aggregated_errors_object.exceptions[0])
+        )
+        self.assertIn(
+            "asparagine (on rows: [3])", str(tl.aggregated_errors_object.exceptions[0])
+        )
+
+        self.assertIn(
+            "Tracer Name and Tracer Number",
+            str(tl.aggregated_errors_object.exceptions[1]),
+        )
+        self.assertIn(
+            "Tracer Number 2 ", str(tl.aggregated_errors_object.exceptions[1])
+        )
+        self.assertIn(
+            "one Tracer Name is allowed per Tracer Number",
+            str(tl.aggregated_errors_object.exceptions[1]),
+        )
+        self.assertIn(
+            "threonine-[13C6] (on rows: [4])",
+            str(tl.aggregated_errors_object.exceptions[1]),
+        )
+        self.assertIn(
+            "threonine-[14C6] (on rows: [5])",
+            str(tl.aggregated_errors_object.exceptions[1]),
+        )
+
+        self.assertIn(
+            "Tracer Number and Tracer Name",
+            str(tl.aggregated_errors_object.exceptions[2]),
+        )
+        self.assertIn(
+            "Tracer Name aspartame-[13C6]",
+            str(tl.aggregated_errors_object.exceptions[2]),
+        )
+        self.assertIn(
+            "one Tracer Number is allowed per Tracer Name",
+            str(tl.aggregated_errors_object.exceptions[2]),
+        )
+        self.assertIn(
+            "3 (on rows: [6])", str(tl.aggregated_errors_object.exceptions[2])
+        )
+        self.assertIn(
+            "4 (on rows: [7])", str(tl.aggregated_errors_object.exceptions[2])
+        )
+
+    def test_check_tracer_name_consistent(self):
+        """Assert that an exception is buffered when the supplied tracer name doesn't match the DB generated one."""
+
+        rec, _ = Tracer.objects.get_or_create_tracer(self.LYSINE_TRACER_DATA)
+        tl = TracersLoader()
+
+        self.assertEqual(0, len(tl.aggregated_errors_object.exceptions))
+
+        with self.assertRaises(InfileError):
+            tl.check_tracer_name_consistent(
+                rec,
+                {
+                    "tracer_name": "lysine-[14C6]",
+                    "rownum": 2,
+                    "isotopes": [{"rownum": 2}],
+                },
+            )
+
+        self.assertEqual(1, len(tl.aggregated_errors_object.exceptions))
+        self.assertEqual(InfileError, type(tl.aggregated_errors_object.exceptions[0]))
+        self.assertIn(
+            "supplied tracer name [lysine-[14C6]]",
+            str(tl.aggregated_errors_object.exceptions[0]),
+        )
+        self.assertIn(
+            "generated name [lysine-[13C6]]",
+            str(tl.aggregated_errors_object.exceptions[0]),
+        )
+        self.assertIn("on rows ['2']", str(tl.aggregated_errors_object.exceptions[0]))


### PR DESCRIPTION
## Summary Change Description

Added a tracers loader and associated tests.

Either individual column data (compound, element, mass number, count, and positions) or tracer name is required.  There is also a tracer number column (to associate multiple rows with different isotopes for the same tracer), but if you just supply tracer name, you don't need it, and in both cases, it is never added to the database.

Note that the intention is to make it easier to construct tracers without worrying about formatting, as some users have had difficulty with the formatting of tracer names.  This will dovetail with an excel(/google sheet) formula I created to automatically construct the name, so that users will see the construction of the name as they add data.

Also note that the plan is to pre-populate all tracers in the tracers tab when a partially filled-out excel file is generated to give to them when they submit an accucor file.  And the Animals sheet's infusate column will have drop-downs that are populated (in part) from the tracers sheet contents.

## Affected Issues/Pull Requests

- Partially addresses #822
- Merges into PR #899
- Next PR: #901

## Review Notes
<!--
For added context for reviewers, add comments to relevant lines of code.  Use
this space to describe any general areas of concern not linked to a specific
line of code that reviewers should pay particular attention to, e.g. please
make sure I have accounted for all possible inputs.
-->
See comments in-line.

## Checklist
<!--
If any of the checkbox requirements are not met, uncheck them and add an
explanation. E.g. Linting errors pre-date this PR.
-->
This pull request will be merged once the following requirements are met.  The
author and/or reviewers should uncheck any unmet requirements:

- Review requirements
  - Minimum approvals: 1 <!-- Edit as desired (e.g. based on complexity) -->
  - No changes requested
  - All blocking issues resolved by reviewers
  - Specific reviewers: @__add_username_here__
    <!--
    Require reviewers with specific expertise to be included among the minimum
    number of reviewers by tagging them.  Also please send them a message.
    -->
  - Review period: 2 days <!-- Edit as desired (e.g. based on complexity) -->
- Associated issue/pull request requirements:
  <!--
  Assert that all requirements in issues marked "resolved" are done and that
  all required pull requests are merged.  If any are not done, either edit or
  split the issue or explain the unmerged affected pull requests.
  -->
  - [x] All requirements in affected issues marked "resolved" are satisfied
  - [x] All required pull requests are merged *(or none)*
- Basic requirements
  <!--
  Uncheck items to acknowledge failures/conflicts you intend to address.
  Add an explanation if any won't be addressed before merge.
  -->
  - [x] [All linters pass](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#linting)
  - [x] [All tests pass](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#quality-control)
  - [x] All conflicts resolved
- Overhead requirements
  <!--
  These are additional requirements that are not directly associated with
  resolving the affected issue(s).
  -->
  - [x] [New/changed method tests implemented/updated *(or no change)*](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#test-implementation)
  - [ ] [Updated *Unreleased* section of `changelog.md` *(or no change)*](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/changelog.md)
  - [x] [Migrations created & committed *(or no change)*](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#migration-process)
