### PR TITLE
Added comments to the excel headers

### DIFF
--- a/DataRepo/loaders/compounds_loader.py
+++ b/DataRepo/loaders/compounds_loader.py
@@ -4,6 +4,7 @@ from typing import Optional
 from django.db import transaction
 from django.db.utils import IntegrityError
 
+from DataRepo.loaders.table_column import TableColumn
 from DataRepo.loaders.table_loader import TableLoader
 from DataRepo.models import Compound, CompoundSynonym
 from DataRepo.utils.exceptions import (
@@ -72,6 +73,18 @@ class CompoundsLoader(TableLoader):
             "compound": NAME_KEY,
         },
     }
+
+    DataColumnMetadata = DataTableHeaders(
+        NAME=TableColumn.init_flat(field=Compound.name),
+        HMDB_ID=TableColumn.init_flat(field=Compound.hmdb_id),
+        FORMULA=TableColumn.init_flat(field=Compound.formula),
+        SYNONYMS=TableColumn.init_flat(
+            field=CompoundSynonym.name,
+            header_required=True,
+            value_required=False,
+            format="Semicolon-delimited list of synonym names.",
+        ),
+    )
 
     # List of model classes that the loader enters records into.  Used for summarized results & some exception handling
     Models = [Compound, CompoundSynonym]

--- a/DataRepo/loaders/protocols_loader.py
+++ b/DataRepo/loaders/protocols_loader.py
@@ -3,6 +3,7 @@ from typing import Dict
 
 from django.db import transaction
 
+from DataRepo.loaders.table_column import TableColumn
 from DataRepo.loaders.table_loader import TableLoader
 from DataRepo.models import Protocol
 from DataRepo.utils.file_utils import is_excel
@@ -74,6 +75,12 @@ class ProtocolsLoader(TableLoader):
             "description": DESC_KEY,
         },
     }
+
+    DataColumnMetadata = DataTableHeaders(
+        NAME=TableColumn.init_flat(field=Protocol.name),
+        CATEGORY=TableColumn.init_flat(field=Protocol.category),
+        DESCRIPTION=TableColumn.init_flat(field=Protocol.description),
+    )
 
     # List of model classes that the loader enters records into.  Used for summarized results & some exception handling
     Models = [Protocol]

--- a/DataRepo/loaders/sequences_loader.py
+++ b/DataRepo/loaders/sequences_loader.py
@@ -4,6 +4,7 @@ from typing import Dict
 
 from django.db import transaction
 
+from DataRepo.loaders.table_column import TableColumn
 from DataRepo.loaders.table_loader import TableLoader
 from DataRepo.models import LCMethod, MSRunSequence
 from DataRepo.utils.exceptions import RequiredColumnValueWhenNovel
@@ -99,6 +100,31 @@ class SequencesLoader(TableLoader):
             "description": LC_DESC_KEY,
         },
     }
+
+    DataColumnMetadata = DataTableHeaders(
+        ID=TableColumn.init_flat(
+            name="Sequence Number",
+            help_text="Sequential integer starting from 1.",
+            guidance="This column is used to populate Sequence Number choices in the Peak Annotation Details sheet.",
+            type=int,
+        ),
+        OPERATOR=TableColumn.init_flat(
+            name="Operator",
+            help_text="Researcher who operated the Mass Spec instrument.",
+        ),
+        DATE=TableColumn.init_flat(
+            field=MSRunSequence.date,
+            format="Format: YYYY-MM-DD.",
+        ),
+        INSTRUMENT=TableColumn.init_flat(field=MSRunSequence.instrument),
+        LC_PROTOCOL=TableColumn.init_flat(field=LCMethod.type),
+        LC_RUNLEN=TableColumn.init_flat(
+            field=LCMethod.run_length,
+            format="Units: minutes.",
+        ),
+        LC_DESC=TableColumn.init_flat(field=LCMethod.description),
+        NOTES=TableColumn.init_flat(field=MSRunSequence.notes),
+    )
 
     # List of model classes that the loader enters records into.  Used for summarized results & some exception handling
     Models = [MSRunSequence, LCMethod]

--- a/DataRepo/loaders/study_table_loader.py
+++ b/DataRepo/loaders/study_table_loader.py
@@ -2,6 +2,7 @@ from collections import namedtuple
 
 from django.db import transaction
 
+from DataRepo.loaders.table_column import TableColumn
 from DataRepo.loaders.table_loader import TableLoader
 from DataRepo.models import Study
 
@@ -55,6 +56,12 @@ class StudyTableLoader(TableLoader):
             "description": DESC_KEY,
         },
     }
+
+    DataColumnMetadata = DataTableHeaders(
+        CODE=TableColumn.init_flat(field=Study.code),
+        NAME=TableColumn.init_flat(field=Study.name),
+        DESCRIPTION=TableColumn.init_flat(field=Study.description),
+    )
 
     # List of model classes that the loader enters records into.  Used for summarized results & some exception handling
     Models = [Study]

