### PR TITLE
Clean up archive files stored to disk during an atomic transaction that rolls back

### DIFF
--- a/DataRepo/models/archive_file.py
+++ b/DataRepo/models/archive_file.py
@@ -5,8 +5,13 @@ import os
 from pathlib import Path
 
 from django.core.files import File
-from django.db import models, transaction
+from django.db import ProgrammingError, models, transaction
+from django.db.models.signals import post_delete
+from django.dispatch import receiver
+from django.forms import model_to_dict
 from django.utils.text import get_valid_filename
+
+from DataRepo.models.utilities import exists_in_db
 
 
 class DataTypeManager(models.Manager):
@@ -286,3 +291,51 @@ class ArchiveFile(models.Model):
                 hash_obj.update(chunk)
 
         return hash_obj.hexdigest()
+
+
+@receiver(post_delete, sender=ArchiveFile)
+def post_archive_file_delete_commit(**kwargs):
+    """Schedule a call to delete_archive_file upon deletion commit (when we are guaranteed that the transaction won't be
+    rolled back).
+
+    The purpose is to delete the file associated with an ArchiveFile record when it is being deleted.
+
+    NOTE: There are scenarios however where files in the archive can be orphaned and not cleaned up.  For example, if
+    rec.file_location is changed (i.e. delete is not called).
+
+    References:
+        https://stackoverflow.com/a/52703242/2057516
+    Args:
+        kwargs (dict)
+    Exceptions:
+        None
+    Returns:
+        None
+    """
+    print("BUFFERING POST-COMMIT DELETE")
+    transaction.on_commit(lambda: delete_archive_file(kwargs["instance"]))
+
+
+def delete_archive_file(deleted_rec: ArchiveFile) -> None:
+    """Given a deleted record instance (or a record being deleted during a safe transaction commit), delete the file on
+    disk associated with the record.
+
+    References:
+        https://stackoverflow.com/a/16041527/2057516
+    Args:
+        deleted_rec (ArchiveFile)
+    Exceptions:
+        None
+    RTeturns:
+        None
+    """
+    if deleted_rec.file_location and os.path.isfile(deleted_rec.file_location.path):
+        if exists_in_db(deleted_rec):
+            raise ProgrammingError(
+                f"Calling delete_archive_file on existing database record: {model_to_dict(deleted_rec)} is not allowed."
+            )
+        else:
+            print(f"DELETING FILE: {deleted_rec.file_location.path}")
+            os.remove(deleted_rec.file_location.path)
+    else:
+        print(f"{deleted_rec.file_location.path} WAS NOT A FILE")

--- a/DataRepo/tests/models/test_archive_file.py
+++ b/DataRepo/tests/models/test_archive_file.py
@@ -1,11 +1,17 @@
+import os
 from pathlib import Path
 
 from django.conf import settings
 from django.core.files import File
+from django.db import transaction
 from django.test import override_settings
 
 from DataRepo.models import ArchiveFile, DataFormat, DataType
-from DataRepo.tests.tracebase_test_case import TracebaseTestCase
+from DataRepo.models.utilities import exists_in_db
+from DataRepo.tests.tracebase_test_case import (
+    TracebaseArchiveTestCase,
+    TracebaseTestCase,
+)
 
 
 @override_settings(CACHES=settings.TEST_CACHES)
@@ -59,6 +65,97 @@ class ArchiveFileTests(TracebaseTestCase):
         fn = "DataRepo/data/tests/small_obob/small_obob_maven_6eaas_inf_lactate_mzxmls/BAT-xz971.mzXML"
         self.assertFalse(ArchiveFile.file_is_binary(fn))
 
