### PR TITLE
Added the ability to submit mzXML file **names** on the validation page

### DIFF
--- a/DataRepo/templates/DataRepo/validate_submission.html
+++ b/DataRepo/templates/DataRepo/validate_submission.html
@@ -12,39 +12,11 @@
     <script src="{% static 'js/file_list_drop_area.js' %}"></script>
     <script>
         document.addEventListener("DOMContentLoaded", function(){
-            let dropArea = document.getElementById('drop-area')
-
-            ;['dragenter', 'dragover', 'dragleave', 'drop'].forEach(eventName => {
-                dropArea.addEventListener(eventName, preventDefaults, false)
-            })
-
-            ;['dragenter', 'dragover'].forEach(eventName => {
-                dropArea.addEventListener(eventName, highlight, false)
-            })
-
-            ;['dragleave', 'drop'].forEach(eventName => {
-                dropArea.addEventListener(eventName, unhighlight, false)
-            })
-
-            dropArea.addEventListener('drop', handleDrop, false)
-
-            listformelem = document.getElementById('mzxml_file_list_input_id');
-            listdispelem = document.getElementById('pending-files');
-
-            function handleDrop(e) {
-                let dt = e.dataTransfer
-                let files = dt.files
-
-                handleFiles(files, listformelem, listdispelem)
-            }
-
-            function highlight(e) {
-                dropArea.classList.add('highlight')
-            }
-
-            function unhighlight(e) {
-                dropArea.classList.remove('highlight')
-            }
+            initDropArea(
+                document.getElementById('drop-area'),
+                document.getElementById('mzxml_file_list_input_id'),
+                document.getElementById('pending-files')
+            )
         })
     </script>
 {% endblock %}

--- a/DataRepo/templates/DataRepo/validate_submission.html
+++ b/DataRepo/templates/DataRepo/validate_submission.html
@@ -30,7 +30,9 @@
             <label for="accucor_files" class="form-label">AccuCor Files:</label>{{ form.accucor_files }}<br>
             <label for="isocorr_files" class="form-label">IsoCorr Files:</label>{{ form.isocorr_files }}<br>
             {{ form.mzxml_file_list }}
+            <!-- Hidden buttons for this form, controlled by the buttons under the second form via javascript -->
             <button type="submit" class="btn btn-primary" id="validate" style="display: none;">Validate</button>
+            <button type="reset" class="btn btn-secondary" id="clear" style="display: none;">Clear</button>
             {{ form.management_form }}
         </form>
 
@@ -47,11 +49,13 @@
             <pre id="pending-files" class="drop-area-list-indent"></pre>
         </div>
 
+        <br>
+
         <span class="text-error">{{ form.errors.val }}</span>
         <span class="text-error">{{ form.non_field_errors }}</span>
 
         <button class="btn btn-primary" id="faux-validate" onclick="document.getElementById('submission-validation').submit();">Validate</button>
-        <button class="btn btn-secondary" id="clear" onclick="document.getElementById('drop-area-input').value = null;document.getElementById('mzxml_file_list_input_id').value = null;document.getElementById('pending-files').innerHTML = '';">Clear</button>
+        <button class="btn btn-secondary" id="faux-clear" onclick="document.getElementById('drop-area-input').value = null;document.getElementById('mzxml_file_list_input_id').value = null;document.getElementById('pending-files').innerHTML = '';document.getElementById('submission-validation').reset();">Clear</button>
 
         <br>
 

--- a/DataRepo/templates/DataRepo/validate_submission.html
+++ b/DataRepo/templates/DataRepo/validate_submission.html
@@ -6,6 +6,47 @@
     {{ block.super }}
 
     <link href="{% static 'css/hierarchical_formsets.css' %}" rel="stylesheet">
+
+    <!-- The following is based mostly on https://www.smashingmagazine.com/2018/01/drag-drop-file-uploader-vanilla-js/ -->
+    <link href="{% static 'css/drop_area.css' %}" rel="stylesheet">
+    <script src="{% static 'js/file_list_drop_area.js' %}"></script>
+    <script>
+        document.addEventListener("DOMContentLoaded", function(){
+            let dropArea = document.getElementById('drop-area')
+
+            ;['dragenter', 'dragover', 'dragleave', 'drop'].forEach(eventName => {
+                dropArea.addEventListener(eventName, preventDefaults, false)
+            })
+
+            ;['dragenter', 'dragover'].forEach(eventName => {
+                dropArea.addEventListener(eventName, highlight, false)
+            })
+
+            ;['dragleave', 'drop'].forEach(eventName => {
+                dropArea.addEventListener(eventName, unhighlight, false)
+            })
+
+            dropArea.addEventListener('drop', handleDrop, false)
+
+            listformelem = document.getElementById('mzxml_file_list_input_id');
+            listdispelem = document.getElementById('pending-files');
+
+            function handleDrop(e) {
+                let dt = e.dataTransfer
+                let files = dt.files
+
+                handleFiles(files, listformelem, listdispelem)
+            }
+
+            function highlight(e) {
+                dropArea.classList.add('highlight')
+            }
+
+            function unhighlight(e) {
+                dropArea.classList.remove('highlight')
+            }
+        })
+    </script>
 {% endblock %}
 
 {% block content %}