--- a/DataRepo/loaders/table_column.py
+++ b/DataRepo/loaders/table_column.py
@@ -1,0 +1,419 @@
+import sys
+from typing import List, Optional
+
+from django.db.models import Field
+
+from DataRepo.utils.exceptions import (
+    ConditionallyRequiredOptions,
+    MutuallyExclusiveOptions,
+)
+
+
+class ColumnReference:
+    """This class allows a Loader class to cross-reference a TableColumn.
+
+    The purpose depends on where the reference is used.  In the ColumnHeader class, it is used to populate a header
+    comment, saying something like "Values must match those in column Y of sheet X".  In the ColumnValue class, it is
+    (/will) be used to create drop-down lists for selecting values from a column in another sheet.
+    """
+
+    def __init__(
+        self,
+        header: Optional[str] = None,
+        sheet: Optional[str] = None,
+        loader_class=None,  # No typehint.  See below.
+        loader_header_key: Optional[str] = None,
+    ):
+        """ColumnReference constructor.
+
+        Args:
+            header (string): The name of the header being referenced.  Must match the ColumnHeader.name of that header.
+                Mutually exclusive/required with loader_header_key.
+            sheet (string): The name of the excel sheet being referenced.  Mutually exclusive/required with loader_class
+            loader_class (TableLoader): A concrete TableLoader class where the sheet can be derived.  Mutually exclusive
+                /required with sheet.
+            loader_header_key (string): A header key defined in the loader_class.  Mutually exclusive/required with
+                header.
+
+        Exceptions:
+            ConditionallyRequiredOptions
+            MutuallyExclusiveOptions
+
+        Returns:
+            instance
+        """
+        self.header = header
+        self.sheet = sheet
+        self.loader_class = loader_class
+        self.loader_header_key = loader_header_key
+
+        # Cannot import loader class at compile(/"interpretation") time, because the import would be circular.  Instead,
+        # we must evaluate the class to check its type at execution time.  There are 2 ways to do this:
+        # - getattr(sys.modules[__name__], "Foo")
+        # - globals()["Foo"]  # When both are in the same file but reference one another (which is prohibited as well)
+        # Below, I use the fact that both table_column.py and table_loader.py are in the same directory...
+        table_loader_pypath = self.__module__.rsplit(".", 1)[0] + ".table_loader"
+        TableLoader = getattr(sys.modules[table_loader_pypath], "TableLoader")
+        if loader_class is not None and not issubclass(loader_class, TableLoader):
+            bases = ", ".join([bc.__name__ for bc in loader_class.__bases__])
+            raise TypeError(
+                f"loader_class must be a derived class of {TableLoader.__name__}, not {bases}."
+            )
+
+        if loader_class is None:
+            if header is None or sheet is None:
+                raise ConditionallyRequiredOptions(
+                    "header and sheet are required when loader is undefined."
+                )
+        else:
+            if sheet is not None:
+                raise MutuallyExclusiveOptions(
+                    "loader and sheet are mutually exclusive."
+                )
+            self.sheet = loader_class.DataSheetName
+            if loader_header_key is not None and header is not None:
+                raise MutuallyExclusiveOptions(
+                    "loader_header_key and header are mutually exclusive when loader is defined."
+                )
+            elif loader_header_key is None and header is None:
+                raise ConditionallyRequiredOptions(
+                    "Either loader_header_key or header is required when loader is defined."
+                )
+
+            if loader_header_key is not None:
+                # Note, this is not the same as getattr(loader_class.DataHeaders, loader_header_key)
+                # TODO: Refactor TableLoader to consolidate loader_class.DataHeaders and
+                # loader_class.DataColumnMetadata.KEY.header.name - THIS WILL SIMPLIFY TableLoader somewhat
+                self.header = getattr(
+                    loader_class.DataColumnMetadata, loader_header_key
+                ).header.name
+
+
+class ColumnHeader:
+    """Defines metadata associated with an excel column header, e.g. for decorating the header."""
+
+    def __init__(
+        self,
+        name: Optional[str] = None,
+        field: Optional[Field] = None,
+        guidance: Optional[str] = None,
+        format: Optional[str] = None,
+        reference: Optional[ColumnReference] = None,
+        # ColumnHeader arguments set by field, but can be supplied (e.g. if None or to override)
+        help_text: Optional[str] = None,
+        required: Optional[bool] = None,
+        unique: Optional[bool] = None,
+        # Option for the generated name (when field is supplied)
+        include_model_in_header: bool = True,
+    ):
+        """ColumnHeader constructor.
+
+        Args:
+            name (str): Header name.  Can override the field derived header.  Required if no field.
+            field (Field): Model field from which to derive data, if provided.  Required if no name.
+            guidance (str): Details added to Model.field.help_text when it differs from the model.
+            format (str): Add to provide notes about units, delimiting strings, etc.
+            reference (ColumnReference): Used to add to a header comment when columns are related.
+            help_text (str): Description of the column data.  Can override the field derived value.
+            required (bool): Whether the header is required to be present.  Derived from field.blank, but can be
+                overridden.
+            unique (bool): Whether the values in the column must be unique.  Derived from field.unique, but can be
+                overridden.
+            include_model_in_header (bool): Option to include the field's model name in the header (if name not
+                supplied).
+
+        Exceptions:
+            ConditionallyRequiredOptions
+
+        Returns:
+            instance
+        """
+        if name is None and field is None:
+            raise ConditionallyRequiredOptions("name or field is required")
+
+        # field is not saved here, but it can be supplied to automaticallt set some attributes
+        if field is not None:
+            # Convert to the class
+            field = field.field
+
+            if name is None:
+                if include_model_in_header:
+                    name = make_title(field.model.__name__, field.name)
+                else:
+                    name = make_title(field.name)
+
+            # Handle overrides and unset/missing attributes.  If anything is invalid, it should be caught downstream.
+            if (
+                hasattr(field, "help_text")
+                and field.help_text is not None
+                and help_text is None
+            ):
+                help_text = field.help_text
+            if hasattr(field, "blank") and field.blank is not None and required is None:
+                required = not field.blank
+            if hasattr(field, "unique") and field.unique is not None:
+                unique = field.unique
+
+        # Default values
+        if required is None:
+            required = True
+        if unique is None:
+            unique = False
+
+        self.name = name
+        self.required = required
+        self.help_text = help_text
+        self.format = format
+        self.guidance = guidance
+        self.reference = reference
+        self.unique = unique
+
+    @property
+    def comment(self):
+        """Content of the header comment, composed based on instance attributes.
+        Args:
+            None
+        Exceptions:
+            None
+        Returns:
+            comment (string)
+        """
+        if (
+            self.help_text is None
+            and self.guidance is None
+            and self.format is None
+            and self.reference is None
+            and self.unique is None
+            and (self.required is None or not self.required)
+        ):
+            return None
+
+        comment = ""
+        if self.help_text is not None:
+            comment += self.help_text
+        if self.guidance is not None:
+            if comment != "":
+                comment += "\n\n"
+            comment += self.guidance
+        if self.format is not None:
+            if comment != "":
+                comment += "\n\n"
+            comment += self.format
+        if self.reference is not None:
+            if comment != "":
+                comment += "\n\n"
+            comment += f"Must match a value in column '{self.reference.header}' in sheet: {self.reference.sheet}."
+        if self.unique is not None and self.unique:
+            if comment != "":
+                comment += "\n\n"
+            comment += "Must be unique."
+        if not self.required:
+            if comment != "":
+                comment += "\n\n"
+            comment += "Optional."
+
+        return comment
+
+
+class ColumnValue:
+    """This is a *template* for any cell in a table column (except the header cell).  The attributes here are
+    collectively applied to every (non-header) cell in a column.
+
+    For example, all the values must be of a single type.  They can be required to be unique or be derived via formula.
+    They can be derived from a set of static choices, or via the values from a column in another sheet.
+    """
+
+    def __init__(
+        self,
+        field: Optional[Field] = None,
+        default=None,
+        required: Optional[bool] = None,
+        type: Optional[type] = str,
+        static_choices: Optional[List[tuple]] = None,
+        dynamic_choices: Optional[ColumnReference] = None,
+        unique: Optional[bool] = None,
+        formula: Optional[str] = None,
+    ):
+        """ColumnValue constructor.
+
+        Args:
+            field (Field): Model field from which to derive data, if provided.  Required if no name.
+            default (object): Details added to Model.field.help_text when it differs from the model.
+            required (bool): Whether a value is required to be present.  Derived from field.blank, but can be
+                overridden.
+            type (type) [str]: The type of data expected in the excel column.
+            static_choices (list of tuples): (Will be) used to populate a drop-down list.  Derived from the model field,
+                but can be overridden.
+            dynamic_choices (ColumnReference): (Will be) used to populate a drop-down list using the contents of a
+                column in another sheet.  Overrides static_choices.
+            unique (bool): Whether the values in the column must be unique.  Derived from field.unique, but can be
+                overridden.
+            formula (string): Excel formula to use to populate the column.
+
+        Exceptions:
+            None
+
+        Returns:
+            instance
+        """
+        if field is not None:
+            # Convert to the class
+            field = field.field
+
+            # Handle overrides and unset/missing attributes.  If anything is invalid, it should be caught downstream.
+            if hasattr(field, "unique") and field.unique is not None and unique is None:
+                unique = field.unique
+            if (
+                hasattr(field, "default")
+                and field.default is not None
+                and default is None
+            ):
+                default = field.default
+            if hasattr(field, "blank") and field.blank is not None and required is None:
+                required = not field.blank
+            if (
+                hasattr(field, "choices")
+                and field.choices is not None
+                and static_choices is None
+            ):
+                static_choices = field.choices
+
+        # Default values
+        if required is None:
+            required = True
+        if unique is None:
+            unique = False
+
+        self.default = default
+        self.required = required
+        self.static_choices = static_choices
+        self.dynamic_choices = dynamic_choices
+        self.type = type
+        self.unique = unique
+        self.formula = formula
+
+
+class TableColumn:
+    """A container of ColumnHeader and ColumnValue (template).  This provides the interface into those objects."""
+
+    def __init__(
+        self,
+        field: Optional[Field] = None,
+        header: Optional[ColumnHeader] = None,
+        value: Optional[ColumnValue] = None,
+        readonly: bool = False,
+    ):
+        """TableColumn constructor.
+        Args:
+            header (ColumnHeader): Object describing header metadata.
+            value (ColumnValue): Object describing metadata associated with every cell below the header.
+            field (Field): Model field associated with the table column.
+            readonly (bool): Whether the column may be only read (i.e. not edited).
+        Exceptions:
+            None
+        Returns:
+            instance (TableColumn)
+        """
+        self.field = field
+        self.model = None
+        if field is not None:
+            # Convert to the class
+            self.field = field.field
+            self.model = field.field.model
+
+        if header is None:
+            if field is None:
+                raise ConditionallyRequiredOptions("header or field is required")
+            header = ColumnHeader(field=field)
+        self.header = header
+
+        if value is None:
+            value = ColumnValue(field=field)
+        self.value = value
+
+        self.readonly = readonly
+
+    @classmethod
+    def init_flat(
+        cls,
+        field: Optional[Field] = None,
+        readonly: bool = False,
+        # ColumnHeader arguments not set by field
+        name: Optional[str] = None,
+        guidance: Optional[str] = None,
+        format: Optional[str] = None,
+        reference: Optional[ColumnReference] = None,
+        # ColumnValue arguments not set by field
+        type: Optional[type] = str,
+        unique: Optional[bool] = None,
+        dynamic_choices: Optional[ColumnReference] = None,
+        formula: Optional[str] = None,
+        # ColumnHeader arguments set by field (to override or if None)
+        help_text: Optional[str] = None,
+        header_required: Optional[bool] = None,
+        # ColumnValue arguments set by field (to override or if None)
+        default=None,
+        value_required: Optional[bool] = None,
+        static_choices: Optional[List[tuple]] = None,
+    ):
+        """Alternate TableColumn constructor.  (This is the pythonic was to implement multiple constructors.)
+        Args:
+            field (Field): A model field that can be used to derive some instance attributes.
+            readonly (bool): Whether the column cannot be edited.
+            name (str): Header.
+            guidance (str): Additional notes to help_text, if the excel version differs from the model field.
+            format (str): Notes on units or delimited values.
+            reference (ColumnReference): Reference to a column in another sheet for populating the header comment.
+            type (type): The type of data expected in the excel column.
+            unique (bool): Whether the column values must be unique.
+            dynamic_choices (ColumnReference): The excel column used to populate a dropdown.
+            formula (str): The formula used to populate a column.
+            help_text (str): Details about the data contained in the column (derived from field).
+            header_required (bool): Whether the column is required to be present (derived from field).
+            default (object): A default value for the column.
+            value_required (bool): Whether every cell must have a value (derived from field).
+            static_choices (list of tuples): Possible values in the column (derived from field).
+        Exceptions:
+            None
+        Returns:
+            instance (TableColumn)
+        """
+        return cls(
+            field=field,
+            header=ColumnHeader(
+                field=field,
+                name=name,
+                guidance=guidance,
+                format=format,
+                reference=reference,
+                # Set by field (but provided for overriding)
+                help_text=help_text,
+                required=header_required,
+            ),
+            value=ColumnValue(
+                field=field,
+                type=type,
+                unique=unique,
+                dynamic_choices=dynamic_choices,
+                formula=formula,
+                # Set by field (but provided for overriding)
+                default=default,
+                required=value_required,
+                static_choices=static_choices,
+            ),
+            readonly=readonly,
+        )
+
+
+def make_title(*args: str):
+    """Takes any number of string arguments, splits each one on space, and joins the flattened result together, with
+    each word getting title-case applied unless they are already mixed-case or a single character.
+    """
+    mixed_case_strings = []
+    for word in [word for a in args for word in a.split(" ")]:
+        # If mixed case or a single character
+        if (word != word.lower() and word != word.upper()) or len(word) == 1:
+            mixed_case_strings.append(word)
+        else:
+            mixed_case_strings.append(word.title())
+    return " ".join(mixed_case_strings)

