### PR TITLE
Revised how dataframes are stored for efficiency

### DIFF
--- a/DataRepo/loaders/table_loader.py
+++ b/DataRepo/loaders/table_loader.py
@@ -3,7 +3,6 @@ from abc import ABC, abstractmethod
 from collections import defaultdict, namedtuple
 from typing import Dict, Optional, Type
 
-import pandas as pd
 from django.core.exceptions import ValidationError
 from django.db import IntegrityError, transaction
 from django.db.models import Model, Q
@@ -2444,8 +2443,8 @@ class TableLoader(ABC):
             Exception
 
         Returns:
-            A pandas dataframe with current headers as the column names and any model field that directly maps to a
-            column pre-populated with the record field values.
+            converted_out_dict (dict of dicts): This is intended to match pandas' version of a dict of lists, where the
+                lists are actually dicts indexed by integers
         """
         display_headers = self.get_ordered_display_headers(all=all)
         out_dict: Dict[str, list] = dict([(hdr, []) for hdr in display_headers])
@@ -2476,7 +2475,12 @@ class TableLoader(ABC):
                     if hdr not in out_dict.keys():
                         out_dict[hdr] = [None for _ in range(qs.count())]
 
-        return pd.DataFrame.from_dict(out_dict)
+        # Convert the out_dict into a dict containing pandas' version of a list (a dict indexed by integers)
+        converted_out_dict = dict(
+            (k, dict((i, v) for i, v in enumerate(l))) for k, l in out_dict.items()
+        )
+
+        return converted_out_dict
 
     def get_ordered_display_headers(self, all=False):
         """This returns current header names in the order in which the headers were defined in DataTableHeaders, that do

--- a/DataRepo/tests/loaders/test_table_loader.py
+++ b/DataRepo/tests/loaders/test_table_loader.py
@@ -1486,11 +1486,10 @@ class TableLoaderTests(TracebaseTestCase):
         class TestOneDefLoader(self.TestLoader):
             DataDefaultValues = self.TestLoader.DataTableHeaders(NAME=None, CHOICE="1")
 
-        expected = pd.DataFrame.from_dict({"Name": []})
+        expected = {"Name": {}}
 
         todl = TestOneDefLoader()
-        print(f"DF AS STR: {str(todl.get_dataframe_template())}")
-        self.assertEqual(str(expected), str(todl.get_dataframe_template()))
+        self.assertDictEqual(expected, todl.get_dataframe_template())
 
     def test_get_dataframe_template_populated(self):
         class TestOneDefLoader(self.TestLoader):
@@ -1499,7 +1498,7 @@ class TableLoaderTests(TracebaseTestCase):
         self.TestModel.objects.create(name="A", choice=1)
         self.TestModel.objects.create(name="B", choice=2)
 
-        expected = pd.DataFrame.from_dict({"Name": ["A", "B"]})
+        expected = {"Name": {0: "A", 1: "B"}}
 
         todl = TestOneDefLoader()
         self.assertEqual(str(expected), str(todl.get_dataframe_template(populate=True)))
@@ -1518,5 +1517,5 @@ class TableLoaderTests(TracebaseTestCase):
 
         todl = TestOneDefLoader()
         self.assertDictEqual(
-            expected, todl.get_dataframe_template(all=True, populate=True).to_dict()
+            expected, todl.get_dataframe_template(all=True, populate=True)
         )

--- a/DataRepo/tests/views/upload/test_validation.py
+++ b/DataRepo/tests/views/upload/test_validation.py
@@ -172,10 +172,10 @@ class DataValidationViewTests(TracebaseTransactionTestCase):
 
     def assert_dfs_dicts(self, expected, dfs_dict):
         self.assertEqual(len(expected.keys()), len(dfs_dict.keys()))
-        self.assertDictEqual(expected["Animals"], dfs_dict["Animals"].to_dict())
-        self.assertDictEqual(expected["Samples"], dfs_dict["Samples"].to_dict())
-        self.assertDictEqual(expected["Treatments"], dfs_dict["Treatments"].to_dict())
-        self.assertDictEqual(expected["Tissues"], dfs_dict["Tissues"].to_dict())
+        self.assertDictEqual(expected["Animals"], dfs_dict["Animals"])
+        self.assertDictEqual(expected["Samples"], dfs_dict["Samples"])
+        self.assertDictEqual(expected["Treatments"], dfs_dict["Treatments"])
+        self.assertDictEqual(expected["Tissues"], dfs_dict["Tissues"])
 
     def test_get_or_create_study_dataframes_get(self):
         """


### PR DESCRIPTION
## Summary Change Description

I realized that a number of methods were converting back and forth between dataframes and dicts and I realized that it would all be much easier if I save the production of actual dataframes until after the samples (etc) have been added.

So I converted all instances of `dfs_dict` from a `dict of pandas dataframes` to a `dict of pandas' style dicts`, e.g. `{"columnname": {0: "row 1 value", 1: "row 2 value"}}`.

This prevents the necessity of various methods converting back and forth between dataframes and dicts.  It also addresses issues of places where I was temporarily using lists instead of pandas' version of lists (dicts keyed by sequential integeras starting from 0).

## Affected Issues/Pull Requests

- Resolves no issue, but related to #829
- Merges into PR #930
- Next PR: #932

## Review Notes
<!--
For added context for reviewers, add comments to relevant lines of code.  Use
this space to describe any general areas of concern not linked to a specific
line of code that reviewers should pay particular attention to, e.g. please
make sure I have accounted for all possible inputs.
-->
See comments in-line.

## Checklist
<!--
If any of the checkbox requirements are not met, uncheck them and add an
explanation. E.g. Linting errors pre-date this PR.
-->
This pull request will be merged once the following requirements are met.  The
author and/or reviewers should uncheck any unmet requirements:

- Review requirements
  - Minimum approvals: 1 <!-- Edit as desired (e.g. based on complexity) -->
  - No changes requested
  - All blocking issues resolved by reviewers
  - Specific reviewers: @__add_username_here__
    <!--
    Require reviewers with specific expertise to be included among the minimum
    number of reviewers by tagging them.  Also please send them a message.
    -->
  - Review period: 2 days <!-- Edit as desired (e.g. based on complexity) -->
- Associated issue/pull request requirements:
  <!--
  Assert that all requirements in issues marked "resolved" are done and that
  all required pull requests are merged.  If any are not done, either edit or
  split the issue or explain the unmerged affected pull requests.
  -->
  - [x] All requirements in affected issues marked "resolved" are satisfied
  - [x] All required pull requests are merged *(or none)*
- Basic requirements
  <!--
  Uncheck items to acknowledge failures/conflicts you intend to address.
  Add an explanation if any won't be addressed before merge.
  -->
  - [x] [All linters pass](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#linting)
  - [x] [All tests pass](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#quality-control)
  - [x] All conflicts resolved
- Overhead requirements
  <!--
  These are additional requirements that are not directly associated with
  resolving the affected issue(s).
  -->
  - [x] [New/changed method tests implemented/updated *(or no change)*](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#test-implementation)
  - [ ] [Updated *Unreleased* section of `changelog.md` *(or no change)*](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/changelog.md)
  - [x] [Migrations created & committed *(or no change)*](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#migration-process)
