### PR TITLE
Stubbed out the PeakAnnotationsLoader class with derived classes for file format conversion

### DIFF
--- a/DataRepo/loaders/compounds_loader.py
+++ b/DataRepo/loaders/compounds_loader.py
@@ -95,7 +95,6 @@ class CompoundsLoader(TableLoader):
 
         Args:
             Superclass Args:
-            Superclass Args:
                 df (Optional[pandas dataframe]): Data, e.g. as parsed from a table-like file.
                 dry_run (Optional[boolean]) [False]: Dry run mode.
                 defer_rollback (Optional[boolean]) [False]: Defer rollback mode.  DO NOT USE MANUALLY - A PARENT SCRIPT

--- a/DataRepo/loaders/msruns_loader.py
+++ b/DataRepo/loaders/msruns_loader.py
@@ -11,9 +11,8 @@ from django.db.models import Max, Min, Q
 from DataRepo.loaders.sequences_loader import SequencesLoader
 from DataRepo.loaders.table_column import ColumnReference, TableColumn
 from DataRepo.loaders.table_loader import TableLoader
-from DataRepo.models import MSRunSample, MSRunSequence, PeakGroup
+from DataRepo.models import MSRunSample, MSRunSequence, PeakGroup, Sample
 from DataRepo.models.archive_file import ArchiveFile, DataFormat, DataType