--- a/DataRepo/loaders/table_column.py
+++ b/DataRepo/loaders/table_column.py
@@ -131,7 +131,7 @@ class ColumnHeader:
         if name is None and field is None:
             raise ConditionallyRequiredOptions("name or field is required")
 
-        # field is not saved here, but it can be supplied to automaticallt set some attributes
+        # field is not saved here, but it can be supplied to automatically set some attributes
         if field is not None:
             # Convert to the class
             field = field.field

--- a/DataRepo/loaders/tissues_loader.py
+++ b/DataRepo/loaders/tissues_loader.py
@@ -1,6 +1,7 @@
 from collections import namedtuple
 from typing import Dict
 
+from DataRepo.loaders.table_column import TableColumn
 from DataRepo.loaders.table_loader import TableLoader
 from DataRepo.models import Tissue
 
@@ -54,6 +55,11 @@ class TissuesLoader(TableLoader):
             "description": DESC_KEY,
         },
     }
+
+    DataColumnMetadata = DataTableHeaders(
+        NAME=TableColumn.init_flat(field=Tissue.name),
+        DESCRIPTION=TableColumn.init_flat(field=Tissue.description),
+    )
 
     # List of model classes that the loader enters records into.  Used for summarized results & some exception handling
     Models = [Tissue]

