### PR TITLE
Added code to autofit comment boxes to the text content.

### DIFF
--- a/DataRepo/tests/utils/test_text_utils.py
+++ b/DataRepo/tests/utils/test_text_utils.py
@@ -1,0 +1,40 @@
+from DataRepo.tests.tracebase_test_case import TracebaseTestCase
+from DataRepo.utils.text_utils import autowrap
+
+
+class TextUtilsTests(TracebaseTestCase):
+    def test_autowrap(self):
+        self.assertEqual(
+            (
+                (
+                    "This is a test of\n"
+                    "the autowrap method\n"
+                    "\n"
+                    "with lines longer\n"
+                    "than 20 characters.\n"
+                    "and a line that's ex\n"
+                    "-actly 20 characters\n\n\n"
+                    "You betcha."
+                ),
+                10,
+                20,
+            ),
+            autowrap(
+                (
+                    "This is a test of the autowrap method\n"
+                    "\n"
+                    "with lines longer than 20 characters.\n"
+                    "and a line that's ex\n"
+                    "-actly 20 characters\n\n\n"
+                    "You betcha."
+                ),
+                default_width=20,
+            ),
+        )
+        self.assertEqual(
+            ("A", 1, 1),
+            autowrap(
+                "A",
+                default_width=20,
+            ),
+        )

--- a/DataRepo/utils/text_utils.py
+++ b/DataRepo/utils/text_utils.py
@@ -1,0 +1,50 @@
+import textwrap
+
+
+def autowrap(text: str, default_width: int = 80, **kwargs):
+    """Given text (containing hard-returns), this method uses textwrap.wrap() to wrap long lines to a max length as
+    determined by textwrap.wrap's 'width' argument.  The default for that argument is 70, but this method sets it to a
+    default of 80.  It returns the wrapped text string, the number of lines in the result, and the length of the longest
+    line.
+
+    This is intended to be used to determine text box dimensions (after applying font and line sizes).
+
+    Args:
+        text (string): The text/content to be wrapped.
+        default_width (integer): The number of characters allowed on a line (including white space) is kwargs["width"]
+            is not set.
+        kwargs (dict): Keyword arguments supplied directly to textwrap.wrap()
+    Exceptions:
+        None
+    Returns:
+        wrapped (string): The input text with hard-returns inserted in lines that exceed kwargs["width"].
+        nlines (int): The number of lines in the outout (not including a line after the last trailing hard return).
+        max_width (int): The number of characters on the longest line.  Note, this does not account for variable width
+            fonts.  If the intention is to use this to compute text box width, use a fixed-witdh font, or parse the
+            lines in {wrapped} to determine the longest line.
+    """
+    wrapped = ""
+    nlines = 0
+    max_width = 0
+
+    if text == "":
+        # Avoid issues with removing a non-existent character
+        return wrapped, nlines, max_width
+
+    if kwargs.get("width") is None:
+        kwargs["width"] = default_width
+
+    for line in text.split("\n"):
+        if line == "":
+            # textwrap.wrap() returns an empty list when line is ""
+            nlines += 1
+            wrapped += "\n"
+            continue
+
+        for wrappedline in textwrap.wrap(line, **kwargs):
+            nlines += 1
+            if len(wrappedline) > max_width:
+                max_width = len(wrappedline)
+            wrapped += f"{wrappedline}\n"
+
+    return wrapped[:-1], nlines, max_width

--- a/DataRepo/views/upload/validation.py
+++ b/DataRepo/views/upload/validation.py
@@ -50,6 +50,7 @@ from DataRepo.utils.lcms_metadata_parser import (
     LCMS_FL_SAMPLE_HDR,
     LCMS_PEAK_ANNOT_HDR,
 )
+from DataRepo.utils.text_utils import autowrap
 
 
 class DataValidationView(FormView):
@@ -394,7 +395,22 @@ class DataValidationView(FormView):
                 comment = column_metadata[sheet][header].comment
                 if comment is not None:
                     cell = self.header_to_cell(sheet=sheet, header=header)
-                    worksheet.write_comment(cell, comment)
+                    wrapped, nlines, nchars = autowrap(comment)
+                    font_width = 8
+                    font_height = 10
+                    line_height = 18
+                    worksheet.write_comment(
+                        cell,
+                        wrapped,
+                        {
+                            "author": "TraceBase Dev Team",
+                            "color": "#FEF49C",
+                            "font_name": "Courier",  # Fixed width for box height/width calcs
+                            "font_size": font_height,
+                            "height": nlines * line_height,
+                            "width": nchars * font_width,
+                        },
+                    )
             xlsxwriter.sheets[sheet].autofit()
 
     def extract_autofill_from_peak_annotation_files(self):


### PR DESCRIPTION
## Summary Change Description

This was a quick little tweak to the comment box dimensions.

I basically used textwrap.wrap(), combined with a fixed width font to be able to predictably calculate box dimensions.  It's not perfect, but any ill-sized comment windows can be manually tweaked by users if necessary.

- Added author
- Changed the color
- Added method: autowrap inside a new file: text_utils.py

## Affected Issues/Pull Requests

- Partially addresses #829
- Merges into PR #937

## Review Notes
<!--
For added context for reviewers, add comments to relevant lines of code.  Use
this space to describe any general areas of concern not linked to a specific
line of code that reviewers should pay particular attention to, e.g. please
make sure I have accounted for all possible inputs.
-->
See comments in-line.

## Checklist
<!--
If any of the checkbox requirements are not met, uncheck them and add an
explanation. E.g. Linting errors pre-date this PR.
-->
This pull request will be merged once the following requirements are met.  The
author and/or reviewers should uncheck any unmet requirements:

- Review requirements
  - Minimum approvals: 1 <!-- Edit as desired (e.g. based on complexity) -->
  - No changes requested
  - All blocking issues resolved by reviewers
  - Specific reviewers: @__add_username_here__
    <!--
    Require reviewers with specific expertise to be included among the minimum
    number of reviewers by tagging them.  Also please send them a message.
    -->
  - Review period: 2 days <!-- Edit as desired (e.g. based on complexity) -->
- Associated issue/pull request requirements:
  <!--
  Assert that all requirements in issues marked "resolved" are done and that
  all required pull requests are merged.  If any are not done, either edit or
  split the issue or explain the unmerged affected pull requests.
  -->
  - [x] All requirements in affected issues marked "resolved" are satisfied
  - [x] All required pull requests are merged *(or none)*
- Basic requirements
  <!--
  Uncheck items to acknowledge failures/conflicts you intend to address.
  Add an explanation if any won't be addressed before merge.
  -->
  - [x] [All linters pass](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#linting)
  - [x] [All tests pass](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#quality-control)
  - [x] All conflicts resolved
- Overhead requirements
  <!--
  These are additional requirements that are not directly associated with
  resolving the affected issue(s).
  -->
  - [x] [New/changed method tests implemented/updated *(or no change)*](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#test-implementation)
  - [ ] [Updated *Unreleased* section of `changelog.md` *(or no change)*](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/changelog.md)
  - [x] [Migrations created & committed *(or no change)*](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#migration-process)
