### PR TITLE
Changed the accucor and isocorr validation file fields into a single field

### DIFF
--- a/DataRepo/templates/DataRepo/validate_submission.html
+++ b/DataRepo/templates/DataRepo/validate_submission.html
@@ -13,10 +13,8 @@
         <h3>Validate Animal/Sample and AccuCor/IsoCorr Files for Submission</h3>
         <form action="{% url 'validate' %}" id="submission-validation" method="POST" enctype="multipart/form-data">
             {% csrf_token %}
-            <label for="animal_sample_table" class="form-label">Animal and Sample Table:</label>{{ form.animal_sample_table }}<br>
-            <label for="accucor_files" class="form-label">AccuCor Files:</label>{{ form.accucor_files }}<br>
-            <label for="isocorr_files" class="form-label">IsoCorr Files:</label>{{ form.isocorr_files }}<br>
-            <span class="text-danger">{{ form.errors.val }}</span>
+            <label for="animal_sample_table" class="form-label">Animal and Sample Table:</label>{{ form.animal_sample_table }}<span class="text-danger">{{ form.animal_sample_table.errors }}</span>{% if not form.animal_sample_table.errors %}<br>{% endif %}
+            <label for="peak_annotation_files" class="form-label">Peak Annotation Files:</label>{{ form.peak_annotation_files }}<span class="text-danger">{{ form.peak_annotation_files.errors }}</span>{% if not form.peak_annotation_files.errors %}<br>{% endif %}
             <span class="text-danger">{{ form.non_field_errors }}</span>
             <button type="submit" class="btn btn-primary" id="validate">Validate</button>
             {{ form.management_form }}

--- a/DataRepo/tests/loaders/test_accucor_data_loader.py
+++ b/DataRepo/tests/loaders/test_accucor_data_loader.py
@@ -1,0 +1,45 @@
+from DataRepo.loaders.accucor_data_loader import AccuCorDataLoader
+from DataRepo.tests.tracebase_test_case import TracebaseTestCase
+
+
+class AccuCorDataLoaderTests(TracebaseTestCase):
+    def test_is_accucor_file(self):
+        self.assertFalse(
+            AccuCorDataLoader.is_accucor(
+                file="DataRepo/data/tests/submission_v3/study.xlsx"
+            )
+        )
+        self.assertTrue(
+            AccuCorDataLoader.is_accucor(
+                file="DataRepo/data/tests/accucor_with_multiple_labels/accucor.xlsx"
+            )
+        )
+        self.assertFalse(
+            AccuCorDataLoader.is_accucor(
+                file="DataRepo/data/tests/multiple_tracers/bcaafasted_cor.xlsx"
+            )
+        )
+
+    def test_excel_only(self):
+        self.assertFalse(
+            AccuCorDataLoader.is_isocorr(
+                "DataRepo/data/tests/singly_labeled_isocorr/small_cor.csv"
+            )
+        )
+
+    def test_is_isocorr_sheets(self):
+        self.assertFalse(
+            AccuCorDataLoader.is_isocorr(
+                file="DataRepo/data/tests/submission_v3/study.xlsx"
+            )
+        )
+        self.assertTrue(
+            AccuCorDataLoader.is_isocorr(
+                file="DataRepo/data/tests/multiple_tracers/bcaafasted_cor.xlsx"
+            )
+        )
+        self.assertFalse(
+            AccuCorDataLoader.is_isocorr(
+                file="DataRepo/data/tests/accucor_with_multiple_labels/accucor.xlsx"
+            )
+        )

--- a/DataRepo/tests/test_views.py
+++ b/DataRepo/tests/test_views.py
@@ -966,7 +966,7 @@ class ValidationViewTests(TracebaseTransactionTestCase):
     def validate_some_files(self, sample_file, accucor_files):
         # Test the get_validation_results function
         vo = DataValidationView()
-        vo.set_files(sample_file, accucor_files)
+        vo.set_files(sample_file=sample_file, peak_annotation_files=accucor_files)
         # Now try validating the load files
         valid, results, exceptions, _ = vo.get_validation_results()
 
@@ -1036,7 +1036,7 @@ class ValidationViewTests(TracebaseTransactionTestCase):
         ]
 
         dvv = DataValidationView()