--- a/DataRepo/tests/loaders/test_table_column.py
+++ b/DataRepo/tests/loaders/test_table_column.py
@@ -1,0 +1,143 @@
+from collections import namedtuple
+
+from django.db.models import AutoField, CharField, Model
+from django.test.utils import isolate_apps
+
+from DataRepo.loaders.table_column import (
+    ColumnHeader,
+    ColumnReference,
+    ColumnValue,
+    TableColumn,
+    make_title,
+)
+from DataRepo.loaders.table_loader import TableLoader
+from DataRepo.tests.tracebase_test_case import TracebaseTestCase
+from DataRepo.utils.exceptions import (
+    ConditionallyRequiredOptions,
+    MutuallyExclusiveOptions,
+)
+
+
+# Class (Model) used for testing
+class TestTableColumnModel(Model):
+    id = AutoField(primary_key=True)
+    name = CharField(unique=True, help_text="This be the name.")
+    choice = CharField(choices=[("1", "1"), ("2", "2")])
+
+    # Necessary for temporary models
+    class Meta:
+        app_label = "loader"
+
+
+class TestLoader(TableLoader):
+    DataSheetName = "test"
+    DataTableHeaders = namedtuple("DataTableHeaders", ["NAME", "CHOICE"])
+    DataHeaders = DataTableHeaders(NAME="NOT Loader Name Header", CHOICE="Choice")
+    DataRequiredHeaders = ["NAME"]
+    DataRequiredValues = DataRequiredHeaders
+    DataUniqueColumnConstraints = [["NAME"]]
+    FieldToDataHeaderKey = {
+        TestTableColumnModel.__name__: {"name": "NAME", "choice": "CHOICE"}
+    }
+    DataColumnMetadata = DataTableHeaders(
+        NAME=TableColumn.init_flat(name="Loader Name Header"),
+        CHOICE=TableColumn.init_flat(field=TestTableColumnModel.choice),
+    )
+    Models = [TestTableColumnModel]
+
+    def load_data(self):
+        return None
+
+
+class ColumnReferenceTests(TracebaseTestCase):
+    def test_ColumnReference(self):
+        # Test no args
+        with self.assertRaises(ConditionallyRequiredOptions):
+            ColumnReference()
+
+        # Basic case, no loader, success
+        cr = ColumnReference(header="Name", sheet="Sheet1")
+        self.assertEqual("Name", cr.header)
+        self.assertEqual("Sheet1", cr.sheet)
+
+        # Test loader arg only
+        with self.assertRaises(ConditionallyRequiredOptions):
+            ColumnReference(loader_class=TestLoader)
+
+        # test loader with header name case
+        crl = ColumnReference(loader_class=TestLoader, header="Loader Name Header")
+        self.assertEqual("Loader Name Header", crl.header)
+        self.assertEqual("test", crl.sheet)
+
+        # test loader with header key case
+        crlk = ColumnReference(loader_class=TestLoader, loader_header_key="NAME")
+        self.assertEqual("Loader Name Header", crlk.header)
+        self.assertEqual("test", crlk.sheet)
+
+        # Test mutex errors
+        with self.assertRaises(MutuallyExclusiveOptions):
+            ColumnReference(loader_class=TestLoader, sheet="Sheet1")
+        with self.assertRaises(MutuallyExclusiveOptions):
+            ColumnReference(
+                loader_class=TestLoader, header="Name", loader_header_key="NAME"
+            )
+
+
+class ColumnHeaderTests(TracebaseTestCase):
+    def test_ColumnHeader(self):
+        chn = ColumnHeader(name="Test header")
+        self.assertEqual("Test header", chn.name)
+        chf = ColumnHeader(field=TestTableColumnModel.name)
+        self.assertEqual("TestTableColumnModel Name", chf.name)
+        chfn = ColumnHeader(
+            field=TestTableColumnModel.name, include_model_in_header=False
+        )
+        self.assertEqual("Name", chfn.name)
+
+    def test_ColumnHeader_comment(self):
+        chf = ColumnHeader(field=TestTableColumnModel.name)
+        self.assertEqual("This be the name.\n\nMust be unique.", chf.comment)
+
+
+class ColumnValueTests(TracebaseTestCase):
+    def test_ColumnValue(self):
+        cv = ColumnValue()
+        self.assertTrue(cv.required)
+        cvf = ColumnValue(field=TestTableColumnModel.choice)
+        self.assertEqual([("1", "1"), ("2", "2")], cvf.static_choices)
+
+
+@isolate_apps("DataRepo.tests.apps.loader")
+class TableColumnTests(TracebaseTestCase):
+    def test_TableColumn(self):
+        tch = TableColumn(
+            header=ColumnHeader(name="Test header"),
+        )
+        self.assertTrue(isinstance(tch, TableColumn))
+        tcf = TableColumn(
+            field=TestTableColumnModel.name,
+        )
+        self.assertTrue(isinstance(tcf, TableColumn))
+        tchr = TableColumn(
+            header=ColumnHeader(name="Test header"),
+            readonly=True,
+        )
+        self.assertTrue(isinstance(tchr, TableColumn))
+        with self.assertRaises(ConditionallyRequiredOptions):
+            TableColumn()
+
+    def test_init_flat(self):
+        tcn = TableColumn.init_flat(
+            field=TestTableColumnModel.choice, name="Test header"
+        )
+        self.assertTrue(isinstance(tcn, TableColumn))
+        self.assertEqual("Test header", tcn.header.name)
+        self.assertEqual([("1", "1"), ("2", "2")], tcn.value.static_choices)
+
+
+class TableColumnUtilityMethodsTests(TracebaseTestCase):
+    def test_make_title(self):
+        self.assertEqual("CamelCase Test", make_title("CamelCase", "test"))
+        self.assertEqual("Uppercase Test", make_title("UPPERCASE", "test"))
+        self.assertEqual("Lowercasetest", make_title("lowercasetest"))
+        self.assertEqual("This Is a Test", make_title("this is a test"))

--- a/DataRepo/tests/loaders/test_table_loader.py
+++ b/DataRepo/tests/loaders/test_table_loader.py
@@ -6,6 +6,7 @@ from django.db import IntegrityError
 from django.db.models import AutoField, CharField, Model, UniqueConstraint
 from django.test.utils import isolate_apps
 
+from DataRepo.loaders.table_column import TableColumn
 from DataRepo.loaders.table_loader import TableLoader
 from DataRepo.tests.tracebase_test_case import TracebaseTestCase
 from DataRepo.utils.exceptions import (
@@ -72,6 +73,10 @@ class TableLoaderTests(TracebaseTestCase):
             DataRequiredValues = DataRequiredHeaders
             DataUniqueColumnConstraints = [["NAME"]]
             FieldToDataHeaderKey = {mdl.__name__: {"name": "NAME", "choice": "CHOICE"}}
+            DataColumnMetadata = DataTableHeaders(
+                NAME=TableColumn.init_flat(name="Name Header"),
+                CHOICE=TableColumn.init_flat(field=mdl.choice),
+            )
             Models = [mdl]
 
             def load_data(self):
@@ -95,6 +100,11 @@ class TableLoaderTests(TracebaseTestCase):
                 "TestUCModel": {"name": "NAME", "uf1": "UFONE", "uf2": "UFTWO"}
             }
             Models = [mdl]
+            DataColumnMetadata = DataTableHeaders(
+                NAME=TableColumn.init_flat(name="Name Header"),
+                UFONE=TableColumn.init_flat(name="UFOne Header"),
+                UFTWO=TableColumn.init_flat(name="UFTwo Header"),
+            )
 
             def load_data(self):
                 return None
@@ -389,6 +399,10 @@ class TableLoaderTests(TracebaseTestCase):
             DataUniqueColumnConstraints = [["NAME"]]
             FieldToDataHeaderKey = {"TestModel": {"name": "NAME", "choice": "CHOICE"}}
             Models = [self.TestModel]
+            DataColumnMetadata = DataTableHeaders(
+                NAME=TableColumn.init_flat(name="Name Header"),
+                CHOICE=TableColumn.init_flat(name="Choice Header"),
+            )
 
             def load_data(self):
                 return None
@@ -444,6 +458,10 @@ class TableLoaderTests(TracebaseTestCase):
             DataUniqueColumnConstraints = [["NAME"]]
             FieldToDataHeaderKey = {"TestModel": {"name": "NAME", "choice": "CHOICE"}}
             Models = [self.TestModel]
+            DataColumnMetadata = DataTableHeaders(
+                NAME=TableColumn.init_flat(name="Name Header"),
+                CHOICE=TableColumn.init_flat(name="Choice Header"),
+            )
 
             def load_data(self):
                 return None
@@ -586,6 +604,10 @@ class TableLoaderTests(TracebaseTestCase):
             DataUniqueColumnConstraints = None
             FieldToDataHeaderKey = None
             Models = None
+            DataColumnMetadata = DataTableHeaders(
+                NAME=TableColumn.init_flat(name="Name Header"),
+                CHOICE=TableColumn.init_flat(name="Choice Header"),
+            )
 
             def load_data(self):
                 return None