-from DataRepo.models.sample import Sample
 from DataRepo.models.utilities import update_rec
 from DataRepo.utils.exceptions import (
     AggregatedErrors,

--- a/DataRepo/loaders/peak_annotations_loader.py
+++ b/DataRepo/loaders/peak_annotations_loader.py
@@ -135,9 +135,10 @@ class PeakAnnotationsLoader(ABC):
         Returns:
             None
         """
-        for sheet, column_dict in cls.add_columns_dict.items():
-            for new_column, method in column_dict.items():
-                df_dict[sheet][new_column] = method(df_dict[sheet])
+        if cls.add_columns_dict is not None:
+            for sheet, column_dict in cls.add_columns_dict.items():
+                for new_column, method in column_dict.items():
+                    df_dict[sheet][new_column] = method(df_dict[sheet])
 
     @classmethod
     def merge_df_sheets(cls, df_dict, _outdf=None, _merge_dict=None, _first_sheet=None):

--- a/DataRepo/loaders/peak_annotations_loader.py
+++ b/DataRepo/loaders/peak_annotations_loader.py
@@ -72,7 +72,7 @@ class PeakAnnotationsLoader(ABC):
     FORMULA_KEY = "FORMULA"
     COMPOUND_KEY = "COMPOUND"
 
-    DataSheetName = "Peak Annotation Details"
+    DataSheetName = "Corrected"
 
     # The tuple used to store different kinds of data per column at the class level
     DataTableHeaders = namedtuple(

--- a/DataRepo/loaders/peak_annotations_loader.py
+++ b/DataRepo/loaders/peak_annotations_loader.py
@@ -156,7 +156,7 @@ class PeakAnnotationsLoader(ABC):
         Returns:
             outdf (pandas DataFrame): Converted single DataFrame
         """
-        # If there's only 1 key in the merge_dict and its value is None, it is inferred to mean that no merge is
+        # If the value for key 'next_merge_dict' is None, it is inferred to mean that no merge is
         # necessary.  Just set the outdf to that one dataframe indicated by the sole sheet key.
         single_sheet = (
             cls.merge_dict["first_sheet"]

--- a/DataRepo/loaders/peak_annotations_loader.py
+++ b/DataRepo/loaders/peak_annotations_loader.py
@@ -1,0 +1,213 @@
+from abc import ABC, abstractmethod
+import pandas as pd
+
+from DataRepo.loaders.table_loader import TableLoader
+from DataRepo.models import PeakData, PeakGroup
+
+
+class PeakAnnotationsLoader(TableLoader, ABC):
+    @property
+    @abstractmethod
+    def merged_column_rename_dict(self):
+        """A dict that describes how to rename all columns in the final merged pandas DataFrame.
+        It does not have to have a key for every column - just the ones that need to be renamed.
+        Example:
+            {
+                "formula": "Formula",
+                "medMz": "MedMz",
+                "medRt": "MedRt",
+                "isotopeLabel": "IsotopeLabel",
+                "compound": "Compound",
+            }
+        """
+        pass
+
+    @property
+    @abstractmethod
+    def merge_dict(self):
+        """A recursively constructed dict describing how to merge the sheets in df_dict.
+        Example:
+            {
+                "first_sheet": "Corrected",  # This key ponly occurs once in the outermost dict
+                "next_merge_dict": {
+                    "on": ["Compound", "C_Label"],
+                    "left_columns": None,  # all
+                    "right_sheet": "Original",
+                    "right_columns": ["formula", "medMz", "medRt", "isotopeLabel"],
+                    "how": "left",
+                    "next_merge_dict": None,
+                }
+            }
+        """
+        pass
+
+    @property
+    @abstractmethod
+    def add_columns_dict(self):
+        """2D dict of methods that take a pandas DataFrame, keyed on sheet name and new column name.
+        Example:
+            {
+                "Original": {
+                    "C_Label": lambda df: df["isotopeLabel"].str.split("-").str.get(-1).replace({"C12 PARENT": "0"}),
+                    "Compound": lambda df: df["compound"],
+                }
+            }
+        """
+        pass
+
+    def convert_df(self, df):
+
+        single_sheet = self.merge_dict["first_sheet"]
+        # If there's only 1 key in the merge_dict and its value is None, it is inferred to mean that no merge is
+        # necessary.  Just set the outdf to that one dataframe indicated by the sole sheet key.
+        if self.merge_dict["next_merge_dict"] is not None:
+            single_sheet = None
+
+        if isinstance(df, pd.DataFrame):
+            outdf = df.copy(deep=True)
+            if single_sheet is None:
+                ValueError(f"A dataframe dict containing the following sheets/keys: {list(df.keys())} is required.")
+            self.add_df_columns({single_sheet: outdf})
+        elif isinstance(df, dict):
+            outdf = dict((sheet, adf.copy(deep=True)) for sheet, adf in df.items())
+            # If there's only 1 sheet that we need
+            if single_sheet is not None:
+                if single_sheet in outdf.keys():
+                    self.add_df_columns(outdf)
+                else:
+                    ValueError(f"Sheet [{single_sheet}] missing in the dataframe dict: {list(outdf.keys())}")
+
+            outdf = self.merge_df_sheets(outdf)
+
+        return outdf.rename(columns=self.column_renames)
+
+    def add_df_columns(self, df_dict: dict):
+        """Creates/adds columns to a pandas DataFrame dict based on the methods in self.add_columns_dict that generate
+        columns from existing DataFrame columns.
+        Args:
+            df_dict (dict of pandas DataFrames)
+        Exceptions:
+            None
+        Returns:
+            None
+        """
+        for sheet, column_dict in self.add_columns_dict.items():
+            for new_column, method in column_dict.items():
+                df_dict[sheet][new_column] = method(df_dict[sheet])
+
+    def merge_df_sheets(self, df_dict, _outdf=None, _merge_dict=None, _first_sheet=None):
+        """Uses self.merge_dict to recursively merge df_dict's sheets into a single merged dataframe.
+        Args:
+            df_dict (dict of pandas DataFrames): A dict of dataframes keyed on sheet names (i.e. the return of
+                read_from_file when called with an excel doc)
+            _outdf (Optional[pandas DataFrame]) [df_dict[self.merge_dict["first_sheet"]]]: Used in recursive calls to
+                build up a dataframe from 2 or more sheets in df_dict.
+            _merge_dict (Optional[dict]) [self.merge_dict]: A recursively constructed dict describing how to merge the
+                sheets in df_dict.  Example:
+                    {
+                        "first_sheet": "Corrected",  # This key ponly occurs once in the outermost dict
+                        "next_merge_dict": {
+                            "on": ["Compound", "C_Label"],
+                            "left_columns": None,  # all
+                            "right_sheet": "Original",
+                            "right_columns": ["formula", "medMz", "medRt", "isotopeLabel"],
+                            "how": "left",
+                            "next_merge_dict": None,
+                        }
+                    }
+            _first_sheet (Optional[str]) [self.merge_dict["first_sheet"]]: The first sheet to use as the left dataframe
+                in the first merge.  Every subsequence recursive merge uses outdf and does not use _first_sheet.
+        Exceptions:
+            Buffers:
+                None
+            Raises:
+                KeyError
+        Returns:
+            _outdf (pandas DataFrame): Dataframe that has been merged from df_dict based on _merge_dict.  Note, if
+                _merge_dict["next_merge_dict"] is None at the outermost level of the dict,
+                df_dict[self.merge_dict["first_sheet"]] is returned (i.e. no merge is performed).
+        """
+        if _merge_dict is None:
+            _merge_dict = self.merge_dict.copy()
+
+        if _outdf is None:
+            if _first_sheet is None:
+                if "first_sheet" not in _merge_dict.keys():
+                    raise KeyError("'first_sheet' not supplied and not in merge_dict.")
+                _first_sheet = _merge_dict["first_sheet"]
+            _outdf = df_dict[_first_sheet]
+
+        if _merge_dict["next_merge_dict"] is None:
+            return _outdf
+
+        left_df = _outdf
+        if _merge_dict["left_columns"] is not None:
+            left_df = _outdf.drop_duplicates(subset=_merge_dict["left_columns"])
+
+        right_df = df_dict[_merge_dict["right_sheet"]]
+        if _merge_dict["right_columns"] is not None:
+            right_df = _outdf.drop_duplicates(subset=_merge_dict["right_columns"])
+
+        _outdf = pd.merge(
+            left=left_df,
+            right=right_df,
+            on=_merge_dict["on"],
+            how=_merge_dict["how"],
+        )
+
+        if _merge_dict["next_merge_dict"] is None:
+            return _outdf
+        
+        return self.merge_df_sheets(
+            df_dict,
+            _outdf=_outdf,
+            _merge_dict=_merge_dict["next_merge_dict"].copy(),
+        )
+
+
+class IsocorrLoader(PeakAnnotationsLoader):
+    merged_column_rename_dict = {
+        "formula": "Formula",
+        "medMz": "MedMz",
+        "medRt": "MedRt",
+        "isotopeLabel": "IsotopeLabel",
+        "compound": "Compound",
+    }
+
+    add_columns_dict = None
+
+    # No merge necessary, just use the absolte sheet
+    merge_dict = {
+        "first_sheet": "absolte",
+        "next_merge_dict": None,
+    }
+
+class AccucorLoader(PeakAnnotationsLoader):
+    merged_column_rename_dict = {
+        "formula": "Formula",
+        "medMz": "MedMz",
+        "medRt": "MedRt",
+        "isotopeLabel": "IsotopeLabel",
+        "Compound": "Compound",
+    }
+
+    add_columns_dict = {
+        # Sheet: dict
+        "Original": {
+            # New column name: method that takes a dataframe to create the new column
+            "C_Label": lambda df: df["isotopeLabel"].str.split("-").str.get(-1).replace({"C12 PARENT": "0"}),
+            "Compound": lambda df: df["compound"],
+        }
+    }
+
+    merge_dict = {
+        "first_sheet": "Corrected",  # This key ponly occurs once in the outermost dict
+        "next_merge_dict": {
+            "on": ["Compound", "C_Label"],
+            "left_columns": None,  # all
+            "right_sheet": "Original",
+            "right_columns": ["formula", "medMz", "medRt", "isotopeLabel"],
+            "how": "left",
+            "next_merge_dict": None,
+        }
+    }

--- a/DataRepo/tests/loaders/test_peak_annotations_loader.py
+++ b/DataRepo/tests/loaders/test_peak_annotations_loader.py
@@ -58,7 +58,7 @@ class PeakAnnotationsLoaderTests(TracebaseTestCase):
         tmpdf = dict(
             (sheet, adf.copy(deep=True)) for sheet, adf in self.ACCUCOR_DF_DICT.items()
         )
-        AccucorLoader.add_df_columns(tmpdf)
+        AccucorLoader().add_df_columns(tmpdf)
         expected_df_dict = self.get_accucor_df_with_added_columns()
 
         # Sort the columns (because the column order doesn't matter)
@@ -74,12 +74,14 @@ class PeakAnnotationsLoaderTests(TracebaseTestCase):
         tmpdf = dict(
             (sheet, adf.copy(deep=True)) for sheet, adf in self.ISOCORR_DF_DICT.items()
         )
-        IsocorrLoader.add_df_columns(tmpdf)
+        IsocorrLoader().add_df_columns(tmpdf)
         pd.testing.assert_frame_equal(self.ISOCORR_DF_DICT["absolte"], tmpdf["absolte"])
         self.assertEqual(len(self.ISOCORR_DF_DICT.keys()), len(tmpdf.keys()))
 
     def test_merge_df_sheets_accucor(self):
-        outdf = AccucorLoader.merge_df_sheets(self.get_accucor_df_with_added_columns())
+        outdf = AccucorLoader().merge_df_sheets(
+            self.get_accucor_df_with_added_columns()
+        )
         expected = pd.DataFrame.from_dict(
             {
                 "medMz": [104.035217, 105.038544, 74.024673, 75.028],
@@ -110,7 +112,7 @@ class PeakAnnotationsLoaderTests(TracebaseTestCase):
         tmpdf = dict(
             (sheet, adf.copy(deep=True)) for sheet, adf in self.ISOCORR_DF_DICT.items()
         )
-        outdf = IsocorrLoader.merge_df_sheets(tmpdf)
+        outdf = IsocorrLoader().merge_df_sheets(tmpdf)
         # We should get back the dataframe of the absolte sheet, unchanged
         pd.testing.assert_frame_equal(self.ISOCORR_DF_DICT["absolte"], outdf)
 
@@ -138,7 +140,7 @@ class PeakAnnotationsLoaderTests(TracebaseTestCase):
         tmpdf = dict(
             (sheet, adf.copy(deep=True)) for sheet, adf in self.ACCUCOR_DF_DICT.items()
         )
-        outdf = AccucorLoader.convert_df(tmpdf)
+        outdf = AccucorLoader().convert_df(tmpdf)
         expected = self.get_converted_accucor_df()
 
         # Sort the columns of both dataframes (because the column order doesn't matter)
@@ -148,7 +150,7 @@ class PeakAnnotationsLoaderTests(TracebaseTestCase):
 
     def test_convert_df_accucor_tsv(self):
         with self.assertRaises(RequiredHeadersError) as ar:
-            AccucorLoader.convert_df(self.ACCUCOR_DF_DICT["Corrected"])
+            AccucorLoader().convert_df(self.ACCUCOR_DF_DICT["Corrected"])
         self.assertIn(
             "missing: ['MedMz', 'MedRt', 'IsotopeLabel', 'Formula']", str(ar.exception)
         )
@@ -177,14 +179,14 @@ class PeakAnnotationsLoaderTests(TracebaseTestCase):
             (sheet, adf.copy(deep=True)) for sheet, adf in self.ISOCORR_DF_DICT.items()
         )
         expected = self.get_converted_isocorr_df()
-        outdf = IsocorrLoader.convert_df(tmpdf)
+        outdf = IsocorrLoader().convert_df(tmpdf)
         outdf = outdf.reindex(sorted(outdf.columns), axis=1)
         pd.testing.assert_frame_equal(expected, outdf)
 
     def test_convert_df_isocorr_tsv(self):
         tmpdf = self.ISOCORR_DF_DICT["absolte"].copy(deep=True)
         expected = self.get_converted_isocorr_df()
-        outdf = IsocorrLoader.convert_df(tmpdf)
+        outdf = IsocorrLoader().convert_df(tmpdf)
         outdf = outdf.reindex(sorted(outdf.columns), axis=1)
         pd.testing.assert_frame_equal(expected, outdf)
 
@@ -198,7 +200,7 @@ class PeakAnnotationsLoaderTests(TracebaseTestCase):
             "Corrected": pd.DataFrame.from_dict(tmpcorr),
         }
         expected = self.get_converted_accucor_df()
-        outdf = AccucorLoader.convert_df(tmpdf)
+        outdf = AccucorLoader().convert_df(tmpdf)
         outdf = outdf.reindex(sorted(outdf.columns), axis=1)
         pd.testing.assert_frame_equal(expected, outdf)
 
@@ -211,7 +213,7 @@ class PeakAnnotationsLoaderTests(TracebaseTestCase):
         tmpdict = dict(**tmporig, **tmpcorr)
         tmpdf = pd.DataFrame.from_dict(tmpdict)
         expected = self.get_converted_accucor_df()
-        outdf = AccucorLoader.convert_df(tmpdf)
+        outdf = AccucorLoader().convert_df(tmpdf)
         outdf = outdf.reindex(sorted(outdf.columns), axis=1)
         pd.testing.assert_frame_equal(expected, outdf)
 
@@ -222,7 +224,7 @@ class PeakAnnotationsLoaderTests(TracebaseTestCase):
             "absolte": pd.DataFrame.from_dict(tmpabso),
         }
         expected = self.get_converted_isocorr_df()
-        outdf = IsocorrLoader.convert_df(tmpdf)
+        outdf = IsocorrLoader().convert_df(tmpdf)
         outdf = outdf.reindex(sorted(outdf.columns), axis=1)
         pd.testing.assert_frame_equal(expected, outdf)
 
@@ -231,6 +233,26 @@ class PeakAnnotationsLoaderTests(TracebaseTestCase):
         tmpabso["metaGroupId"] = [2, 2, 3, 3]
         tmpdf = pd.DataFrame.from_dict(tmpabso)
         expected = self.get_converted_isocorr_df()
-        outdf = IsocorrLoader.convert_df(tmpdf)
+        outdf = IsocorrLoader().convert_df(tmpdf)
         outdf = outdf.reindex(sorted(outdf.columns), axis=1)
+        pd.testing.assert_frame_equal(expected, outdf)
+
+    def test_AccucorLoader_constructor_conversion(self):
+        al = AccucorLoader(df=self.ACCUCOR_DF_DICT)
+        outdf = al.df
+        expected = self.get_converted_accucor_df()
+
+        # Sort the columns of both dataframes (because the column order doesn't matter)
+        outdf = outdf.reindex(sorted(outdf.columns), axis=1)
+
+        pd.testing.assert_frame_equal(expected, outdf)
+
+    def test_IsocorrLoader_constructor_conversion(self):
+        il = IsocorrLoader(df=self.ISOCORR_DF_DICT)
+        outdf = il.df
+        expected = self.get_converted_isocorr_df()
+
+        # Sort the columns of both dataframes (because the column order doesn't matter)
+        outdf = outdf.reindex(sorted(outdf.columns), axis=1)
+
         pd.testing.assert_frame_equal(expected, outdf)

--- a/DataRepo/tests/loaders/test_peak_annotations_loader.py
+++ b/DataRepo/tests/loaders/test_peak_annotations_loader.py
@@ -1,0 +1,236 @@
+import pandas as pd
+
+from DataRepo.loaders.peak_annotations_loader import (
+    AccucorLoader,
+    IsocorrLoader,
+)
+from DataRepo.tests.tracebase_test_case import TracebaseTestCase
+from DataRepo.utils.exceptions import RequiredHeadersError
+
+
+class PeakAnnotationsLoaderTests(TracebaseTestCase):
+    ORIG_DICT = {
+        "medMz": [104.035217, 105.038544, 74.024673, 75.028],
+        "medRt": [12.73, 12.722, 12.621, 12.614],
+        "isotopeLabel": ["C12 PARENT", "C13-label-1", "C12 PARENT", "C13-label-1"],
+        "compound": ["Serine", "Serine", "Glycine", "Glycine"],
+        "formula": ["C3H7NO3", "C3H7NO3", "C2H5NO2", "C2H5NO2"],
+    }
+    CORR_DICT = {
+        "Compound": ["Serine", "Serine", "Glycine", "Glycine"],
+        "C_Label": [0, 1, 0, 1],
+        "blank_1_404020": [966.2099201, 0, 1230.735038, 0],
+        "072920_XXX1_1_TS1": [124298.5248, 393.3480206, 90053.99839, 0],
+        "072920_XXX1_2_bra": [2106922.129, 0, 329490.6364, 4910.491834],
+    }
+    ACCUCOR_DF_DICT = {
+        "Original": pd.DataFrame.from_dict(ORIG_DICT),
+        "Corrected": pd.DataFrame.from_dict(CORR_DICT),
+    }
+    ABSO_DICT = {
+        "formula": ["C4H6O4", "C4H6O4", "C5H10N2O3", "C5H10N2O3"],
+        "medMz": [117.0192, 118.0225, 145.0617, 147.062],
+        "medRt": [12.17531, 12.17531, 12.62156, 12.64316],
+        "isotopeLabel": ["C12 PARENT", "C13-label-1", "C12 PARENT", "C13N15-label-1-1"],
+        "compound": ["succinate", "succinate", "glutamine", "glutamine"],
+        "xz971_bat": [148238551.1, 517370.4887, 15618575.73, 0],
+        "xz971_br": [74223142.68, 310838.2786, 37308464.02, 0],
+    }
+    ISOCORR_DF_DICT = {
+        "absolte": pd.DataFrame.from_dict(ABSO_DICT),
+    }
+
+    def get_accucor_df_with_added_columns(self):
+        expected_orig_dict = self.ORIG_DICT.copy()
+        expected_orig_dict["Compound"] = self.ORIG_DICT["compound"]
+        expected_orig_dict["C_Label"] = [0, 1, 0, 1]
+        expected_orig_df = pd.DataFrame.from_dict(expected_orig_dict)
+        # Sort the columns (because the column order doesn't matter)
+        expected_orig_df = expected_orig_df.reindex(
+            sorted(expected_orig_df.columns), axis=1
+        )
+        return {
+            "Original": expected_orig_df,
+            "Corrected": self.ACCUCOR_DF_DICT["Corrected"],
+        }
+
+    def test_add_df_columns_accucor(self):
+        tmpdf = dict(
+            (sheet, adf.copy(deep=True)) for sheet, adf in self.ACCUCOR_DF_DICT.items()
+        )
+        AccucorLoader.add_df_columns(tmpdf)
+        expected_df_dict = self.get_accucor_df_with_added_columns()
+
+        # Sort the columns (because the column order doesn't matter)
+        tmpdf["Original"] = tmpdf["Original"].reindex(
+            sorted(tmpdf["Original"].columns), axis=1
+        )
+
+        pd.testing.assert_frame_equal(expected_df_dict["Original"], tmpdf["Original"])
+        pd.testing.assert_frame_equal(expected_df_dict["Corrected"], tmpdf["Corrected"])
+        self.assertEqual(len(self.ACCUCOR_DF_DICT.keys()), len(tmpdf.keys()))
+
+    def test_add_df_columns_isocorr(self):
+        tmpdf = dict(
+            (sheet, adf.copy(deep=True)) for sheet, adf in self.ISOCORR_DF_DICT.items()
+        )
+        IsocorrLoader.add_df_columns(tmpdf)
+        pd.testing.assert_frame_equal(self.ISOCORR_DF_DICT["absolte"], tmpdf["absolte"])
+        self.assertEqual(len(self.ISOCORR_DF_DICT.keys()), len(tmpdf.keys()))
+
+    def test_merge_df_sheets_accucor(self):
+        outdf = AccucorLoader.merge_df_sheets(self.get_accucor_df_with_added_columns())
+        expected = pd.DataFrame.from_dict(
+            {
+                "medMz": [104.035217, 105.038544, 74.024673, 75.028],
+                "medRt": [12.73, 12.722, 12.621, 12.614],
+                "isotopeLabel": [
+                    "C12 PARENT",
+                    "C13-label-1",
+                    "C12 PARENT",
+                    "C13-label-1",
+                ],
+                "compound": ["Serine", "Serine", "Glycine", "Glycine"],
+                "formula": ["C3H7NO3", "C3H7NO3", "C2H5NO2", "C2H5NO2"],
+                "Compound": ["Serine", "Serine", "Glycine", "Glycine"],
+                "C_Label": [0, 1, 0, 1],
+                "blank_1_404020": [966.2099201, 0, 1230.735038, 0],
+                "072920_XXX1_1_TS1": [124298.5248, 393.3480206, 90053.99839, 0],
+                "072920_XXX1_2_bra": [2106922.129, 0, 329490.6364, 4910.491834],
+            }
+        )
+
+        # Sort the columns of both dataframes (because the column order doesn't matter)
+        expected = expected.reindex(sorted(expected.columns), axis=1)
+        outdf = outdf.reindex(sorted(outdf.columns), axis=1)
+
+        pd.testing.assert_frame_equal(expected, outdf)
+
+    def test_merge_df_sheets_isocorr(self):
+        tmpdf = dict(
+            (sheet, adf.copy(deep=True)) for sheet, adf in self.ISOCORR_DF_DICT.items()
+        )
+        outdf = IsocorrLoader.merge_df_sheets(tmpdf)
+        # We should get back the dataframe of the absolte sheet, unchanged
+        pd.testing.assert_frame_equal(self.ISOCORR_DF_DICT["absolte"], outdf)
+
+    def get_converted_accucor_df(self):
+        df = pd.DataFrame.from_dict(
+            {
+                "MedMz": [104.035217, 105.038544, 74.024673, 75.028],
+                "MedRt": [12.73, 12.722, 12.621, 12.614],
+                "IsotopeLabel": [
+                    "C12 PARENT",
+                    "C13-label-1",
+                    "C12 PARENT",
+                    "C13-label-1",
+                ],
+                "Formula": ["C3H7NO3", "C3H7NO3", "C2H5NO2", "C2H5NO2"],
+                "Compound": ["Serine", "Serine", "Glycine", "Glycine"],
+                "blank_1_404020": [966.2099201, 0, 1230.735038, 0],
+                "072920_XXX1_1_TS1": [124298.5248, 393.3480206, 90053.99839, 0],
+                "072920_XXX1_2_bra": [2106922.129, 0, 329490.6364, 4910.491834],
+            },
+        )
+        return df.reindex(sorted(df.columns), axis=1)
+
+    def test_convert_df_accucor_excel(self):
+        tmpdf = dict(
+            (sheet, adf.copy(deep=True)) for sheet, adf in self.ACCUCOR_DF_DICT.items()
+        )
+        outdf = AccucorLoader.convert_df(tmpdf)
+        expected = self.get_converted_accucor_df()
+
+        # Sort the columns of both dataframes (because the column order doesn't matter)
+        outdf = outdf.reindex(sorted(outdf.columns), axis=1)
+
+        pd.testing.assert_frame_equal(expected, outdf)
+
+    def test_convert_df_accucor_tsv(self):
+        with self.assertRaises(RequiredHeadersError) as ar:
+            AccucorLoader.convert_df(self.ACCUCOR_DF_DICT["Corrected"])
+        self.assertIn(
+            "missing: ['MedMz', 'MedRt', 'IsotopeLabel', 'Formula']", str(ar.exception)
+        )
+
+    def get_converted_isocorr_df(self):
+        df = pd.DataFrame.from_dict(
+            {
+                "Formula": ["C4H6O4", "C4H6O4", "C5H10N2O3", "C5H10N2O3"],
+                "MedMz": [117.0192, 118.0225, 145.0617, 147.062],
+                "MedRt": [12.17531, 12.17531, 12.62156, 12.64316],
+                "IsotopeLabel": [
+                    "C12 PARENT",
+                    "C13-label-1",
+                    "C12 PARENT",
+                    "C13N15-label-1-1",
+                ],
+                "Compound": ["succinate", "succinate", "glutamine", "glutamine"],
+                "xz971_bat": [148238551.1, 517370.4887, 15618575.73, 0],
+                "xz971_br": [74223142.68, 310838.2786, 37308464.02, 0],
+            },
+        )
+        return df.reindex(sorted(df.columns), axis=1)
+
+    def test_convert_df_isocorr_excel(self):
+        tmpdf = dict(
+            (sheet, adf.copy(deep=True)) for sheet, adf in self.ISOCORR_DF_DICT.items()
+        )
+        expected = self.get_converted_isocorr_df()
+        outdf = IsocorrLoader.convert_df(tmpdf)
+        outdf = outdf.reindex(sorted(outdf.columns), axis=1)
+        pd.testing.assert_frame_equal(expected, outdf)
+
+    def test_convert_df_isocorr_tsv(self):
+        tmpdf = self.ISOCORR_DF_DICT["absolte"].copy(deep=True)
+        expected = self.get_converted_isocorr_df()
+        outdf = IsocorrLoader.convert_df(tmpdf)
+        outdf = outdf.reindex(sorted(outdf.columns), axis=1)
+        pd.testing.assert_frame_equal(expected, outdf)
+
+    def test_extra_columns_excluded_accucor_excel(self):
+        tmporig = self.ORIG_DICT.copy()
+        tmporig["metaGroupId"] = [2, 2, 3, 3]
+        tmpcorr = self.CORR_DICT.copy()
+        tmpcorr["adductName"] = [0, 0, 0, 0]
+        tmpdf = {
+            "Original": pd.DataFrame.from_dict(tmporig),
+            "Corrected": pd.DataFrame.from_dict(tmpcorr),
+        }
+        expected = self.get_converted_accucor_df()
+        outdf = AccucorLoader.convert_df(tmpdf)
+        outdf = outdf.reindex(sorted(outdf.columns), axis=1)
+        pd.testing.assert_frame_equal(expected, outdf)
+
+    def test_extra_columns_excluded_accucor_tsv(self):
+        tmporig = self.ORIG_DICT.copy()
+        tmporig["metaGroupId"] = [2, 2, 3, 3]
+        tmpcorr = self.CORR_DICT.copy()
+        tmpcorr["adductName"] = [0, 0, 0, 0]
+        # Merge the sheets (they happen to have the rows in the same order)
+        tmpdict = dict(**tmporig, **tmpcorr)
+        tmpdf = pd.DataFrame.from_dict(tmpdict)
+        expected = self.get_converted_accucor_df()
+        outdf = AccucorLoader.convert_df(tmpdf)
+        outdf = outdf.reindex(sorted(outdf.columns), axis=1)
+        pd.testing.assert_frame_equal(expected, outdf)
+
+    def test_extra_columns_excluded_isocorr_excel(self):
+        tmpabso = self.ABSO_DICT.copy()
+        tmpabso["metaGroupId"] = [2, 2, 3, 3]
+        tmpdf = {
+            "absolte": pd.DataFrame.from_dict(tmpabso),
+        }
+        expected = self.get_converted_isocorr_df()
+        outdf = IsocorrLoader.convert_df(tmpdf)
+        outdf = outdf.reindex(sorted(outdf.columns), axis=1)
+        pd.testing.assert_frame_equal(expected, outdf)
+
+    def test_extra_columns_excluded_isocorr_tsv(self):
+        tmpabso = self.ABSO_DICT.copy()
+        tmpabso["metaGroupId"] = [2, 2, 3, 3]
+        tmpdf = pd.DataFrame.from_dict(tmpabso)
+        expected = self.get_converted_isocorr_df()
+        outdf = IsocorrLoader.convert_df(tmpdf)
+        outdf = outdf.reindex(sorted(outdf.columns), axis=1)
+        pd.testing.assert_frame_equal(expected, outdf)

--- a/DataRepo/utils/exceptions.py
+++ b/DataRepo/utils/exceptions.py
@@ -252,9 +252,9 @@ class RequiredColumnValuesWhenNovel(RequiredColumnValues):
 
 
 class RequiredHeadersError(InfileError, HeaderError):
-    def __init__(self, missing, message=None, **kwargs):
+    def __init__(self, missing: list, message=None, **kwargs):
         if not message:
-            message = f"Required header(s) missing: [{missing}] in %s."
+            message = f"Required header(s) missing: {missing} in %s."
         super().__init__(message, **kwargs)
         self.missing = missing
 


### PR DESCRIPTION
## Summary Change Description

I created an abstract base class called `PeakAnnotationsLoader` and 2 derived classes (`AccucorLoader` and `IsocorrLoader`).  The only things in the derived classes are data structuires that describe how to convert the dataframe(s) (returned by `read_from_file` on those file types) into a universal "peak annotation" format (a single dataframe).  I'll comment on the specifics in-line, but just note that the `convert_df(df)` method resides in the superclass, and if there is ever a conversion step for a new format that requires something more/different, you could quickly just override that method (though I don't think that would be necessary).