-        dvv.set_files(sf, afs)
+        dvv.set_files(sample_file=sf, peak_annotation_files=afs)
 
         sfn = os.path.basename(sf)
         sfp = os.path.join(tmpdir, str(sfn))

--- a/DataRepo/views/upload/validation.py
+++ b/DataRepo/views/upload/validation.py
@@ -99,9 +99,9 @@ class DataValidationView(FormView):
         self.isocorr_filenames = []
         if peak_annotation_files is not None and len(peak_annotation_files) > 0:
             # Convince mypy that peak_annotation_files is defined
-            peak_annot_files: List[str] = cast(List[str], peak_annotation_files)
-            for index, peak_annot_file in enumerate(peak_annot_files):
-                peak_annotation_filename = peak_annot_files[index]
+            peak_annot_filenames: List[str] = cast(List[str], peak_annotation_filenames)
+            for index, peak_annot_file in enumerate(peak_annotation_files):
+                peak_annotation_filename = peak_annot_filenames[index]
                 if AccuCorDataLoader.is_accucor(peak_annot_file):
                     self.accucor_files.append(peak_annot_file)
                     self.accucor_filenames.append(peak_annotation_filename)
@@ -109,7 +109,7 @@ class DataValidationView(FormView):
                     self.isocorr_files.append(peak_annot_file)
                     self.isocorr_filenames.append(peak_annotation_filename)
                 else:
-                    not_peak_annot_files.append(peak_annot_files[index])
+                    not_peak_annot_files.append(peak_annot_filenames[index])
 
         if len(not_peak_annot_files) > 0:
             raise ValidationError(


### PR DESCRIPTION
## Summary Change Description

- Improved the form's clean method so that errors would be associated with their fields.
- Added a check to the form's clean method to ensure that the files are excel and that the peak annotation files were specifically either accucor or isocorr (individually).
- Changed the order of the set_files args and made the sample arg optional.
- Added methods: is_accucor and is_isocorr to the AccucorDataLoader class.
- Changed the way things were imported from django.forms so that it would look cleaner.

## Affected Issues/Pull Requests

- Partially addresses #829
- Merges into PR #924
- Next PR: #925

## Review Notes
<!--
For added context for reviewers, add comments to relevant lines of code.  Use
this space to describe any general areas of concern not linked to a specific
line of code that reviewers should pay particular attention to, e.g. please
make sure I have accounted for all possible inputs.
-->
See comments in-line.

## Checklist
<!--
If any of the checkbox requirements are not met, uncheck them and add an
explanation. E.g. Linting errors pre-date this PR.
-->
This pull request will be merged once the following requirements are met.  The
author and/or reviewers should uncheck any unmet requirements:

- Review requirements
  - Minimum approvals: 1 <!-- Edit as desired (e.g. based on complexity) -->
  - No changes requested
  - All blocking issues resolved by reviewers
  - Specific reviewers: @__add_username_here__
    <!--
    Require reviewers with specific expertise to be included among the minimum
    number of reviewers by tagging them.  Also please send them a message.
    -->
  - Review period: 2 days <!-- Edit as desired (e.g. based on complexity) -->
- Associated issue/pull request requirements:
  <!--
  Assert that all requirements in issues marked "resolved" are done and that
  all required pull requests are merged.  If any are not done, either edit or
  split the issue or explain the unmerged affected pull requests.
  -->
  - [x] All requirements in affected issues marked "resolved" are satisfied
  - [x] All required pull requests are merged *(or none)*
- Basic requirements
  <!--
  Uncheck items to acknowledge failures/conflicts you intend to address.
  Add an explanation if any won't be addressed before merge.
  -->
  - [x] [All linters pass](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#linting)
  - [x] [All tests pass](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#quality-control)
  - [x] All conflicts resolved
- Overhead requirements
  <!--
  These are additional requirements that are not directly associated with
  resolving the affected issue(s).
  -->
  - [x] [New/changed method tests implemented/updated *(or no change)*](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#test-implementation)
  - [ ] [Updated *Unreleased* section of `changelog.md` *(or no change)*](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/changelog.md)
  - [x] [Migrations created & committed *(or no change)*](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#migration-process)