@@ -16,11 +57,32 @@
             <label for="animal_sample_table" class="form-label">Animal and Sample Table:</label>{{ form.animal_sample_table }}<br>
             <label for="accucor_files" class="form-label">AccuCor Files:</label>{{ form.accucor_files }}<br>
             <label for="isocorr_files" class="form-label">IsoCorr Files:</label>{{ form.isocorr_files }}<br>
-            <button type="submit" class="btn btn-primary" id="validate">Validate</button>
-            {{ form.errors.val }}
+            {{ form.mzxml_file_list }}
+            <button type="submit" class="btn btn-primary" id="validate" style="display: none;">Validate</button>
             {{ form.management_form }}
         </form>
+
+        <!-- The 2 form strategy (the one below for adding (mzXML) file names by drag and drop of the actual files and the one above to just submit their names (because that's all we need, and these files can be numerous and large) is based on https://stackoverflow.com/questions/2175831/is-it-possible-to-use-input-type-file-just-to-post-the-filename-without-actu -->
+
+        <div id="drop-area">
+            <form>
+                <!-- Hidden form that does not submit - just used as a target to drop files, from which, just their names are extracted to populate the other form's hidden character input -->
+                <label class="btn btn-secondary">
+                    <input type="file" multiple id="drop-area-input" onchange="handleFiles(this.files);"/>
+                    Add mzXML Files
+                </label>  <span class="drop-area-message">(Drag and drop here)</span>
+            </form>
+            <pre id="pending-files" class="drop-area-list-indent"></pre>
+        </div>
+
+        <span class="text-error">{{ form.errors.val }}</span>
+        <span class="text-error">{{ form.non_field_errors }}</span>
+
+        <button class="btn btn-primary" id="faux-validate" onclick="document.getElementById('submission-validation').submit();">Validate</button>
+        <button class="btn btn-secondary" id="clear" onclick="document.getElementById('drop-area-input').value = null;document.getElementById('mzxml_file_list_input_id').value = null;document.getElementById('pending-files').innerHTML = '';">Clear</button>
+
         <br>
+
         <div class="text-muted small">
             Validating your submission is an optional check to catch simple mistakes that will speed up the loading of your data to TraceBase by reducing the number of interactions between you (the submitter) and the TraceBase curators.<br>
             Once you have resolved any issues that you know how to fix (leaving any issues you do not know how to resolve), you may move on to the <a href="{{ submission_url }}">submission form</a>.<br>

--- a/DataRepo/views/upload/validation.py
+++ b/DataRepo/views/upload/validation.py
@@ -78,18 +78,18 @@ class DataValidationView(FormView):
         try:
             sample_file = request.FILES["animal_sample_table"]
             tmp_sample_file = sample_file.temporary_file_path()
-        except Exception:
+        except KeyError:
             # Ignore missing study file (allow user to validate just the accucor/isocorr file(s))
             sample_file = None
             tmp_sample_file = None
         try:
             accucor_files = request.FILES.getlist("accucor_files")
-        except Exception:
+        except KeyError:
             # Ignore missing accucor files (allow user to validate just the sample file)
             accucor_files = []
         try:
             isocorr_files = request.FILES.getlist("isocorr_files")
-        except Exception:
+        except KeyError:
             # Ignore missing isocorr files (allow user to validate just the sample file)
             isocorr_files = []
 

--- a/DataRepo/views/upload/validation.py
+++ b/DataRepo/views/upload/validation.py
@@ -75,7 +75,13 @@ class DataValidationView(FormView):
         form_class = self.get_form_class()
         form = self.get_form(form_class)
 
-        sample_file = request.FILES["animal_sample_table"]
+        try:
+            sample_file = request.FILES["animal_sample_table"]
+            tmp_sample_file = sample_file.temporary_file_path()
+        except Exception:
+            # Ignore missing study file (allow user to validate just the accucor/isocorr file(s))
+            sample_file = None
+            tmp_sample_file = None
         try:
             accucor_files = request.FILES.getlist("accucor_files")
         except Exception:
@@ -88,7 +94,7 @@ class DataValidationView(FormView):
             isocorr_files = []
 
         self.set_files(
-            sample_file.temporary_file_path(),
+            tmp_sample_file,
             [afp.temporary_file_path() for afp in accucor_files],
             [ifp.temporary_file_path() for ifp in isocorr_files],
             sample_file_name=sample_file,

--- a/static/css/drop_area.css
+++ b/static/css/drop_area.css
@@ -1,0 +1,26 @@
+#drop-area {
+  border: 2px dashed #ccc;
+  border-radius: 20px;
+  width: 480px;
+  font-family: sans-serif;
+  margin: 10px;
+  padding: 20px;
+}
+
+#drop-area.highlight {
+  border-color: purple;
+}
+
+#drop-area-input {
+  display: none;
+}
+
+.drop-area-list-indent {
+  padding-left: 2em;
+}
+
+.drop-area-message {
+  color: #bfc3c6 !important;
+  font-size: 1.5rem !important;
+  padding: 1.5rem !important;
+}

