### PR TITLE
Add function to detect peak annotation DataFormat

### DIFF
--- a/DataRepo/loaders/accucor_data_loader.py
+++ b/DataRepo/loaders/accucor_data_loader.py
@@ -72,6 +72,7 @@ from DataRepo.utils.exceptions import (
     NoSampleHeaders,
     NoSamplesError,
     NoTracerLabeledElements,
+    PeakAnnotationParseError,
     PeakAnnotFileMismatches,
     ResearcherNotNew,
     SampleColumnInconsistency,
@@ -2173,14 +2174,20 @@ class AccuCorDataLoader:
         enable_caching_updates()
 
     @classmethod
-    def detect_data_format(cls, file):
-        """Detect the data format of an Excel workbook
+    def detect_data_format(cls, file: str):
+        """Detect the data format of a peak annotation file
+
+        Currently, this only works with Excel workbooks, other file format will
+        return `None`.
 
         Args:
-            file: path to Excel file
+            file (str): path to a peak annotation file
 
         Returns:
-            data_format: DataFormat model object or None if unknown
+            data_format (Optional[DataFormat]): DataFormat model object or None if unknown
+
+        Raises:
+            PeakAnnotationParseError
         """
 
         data_format = None
@@ -2190,6 +2197,15 @@ class AccuCorDataLoader:
                 data_format = DataFormat.objects.get(code="accucor")
             elif sheets == cls.ISOCORR_SHEETS:
                 data_format = DataFormat.objects.get(code="isocorr")
+            else:
+                raise PeakAnnotationParseError(
+                    message=f'Unable to determine data format of peak annoataion file "{file}".\n'
+                    "The list of sheets did not match known data formats.\n"
+                    f"Found sheets: {sheets}\n"
+                    "Known formats:\n"
+                    f"accucor: {cls.ACCUCOR_SHEETS}\n"
+                    f"isocorr: {cls.ISOCORR_SHEETS}\n"
+                )
         return data_format
 
     @classmethod

--- a/DataRepo/loaders/accucor_data_loader.py
+++ b/DataRepo/loaders/accucor_data_loader.py
@@ -2184,10 +2184,7 @@ class AccuCorDataLoader:
         """
 
         data_format = None
-        if not is_excel(file):
-            # Accucor format is assumed if files are not Excel
-            data_format = DataFormat.objects.get(code="accucor")
-        else:
+        if is_excel(file):
             sheets = get_sheet_names(file)
             if sheets == cls.ACCUCOR_SHEETS:
                 data_format = DataFormat.objects.get(code="accucor")

--- a/DataRepo/loaders/accucor_data_loader.py
+++ b/DataRepo/loaders/accucor_data_loader.py
@@ -2173,6 +2173,29 @@ class AccuCorDataLoader:
         enable_caching_updates()
 
     @classmethod
+    def detect_data_format(cls, file):
+        """Detect the data format of an Excel workbook
+
+        Args:
+            file: path to Excel file
+
+        Returns:
+            data_format: DataFormat model object or None if unknown
+        """
+
+        data_format = None
+        if not is_excel(file):
+            # Accucor format is assumed if files are not Excel
+            data_format = DataFormat.objects.get(code="accucor")
+        else:
+            sheets = get_sheet_names(file)
+            if sheets == cls.ACCUCOR_SHEETS:
+                data_format = DataFormat.objects.get(code="accucor")
+            elif sheets == cls.ISOCORR_SHEETS:
+                data_format = DataFormat.objects.get(code="isocorr")
+        return data_format
+
+    @classmethod
     def is_accucor(cls, file=None, sheets=None):
         if (file is None and sheets is None) or (
             file is not None and sheets is not None

--- a/DataRepo/tests/loaders/test_accucor_data_loader.py
+++ b/DataRepo/tests/loaders/test_accucor_data_loader.py
@@ -1,8 +1,46 @@
 from DataRepo.loaders.accucor_data_loader import AccuCorDataLoader
+from DataRepo.models import DataFormat
 from DataRepo.tests.tracebase_test_case import TracebaseTestCase
 
 
 class AccuCorDataLoaderTests(TracebaseTestCase):
+
+    fixtures = ["data_formats.yaml"]
+    accucor_format = DataFormat.objects.get(code="accucor")
+    isocorr_format = DataFormat.objects.get(code="isocorr")
+
+    def test_detect_filetype_accucor_xlsx(self):
+        self.assertEquals(
+            AccuCorDataLoader.detect_data_format(
+                file="DataRepo/data/tests/accucor_with_multiple_labels/accucor.xlsx"
+            ),
+            self.accucor_format,
+        )
+
+    def test_detect_filetype_accucor_csv(self):
+        self.assertEquals(
+            AccuCorDataLoader.detect_data_format(
+                file="DataRepo/data/tests/singly_labeled_isocorr/small_cor.csv"
+            ),
+            self.accucor_format,
+        )
+
+    def test_detect_filetype_isocorr(self):
+        self.assertEquals(
+            AccuCorDataLoader.detect_data_format(
+                file="DataRepo/data/tests/multiple_tracers/bcaafasted_cor.xlsx"
+            ),
+            self.isocorr_format,
+        )
+
+    def test_detect_filetype_none(self):
+        self.assertEquals(
+            AccuCorDataLoader.detect_data_format(
+                file="DataRepo/data/tests/submission_v3/study.xlsx"
+            ),
+            None,
+        )
+
     def test_is_accucor_file(self):
         self.assertFalse(
             AccuCorDataLoader.is_accucor(

--- a/DataRepo/tests/loaders/test_accucor_data_loader.py
+++ b/DataRepo/tests/loaders/test_accucor_data_loader.py
@@ -16,15 +16,6 @@ class AccuCorDataLoaderTests(TracebaseTestCase):
             accucor_format,
         )
 
-    def test_detect_filetype_accucor_csv(self):
-        accucor_format = DataFormat.objects.get(code="accucor")
-        self.assertEquals(
-            AccuCorDataLoader.detect_data_format(
-                file="DataRepo/data/tests/singly_labeled_isocorr/small_cor.csv"
-            ),
-            accucor_format,
-        )
-
     def test_detect_filetype_isocorr(self):
         isocorr_format = DataFormat.objects.get(code="isocorr")
         self.assertEquals(
@@ -34,7 +25,15 @@ class AccuCorDataLoaderTests(TracebaseTestCase):
             isocorr_format,
         )
 
-    def test_detect_filetype_none(self):
+    def test_detect_filetype_csv(self):
+        self.assertEquals(
+            AccuCorDataLoader.detect_data_format(
+                file="DataRepo/data/tests/singly_labeled_isocorr/small_cor.csv"
+            ),
+            None,
+        )
+
+    def test_detect_filetype_invalid_xlsx(self):
         self.assertEquals(
             AccuCorDataLoader.detect_data_format(
                 file="DataRepo/data/tests/submission_v3/study.xlsx"

--- a/DataRepo/tests/loaders/test_accucor_data_loader.py
+++ b/DataRepo/tests/loaders/test_accucor_data_loader.py
@@ -6,31 +6,32 @@ from DataRepo.tests.tracebase_test_case import TracebaseTestCase
 class AccuCorDataLoaderTests(TracebaseTestCase):
 
     fixtures = ["data_formats.yaml"]
-    accucor_format = DataFormat.objects.get(code="accucor")
-    isocorr_format = DataFormat.objects.get(code="isocorr")
 
     def test_detect_filetype_accucor_xlsx(self):
+        accucor_format = DataFormat.objects.get(code="accucor")
         self.assertEquals(
             AccuCorDataLoader.detect_data_format(
                 file="DataRepo/data/tests/accucor_with_multiple_labels/accucor.xlsx"
             ),
-            self.accucor_format,
+            accucor_format,
         )
 
     def test_detect_filetype_accucor_csv(self):
+        accucor_format = DataFormat.objects.get(code="accucor")
         self.assertEquals(
             AccuCorDataLoader.detect_data_format(
                 file="DataRepo/data/tests/singly_labeled_isocorr/small_cor.csv"
             ),
-            self.accucor_format,
+            accucor_format,
         )
 
     def test_detect_filetype_isocorr(self):
+        isocorr_format = DataFormat.objects.get(code="isocorr")
         self.assertEquals(
             AccuCorDataLoader.detect_data_format(
                 file="DataRepo/data/tests/multiple_tracers/bcaafasted_cor.xlsx"
             ),
-            self.isocorr_format,
+            isocorr_format,
         )
 
     def test_detect_filetype_none(self):

--- a/DataRepo/tests/loaders/test_accucor_data_loader.py
+++ b/DataRepo/tests/loaders/test_accucor_data_loader.py
@@ -1,6 +1,7 @@
 from DataRepo.loaders.accucor_data_loader import AccuCorDataLoader
 from DataRepo.models import DataFormat
 from DataRepo.tests.tracebase_test_case import TracebaseTestCase
+from DataRepo.utils.exceptions import PeakAnnotationParseError
 
 
 class AccuCorDataLoaderTests(TracebaseTestCase):
@@ -34,12 +35,10 @@ class AccuCorDataLoaderTests(TracebaseTestCase):
         )
 
     def test_detect_filetype_invalid_xlsx(self):
-        self.assertEquals(
+        with self.assertRaises(PeakAnnotationParseError):
             AccuCorDataLoader.detect_data_format(
                 file="DataRepo/data/tests/submission_v3/study.xlsx"
             ),
-            None,
-        )
 
     def test_is_accucor_file(self):
         self.assertFalse(

--- a/DataRepo/utils/exceptions.py
+++ b/DataRepo/utils/exceptions.py
@@ -1984,6 +1984,14 @@ class PeakAnnotFileMismatches(Exception):
         self.peak_annotation_filename = peak_annotation_filename
 
 
+class PeakAnnotationParseError(Exception):
+    def __init__(
+        self, message="Unknown problem attempting to parse peak annotation file"
+    ):
+        self.message = message
+        super().__init__(self.message)
+
+
 class MismatchedSampleHeaderMZXML(Exception):
     def __init__(self, mismatching_mzxmls):
         message = (


### PR DESCRIPTION
<!-- markdownlint-disable-next-line first-line-heading -->
## Summary Change Description
<!-- Briefly describe the changes in this pull request (put details in the
developer section of the linked issue(s)). -->
Adds a function that detects the DataFormat of a peak annotation file.

## Affected Issues/Pull Requests

- Resolves #958
<!--
- Partially addresses #__issue_number__
- Merges into PR #__pull_request_number__
- Requires merge of PR #__pull_request_number__
-->

## Review Notes
<!--
For added context for reviewers, add comments to relevant lines of code.  Use
this space to describe any general areas of concern not linked to a specific
line of code that reviewers should pay particular attention to, e.g. please
make sure I have accounted for all possible inputs.
-->
See comments in-line.

## Checklist
<!--
If any of the checkbox requirements are not met, uncheck them and add an
explanation. E.g. Linting errors pre-date this PR.
-->
This pull request will be merged once the following requirements are met.  The
author and/or reviewers should uncheck any unmet requirements:

- Review requirements
  - Minimum approvals: 1 <!-- Edit as desired (e.g. based on complexity) -->
  - No changes requested
  - All blocking issues resolved by reviewers
  - Specific reviewers: @__add_username_here__
    <!--
    Require reviewers with specific expertise to be included among the minimum
    number of reviewers by tagging them.  Also please send them a message.
    -->
  - Review period: 2 days <!-- Edit as desired (e.g. based on complexity) -->
- Associated issue/pull request requirements:
  <!--
  Assert that all requirements in issues marked "resolved" are done and that
  all required pull requests are merged.  If any are not done, either edit or
  split the issue or explain the unmerged affected pull requests.
  -->
  - [x] All requirements in affected issues marked "resolved" are satisfied
  - [x] All required pull requests are merged *(or none)*
- Basic requirements
  <!--
  Uncheck items to acknowledge failures/conflicts you intend to address.
  Add an explanation if any won't be addressed before merge.
  -->
  - [x] [All linters pass](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#linting)
  - [x] [All tests pass](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#quality-control)
  - [x] All conflicts resolved
- Overhead requirements
  <!--
  These are additional requirements that are not directly associated with
  resolving the affected issue(s).
  -->
  - [x] [New/changed method tests implemented/updated *(or no change)*](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#test-implementation)
  - [ ] [Updated *Unreleased* section of `changelog.md` *(or no change)*](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/changelog.md)
  - [x] [Migrations created & committed *(or no change)*](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#migration-process)