## Affected Issues/Pull Requests

- Partially addresses #825

## Review Notes

See comments in-line.

## Checklist
<!--
If any of the checkbox requirements are not met, uncheck them and add an
explanation. E.g. Linting errors pre-date this PR.
-->
This pull request will be merged once the following requirements are met.  The
author and/or reviewers should uncheck any unmet requirements:

- Review requirements
  - Minimum approvals: 1 <!-- Edit as desired (e.g. based on complexity) -->
  - No changes requested
  - All blocking issues resolved by reviewers
  - Specific reviewers: @__add_username_here__
    <!--
    Require reviewers with specific expertise to be included among the minimum
    number of reviewers by tagging them.  Also please send them a message.
    -->
  - Review period: 2 days <!-- Edit as desired (e.g. based on complexity) -->
- Associated issue/pull request requirements:
  <!--
  Assert that all requirements in issues marked "resolved" are done and that
  all required pull requests are merged.  If any are not done, either edit or
  split the issue or explain the unmerged affected pull requests.
  -->
  - [x] All requirements in affected issues marked "resolved" are satisfied
  - [x] All required pull requests are merged *(or none)*
- Basic requirements
  <!--
  Uncheck items to acknowledge failures/conflicts you intend to address.
  Add an explanation if any won't be addressed before merge.
  -->
  - [x] [All linters pass](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#linting)
  - [x] [All tests pass](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#quality-control)
  - [x] All conflicts resolved
- Overhead requirements
  <!--
  These are additional requirements that are not directly associated with
  resolving the affected issue(s).
  -->
  - [x] [New/changed method tests implemented/updated *(or no change)*](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#test-implementation)
  - [ ] [Updated *Unreleased* section of `changelog.md` *(or no change)*](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/changelog.md)
  - [x] [Migrations created & committed *(or no change)*](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#migration-process)