@@ -599,13 +621,13 @@ class TableLoaderTests(TracebaseTestCase):
         self.assertEqual(
             (
                 "Invalid attributes:\n"
-                "\tattribute [TestInvalidLoader.DataHeaders] namedtuple required, <class 'NoneType'> set\n"
+                "\tattribute [TestInvalidLoader.DataHeaders] namedtuple required, NoneType set\n"
                 "\tattribute [TestInvalidLoader.DataRequiredHeaders] N-dimensional list of strings required, "
                 "but contains ['NoneType']\n"
                 "\tattribute [TestInvalidLoader.DataRequiredValues] N-dimensional list of strings required, "
                 "but contains ['NoneType']\n"
-                "\tattribute [TestInvalidLoader.DataUniqueColumnConstraints] list required, <class 'NoneType'> set\n"
-                "\tattribute [TestInvalidLoader.FieldToDataHeaderKey] dict required, <class 'NoneType'> set\n"
+                "\tattribute [TestInvalidLoader.DataUniqueColumnConstraints] list required, NoneType set\n"
+                "\tattribute [TestInvalidLoader.FieldToDataHeaderKey] dict required, NoneType set\n"
                 "\tModels is required to have at least 1 Model class"
             ),
             str(aes.exceptions[0]),
@@ -632,6 +654,9 @@ class TableLoaderTests(TracebaseTestCase):
             DataUniqueColumnConstraints = [["TEST"]]
             FieldToDataHeaderKey = {"TestModel": {"name": "TEST"}}
             Models = [TestModel]
+            DataColumnMetadata = DataTableHeaders(
+                TEST=TableColumn.init_flat(name="Test Header")
+            )
 
             def load_data(self):
                 pass
@@ -734,8 +759,8 @@ class TableLoaderTests(TracebaseTestCase):
             # pylint: enable=abstract-class-instantiated
         self.assertEqual(
             (
-                "Can't instantiate abstract class TestEmptyLoader with abstract methods DataHeaders, "
-                "DataRequiredHeaders, DataRequiredValues, DataSheetName, DataTableHeaders, "
+                "Can't instantiate abstract class TestEmptyLoader with abstract methods DataColumnMetadata, "
+                "DataHeaders, DataRequiredHeaders, DataRequiredValues, DataSheetName, DataTableHeaders, "
                 "DataUniqueColumnConstraints, FieldToDataHeaderKey, Models, load_data"
             ),
             str(ar.exception),
@@ -1519,3 +1544,12 @@ class TableLoaderTests(TracebaseTestCase):
         self.assertDictEqual(
             expected, todl.get_dataframe_template(all=True, populate=True)
         )
+
+    def test_get_header_metadata(self):
+        tl = self.TestLoader()
+        print(tl.get_header_metadata())
+        self.assertListEqual(
+            ["Choice", "Name"], sorted(tl.get_header_metadata().keys())
+        )
+        # Just going to assert a single attribute is properly set
+        self.assertEqual("TestModel Choice", tl.get_header_metadata()["Choice"].name)

--- a/DataRepo/tests/loaders/test_table_loader.py
+++ b/DataRepo/tests/loaders/test_table_loader.py
@@ -1547,7 +1547,6 @@ class TableLoaderTests(TracebaseTestCase):
 
     def test_get_header_metadata(self):
         tl = self.TestLoader()
-        print(tl.get_header_metadata())
         self.assertListEqual(
             ["Choice", "Name"], sorted(tl.get_header_metadata().keys())
         )

--- a/DataRepo/tests/management/test_load_table.py
+++ b/DataRepo/tests/management/test_load_table.py
@@ -5,6 +5,7 @@ from collections import namedtuple
 from django.db.models import AutoField, CharField, Model
 from django.test.utils import isolate_apps
 
+from DataRepo.loaders.table_column import TableColumn
 from DataRepo.loaders.table_loader import TableLoader
 from DataRepo.management.commands.load_table import LoadTableCommand
 from DataRepo.tests.tracebase_test_case import TracebaseTestCase
@@ -33,6 +34,9 @@ class TestLoader(TableLoader):
     DataDefaultValues = DataTableHeaders(TEST="five")
     DataUniqueColumnConstraints = [["TEST"]]
     FieldToDataHeaderKey = {"LoadTableTestModel": {"name": "TEST"}}
+    DataColumnMetadata = DataTableHeaders(
+        TEST=TableColumn.init_flat(name="Test Header")
+    )
     Models = [LoadTableTestModel]
 
     def load_data(self):

--- a/DataRepo/tests/views/upload/test_validation.py
+++ b/DataRepo/tests/views/upload/test_validation.py
@@ -3,6 +3,7 @@ import re
 from io import BytesIO
 
 from DataRepo.loaders import ProtocolsLoader, SampleTableLoader, TissuesLoader
+from DataRepo.loaders.table_column import ColumnHeader, TableColumn
 from DataRepo.models import Protocol, Tissue
 from DataRepo.tests.tracebase_test_case import TracebaseTransactionTestCase
 from DataRepo.utils.exceptions import (
@@ -667,3 +668,41 @@ class DataValidationViewTests(TracebaseTransactionTestCase):
         dvv.annotate_study_excel(xlsxwriter)
         xlsxwriter.close()
         self.assertEqual(0, len(base64.b64encode(study_stream.read()).decode("utf-8")))
+
+    def test_header_to_cell(self):
+        dvv = DataValidationView()
+
+        # Get cell location success
+        result = dvv.header_to_cell("Animals", "Age")
+        self.assertEqual("B1", result)
+
+        # Get column letter success
+        result2 = dvv.header_to_cell("Animals", "Age", letter_only=True)
+        self.assertEqual("B", result2)
+
+        # Invalid column name
+        with self.assertRaises(ValueError):
+            result2 = dvv.header_to_cell("Animals", "Invalid")
+
+        # Invalid sheet name
+        with self.assertRaises(ValueError):
+            result2 = dvv.header_to_cell("Invalid", "Age")
+
+    def test_animals_sheet_metadata(self):
+        dvv = DataValidationView()
+        self.assertTrue(isinstance(dvv.animals_sheet_metadata.ANIMAL_AGE, TableColumn))
+
+    def test_samples_sheet_metadata(self):
+        # result = dvv.samples_sheet_metadata
+        dvv = DataValidationView()
+        self.assertTrue(isinstance(dvv.samples_sheet_metadata.SAMPLE_NAME, TableColumn))
+
+    def test_get_animal_header_metadata(self):
+        dvv = DataValidationView()
+        result = dvv.get_animal_header_metadata()
+        self.assertTrue(isinstance(result["Age"], ColumnHeader))
+
+    def test_get_sample_header_metadata(self):
+        dvv = DataValidationView()
+        result = dvv.get_sample_header_metadata()
+        self.assertTrue(isinstance(result["Sample Name"], ColumnHeader))

--- a/DataRepo/utils/exceptions.py
+++ b/DataRepo/utils/exceptions.py
@@ -2511,6 +2511,10 @@ class MutuallyExclusiveOptions(CommandError):
     pass
 
 
+class ConditionallyRequiredOptions(CommandError):
+    pass
+
+
 class NoLoadData(Exception):
     pass
 

--- a/DataRepo/views/upload/validation.py
+++ b/DataRepo/views/upload/validation.py
@@ -3,12 +3,13 @@ import os.path
 import re
 import shutil
 import tempfile
-from collections import defaultdict
+from collections import defaultdict, namedtuple
 from io import BytesIO
 from sqlite3 import ProgrammingError
 from typing import Dict, List, Optional, cast
 
 import pandas as pd
+import xlsxwriter
 import yaml  # type: ignore
 from django.conf import settings
 from django.core.management import call_command
@@ -20,8 +21,18 @@ from DataRepo.forms import DataSubmissionValidationForm
 from DataRepo.loaders.accucor_data_loader import AccuCorDataLoader
 from DataRepo.loaders.protocols_loader import ProtocolsLoader
 from DataRepo.loaders.sample_table_loader import SampleTableLoader
+from DataRepo.loaders.table_column import ColumnReference, TableColumn
 from DataRepo.loaders.tissues_loader import TissuesLoader
-from DataRepo.models import LCMethod, MSRunSample, MSRunSequence, Researcher
+from DataRepo.models import (
+    Animal,
+    InfusateTracer,
+    LCMethod,
+    MSRunSample,
+    MSRunSequence,
+    Researcher,
+    Sample,
+    Study,
+)
 from DataRepo.models.protocol import Protocol
 from DataRepo.utils.exceptions import (
     AllMissingSamplesError,
@@ -65,6 +76,36 @@ class DataValidationView(FormView):
     supported_versions = [default_version]
     ANIMALS_SHEET = "Animals"
     SAMPLES_SHEET = "Samples"
+    SAMPLE_HEADS = SampleTableLoader.DefaultSampleTableHeaders
+    AnimalColumns = namedtuple(
+        "AnimalColumns",
+        [
+            "ANIMAL_NAME",
+            "ANIMAL_AGE",
+            "ANIMAL_SEX",
+            "ANIMAL_GENOTYPE",
+            "ANIMAL_TREATMENT",
+            "ANIMAL_WEIGHT",
+            "INFUSATE",
+            "TRACER_CONCENTRATIONS",
+            "ANIMAL_INFUSION_RATE",
+            "ANIMAL_DIET",
+            "ANIMAL_FEEDING_STATUS",
+            "STUDY_NAME",
+            "STUDY_DESCRIPTION",
+        ],
+    )
+    SampleColumns = namedtuple(
+        "SampleColumns",
+        [
+            "SAMPLE_NAME",
+            "SAMPLE_DATE",
+            "SAMPLE_RESEARCHER",
+            "TISSUE_NAME",
+            "TIME_COLLECTED",
+            "ANIMAL_NAME",
+        ],
+    )
 
     def __init__(self):
         super().__init__()
@@ -306,12 +347,12 @@ class DataValidationView(FormView):
 
         for header in self.samples_ordered_display_headers:
             if (
-                header == SampleTableLoader.DefaultSampleTableHeaders.SAMPLE_NAME
+                header == self.SAMPLE_HEADS.SAMPLE_NAME
                 or header not in self.dfs_dict[self.SAMPLES_SHEET].keys()
             ):
                 continue
 
-            for ridx, val in self.dfs_dict[self.SAMPLES_SHEET][header].items():
+            for val in self.dfs_dict[self.SAMPLES_SHEET][header].values():
                 if val is not None:
                     # If any data has been manually added, we should check for mistakes (so, validate, i.e. autofill-
                     # only = False)
@@ -337,7 +378,23 @@ class DataValidationView(FormView):
         # TODO: Use the xlsxwriter to decorate the excel sheets with errors/warnings as cell comments, colors to
         # indicate errors/warning/required-values/read-only-values, and formulas for inter-sheet population of
         # dropdowns.
-        for sheet in xlsxwriter.sheets.keys():
+        column_metadata = {
+            self.ANIMALS_SHEET: self.get_animal_header_metadata(),
+            self.SAMPLES_SHEET: self.get_sample_header_metadata(),
+            self.tissues_loader.DataSheetName: self.tissues_loader.get_header_metadata(),
+            self.treatments_loader.DataSheetName: self.treatments_loader.get_header_metadata(),
+        }
+        for order_spec in self.get_study_sheet_column_display_order():
+            sheet = order_spec[0]
+            worksheet = xlsxwriter.sheets[sheet]
+            headers = order_spec[1]
+
+            # Add comments to header cells
+            for header in headers:
+                comment = column_metadata[sheet][header].comment
+                if comment is not None:
+                    cell = self.header_to_cell(sheet=sheet, header=header)
+                    worksheet.write_comment(cell, comment)
             xlsxwriter.sheets[sheet].autofit()
 
     def extract_autofill_from_peak_annotation_files(self):
@@ -354,7 +411,7 @@ class DataValidationView(FormView):
         existing_sample_names = []
         if self.dfs_dict_is_valid():
             existing_sample_names = self.dfs_dict[self.SAMPLES_SHEET][
-                SampleTableLoader.DefaultSampleTableHeaders.SAMPLE_NAME
+                self.SAMPLE_HEADS.SAMPLE_NAME
             ].values()
 
         corrected_sheet = 1  # Second sheet in both accucor and isocorr
@@ -388,7 +445,7 @@ class DataValidationView(FormView):
                 and sample_name not in existing_sample_names
             ):
                 self.autofill_dict[self.SAMPLES_SHEET][sample_name] = {
-                    SampleTableLoader.DefaultSampleTableHeaders.SAMPLE_NAME: sample_name
+                    self.SAMPLE_HEADS.SAMPLE_NAME: sample_name
                 }
 
     def extract_autofill_from_exceptions(
@@ -536,7 +593,7 @@ class DataValidationView(FormView):
         existing_sample_names = []
         if self.dfs_dict_is_valid():
             existing_sample_names = self.dfs_dict[self.SAMPLES_SHEET][
-                SampleTableLoader.DefaultSampleTableHeaders.SAMPLE_NAME
+                self.SAMPLE_HEADS.SAMPLE_NAME
             ].values()
 
         pattern = self.get_approx_sample_header_replacement_regex()
@@ -545,7 +602,7 @@ class DataValidationView(FormView):
             sample_name = re.sub(pattern, "", sample_header)
             if sample_name not in existing_sample_names:
                 self.autofill_dict[self.SAMPLES_SHEET][sample_name] = {
-                    SampleTableLoader.DefaultSampleTableHeaders.SAMPLE_NAME: sample_name
+                    self.SAMPLE_HEADS.SAMPLE_NAME: sample_name
                 }
 
     def extract_all_missing_tissues(self, exc):
@@ -700,6 +757,34 @@ class DataValidationView(FormView):
                 self.tissues_loader.get_ordered_display_headers(),
             ],
         ]
+
+    def header_to_cell(self, sheet, header, letter_only=False):
+        """Convert a sheet name and header string into the corresponding excel cell location, e.g. "A1".
+        Args:
+            sheet (string): Name of the target sheet
+            header (string): Name of the column header
+            letter_only (boolean): Whether to include the row number
+        Exceptions:
+            Raises:
+                ValueError
+        Returns:
+            (string): Cell location or column letter
+        """
+        headers = []
+        if sheet == self.ANIMALS_SHEET:
+            headers = self.animals_ordered_display_headers
+        elif sheet == self.SAMPLES_SHEET:
+            headers = self.samples_ordered_display_headers
+        elif sheet == ProtocolsLoader.DataSheetName:
+            headers = self.treatments_loader.get_ordered_display_headers()
+        elif sheet == TissuesLoader.DataSheetName:
+            headers = self.tissues_loader.get_ordered_display_headers()
+        else:
+            raise ValueError(f"Invalid sheet: [{sheet}].")
+        column_letter = xlsxwriter.utility.xl_col_to_name(headers.index(header))
+        if letter_only:
+            return column_letter
+        return f"{column_letter}1"
 
     def get_next_row_index(self, sheet):
         """Retrieves the next row index from self.dfs_dict[sheet] (from the first arbitrary column).
@@ -873,24 +958,10 @@ class DataValidationView(FormView):
         Exceptions:
             None
         Returns:
-            None
+            dict of empty dicts keyed on header
         """
         # TODO: Eliminate this property once the sample table loader is split and inherits from TableLoader
-        return {
-            SampleTableLoader.DefaultSampleTableHeaders.ANIMAL_NAME: {},
-            SampleTableLoader.DefaultSampleTableHeaders.ANIMAL_AGE: {},
-            SampleTableLoader.DefaultSampleTableHeaders.ANIMAL_SEX: {},
-            SampleTableLoader.DefaultSampleTableHeaders.ANIMAL_GENOTYPE: {},
-            SampleTableLoader.DefaultSampleTableHeaders.ANIMAL_WEIGHT: {},
-            SampleTableLoader.DefaultSampleTableHeaders.INFUSATE: {},
-            SampleTableLoader.DefaultSampleTableHeaders.TRACER_CONCENTRATIONS: {},
-            SampleTableLoader.DefaultSampleTableHeaders.ANIMAL_INFUSION_RATE: {},
-            SampleTableLoader.DefaultSampleTableHeaders.ANIMAL_DIET: {},
-            SampleTableLoader.DefaultSampleTableHeaders.ANIMAL_FEEDING_STATUS: {},
-            SampleTableLoader.DefaultSampleTableHeaders.ANIMAL_TREATMENT: {},
-            SampleTableLoader.DefaultSampleTableHeaders.STUDY_NAME: {},
-            SampleTableLoader.DefaultSampleTableHeaders.STUDY_DESCRIPTION: {},
-        }
+        return dict((h, {}) for h in self.animals_ordered_display_headers)
 
     @property
     def animals_ordered_display_headers(self):
@@ -903,7 +974,7 @@ class DataValidationView(FormView):
         Exceptions:
             None
         Returns:
-            None
+            list of strings
         """
         # TODO: Eliminate this property once the sample table loader is split and inherits from TableLoader
         return [
@@ -923,6 +994,70 @@ class DataValidationView(FormView):
         ]
 
     @property
+    def animals_sheet_metadata(self):
+        """Property to return metadata about the excel column.
+        Args:
+            None
+        Exceptions:
+            None
+        Returns:
+            namedtuple (AnimalColumns) of TableColumns
+        """
+        # TODO: Eliminate this property once the sample table loader is split and inherits from TableLoader
+        return self.AnimalColumns(
+            ANIMAL_NAME=TableColumn.init_flat(
+                field=Animal.name,
+                reference=ColumnReference(
+                    header=self.SAMPLE_HEADS.ANIMAL_NAME,
+                    sheet=self.SAMPLES_SHEET,
+                ),
+            ),
+            ANIMAL_AGE=TableColumn.init_flat(
+                field=Animal.age,
+                format="Units: weeks (integer or decimal).",
+            ),
+            ANIMAL_SEX=TableColumn.init_flat(field=Animal.sex),
+            ANIMAL_GENOTYPE=TableColumn.init_flat(field=Animal.genotype),
+            ANIMAL_WEIGHT=TableColumn.init_flat(field=Animal.body_weight),
+            INFUSATE=TableColumn.init_flat(
+                field=Animal.age,
+                guidance=(
+                    "Individual tracer compounds will be formatted: compound_name-[weight element count,weight "
+                    "element count]\nexample: valine-[13C5,15N1]\n"
+                    "\n"
+                    "Mixtures of compounds will be formatted: tracer_group_name {tracer; tracer}\n"
+                    "example:\n"
+                    "BCAAs {isoleucine-[13C6,15N1];leucine-[13C6,15N1];valine-[13C5,15N1]}"
+                ),
+            ),
+            TRACER_CONCENTRATIONS=TableColumn.init_flat(
+                field=InfusateTracer.concentration,
+                guidance=(
+                    f"Multiple tracers in a single {self.SAMPLE_HEADS.INFUSATE} should have "
+                    f"{self.SAMPLE_HEADS.TRACER_CONCENTRATIONS} specified as a semi-colon delimited list in the "
+                    f"same order and cardinality as the list of tracers in the {self.SAMPLE_HEADS.INFUSATE} column."
+                ),
+            ),
+            ANIMAL_INFUSION_RATE=TableColumn.init_flat(field=Animal.infusion_rate),
+            ANIMAL_DIET=TableColumn.init_flat(field=Animal.diet),
+            ANIMAL_FEEDING_STATUS=TableColumn.init_flat(
+                field=Animal.feeding_status,
+                guidance=(
+                    "Any value can be entered, despite the list of choices.  Indicate length of fasting/feeding in "
+                    f"'{self.SAMPLE_HEADS.STUDY_DESCRIPTION}'."
+                ),
+                static_choices=[
+                    ("fasted", "fasted"),
+                    ("fed", "fed"),
+                    ("refed", "refed"),
+                ],
+            ),
+            ANIMAL_TREATMENT=TableColumn.init_flat(field=Animal.treatment),
+            STUDY_NAME=TableColumn.init_flat(field=Study.name),
+            STUDY_DESCRIPTION=TableColumn.init_flat(field=Study.description),
+        )
+
+    @property
     def samples_dict(self):
         """Property to return an empty dict template for the Samples sheet.
         Args:
@@ -930,17 +1065,10 @@ class DataValidationView(FormView):
         Exceptions:
             None
         Returns:
-            None
+            dict of empty dicts keyed on header.
         """
         # TODO: Eliminate this property once the sample table loader is split and inherits from TableLoader
-        return {
-            SampleTableLoader.DefaultSampleTableHeaders.SAMPLE_NAME: {},
-            SampleTableLoader.DefaultSampleTableHeaders.SAMPLE_DATE: {},
-            SampleTableLoader.DefaultSampleTableHeaders.SAMPLE_RESEARCHER: {},
-            SampleTableLoader.DefaultSampleTableHeaders.TISSUE_NAME: {},
-            SampleTableLoader.DefaultSampleTableHeaders.TIME_COLLECTED: {},
-            SampleTableLoader.DefaultSampleTableHeaders.ANIMAL_NAME: {},
-        }
+        return dict((h, {}) for h in self.samples_ordered_display_headers)
 
     @property
     def samples_ordered_display_headers(self):
@@ -953,7 +1081,7 @@ class DataValidationView(FormView):
         Exceptions:
             None
         Returns:
-            None
+            list of strings (headers)
         """
         # TODO: Eliminate this property once the sample table loader is split and inherits from TableLoader
         return [
@@ -964,6 +1092,53 @@ class DataValidationView(FormView):
             SampleTableLoader.DefaultSampleTableHeaders.TIME_COLLECTED,
             SampleTableLoader.DefaultSampleTableHeaders.ANIMAL_NAME,
         ]
+
+    @property
+    def samples_sheet_metadata(self):
+        """Property to return metadata about the excel column.
+        Args:
+            None
+        Exceptions:
+            None
+        Returns:
+            namedtuple (SampleColumns) of TableColumns
+        """
+        # TODO: Eliminate this property once the sample table loader is split and inherits from TableLoader
+        return self.SampleColumns(
+            SAMPLE_NAME=TableColumn.init_flat(
+                field=Sample.name,
+                guidance=(
+                    "MUST match the sample names in the peak annotation file, minus any appended suffixes (e.g. "
+                    "'_pos')."
+                ),
+            ),
+            SAMPLE_DATE=TableColumn.init_flat(
+                field=Sample.date,
+                format="Format: YYYY-MM-DD.",
+            ),
+            SAMPLE_RESEARCHER=TableColumn.init_flat(
+                name=self.SAMPLE_HEADS.SAMPLE_RESEARCHER,
+                help_text="Name of researcher who collected the sample.",
+            ),
+            TISSUE_NAME=TableColumn.init_flat(
+                field=Sample.tissue,
+                reference=ColumnReference(
+                    loader_class=TissuesLoader,
+                    loader_header_key=TissuesLoader.NAME_KEY,
+                ),
+            ),
+            TIME_COLLECTED=TableColumn.init_flat(
+                field=Sample.time_collected,
+                format="Units: minutes.",
+            ),
+            ANIMAL_NAME=TableColumn.init_flat(
+                field=Sample.animal,
+                reference=ColumnReference(
+                    header=self.SAMPLE_HEADS.ANIMAL_NAME,
+                    sheet=self.ANIMALS_SHEET,
+                ),
+            ),
+        )
 
     def get_study_dfs_dict(self, version=default_version):
         """Read in each sheet in self.animal_sample_file as a dict of dicts keyed on sheet (filling in any missing
@@ -1015,15 +1190,14 @@ class DataValidationView(FormView):
         if version == self.default_version or version.startswith(
             f"{self.default_version}."
         ):
-            animal_sample_headers = SampleTableLoader.DefaultSampleTableHeaders
             return {
                 # TODO: Update the animal and sample entries below once the loader has been refactored
                 # The sample table loader has not yet been refactored/split
                 self.ANIMALS_SHEET: {
-                    animal_sample_headers.ANIMAL_NAME: str,
-                    animal_sample_headers.ANIMAL_TREATMENT: str,
+                    self.SAMPLE_HEADS.ANIMAL_NAME: str,
+                    self.SAMPLE_HEADS.ANIMAL_TREATMENT: str,
                 },
-                self.SAMPLES_SHEET: {animal_sample_headers.ANIMAL_NAME: str},
+                self.SAMPLES_SHEET: {self.SAMPLE_HEADS.ANIMAL_NAME: str},
                 ProtocolsLoader.DataSheetName: self.treatments_loader.get_column_types(),
                 TissuesLoader.DataSheetName: self.tissues_loader.get_column_types(),
             }
@@ -1427,12 +1601,39 @@ class DataValidationView(FormView):
 
         return (
             # Required headers present in each sheet
-            SampleTableLoader.DefaultSampleTableHeaders.SAMPLE_NAME
-            in self.dfs_dict[self.SAMPLES_SHEET].keys()
-            and SampleTableLoader.DefaultSampleTableHeaders.ANIMAL_NAME
+            self.SAMPLE_HEADS.SAMPLE_NAME in self.dfs_dict[self.SAMPLES_SHEET].keys()
+            and self.SAMPLE_HEADS.ANIMAL_NAME
             in self.dfs_dict[self.ANIMALS_SHEET].keys()
             and missing_treat_heads is None
             and missing_tiss_heads is None
+        )
+
+    def get_animal_header_metadata(self):
+        """Returns a dict keyed on current animal headers, whose values are ColumnHeader objects.
+        Args:
+            None
+        Exceptions:
+            None
+        Returns:
+            dict of ColumnHeaders keyed on column names
+        """
+        return dict(
+            (getattr(self.SAMPLE_HEADS, hk), v.header)
+            for hk, v in self.animals_sheet_metadata._asdict().items()
+        )
+
+    def get_sample_header_metadata(self):
+        """Returns a dict keyed on current sample headers, whose values are ColumnHeader objects.
+        Args:
+            None
+        Exceptions:
+            None
+        Returns:
+            dict of ColumnHeaders keyed on column names
+        """
+        return dict(
+            (getattr(self.SAMPLE_HEADS, hk), v.header)
+            for hk, v in self.samples_sheet_metadata._asdict().items()
         )
 
 


### PR DESCRIPTION
## Summary Change Description

<img width="843" alt="headercomments" src="https://github.com/Princeton-LSI-ResearchComputing/tracebase/assets/2300532/733ae093-d441-4fa1-b372-a980d7a81d34">

In preparation for the other plans for the excel file export and the submission process in general, I also implemented a way to store numerous pieces of metadata associated with excel sheets/columns that are collectively used to build comments, among other things.  Much of the data is derived from the models saved in the loader classes.

Details:

- `validation.py`
  - Added methods:
    - `get_sample_header_metadata`
    - `get_animal_header_metadata`
    - `samples_sheet_metadata`
    - `animals_sheet_metadata`
    - `header_to_cell`
  - Added attributes to the `DataValidationView` class:
    - `SampleColumns`
    - `AnimalColumns`
    - `SAMPLE_HEADS`
- `exceptions.py`
  - Added class: ConditionallyRequiredOptions
- `table_loader.py`
  - Added a new abstract attribute to `TableLoader`: `DataColumnMetadata`, which is a `namedtuple` of `TableColumns`
  - Added method: `get_header_metadata` to `TableLoader` to get the `ColumnHeader` data by header names instead of keys
- Added a file in the loaders directory: table_column.py which defines classes to hold the excel column metadata:
  - `ColumnReference` (in order to add a comment like "must match values in sheet/column" and to use to populate dropdowns from the content of another sheet)
  - `ColumnHeader`
  - `ColumnValue`
  - `TableColumn` (which contains a ColumnHeader and ColumnValue object)

## Affected Issues/Pull Requests

- Partially addresses #829
- Merges into PR #936
- Next PR: #938

## Review Notes
<!--
For added context for reviewers, add comments to relevant lines of code.  Use
this space to describe any general areas of concern not linked to a specific
line of code that reviewers should pay particular attention to, e.g. please
make sure I have accounted for all possible inputs.
-->
See comments in-line.

## Checklist
<!--
If any of the checkbox requirements are not met, uncheck them and add an
explanation. E.g. Linting errors pre-date this PR.
-->
This pull request will be merged once the following requirements are met.  The
author and/or reviewers should uncheck any unmet requirements:

- Review requirements
  - Minimum approvals: 1 <!-- Edit as desired (e.g. based on complexity) -->
  - No changes requested
  - All blocking issues resolved by reviewers
  - Specific reviewers: @__add_username_here__
    <!--
    Require reviewers with specific expertise to be included among the minimum
    number of reviewers by tagging them.  Also please send them a message.
    -->
  - Review period: 2 days <!-- Edit as desired (e.g. based on complexity) -->
- Associated issue/pull request requirements:
  <!--
  Assert that all requirements in issues marked "resolved" are done and that
  all required pull requests are merged.  If any are not done, either edit or
  split the issue or explain the unmerged affected pull requests.
  -->
  - [x] All requirements in affected issues marked "resolved" are satisfied
  - [x] All required pull requests are merged *(or none)*
- Basic requirements
  <!--
  Uncheck items to acknowledge failures/conflicts you intend to address.
  Add an explanation if any won't be addressed before merge.
  -->
  - [x] [All linters pass](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#linting)
  - [x] [All tests pass](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#quality-control)
  - [x] All conflicts resolved
- Overhead requirements
  <!--
  These are additional requirements that are not directly associated with
  resolving the affected issue(s).
  -->
  - [x] [New/changed method tests implemented/updated *(or no change)*](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#test-implementation)
  - [x] [Updated *Unreleased* section of `changelog.md` *(or no change)*](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/changelog.md)
  - [x] [Migrations created & committed *(or no change)*](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#migration-process)
