### PR TITLE
Removed mzXML file form field and lcms tsv download

### DIFF
--- a/DataRepo/forms.py
+++ b/DataRepo/forms.py
@@ -330,16 +330,9 @@ class DataSubmissionValidationForm(forms.Form):
     isocorr_files = MultipleFileField(
         required=False, widget=MultipleFileInput(attrs={"multiple": True})
     )
-    # Field to take a hard-return delimited list of mzXML file names.  This will be compiled using javascript in the
-    # template
-    mzxml_file_list = forms.CharField(
-        required=False,
-        widget=forms.HiddenInput(attrs={"id": "mzxml_file_list_input_id"}),
-    )
 
     def clean(self):
         """Ensure that at least a sample or peak annotation file is supplied.
-        If mzXML files are supplied, ensure only 1 peak annotation file was supplied.
 
         Args:
             None
@@ -352,10 +345,9 @@ class DataSubmissionValidationForm(forms.Form):
         """
         super().clean()
 
-        study_doc = self.cleaned_data.get("animal_sample_table")
-        accucor_files = self.cleaned_data.get("accucor_files")
-        isocorr_files = self.cleaned_data.get("isocorr_files")
-        mzxml_file_list = self.cleaned_data.get("mzxml_file_list")
+        study_doc = self.cleaned_data.get("animal_sample_table", None)
+        accucor_files = self.cleaned_data.get("accucor_files", None)
+        isocorr_files = self.cleaned_data.get("isocorr_files", None)
 
         num_accucor = 0 if accucor_files is None else len(accucor_files)
         num_isocorr = 0 if isocorr_files is None else len(isocorr_files)
@@ -364,19 +356,6 @@ class DataSubmissionValidationForm(forms.Form):
             raise forms.ValidationError(
                 "Either an Animal/Sample Table, Accucor, or Isocorr file is required.",
                 code="TooFewFiles",
-            )
-        elif mzxml_file_list is not None and (
-            (num_accucor == 0 and num_isocorr == 0)
-            or num_accucor > 1
-            or num_isocorr > 1
-            or (num_accucor > 0 and num_isocorr > 0)
-        ):
-            raise forms.ValidationError(
-                (
-                    f"mzXML files require either 1 Accucor [{num_accucor} submitted] or 1 Isocorr [{num_isocorr} "
-                    "submitted] file."
-                ),
-                code="1 peak annotation file",
             )
 
         return self.cleaned_data

--- a/DataRepo/templates/DataRepo/validate_submission.html
+++ b/DataRepo/templates/DataRepo/validate_submission.html
@@ -6,20 +6,6 @@
     {{ block.super }}
 
     <link href="{% static 'css/hierarchical_formsets.css' %}" rel="stylesheet">
-
-    <!-- The following is based mostly on https://www.smashingmagazine.com/2018/01/drag-drop-file-uploader-vanilla-js/ -->
-    <link href="{% static 'css/drop_area.css' %}" rel="stylesheet">
-    <script src="{% static 'js/browser_download.js' %}"></script>
-    <script src="{% static 'js/file_list_drop_area.js' %}"></script>
-    <script>
-        document.addEventListener("DOMContentLoaded", function(){
-            initDropArea(
-                document.getElementById('drop-area'),
-                document.getElementById('mzxml_file_list_input_id'),
-                document.getElementById('pending-files')
-            )
-        })
-    </script>
 {% endblock %}
 
 {% block content %}
@@ -30,33 +16,11 @@
             <label for="animal_sample_table" class="form-label">Animal and Sample Table:</label>{{ form.animal_sample_table }}<br>
             <label for="accucor_files" class="form-label">AccuCor Files:</label>{{ form.accucor_files }}<br>
             <label for="isocorr_files" class="form-label">IsoCorr Files:</label>{{ form.isocorr_files }}<br>
-            {{ form.mzxml_file_list }}
-            <!-- Hidden buttons for this form, controlled by the buttons under the second form via javascript -->
-            <button type="submit" class="btn btn-primary" id="validate" style="display: none;">Validate</button>
-            <button type="reset" class="btn btn-secondary" id="clear" style="display: none;">Clear</button>
+            <span class="text-danger">{{ form.errors.val }}</span>
+            <span class="text-danger">{{ form.non_field_errors }}</span>
+            <button type="submit" class="btn btn-primary" id="validate">Validate</button>
             {{ form.management_form }}
         </form>