+
+class ArchiveFileArchiveTests(TracebaseArchiveTestCase):
+    record_id = None
+    fixtures = ["data_types.yaml", "data_formats.yaml"]
+
+    @classmethod
+    def setUpTestData(cls):
+        path = Path("DataRepo/data/tests/small_obob/small_obob_maven_6eaas_inf.xlsx")
+        with path.open(mode="rb") as f:
+            myfile = File(f, name=path.name)
+        ms_peak_annotation = DataType.objects.get(code="ms_peak_annotation")
+        accucor_format = DataFormat.objects.get(code="accucor")
+        cls.rec_dict = {
+            "filename": "small_obob_maven_6eaas_inf.xlsx",
+            "file_location": myfile,
+            "checksum": "558ea654d7f2914ca4527580edf4fac11bd151c3",
+            "data_type": ms_peak_annotation,
+            "data_format": accucor_format,
+        }
+        super().setUpTestData()
+
+    def setUp(self):
+        super().setUp()
+        self.rec = None
+
+    def create_archive_file(self):
+        path = Path("DataRepo/data/tests/small_obob/small_obob_maven_6eaas_inf.xlsx")
+        with path.open(mode="rb") as f:
+            myfile = File(f, name=path.name)
+            ms_peak_annotation = DataType.objects.get(code="ms_peak_annotation")
+            accucor_format = DataFormat.objects.get(code="accucor")
+            rec_dict = {
+                "filename": "small_obob_maven_6eaas_inf.xlsx",
+                "file_location": myfile,
+                "checksum": "558ea654d7f2914ca4527580edf4fac11bd151c3",
+                "data_type": ms_peak_annotation,
+                "data_format": accucor_format,
+            }
+            self.rec = ArchiveFile.objects.create(**rec_dict)
+            self.rec.full_clean()
+        self.assertTrue(
+            os.path.isfile(self.rec.file_location.path),
+            msg="Asserts created file was saved to disk.",
+        )
+
+    @transaction.atomic
+    def delete_during_transaction_failure(self):
+        self.create_archive_file()
+        self.rec.delete()
+        self.assertTrue(
+            os.path.isfile(self.rec.file_location.path),
+            msg="Asserts created file does not delete during transaction.",
+        )
+        raise ValueError("TEST")
+
+    @transaction.atomic
+    def delete_during_transaction_success(self):
+        self.create_archive_file()
+        self.rec.delete()
+        self.assertTrue(
+            os.path.isfile(self.rec.file_location.path),
+            msg="Asserts created file does not delete during transaction.",
+        )
+
+    def test_post_delete_commit_failure(self):
+        """Tests that archive files are cleaned up after rollback."""
+        try:
+            self.delete_during_transaction_failure()
+        except ValueError:
+            pass
+        self.assertIsNotNone(self.rec)
+        self.assertIsNotNone(self.rec.file_location)
+        self.assertIn(self.ARCHIVE_DIR, str(self.rec.file_location.path))
+        self.assertTrue(
+            os.path.isfile(self.rec.file_location.path),
+            msg="Asserts created file was not deleted due to transaction rollback.",
+        )
+        self.assertFalse(exists_in_db(self.rec))
+
+    def test_post_delete_commit_success(self):
+        """Tests that archive files are cleaned up after rollback."""
+        self.delete_during_transaction_success()
+        self.assertIsNotNone(self.rec)
+        self.assertIsNotNone(self.rec.file_location)
+        self.assertIn(self.ARCHIVE_DIR, str(self.rec.file_location.path))
+        self.assertFalse(
+            os.path.isfile(self.rec.file_location.path),
+            msg="Asserts created file was deleted after transaction commit due to call to record delete.",
+        )
+        self.assertFalse(exists_in_db(self.rec))
+
     def test_get_or_create_override(self):
         """This tests the essential functionality of the get_or_create method override, which is to ignore the
         randomized hash string appended to file_location.  but it also tests the conveniences (takes a path string,
@@ -82,10 +179,16 @@ class ArchiveFileTests(TracebaseTestCase):
         self.assertEqual("mzxml", created_rec.data_format.code)
         self.assertEqual("ms_data", created_rec.data_type.code)
         self.assertEqual("BAT-xz971.mzXML", created_rec.filename)
+        self.assertTrue(
+            os.path.isfile(created_rec.file_location.path),
+            msg="Asserts mzXML file was created in the archive.",
+        )
 
         # Called a second time to "get"
         gotten_rec, second_created = ArchiveFile.objects.get_or_create(**rec_dict)
         self.assertFalse(second_created)
         self.assertEqual(created_rec.id, gotten_rec.id)
-
-        # TODO: Figure out how to test that the file_location is an actual stored file
+        self.assertTrue(
+            os.path.isfile(gotten_rec.file_location.path),
+            msg="Asserts mzXML file still exists.",
+        )

--- a/DataRepo/utils/exceptions.py
+++ b/DataRepo/utils/exceptions.py
@@ -5,7 +5,11 @@ import warnings
 from collections import defaultdict
 from typing import TYPE_CHECKING, Dict, Optional
 
-from django.core.exceptions import ObjectDoesNotExist, ValidationError
+from django.core.exceptions import (
+    MultipleObjectsReturned,
+    ObjectDoesNotExist,
+    ValidationError,
+)
 from django.core.management import CommandError
 from django.db.utils import ProgrammingError
 from django.forms.models import model_to_dict
@@ -2627,6 +2631,15 @@ class RecordDoesNotExist(InfileError, ObjectDoesNotExist):
             message = (
                 f"{model.__name__} record matching {query_dict} from %s does not exist."
             )
+        super().__init__(message, **kwargs)
+        self.query_dict = query_dict
+        self.model = model
+
+
+class MultipleRecordsReturned(InfileError, MultipleObjectsReturned):
+    def __init__(self, model, query_dict, message=None, **kwargs):
+        if message is None:
+            message = f"{model.__name__} record matching {query_dict} from %s returned multiple records."
         super().__init__(message, **kwargs)
         self.query_dict = query_dict
         self.model = model

--- a/TraceBase/runner.py
+++ b/TraceBase/runner.py
@@ -8,11 +8,9 @@ class TraceBaseTestSuiteRunner(DiscoverRunner):
     def setup_test_environment(self, *args, **kwargs):
         """Switch to in-memory storage."""
         super().setup_test_environment(*args, **kwargs)
-        settings._original_file_storage = settings.STORAGES["default"]
-        settings.STORAGES["default"] = settings.STORAGES["testing"]
+        settings.STORAGES = settings.TEST_STORAGES
 
     def teardown_test_environment(self, *args, **kwargs):
         """Switch back to the original file storage."""
         super().teardown_test_environment(*args, **kwargs)
-        settings.STORAGES["default"] = settings._original_file_storage
-        del settings._original_file_storage
+        settings.STORAGES = settings.DEFAULT_STORAGES

--- a/TraceBase/settings.py
+++ b/TraceBase/settings.py
@@ -148,8 +148,11 @@ STATICFILES_DIRS = [os.path.join(BASE_DIR, "static")]
 # File storage location
 MEDIA_URL = "/archive/"
 MEDIA_ROOT = env.str("ARCHIVE_DIR", default=os.path.join(BASE_DIR, "archive"))
+TEST_MEDIA_ROOT = env.str(
+    "TEST_ARCHIVE_DIR", default=os.path.join(BASE_DIR, "archive_test")
+)
 
-STORAGES = {
+DEFAULT_STORAGES = {
     # Django defaults:
     "default": {
         "BACKEND": "django.core.files.storage.FileSystemStorage",
@@ -157,14 +160,28 @@ STORAGES = {
     "staticfiles": {
         "BACKEND": "django.contrib.staticfiles.storage.StaticFilesStorage",
     },
-    # Testing/production
-    "testing": {
-        "BACKEND": "django.core.files.storage.InMemoryStorage",
-    },
     "production": {
         "BACKEND": "django.core.files.storage.FileSystemStorage",
     },
 }
+TEST_STORAGES = {
+    "default": {
+        "BACKEND": "django.core.files.storage.InMemoryStorage",
+    },
+    "staticfiles": {
+        "BACKEND": "django.contrib.staticfiles.storage.StaticFilesStorage",
+    },
+}
+TEST_FILE_STORAGES = {
+    "default": {
+        "BACKEND": "django.core.files.storage.FileSystemStorage",
+    },
+    "staticfiles": {
+        "BACKEND": "django.contrib.staticfiles.storage.StaticFilesStorage",
+    },
+}
+
+STORAGES = DEFAULT_STORAGES
 
 # File storage handling for tests
 # https://stackoverflow.com/questions/38345977/filefield-force-using-temporaryuploadedfile


### PR DESCRIPTION
## Summary Change Description

This actually addresses 2 concerns:

1. Calls to `archive_file_record.delete()` will clean up the files saved in the archive, but only if the record doesn't currently exist in the database.
2. If there's a rollback in the MSRunsLoader, the mzXML files created in the archive directory are deleted

Note that this DOES NOT clean up vestigial files that are orphaned due to a record **update** (save a changed existing record).

See the comment on the issue:

> As I was working on this, I realized that this strategy of heading off the ArchiveFile creation by trying to front-load the code with anything that can go wrong so as to not create files on the file system is not a scalable strategy. Any exception after the creation of an ArchiveFile record, and subsequent rollback, will cause files to be left behind.
> 
> I did improve the msrun_sequence code, but the best solution IMO is to use a post_delete transaction.on_commit signal/method in the ArchiveFile model class.

Details:

- Added a new tracebase test case class: TracebaseArchiveTestCase
- Tweaked the settings to make them more straightforward to handle archive files.
- Created the exception class MultipleRecordsReturned.
- Handled a type issue reported in mypy about factory-created TestCase classes.
- Added a post-delete signal method: post_archive_file_delete_commit and a delete_archive_file method, both in the archive_file.oy model file.
- Added a method in MSRunsLoader for handling file cleanup in the event of a rollback: clean_up_created_mzxmls_in_archive.
- Improved the get_msrun_sequence code.

## Affected Issues/Pull Requests

- Resolves #976

## Review Notes
<!--
For added context for reviewers, add comments to relevant lines of code.  Use
this space to describe any general areas of concern not linked to a specific
line of code that reviewers should pay particular attention to, e.g. please
make sure I have accounted for all possible inputs.
-->
See comments in-line.

## Checklist
<!--
If any of the checkbox requirements are not met, uncheck them and add an
explanation. E.g. Linting errors pre-date this PR.
-->
This pull request will be merged once the following requirements are met.  The
author and/or reviewers should uncheck any unmet requirements:

- Review requirements
  - Minimum approvals: 1 <!-- Edit as desired (e.g. based on complexity) -->
  - No changes requested
  - All blocking issues resolved by reviewers
  - Specific reviewers: @__add_username_here__
    <!--
    Require reviewers with specific expertise to be included among the minimum
    number of reviewers by tagging them.  Also please send them a message.
    -->
  - Review period: 2 days <!-- Edit as desired (e.g. based on complexity) -->
- Associated issue/pull request requirements:
  <!--
  Assert that all requirements in issues marked "resolved" are done and that
  all required pull requests are merged.  If any are not done, either edit or
  split the issue or explain the unmerged affected pull requests.
  -->
  - [x] All requirements in affected issues marked "resolved" are satisfied
  - [x] All required pull requests are merged *(or none)*
- Basic requirements
  <!--
  Uncheck items to acknowledge failures/conflicts you intend to address.
  Add an explanation if any won't be addressed before merge.
  -->
  - [x] [All linters pass](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#linting)
  - [x] [All tests pass](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#quality-control)
  - [x] All conflicts resolved
- Overhead requirements
  <!--
  These are additional requirements that are not directly associated with
  resolving the affected issue(s).
  -->
  - [x] [New/changed method tests implemented/updated *(or no change)*](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#test-implementation)
  - [ ] [Updated *Unreleased* section of `changelog.md` *(or no change)*](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/changelog.md)
  - [x] [Migrations created & committed *(or no change)*](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#migration-process)
