### PR TITLE
Save the mzXML file in the archive, duh

### DIFF
--- a/DataRepo/models/archive_file.py
+++ b/DataRepo/models/archive_file.py
@@ -184,15 +184,16 @@ class ArchiveFileQuerySet(models.QuerySet):
             with path_obj.open(mode=mode) as file_handle:
                 tmp_file_location = File(file_handle, name=path_obj.name)
 
-            if created:
-                archivefile_rec.file_location = tmp_file_location
-                archivefile_rec.full_clean()
-                archivefile_rec.save()
-            elif archivefile_rec.file_location is None:
-                # Re-do the get_or_create WITH the file_location (since we know a record exists WITHOUT a value for
-                # file_location) in order to generate the expected/usual exception about a unique-constraint violation
-                kwargs["file_location"] = tmp_file_location
-                archivefile_rec = super().get_or_create(**kwargs)
+                if created:
+                    archivefile_rec.file_location = tmp_file_location
+                    archivefile_rec.full_clean()
+                    archivefile_rec.save()
+                elif archivefile_rec.file_location is None:
+                    # Re-do the get_or_create WITH the file_location (since we know a record exists WITHOUT a value for
+                    # file_location) in order to generate the expected/usual exception about a unique-constraint
+                    # violation
+                    kwargs["file_location"] = tmp_file_location
+                    archivefile_rec = super().get_or_create(**kwargs)
 
         return archivefile_rec, created
 

--- a/DataRepo/models/archive_file.py
+++ b/DataRepo/models/archive_file.py
@@ -187,6 +187,7 @@ class ArchiveFileQuerySet(models.QuerySet):
             if created:
                 archivefile_rec.file_location = tmp_file_location
                 archivefile_rec.full_clean()
+                archivefile_rec.save()
             elif archivefile_rec.file_location is None:
                 # Re-do the get_or_create WITH the file_location (since we know a record exists WITHOUT a value for
                 # file_location) in order to generate the expected/usual exception about a unique-constraint violation

--- a/DataRepo/tests/loaders/test_msruns_loader.py
+++ b/DataRepo/tests/loaders/test_msruns_loader.py
@@ -1407,4 +1407,4 @@ class MSRunsLoaderTests(TracebaseTestCase):
         )
 
         self.assertIsNotNone(msrs.ms_data_file.file_location)
-        # No exception = successful test
+        # TODO: Figure out how to test that the file_location is an actual stored file

--- a/DataRepo/tests/loaders/test_msruns_loader.py
+++ b/DataRepo/tests/loaders/test_msruns_loader.py
@@ -1400,9 +1400,11 @@ class MSRunsLoaderTests(TracebaseTestCase):
         # This is the method we're testing
         msrl.load_data()
 
-        MSRunSample.objects.get(
+        msrs = MSRunSample.objects.get(
             sample=smpl,
             msrun_sequence=seq,
             ms_data_file__filename="BAT-xz971.mzXML",
         )
+
+        self.assertIsNotNone(msrs.ms_data_file.file_location)
         # No exception = successful test

--- a/DataRepo/tests/models/test_archive_file.py
+++ b/DataRepo/tests/models/test_archive_file.py
@@ -87,3 +87,5 @@ class ArchiveFileTests(TracebaseTestCase):
         gotten_rec, second_created = ArchiveFile.objects.get_or_create(**rec_dict)
         self.assertFalse(second_created)
         self.assertEqual(created_rec.id, gotten_rec.id)
+
+        # TODO: Figure out how to test that the file_location is an actual stored file


### PR DESCRIPTION
## Summary Change Description

Pretty braindead code change.  No explanation necessary.

## Affected Issues/Pull Requests

- Resolves issue with the MSRunsLoader where it wasn't saving the mzXML files.

## Review Notes
<!--
For added context for reviewers, add comments to relevant lines of code.  Use
this space to describe any general areas of concern not linked to a specific
line of code that reviewers should pay particular attention to, e.g. please
make sure I have accounted for all possible inputs.
-->
See comments in-line.

## Checklist
<!--
If any of the checkbox requirements are not met, uncheck them and add an
explanation. E.g. Linting errors pre-date this PR.
-->
This pull request will be merged once the following requirements are met.  The
author and/or reviewers should uncheck any unmet requirements:

- Review requirements
  - Minimum approvals: 1 <!-- Edit as desired (e.g. based on complexity) -->
  - No changes requested
  - All blocking issues resolved by reviewers
  - Specific reviewers: @__add_username_here__
    <!--
    Require reviewers with specific expertise to be included among the minimum
    number of reviewers by tagging them.  Also please send them a message.
    -->
  - Review period: 2 days <!-- Edit as desired (e.g. based on complexity) -->
- Associated issue/pull request requirements:
  <!--
  Assert that all requirements in issues marked "resolved" are done and that
  all required pull requests are merged.  If any are not done, either edit or
  split the issue or explain the unmerged affected pull requests.
  -->
  - [x] All requirements in affected issues marked "resolved" are satisfied
  - [x] All required pull requests are merged *(or none)*
- Basic requirements
  <!--
  Uncheck items to acknowledge failures/conflicts you intend to address.
  Add an explanation if any won't be addressed before merge.
  -->
  - [x] [All linters pass](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#linting)
  - [x] [All tests pass](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#quality-control)
  - [x] All conflicts resolved
- Overhead requirements
  <!--
  These are additional requirements that are not directly associated with
  resolving the affected issue(s).
  -->
  - [x] [New/changed method tests implemented/updated *(or no change)*](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#test-implementation)
  - [ ] [Updated *Unreleased* section of `changelog.md` *(or no change)*](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/changelog.md)
  - [x] [Migrations created & committed *(or no change)*](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#migration-process)