-
-        <!-- The 2 form strategy (the one below for adding (mzXML) file names by drag and drop of the actual files and the one above to just submit their names (because that's all we need, and these files can be numerous and large) is based on https://stackoverflow.com/questions/2175831/is-it-possible-to-use-input-type-file-just-to-post-the-filename-without-actu -->
-
-        <div id="drop-area">
-            <form>
-                <!-- Hidden form that does not submit - just used as a target to drop files, from which, just their names are extracted to populate the other form's hidden character input -->
-                <label class="btn btn-secondary">
-                    <input type="file" multiple id="drop-area-input" onchange="handleFiles(this.files);"/>
-                    Add mzXML Files
-                </label>  <span class="drop-area-message">(Drag and drop here)</span>
-            </form>
-            <pre id="pending-files" class="drop-area-list-indent"></pre>
-        </div>
-
-        <br>
-
-        <span class="text-danger">{{ form.errors.val }}</span>
-        <span class="text-danger">{{ form.non_field_errors }}</span>
-
-        <button class="btn btn-primary" id="faux-validate" onclick="document.getElementById('submission-validation').submit();">Validate</button>
-        <button class="btn btn-secondary" id="faux-clear" onclick="document.getElementById('drop-area-input').value = null;document.getElementById('mzxml_file_list_input_id').value = null;document.getElementById('pending-files').innerHTML = '';document.getElementById('submission-validation').reset();">Clear</button>
 
         <br>
 
@@ -80,20 +44,6 @@
     </div>
 
     {% if results %}
-        {% if lcms_data is not None %}
-
-            <br>
-            <h5 class="text-info">Generated Sample Data:</h5>
-            <div class="small">
-                Data from your peak annotation file <span class="text-info">{{ peak_annot_file_name }}</span> was parsed and the following generated LCMS metadata file can be used to build your sample sheet.<br>
-                <br>
-                <div class="level-indent">
-                    <pre style="display: none;" id="lcms_data">{{ lcms_data }}</pre>
-                    <a href="javascript:browserDownloadText('{{ lcms_filename }}', document.getElementById('lcms_data').innerHTML)"><img src="{% static 'images/lcmsfile.png' %}" alt="{{ lcms_filename }}" width="20"></a>  <a href="javascript:browserDownloadText('{{ lcms_filename }}', document.getElementById('lcms_data').innerHTML)">{{ lcms_filename }}</a>
-                </div>
-            </div>
-
-        {% endif %}
         {% if not valid %}
             <br>
             <h5 class="text-danger">The following issue(s) with the file(s) were found:</h5>

--- a/DataRepo/tests/utils/test_exceptions.py
+++ b/DataRepo/tests/utils/test_exceptions.py
@@ -14,6 +14,8 @@ from DataRepo.utils.exceptions import (
     MultiLoadStatus,
     MutuallyExclusiveOptions,
     NoLoadData,
+    NonUniqueSampleDataHeader,
+    NonUniqueSampleDataHeaders,
     OptionsNotAvailable,
     RequiredColumnValue,
     RequiredColumnValues,
@@ -900,4 +902,27 @@ class ExceptionTests(TracebaseTestCase):
                 "not exist as either a primary compound name or synonym."
             ),
             str(cdne),
+        )
+
+    def test_NonUniqueSampleDataHeader(self):
+        nusdh = NonUniqueSampleDataHeader("c", {"accucor.xlsx": 2})
+        self.assertEqual(
+            (
+                "Sample data header 'c' is not unique across all supplied peak annotation files:\n"
+                "\tOccurs 2 times in accucor.xlsx"
+            ),
+            str(nusdh),
+        )
+
+    def test_NonUniqueSampleDataHeaders(self):
+        nusdhs = NonUniqueSampleDataHeaders(
+            [NonUniqueSampleDataHeader("c", {"accucor.xlsx": 2})]
+        )
+        self.assertEqual(
+            (
+                "The following sample data headers are not unique across all supplied peak annotation files:\n"
+                "\tc\n"
+                "\t\tOccurs 2 times in accucor.xlsx\n"
+            ),
+            str(nusdhs),
         )

--- a/DataRepo/tests/views/upload/test_validation.py
+++ b/DataRepo/tests/views/upload/test_validation.py
@@ -1,71 +1,85 @@
 import re
 
 from DataRepo.tests.tracebase_test_case import TracebaseTransactionTestCase
+from DataRepo.utils.exceptions import NonUniqueSampleDataHeader
 from DataRepo.views.upload.validation import DataValidationView
 
 
 class DataValidationViewTests(TracebaseTransactionTestCase):
     LCMS_DICT = {
         "a": {
-            "sort level": 1,
+            "sort level": 0,
             "tracebase sample name": "a",
             "sample data header": "a",
             "peak annotation filename": "accucor.xlsx",
-            "mzxml filename": "",
         },
         "b": {
             "sort level": 0,
             "tracebase sample name": "b",
             "sample data header": "b",
             "peak annotation filename": "accucor.xlsx",
-            "mzxml filename": "b.typo",
-        },
-        "c": {
-            "sort level": 0,
-            "tracebase sample name": "c",
-            "sample data header": "c",
-            "peak annotation filename": "accucor.xlsx",
-            "mzxml filename": "c.mzXML",
         },
         "d_pos": {
-            "sort level": 1,
+            "sort level": 0,
             "tracebase sample name": "d",
             "sample data header": "d_pos",
             "peak annotation filename": "accucor.xlsx",
-            "mzxml filename": "",
         },
-        "extra": {
-            "sort level": 2,
-            "tracebase sample name": "extra",
-            "sample data header": "",
-            "peak annotation filename": "",
-            "mzxml filename": "extra.mzxml",
-        },
-        "ERROR: c DUPLICATE HEADER 1": {
-            "sort level": 3,
-            "tracebase sample name": "",
-            "sample data header": "ERROR: c DUPLICATE HEADER 1",
+        "c": {
+            "sort level": 1,
+            "error": NonUniqueSampleDataHeader("c", {"accucor.xlsx": 2}),
+            "tracebase sample name": "c",
+            "sample data header": "c",
             "peak annotation filename": "accucor.xlsx",
-            "mzxml filename": "",
-        },
-        "ERROR: b.dupe DUPLICATE MZXML BASENAME 1": {
-            "sort level": 4,
-            "tracebase sample name": "",
-            "sample data header": "",
-            "peak annotation filename": "",
-            "mzxml filename": "ERROR: b.dupe DUPLICATE MZXML BASENAME 1",
         },
     }
 
     def test_build_lcms_dict(self):
-        lcms_dict = DataValidationView.build_lcms_dict(
+        dvv = DataValidationView()
+        lcms_dict = dvv.build_lcms_dict(
             ["a", "b", "c", "c", "d_pos"],  # Sample headers
-            ["b.typo", "b.dupe", "c.mzXML", "extra.mzxml"],  # List of mzxml file names
             "accucor.xlsx",  # Peak annot file
         )
+        # assertDictEqual doesn't work with the exception object, so asserting each individually and comparing exception
+        # strings
+        self.assertEqual(
+            len(self.LCMS_DICT.keys()),
+            len(lcms_dict.keys()),
+        )
         self.assertDictEqual(
-            self.LCMS_DICT,
-            dict(lcms_dict),
+            self.LCMS_DICT["a"],
+            lcms_dict["a"],
+        )
+        self.assertDictEqual(
+            self.LCMS_DICT["b"],
+            lcms_dict["b"],
+        )
+        self.assertEqual(
+            str(self.LCMS_DICT["c"]["error"]),
+            str(lcms_dict["c"]["error"]),
+        )
+        self.assertEqual(
+            self.LCMS_DICT["c"]["peak annotation filename"],
+            lcms_dict["c"]["peak annotation filename"],
+        )
+        self.assertEqual(
+            self.LCMS_DICT["c"]["sample data header"],
+            lcms_dict["c"]["sample data header"],
+        )
+        self.assertEqual(
+            self.LCMS_DICT["c"]["sort level"],
+            lcms_dict["c"]["sort level"],
+        )
+        self.assertEqual(
+            self.LCMS_DICT["c"]["tracebase sample name"],
+            lcms_dict["c"]["tracebase sample name"],
+        )
+        self.assertDictEqual(
+            self.LCMS_DICT["d_pos"],
+            lcms_dict["d_pos"],
+        )
+        self.assertEqual(
+            str(self.LCMS_DICT["c"]["error"]), str(dvv.lcms_build_errors.nusdh_list[0])
         )
 
     def test_get_approx_sample_header_replacement_regex_default(self):
@@ -91,14 +105,11 @@ class DataValidationViewTests(TracebaseTransactionTestCase):
         lcms_data = DataValidationView.lcms_dict_to_tsv_string(self.LCMS_DICT)
         self.assertEqual(
             (
-                "tracebase sample name\tsample data header\tmzxml filename\tpeak annotation filename\n"
-                "b\tb\tb.typo\taccucor.xlsx\n"
-                "c\tc\tc.mzXML\taccucor.xlsx\n"
-                "a\ta\t\taccucor.xlsx\n"
-                "d\td_pos\t\taccucor.xlsx\n"
-                "extra\t\textra.mzxml\t\n"
-                "\tERROR: c DUPLICATE HEADER 1\t\taccucor.xlsx\n"
-                "\t\tERROR: b.dupe DUPLICATE MZXML BASENAME 1\t\n"
+                "tracebase sample name\tsample data header\tpeak annotation filename\n"
+                "a\ta\taccucor.xlsx\n"
+                "b\tb\taccucor.xlsx\n"
+                "d\td_pos\taccucor.xlsx\n"
+                "c\tc\taccucor.xlsx\n"
             ),
             lcms_data,
         )

--- a/DataRepo/utils/exceptions.py
+++ b/DataRepo/utils/exceptions.py
@@ -1710,6 +1710,44 @@ class DuplicateSampleDataHeaders(Exception):
         self.samples = samples
 
 
+class NonUniqueSampleDataHeader(Exception):
+    def __init__(self, header, dupes):
+        dupes_str = ""
+        for file in dupes.keys():
+            dupes_str += f"\n\tOccurs {dupes[file]} times in {file}"
+        message = (
+            f"Sample data header '{header}' is not unique across all supplied peak annotation files:"
+            f"{dupes_str}"
+        )
+        super().__init__(message)
+        self.dupes = dupes
+        self.header = header
+
+
+class NonUniqueSampleDataHeaders(Exception):
+    def __init__(self, nusdh_list: list[NonUniqueSampleDataHeader]):
+        """Takes a dupes dict for duplicate sample data headers across 1 or more peak annotation files.
+
+        Args:
+            dupes = {
+                <value>: {}
+                    "<filename> (sheet <sheetname>)": count,
+                }
+            }
+        """
+        dupes_str = ""
+        for nusdh in nusdh_list:
+            dupes_str += f"\t{nusdh.header}\n"
+            for file in nusdh.dupes.keys():
+                dupes_str += f"\t\tOccurs {nusdh.dupes[file]} times in {file}\n"
+        message = (
+            "The following sample data headers are not unique across all supplied peak annotation files:\n"
+            f"{dupes_str}"
+        )
+        super().__init__(message)
+        self.nusdh_list = nusdh_list
+
+
 class InvalidHeaders(InfileError, ValidationError):
     def __init__(self, headers, expected_headers=None, fileformat=None, **kwargs):
         if expected_headers is None:


### PR DESCRIPTION
## Summary Change Description

This was mainly to remove the mzXML while retaining other related improvements made in the previous PRs, but I also, in the process, worked toward both:

1. Retaining code that I think will be used again, (once the LCMS sheet(s) have a loader), and...
2. Experimenting with an error strategy (a minor amount of effort) that I believe will be much easier for the user to consume (in the form of errors attached to spreadsheet cells via comments).  It was necessary for me to be able to structure the sample sheet excel file creation code in a scalable way.  I needed to see my idea in practice to understand it better, and to plan out the structure of the code in that next step.  These changes may be removed.  I only did a small portion relevant to the lcms code modifications to extract mzXMLs as a sort of exploration of the design idea on what may end up being code that gets pulled.  I commented out calls to that code in `form_valid`, since its usage was removed as a part of the change in plans, and added comments to remove the code if it doesn't end up being used.

## Affected Issues/Pull Requests

- Partially addresses #829
- Merges into PR #922
- Next PR: #925
- Supplants #888

  It turns out that 888 doesn't achieve the goal of reducing the work associated with associating mzXML files.  Note the following comment on slack about this:
    > Just as a preface, I think not including mzXMLs in the intermediate solution is copacetic with our overall goal of lowering the hurdles to submission.  And while specifying a directory could be easier in some cases, we know that not everyone organizes their data in the same way, so it wouldn't make it easier in every case. We also know that the only time we need the user to go to the effort of mapping mzXMLs to samples in specific accucor files is when there are multiple scans of the same sample - but if the file names are identical in those cases, this interface doesn't solve that (since it can't include the directory).
    > 
    > In fact, I don't think there's a whole lot we can do for the user in the submission compilation process if there are multiple identically named files to be divided among multiple accucors, other than point out that there's no name match.  After submission, we may be able to match things up by looking inside the files.
    > 
    > OK, so then I propose the following:
    > 
    > 1. Remove the mzXML drag and drop feature (which I think we agree on)
    > 2. Output an excel file using the current animal/sample template, with samples filled in
    > 3. I think it's worthwhile to also allow an animal/sample sheet input (so that samples can be added). I still think that just rebranding the validation page, limiting it to 1 of each file (animal/sample and peak annotation), and removing errors related to this use case (no animal/sample sheet) is the way to go, but if I can't convince you of that, I'll skip this and make a separate page if you insist.  I'm just not convinced that that goes in the right direction.
    > 4. Make the peak annotation input a single field.
    > 
    > The other alternative I'd proposed earlier, of getting the LCMS loader done first, is moot if we're using the old template.

    > I did spend a few minutes BTW just now, polishing off the commit that I was 98% toward yesterday. I'll post a PR, even though some of the decisions above revert aspects of it.  I'm also having second thoughts about my recommendation of limiting the interface to 1 of each (of the 2) file type(s), at least in the short term.
    > 
    > There's still the problem of timeouts if we try to validate the data and look for errors, but I realized that, if not given a sample sheet, we could simply not try to look for errors at all, and that would make it fast.
    > 
    > And while I was looking at the code just now, I realized that the reason I got on board with 1 at a time strategy was because of the identically named mzXML issue.  By removing that as an obstacle, I don't see any reason we can't take a series of accucor/isocorr and output a list of all the samples in a single sample sheet.
    > 
    > I haven't fully fleshed this idea out, but it's enough to make me want to propose that we at least postpone implementing the limit in the next few commits/PRs.  I say, that can be another incremental step, after the next meeting, and after having worked with the code.

## Review Notes
<!--
For added context for reviewers, add comments to relevant lines of code.  Use
this space to describe any general areas of concern not linked to a specific
line of code that reviewers should pay particular attention to, e.g. please
make sure I have accounted for all possible inputs.
-->
See comments in-line.

## Checklist
<!--
If any of the checkbox requirements are not met, uncheck them and add an
explanation. E.g. Linting errors pre-date this PR.
-->
This pull request will be merged once the following requirements are met.  The
author and/or reviewers should uncheck any unmet requirements:

- Review requirements
  - Minimum approvals: 1 <!-- Edit as desired (e.g. based on complexity) -->
  - No changes requested
  - All blocking issues resolved by reviewers
  - Specific reviewers: @__add_username_here__
    <!--
    Require reviewers with specific expertise to be included among the minimum
    number of reviewers by tagging them.  Also please send them a message.
    -->
  - Review period: 2 days <!-- Edit as desired (e.g. based on complexity) -->
- Associated issue/pull request requirements:
  <!--
  Assert that all requirements in issues marked "resolved" are done and that
  all required pull requests are merged.  If any are not done, either edit or
  split the issue or explain the unmerged affected pull requests.
  -->
  - [x] All requirements in affected issues marked "resolved" are satisfied
  - [x] All required pull requests are merged *(or none)*
- Basic requirements
  <!--
  Uncheck items to acknowledge failures/conflicts you intend to address.
  Add an explanation if any won't be addressed before merge.
  -->
  - [x] [All linters pass](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#linting)
  - [x] [All tests pass](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#quality-control)
  - [x] All conflicts resolved
- Overhead requirements
  <!--
  These are additional requirements that are not directly associated with
  resolving the affected issue(s).
  -->
  - [x] [New/changed method tests implemented/updated *(or no change)*](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#test-implementation)
  - [ ] [Updated *Unreleased* section of `changelog.md` *(or no change)*](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/changelog.md)
  - [x] [Migrations created & committed *(or no change)*](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#migration-process)
