### PR TITLE
Added a method to create the sample and header data in a dict

### DIFF
--- a/DataRepo/tests/views/upload/test_validation.py
+++ b/DataRepo/tests/views/upload/test_validation.py
@@ -1,0 +1,79 @@
+import re
+
+from DataRepo.tests.tracebase_test_case import TracebaseTransactionTestCase
+from DataRepo.views.upload.validation import DataValidationView
+
+
+class DataValidationViewTests(TracebaseTransactionTestCase):
+    def test_build_lcms_dict(self):
+        lcms_dict = DataValidationView.build_lcms_dict(
+            ["a", "b", "c", "c", "d_pos"],  # Sample headers
+            ["b.typo", "b.dupe", "c.mzXML", "extra.mzxml"],  # List of mzxml file names
+            "accucor.xlsx",  # Peak annot file
+        )
+        self.assertDictEqual(
+            {
+                "a": {
+                    "tracebase sample name": "a",
+                    "sample data header": "a",
+                    "peak annotation filename": "accucor.xlsx",
+                    "mzxml filename": None,
+                },
+                "b": {
+                    "tracebase sample name": "b",
+                    "sample data header": "b",
+                    "peak annotation filename": "accucor.xlsx",
+                    "mzxml filename": "b.typo",
+                },
+                "c": {
+                    "tracebase sample name": "c",
+                    "sample data header": "c",
+                    "peak annotation filename": "accucor.xlsx",
+                    "mzxml filename": "c.mzXML",
+                },
+                "d_pos": {
+                    "tracebase sample name": "d",
+                    "sample data header": "d_pos",
+                    "peak annotation filename": "accucor.xlsx",
+                    "mzxml filename": None,
+                },
+                "extra": {
+                    "tracebase sample name": "extra",
+                    "sample data header": None,
+                    "peak annotation filename": None,
+                    "mzxml filename": "extra.mzxml",
+                },
+                "ERROR: c DUPLICATE HEADER 1": {
+                    "tracebase sample name": None,
+                    "sample data header": "ERROR: c DUPLICATE HEADER 1",
+                    "peak annotation filename": "accucor.xlsx",
+                    "mzxml filename": None,
+                },
+                "ERROR: b.dupe DUPLICATE MZXML BASENAME 1": {
+                    "tracebase sample name": None,
+                    "sample data header": None,
+                    "peak annotation filename": None,
+                    "mzxml filename": "ERROR: b.dupe DUPLICATE MZXML BASENAME 1",
+                },
+            },
+            dict(lcms_dict),
+        )
+
+    def test_get_approx_sample_header_replacement_regex_default(self):
+        pattern = DataValidationView.get_approx_sample_header_replacement_regex()
+        samplename = re.sub(pattern, "", "mysample_neg_pos_scan2")
+        self.assertEqual("mysample", samplename)
+
+    def test_get_approx_sample_header_replacement_regex_add_custom(self):
+        pattern = DataValidationView.get_approx_sample_header_replacement_regex(
+            [r"_blah"]
+        )
+        samplename = re.sub(pattern, "", "mysample_pos_blah_scan1")
+        self.assertEqual("mysample", samplename)
+
+    def test_get_approx_sample_header_replacement_regex_just_custom(self):
+        pattern = DataValidationView.get_approx_sample_header_replacement_regex(
+            [r"_blah"], add=False
+        )
+        samplename = re.sub(pattern, "", "mysample_pos_blah")
+        self.assertEqual("mysample_pos", samplename)


### PR DESCRIPTION
## Summary Change Description

- Added get_approx_sample_header_replacement_regex which returns a regex to heuristically convert common sample headers into database sample names.
- Added build_lcms_dict to turn sample headers from a peak annotation file and mzXML file names into an LCMS dict keyed on the unique header name and containing dicts whose keys are headers of the LCMS metadata format.
- Modified form_valid to call build_lcms_dict with the appropriate arguments.
- Created a class attribute to hold common header suffixes.
- Modified set_files to build the file names if not supplied.
- Added tests for the new methods.

## Affected Issues/Pull Requests

- Partially addresses #829 
- Partially addresses #888
- Merges into #918
- Next PR: #922

## Review Notes
<!--
For added context for reviewers, add comments to relevant lines of code.  Use
this space to describe any general areas of concern not linked to a specific
line of code that reviewers should pay particular attention to, e.g. please
make sure I have accounted for all possible inputs.
-->
See comments in-line.

## Checklist
<!--
If any of the checkbox requirements are not met, uncheck them and add an
explanation. E.g. Linting errors pre-date this PR.
-->
This pull request will be merged once the following requirements are met.  The
author and/or reviewers should uncheck any unmet requirements:

- Review requirements
  - Minimum approvals: 1 <!-- Edit as desired (e.g. based on complexity) -->
  - No changes requested
  - All blocking issues resolved by reviewers
  - Specific reviewers: @__add_username_here__
    <!--
    Require reviewers with specific expertise to be included among the minimum
    number of reviewers by tagging them.  Also please send them a message.
    -->
  - Review period: 2 days <!-- Edit as desired (e.g. based on complexity) -->
- Associated issue/pull request requirements:
  <!--
  Assert that all requirements in issues marked "resolved" are done and that
  all required pull requests are merged.  If any are not done, either edit or
  split the issue or explain the unmerged affected pull requests.
  -->
  - [x] All requirements in affected issues marked "resolved" are satisfied
  - [x] All required pull requests are merged *(or none)*
- Basic requirements
  <!--
  Uncheck items to acknowledge failures/conflicts you intend to address.
  Add an explanation if any won't be addressed before merge.
  -->
  - [x] [All linters pass](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#linting)
  - [x] [All tests pass](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#quality-control)
  - [x] All conflicts resolved
- Overhead requirements
  <!--
  These are additional requirements that are not directly associated with
  resolving the affected issue(s).
  -->
  - [x] [New/changed method tests implemented/updated *(or no change)*](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#test-implementation)
  - [ ] [Updated *Unreleased* section of `changelog.md` *(or no change)*](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/changelog.md)
  - [x] [Migrations created & committed *(or no change)*](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#migration-process)
