### PR TITLE
Linked the treatment in the PeakData advanced search results

### DIFF
--- a/DataRepo/templates/DataRepo/search/results/peakdata.html
+++ b/DataRepo/templates/DataRepo/search/results/peakdata.html
@@ -408,7 +408,12 @@
                             <div style="display:none;">None</div>
                             <p title="Animal has no treatment.">None</p>
                         {% else %}
-                            {{ pd.peak_group.msrun_sample.sample.animal.treatment.name }}
+                            <!-- Put displayed link text first for sorting -->
+                            <div style="display:none;">{{ pd.peak_group.msrun_sample.sample.animal.treatment.name }}</div>
+
+                            <a href="{% url 'protocol_detail' pd.peak_group.msrun_sample.sample.animal.treatment.id %}">
+                                {{ pd.peak_group.msrun_sample.sample.animal.treatment.name }}
+                            </a>
                         {% endif %}
                     </td>
 


### PR DESCRIPTION
## Summary Change Description

Copied the code from the `PeakGroups` results and changed the variable names.

## Affected Issues/Pull Requests

- Resolves #746

## Review Notes

746 was already "resolved".  I had just noted that it wasn't linked like it was in the PeakGroups results.

## Checklist
<!--
If any of the checkbox requirements are not met, uncheck them and add an
explanation. E.g. Linting errors pre-date this PR.
-->
This pull request will be merged once the following requirements are met.  The
author and/or reviewers should uncheck any unmet requirements:

- Review requirements
  - Minimum approvals: 1 <!-- Edit as desired (e.g. based on complexity) -->
  - No changes requested
  - All blocking issues resolved by reviewers
  - Specific reviewers: @__add_username_here__
    <!--
    Require reviewers with specific expertise to be included among the minimum
    number of reviewers by tagging them.  Also please send them a message.
    -->
  - Review period: 2 days <!-- Edit as desired (e.g. based on complexity) -->
- Associated issue/pull request requirements:
  <!--
  Assert that all requirements in issues marked "resolved" are done and that
  all required pull requests are merged.  If any are not done, either edit or
  split the issue or explain the unmerged affected pull requests.
  -->
  - [x] All requirements in affected issues marked "resolved" are satisfied
  - [x] All required pull requests are merged *(or none)*
- Basic requirements
  <!--
  Uncheck items to acknowledge failures/conflicts you intend to address.
  Add an explanation if any won't be addressed before merge.
  -->
  - [x] [All linters pass](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#linting)
  - [x] [All tests pass](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#quality-control)
  - [x] All conflicts resolved
- Overhead requirements
  <!--
  These are additional requirements that are not directly associated with
  resolving the affected issue(s).
  -->
  - [x] [New/changed method tests implemented/updated *(or no change)*](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#test-implementation)
  - [ ] [Updated *Unreleased* section of `changelog.md` *(or no change)*](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/changelog.md)
  - [x] [Migrations created & committed *(or no change)*](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#migration-process)