--- a/static/css/hierarchical_formsets.css
+++ b/static/css/hierarchical_formsets.css
@@ -46,3 +46,7 @@
 
   color: var(--bs-table-striped-color);
 }
+
+.text-error {
+  color: #dc3545 !important;
+}

--- a/static/js/file_list_drop_area.js
+++ b/static/js/file_list_drop_area.js
@@ -5,54 +5,54 @@ var listdispelem = null // eslint-disable-line no-var
 /**
  * This initializes all of the global variables.
  */
-function initDropArea(dropArea, listformelem, listdispelem) { // eslint-disable-line no-unused-vars
+function initDropArea (dropArea, listformelem, listdispelem) { // eslint-disable-line no-unused-vars
   ;['dragenter', 'dragover', 'dragleave', 'drop'].forEach(eventName => {
-      dropArea.addEventListener(eventName, preventDefaults, false)
+    dropArea.addEventListener(eventName, preventDefaults, false)
   })
 
   ;['dragenter', 'dragover'].forEach(eventName => {
-      dropArea.addEventListener(eventName, highlight, false)
+    dropArea.addEventListener(eventName, highlight, false)
   })
 
   ;['dragleave', 'drop'].forEach(eventName => {
-      dropArea.addEventListener(eventName, unhighlight, false)
+    dropArea.addEventListener(eventName, unhighlight, false)
   })
 
   dropArea.addEventListener('drop', handleDrop, false)
 
-  globalThis.dropArea = dropArea;
-  globalThis.listformelem = listformelem;
-  globalThis.listdispelem = listdispelem;
+  globalThis.dropArea = dropArea
+  globalThis.listformelem = listformelem
+  globalThis.listdispelem = listdispelem
 
   refreshMzXMLDisplayList()
 }
 
-function preventDefaults(e) { // eslint-disable-line no-unused-vars
+function preventDefaults (e) { // eslint-disable-line no-unused-vars
   e.preventDefault()
   e.stopPropagation()
 }
 
-function highlight(e) {
+function highlight (e) {
   dropArea.classList.add('highlight')
 }
 
-function unhighlight(e) {
+function unhighlight (e) {
   dropArea.classList.remove('highlight')
 }
 
-function handleDrop(e) {
-  let dt = e.dataTransfer
-  let files = dt.files
+function handleDrop (e) {
+  const dt = e.dataTransfer
+  const files = dt.files
 
   handleFiles(files)
 }
 
-function handleFiles(files) { // eslint-disable-line no-unused-vars
+function handleFiles (files) { // eslint-disable-line no-unused-vars
   listformelem.value = getFileNamesString(files, listformelem.value)
   refreshMzXMLDisplayList()
 }
 
-function getFileNamesString(files, curstring) {
+function getFileNamesString (files, curstring) {
   let fileNamesString = ''
   let cumulativeFileList = []
   if (typeof curstring !== 'undefined' && curstring) {
@@ -71,6 +71,6 @@ function getFileNamesString(files, curstring) {
   return fileNamesString
 }
 
-function refreshMzXMLDisplayList() {
+function refreshMzXMLDisplayList () {
   listdispelem.innerHTML = listformelem.value
 }

--- a/static/js/file_list_drop_area.js
+++ b/static/js/file_list_drop_area.js
@@ -1,0 +1,28 @@
+function preventDefaults (e) { // eslint-disable-line no-unused-vars
+  e.preventDefault()
+  e.stopPropagation()
+}
+
+function handleFiles (files, listformelem, listdispelem) { // eslint-disable-line no-unused-vars
+  listformelem.value = getFileNamesString(files, listformelem.value)
+  listdispelem.innerHTML = listformelem.value
+}
+
+function getFileNamesString (files, curstring) {
+  let fileNamesString = ''
+  let cumulativeFileList = []
+  if (typeof curstring !== 'undefined' && curstring) {
+    cumulativeFileList = curstring.split('\n')
+  }
+  for (let i = 0; i < files.length; ++i) {
+    cumulativeFileList.push(files.item(i).name)
+  }
+  fileNamesString = cumulativeFileList.sort((a, b) => {
+    const itemA = a.toUpperCase() // ignore case
+    const itemB = b.toUpperCase()
+    if (itemA < itemB) { return -1 }
+    if (itemA > itemB) { return 1 }
+    return 0
+  }).join('\n')
+  return fileNamesString
+}

--- a/static/js/file_list_drop_area.js
+++ b/static/js/file_list_drop_area.js
@@ -1,14 +1,58 @@
-function preventDefaults (e) { // eslint-disable-line no-unused-vars
+var dropArea = null // eslint-disable-line no-var
+var listformelem = null // eslint-disable-line no-var
+var listdispelem = null // eslint-disable-line no-var
+
+/**
+ * This initializes all of the global variables.
+ */
+function initDropArea(dropArea, listformelem, listdispelem) { // eslint-disable-line no-unused-vars
+  ;['dragenter', 'dragover', 'dragleave', 'drop'].forEach(eventName => {
+      dropArea.addEventListener(eventName, preventDefaults, false)
+  })
+
+  ;['dragenter', 'dragover'].forEach(eventName => {
+      dropArea.addEventListener(eventName, highlight, false)
+  })
+
+  ;['dragleave', 'drop'].forEach(eventName => {
+      dropArea.addEventListener(eventName, unhighlight, false)
+  })
+
+  dropArea.addEventListener('drop', handleDrop, false)
+
+  globalThis.dropArea = dropArea;
+  globalThis.listformelem = listformelem;
+  globalThis.listdispelem = listdispelem;
+
+  refreshMzXMLDisplayList()
+}
+
+function preventDefaults(e) { // eslint-disable-line no-unused-vars
   e.preventDefault()
   e.stopPropagation()
 }
 
-function handleFiles (files, listformelem, listdispelem) { // eslint-disable-line no-unused-vars
-  listformelem.value = getFileNamesString(files, listformelem.value)
-  listdispelem.innerHTML = listformelem.value
+function highlight(e) {
+  dropArea.classList.add('highlight')
 }
 
-function getFileNamesString (files, curstring) {
+function unhighlight(e) {
+  dropArea.classList.remove('highlight')
+}
+
+function handleDrop(e) {
+  let dt = e.dataTransfer
+  let files = dt.files
+
+  handleFiles(files)
+}
+
+function handleFiles(files) { // eslint-disable-line no-unused-vars
+  listformelem.value = getFileNamesString(files, listformelem.value)
+  refreshMzXMLDisplayList()
+}
+
+function getFileNamesString(files, curstring) {
   let fileNamesString = ''
   let cumulativeFileList = []
   if (typeof curstring !== 'undefined' && curstring) {
@@ -25,4 +69,8 @@ function getFileNamesString (files, curstring) {
     return 0
   }).join('\n')
   return fileNamesString
+}
+
+function refreshMzXMLDisplayList() {
+  listdispelem.innerHTML = listformelem.value
 }


### PR DESCRIPTION
## Summary Change Description

<img width="1055" alt="TraceBase - Screenshot 2024-03-19 at 4 06 36 PM" src="https://github.com/Princeton-LSI-ResearchComputing/tracebase/assets/2300532/b21f0c59-0f05-4e37-a2f3-44193d97afd8">

This only adds the ability to **submit** mzXML file names (via drag and drop) on the validation page.  It also makes the sample table an *optional* field and adds a `clean` method to the form class to require at least 1 file (sample or peak annotation) and, if mzXMLs are provided, a single peak annotation file.

This work explicitly does *not* implement (in order to present small PRs for quick/small reviews):

- processing of those names
- any other changes to the validation form (e.g. submitting one at a time - though it does require only 1 if mzXMLs are provided)

## Affected Issues/Pull Requests

- Partially addresses #829
- Partially addresses #888
- Merges into main
- Next PR: #919

## Review Notes

### Please familiarize youreself the breaking up of issue(s) 888 and 829.  Note, 888 is a subset of the items in 829:

#### Steps in 888 (shared with 829):

- `1.` **CURRENT PR:** Integrate the changes in the `dropzone_paths` branch into the Validation Interface to be able to take an mzXML file list
- `2.` Create a method in the ValidationView to build an LCMS file given the mzXML file name list and an accucor file
- `3.` **FINAL** OUTPUT FOR ISSUE #888: Provide the LCMS file for download in the ValidationView.  The issues that follow this one are to work toward a more polished result

This completes 888.

#### Remaining planned steps in 829:

Though note that these steps are only a portion of all of 829.  829 also involves breaking up the accucor load script, but these components can be done *before* that:

- `4.` OPTIONAL [DO LATER?]: Create a method that takes a sample header list and a list of possible suffixes (_pos, _neg, _scan1, etc) and returns a dict of accucor sample header to db sample name (called by the method in step 3 above that generates the LCMS file)
- `5.` Update the ValidationView to supply the LCMS file to the loader
- `6.` Update the accucor load script to create a unique placeholder hash for mzXML files from the LCMS metadata file (and create placeholder ArchiveFile records) when in `--validate` mode
- `7.` Make the ValidationView catch `NoSamplesError` and `MissingSamplesError` (add the list of sample names to the exceptions, if not already there) and pass the sample names and LCMS file to a (placeholder) method (`create_or_update_study_doc`) that will create (or update) the animals/samples excel doc
- `8.` OPTIONAL [DO LATER?]: Make the ValidationView remove `NoSamplesError` and `MissingSamplesError`s from the rendered view
- `9.` Implement the `create_or_update_study_doc` method to generate a file with sample names added
- `10.` OPTIONAL [DO LATER?]: Make the `create_or_update_study_doc` method able to highlight required empty fields
- `11.` OPTIONAL [DO LATER?]: Make the `create_or_update_study_doc` method able to Add placeholders for other required fields (like Animal Name, etc).  Initially, every sample would be added to an "undefined" or "unknown" animal field that is highlighted for edit (and make the non-validate mode raise an error if that undefined value is encountered)
- `12.` Make the ValidationView provide a link to download the created study excel doc (with some stats showing the number of created samples, etc)
- `13.` OPTIONAL/TEMPORARY: Make the ValidationView able to (temporarily) generate the LCMS tsv file, provide it for download along with the study doc, and take it as input.  This is a temporary issue so that users can revalidate data after implementing fixes.  It will be replaced by the ability of the loading scripts to read the LCMS data from the excel study doc (covered in issues #825 and #829)
- `14.` Rebrand the Validation Interface into a "Build a Submission" interface

## Checklist
<!--
If any of the checkbox requirements are not met, uncheck them and add an
explanation. E.g. Linting errors pre-date this PR.
-->
This pull request will be merged once the following requirements are met.  The
author and/or reviewers should uncheck any unmet requirements:

- Review requirements
  - Minimum approvals: 1 <!-- Edit as desired (e.g. based on complexity) -->
  - No changes requested
  - All blocking issues resolved by reviewers
  - Specific reviewers: @__add_username_here__
    <!--
    Require reviewers with specific expertise to be included among the minimum
    number of reviewers by tagging them.  Also please send them a message.
    -->
  - Review period: 2 days <!-- Edit as desired (e.g. based on complexity) -->
- Associated issue/pull request requirements:
  <!--
  Assert that all requirements in issues marked "resolved" are done and that
  all required pull requests are merged.  If any are not done, either edit or
  split the issue or explain the unmerged affected pull requests.
  -->
  - [x] All requirements in affected issues marked "resolved" are satisfied
  - [x] All required pull requests are merged *(or none)*
- Basic requirements
  <!--
  Uncheck items to acknowledge failures/conflicts you intend to address.
  Add an explanation if any won't be addressed before merge.
  -->
  - [x] [All linters pass](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#linting)
  - [x] [All tests pass](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#quality-control)
  - [x] All conflicts resolved
- Overhead requirements
  <!--
  These are additional requirements that are not directly associated with
  resolving the affected issue(s).
  -->
  - [x] [New/changed method tests implemented/updated *(or no change)*](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#test-implementation)
  - [ ] [Updated *Unreleased* section of `changelog.md` *(or no change)*](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/changelog.md)
  - [x] [Migrations created & committed *(or no change)*](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#migration-process)
