### PR TITLE
Improvements to MSRunsLoader.get_msrun_sequence.

### DIFF
--- a/DataRepo/loaders/msruns_loader.py
+++ b/DataRepo/loaders/msruns_loader.py
@@ -5,9 +5,8 @@ from pathlib import Path
 from typing import Dict, Optional
 
 import xmltodict
-from django.db import ProgrammingError, transaction
+from django.db import transaction
 from django.db.models import Max, Min, Q
-from django.forms import model_to_dict
 
 from DataRepo.loaders.sequences_loader import SequencesLoader
 from DataRepo.loaders.table_column import ColumnReference, TableColumn
@@ -15,7 +14,7 @@ from DataRepo.loaders.table_loader import TableLoader
 from DataRepo.models import MSRunSample, MSRunSequence, PeakGroup
 from DataRepo.models.archive_file import ArchiveFile, DataFormat, DataType
 from DataRepo.models.sample import Sample
-from DataRepo.models.utilities import exists_in_db, update_rec
+from DataRepo.models.utilities import update_rec
 from DataRepo.utils.exceptions import (
     AggregatedErrors,
     InfileError,

--- a/DataRepo/loaders/msruns_loader.py
+++ b/DataRepo/loaders/msruns_loader.py
@@ -5,8 +5,9 @@ from pathlib import Path
 from typing import Dict, Optional
 
 import xmltodict
-from django.db import transaction
+from django.db import ProgrammingError, transaction
 from django.db.models import Max, Min, Q
+from django.forms import model_to_dict
 
 from DataRepo.loaders.sequences_loader import SequencesLoader
 from DataRepo.loaders.table_column import ColumnReference, TableColumn
@@ -14,11 +15,12 @@ from DataRepo.loaders.table_loader import TableLoader
 from DataRepo.models import MSRunSample, MSRunSequence, PeakGroup
 from DataRepo.models.archive_file import ArchiveFile, DataFormat, DataType
 from DataRepo.models.sample import Sample
-from DataRepo.models.utilities import update_rec
+from DataRepo.models.utilities import exists_in_db, update_rec
 from DataRepo.utils.exceptions import (
     AggregatedErrors,
     InfileError,
     MixedPolarityErrors,
+    MultipleRecordsReturned,
     MutuallyExclusiveArgs,
     MzxmlParseError,
     RecordDoesNotExist,
@@ -305,6 +307,13 @@ class MSRunsLoader(TableLoader):
             self.date_default = date_default
             self.lc_protocol_name_default = lc_protocol_name_default
             self.instrument_default = instrument_default
+
+        self.msrun_sequence_dict = {}
+        # Save the default MSRunSequence record (if any) in the self.msrun_sequence_dict:
+        self.get_msrun_sequence()
+
+        # This will contain the created ArchiveFile records for mzXML files
+        self.created_mzxml_archive_file_recs = []
 
         # This will contain metadata parsed from the mzXML files (and the created ArchiveFile records to be added to
         # MSRunSample records
@@ -731,8 +740,6 @@ class MSRunsLoader(TableLoader):
 
         return rec, created, updated
 
-        return rec, created, updated
-
     def get_sample_by_name(self, sample_name, from_mzxml=False):
         """Get a Sample record by name.
         Args:
@@ -750,7 +757,7 @@ class MSRunsLoader(TableLoader):
         rec = None
         try:
             rec = Sample.objects.get(name=sample_name)
-        except Sample.DoesNotExist:
+        except Sample.DoesNotExist as dne:
             if from_mzxml:
                 file = (
                     self.file
@@ -767,7 +774,8 @@ class MSRunsLoader(TableLoader):
                             "does not exist.  Please identify the associated sample and add a row with it, the "
                             f"matching mzXML file name(s), and the {self.headers.SEQNAME} to %s."
                         ),
-                    )
+                    ),
+                    orig_exception=dne,
                 )
             else:
                 self.aggregated_errors_object.buffer_error(
@@ -778,7 +786,8 @@ class MSRunsLoader(TableLoader):
                         sheet=self.sheet,
                         column=self.headers.SAMPLENAME,
                         rownum=self.rownum,
-                    )
+                    ),
+                    orig_exception=dne,
                 )
         return rec
 
@@ -863,8 +872,6 @@ class MSRunsLoader(TableLoader):
 
         return rec, created
 
-        return rec, created
-
     def get_msrun_sequence(self, name: Optional[str] = None) -> Optional[MSRunSequence]:
         """Retrieves an MSRunSequence record using either the value in the supplied SEQNAME column or via defaults for
         the Sequences sheet.
@@ -887,11 +894,24 @@ class MSRunsLoader(TableLoader):
         Returns:
             msrseq (Optional[MSRunSequence])
         """
+        rec = None
+        query_dict = {}
+        missing_defaults = []
+        # The origin of the sequence data used to retrieve the sequence
+        origin = (
+            "the default arguments: [operator, date, instrument, and lc_protocol_name]"
+        )
+        lookup_key = name if name is not None else "default"
+
         try:
-            if name is not None:
+            if lookup_key in self.msrun_sequence_dict.keys():
+                # We have already computed the value for this search before, so just return it from the dict
+                return self.msrun_sequence_dict[lookup_key]
+            elif name is not None:
                 # If we have a name, that means that the value is from the data sheet (not the defaults file/sheet)
                 # Record where any possible errors will come from for the catch below
-                file = self.file
+                origin = "infile"
+                error_source = self.file
                 sheet = self.sheet
                 column = self.DefaultsHeaders.DEFAULT_VALUE
                 rownum = self.rownum
@@ -901,54 +921,68 @@ class MSRunsLoader(TableLoader):
                 date = string_to_datetime(
                     date_str,
                     # The following arguments are for error reporting
-                    file=file,
+                    file=error_source,
                     sheet=sheet,
                     column=column,
                     rownum=rownum,
                 )
+
+                query_dict = {
+                    "researcher": operator,
+                    "date": date,
+                    "lc_method__name": lcprotname,
+                    "instrument": instrument,
+                }
             else:
-                # Error-reporting info
                 if self.df is None:
-                    file = (
-                        self.defaults_file
-                        if self.defaults_file is not None
-                        else "the defaults file"
-                    )
+                    # There is no Peak Annotation Details infile present
+                    if self.defaults_file is not None:
+                        origin = "defaultsfile"
+                        error_source = self.defaults_file
+                    else:
+                        # Overloading the file variable to reference the defaults (to present in errors)
+                        error_source = origin
                     sheet = None
+                    column = None
                 else:
-                    file = self.file
-                    sheet = (
-                        self.defaults_sheet
-                        if self.defaults_file is not None
-                        else "the defaults sheet"
-                    )
-                column = self.DefaultsHeaders.DEFAULT_VALUE
+                    if self.defaults_file is not None:
+                        origin = "defaultsfile"
+                        error_source = self.defaults_file
+                        sheet = None
+                        column = self.DefaultsHeaders.DEFAULT_VALUE
+                    elif self.file is not None:
+                        origin = "defaultsfile"  # Really, the sheet in the --infile, but that doesn't matter
+                        error_source = self.file
+                        sheet = self.defaults_sheet
+                        column = self.DefaultsHeaders.DEFAULT_VALUE
+                    else:
+                        error_source = origin
+                        sheet = None
+                        column = None
+                # We aren't processing rows here.  If there was a file, it was done by the sequences loader, so we never
+                # have a row number.
                 rownum = None
 
-                if (
-                    len(
-                        # If all the defaults are set for the sequences loader
-                        [
-                            v
-                            for v in [
-                                self.operator_default,
-                                self.date_default,
-                                self.lc_protocol_name_default,
-                                self.instrument_default,
-                            ]
-                            if v is not None
-                        ]
-                    )
-                    == 4
-                ):
-                    operator = self.operator_default
-                    lcprotname = self.lc_protocol_name_default
-                    instrument = self.instrument_default
-                    date_str = self.date_default
-                    date = string_to_datetime(
-                        date_str,
+                if self.operator_default is not None:
+                    query_dict["researcher"] = self.operator_default
+                else:
+                    missing_defaults.append(SequencesLoader.DataHeaders.OPERATOR)
+
+                if self.lc_protocol_name_default is not None:
+                    query_dict["lc_method__name"] = self.lc_protocol_name_default
+                else:
+                    missing_defaults.append(SequencesLoader.DataHeaders.LCNAME)
+
+                if self.instrument_default is not None:
+                    query_dict["instrument"] = self.instrument_default
+                else:
+                    missing_defaults.append(SequencesLoader.DataHeaders.INSTRUMENT)
+
+                if self.date_default is not None:
+                    query_dict["date"] = string_to_datetime(
+                        self.date_default,
                         # The following arguments are for error reporting
-                        file=file,
+                        file=error_source,
                         sheet=sheet,
                         column=column,
                         # We didn't save this when reading the defaults sheet, so we're going to name the row by the
@@ -956,82 +990,69 @@ class MSRunsLoader(TableLoader):
                         rownum=SequencesLoader.DataHeaders.DATE,
                     )
                 else:
-                    # We didn't save this when reading the defaults sheet, so we're going to name the rows by the
-                    # sequences loader's corresponding column headers
-                    missing_defaults_header_rows = []
-                    if self.operator_default is None:
-                        missing_defaults_header_rows.append(
-                            SequencesLoader.DataHeaders.OPERATOR
-                        )
-                    if self.lc_protocol_name_default is None:
-                        missing_defaults_header_rows.append(
-                            SequencesLoader.DataHeaders.LCNAME
-                        )
-                    if self.instrument_default is None:
-                        missing_defaults_header_rows.append(
-                            SequencesLoader.DataHeaders.INSTRUMENT
-                        )
-                    if self.date_default is None:
-                        missing_defaults_header_rows.append(
-                            SequencesLoader.DataHeaders.DATE
-                        )
-                    rownum = ", ".join(
-                        [
-                            f"{self.DefaultsSheetName} {rowname}"
-                            for rowname in missing_defaults_header_rows
-                        ]
-                    )
+                    missing_defaults.append(SequencesLoader.DataHeaders.DATE)
 
-                    raise RequiredColumnValues(
+            # Don't perform the query if no query exists (i.e. None will be returned)
+            if len(query_dict.keys()) > 0:
+                rec = MSRunSequence.objects.get(**query_dict)
+
+        except MSRunSequence.DoesNotExist as dne:
+            self.aggregated_errors_object.buffer_error(
+                RecordDoesNotExist(
+                    MSRunSequence,
+                    query_dict,
+                    file=error_source,
+                    sheet=sheet,
+                    column=column,
+                    rownum=rownum,
+                ),
+                orig_exception=dne,
+            )
+        except MSRunSequence.MultipleObjectsReturned as mor:
+            if len(missing_defaults) > 0 and origin != "infile":
+                self.aggregated_errors_object.buffer_error(
+                    RequiredColumnValues(
                         [
                             RequiredColumnValue(
-                                file=file,
+                                file=error_source,
                                 sheet=sheet,
                                 column=column,
                                 rownum=f"{self.DefaultsSheetName} {rowname}",
                             )
-                            for rowname in missing_defaults_header_rows
+                            for rowname in missing_defaults
                         ]
-                    )
-
-            msrseq_query_dict = {
-                "researcher": operator,
-                "date": date,
-                "lc_method__name": lcprotname,
-                "instrument": instrument,
-            }
-
-            msrseq = MSRunSequence.objects.get(**msrseq_query_dict)
-
-        except Exception as e:
-            if isinstance(e, InfileError):
-                self.aggregated_errors_object.buffer_error(e)
-            elif isinstance(e, MSRunSequence.DoesNotExist):
-                seqsource = self.file if self.file is not None else self.defaults_file
-                if seqsource is None:
-                    seqsource = "the default arguments: [operator, date, instrument, and lc_protocol_name]"
-                self.aggregated_errors_object.buffer_error(
-                    RecordDoesNotExist(
-                        MSRunSequence,
-                        msrseq_query_dict,
-                        file=seqsource,
-                        sheet=self.sheet,
-                    )
+                    ),
+                    orig_exception=mor,
                 )
             else:
                 self.aggregated_errors_object.buffer_error(
-                    InfileError(
-                        f"{type(e).__name__}: {e}",
-                        file=file,
+                    MultipleRecordsReturned(
+                        MSRunSequence,
+                        query_dict,
+                        file=error_source,
                         sheet=sheet,
                         column=column,
                         rownum=rownum,
                     ),
-                    orig_exception=e,
+                    orig_exception=mor,
                 )
-            msrseq = None
+        except InfileError as ie:
+            self.aggregated_errors_object.buffer_error(ie)
+        except Exception as e:
+            self.aggregated_errors_object.buffer_error(
+                InfileError(
+                    f"{type(e).__name__}: {e}",
+                    file=error_source,
+                    sheet=sheet,
+                    column=column,
+                    rownum=rownum,
+                ),
+                orig_exception=e,
+            )
+        finally:
+            self.msrun_sequence_dict[lookup_key] = rec
 
-        return msrseq
+        return rec
 
     def get_matching_mzxml_metadata(
         self,

--- a/DataRepo/utils/exceptions.py
+++ b/DataRepo/utils/exceptions.py
@@ -5,7 +5,11 @@ import warnings
 from collections import defaultdict
 from typing import TYPE_CHECKING, Dict, Optional
 
-from django.core.exceptions import ObjectDoesNotExist, ValidationError
+from django.core.exceptions import (
+    MultipleObjectsReturned,
+    ObjectDoesNotExist,
+    ValidationError,
+)
 from django.core.management import CommandError
 from django.db.utils import ProgrammingError
 from django.forms.models import model_to_dict
@@ -2627,6 +2631,15 @@ class RecordDoesNotExist(InfileError, ObjectDoesNotExist):
             message = (
                 f"{model.__name__} record matching {query_dict} from %s does not exist."
             )
+        super().__init__(message, **kwargs)
+        self.query_dict = query_dict
+        self.model = model
+
+
+class MultipleRecordsReturned(InfileError, MultipleObjectsReturned):
+    def __init__(self, model, query_dict, message=None, **kwargs):
+        if message is None:
+            message = f"{model.__name__} record matching {query_dict} from %s returned multiple records."
         super().__init__(message, **kwargs)
         self.query_dict = query_dict
         self.model = model


### PR DESCRIPTION
## Summary Change Description

This was the direction I started in WRT #976.  I basically was cleaning up the `get_msrun_sequence` method and cleared up some of the `if` conditionals that did not previously distinguish between lines from the input file that had no sequence name versus mzXML file loads that were not present in the infile.  In fact, then code originally was written to avoid potential errors from the sequence defaults provided on the commentd line if in fact the defaults were not actually needed (i.e. everything was provided with values in `--infile`).

While I was at it, I finished a half-assed attempt I had never completed due to a change in direction: and that was the ability to supply only *some* of the options: `--instrument`, `--operator`, `--date`, and `--lc-protocol-name`.  I'd realized part-way through the original effort that it's pretty likely that for example, only the date was enough to uniquely identify a sequence.  That's why I added an exception in this effort called `MultipleRecordsReturned` (which inherits from both `InfileError` and `MultipleObjectsReturned`).

## Affected Issues/Pull Requests

- Partially addresses #976

## Review Notes

See comments in-line.

## Checklist
<!--
If any of the checkbox requirements are not met, uncheck them and add an
explanation. E.g. Linting errors pre-date this PR.
-->
This pull request will be merged once the following requirements are met.  The
author and/or reviewers should uncheck any unmet requirements:

- Review requirements
  - Minimum approvals: 1 <!-- Edit as desired (e.g. based on complexity) -->
  - No changes requested
  - All blocking issues resolved by reviewers
  - Specific reviewers: @__add_username_here__
    <!--
    Require reviewers with specific expertise to be included among the minimum
    number of reviewers by tagging them.  Also please send them a message.
    -->
  - Review period: 2 days <!-- Edit as desired (e.g. based on complexity) -->
- Associated issue/pull request requirements:
  <!--
  Assert that all requirements in issues marked "resolved" are done and that
  all required pull requests are merged.  If any are not done, either edit or
  split the issue or explain the unmerged affected pull requests.
  -->
  - [x] All requirements in affected issues marked "resolved" are satisfied
  - [x] All required pull requests are merged *(or none)*
- Basic requirements
  <!--
  Uncheck items to acknowledge failures/conflicts you intend to address.
  Add an explanation if any won't be addressed before merge.
  -->
  - [x] [All linters pass](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#linting)
  - [x] [All tests pass](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#quality-control)
  - [x] All conflicts resolved
- Overhead requirements
  <!--
  These are additional requirements that are not directly associated with
  resolving the affected issue(s).
  -->
  - [x] [New/changed method tests implemented/updated *(or no change)*](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#test-implementation)
  - [ ] [Updated *Unreleased* section of `changelog.md` *(or no change)*](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/changelog.md)
  - [x] [Migrations created & committed *(or no change)*](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#migration-process)
