### PR TITLE
Added the ability for ArchiveFile to clean up the archive after the commit of a delete.

### DIFF
--- a/DataRepo/models/archive_file.py
+++ b/DataRepo/models/archive_file.py
@@ -5,8 +5,13 @@ import os
 from pathlib import Path
 
 from django.core.files import File
-from django.db import models, transaction
+from django.db import ProgrammingError, models, transaction
+from django.db.models.signals import post_delete
+from django.dispatch import receiver
+from django.forms import model_to_dict
 from django.utils.text import get_valid_filename
+
+from DataRepo.models.utilities import exists_in_db
 
 
 class DataTypeManager(models.Manager):
@@ -286,3 +291,51 @@ class ArchiveFile(models.Model):
                 hash_obj.update(chunk)
 
         return hash_obj.hexdigest()
+
+
+@receiver(post_delete, sender=ArchiveFile)
+def post_archive_file_delete_commit(**kwargs):
+    """Schedule a call to delete_archive_file upon deletion commit (when we are guaranteed that the transaction won't be
+    rolled back).
+
+    The purpose is to delete the file associated with an ArchiveFile record when it is being deleted.
+
+    NOTE: There are scenarios however where files in the archive can be orphaned and not cleaned up.  For example, if
+    rec.file_location is changed (i.e. delete is not called).
+
+    References:
+        https://stackoverflow.com/a/52703242/2057516
+    Args:
+        kwargs (dict)
+    Exceptions:
+        None
+    Returns:
+        None
+    """
+    print("BUFFERING POST-COMMIT DELETE")
+    transaction.on_commit(lambda: delete_archive_file(kwargs["instance"]))
+
+
+def delete_archive_file(deleted_rec: ArchiveFile) -> None:
+    """Given a deleted record instance (or a record being deleted during a safe transaction commit), delete the file on
+    disk associated with the record.
+
+    References:
+        https://stackoverflow.com/a/16041527/2057516
+    Args:
+        deleted_rec (ArchiveFile)
+    Exceptions:
+        None
+    RTeturns:
+        None
+    """
+    if deleted_rec.file_location and os.path.isfile(deleted_rec.file_location.path):
+        if exists_in_db(deleted_rec):
+            raise ProgrammingError(
+                f"Calling delete_archive_file on existing database record: {model_to_dict(deleted_rec)} is not allowed."
+            )
+        else:
+            print(f"DELETING FILE: {deleted_rec.file_location.path}")
+            os.remove(deleted_rec.file_location.path)
+    else:
+        print(f"{deleted_rec.file_location.path} WAS NOT A FILE")

--- a/DataRepo/models/archive_file.py
+++ b/DataRepo/models/archive_file.py
@@ -312,7 +312,6 @@ def post_archive_file_delete_commit(**kwargs):
     Returns:
         None
     """
-    print("BUFFERING POST-COMMIT DELETE")
     transaction.on_commit(lambda: delete_archive_file(kwargs["instance"]))
 
 
@@ -335,7 +334,4 @@ def delete_archive_file(deleted_rec: ArchiveFile) -> None:
                 f"Calling delete_archive_file on existing database record: {model_to_dict(deleted_rec)} is not allowed."
             )
         else:
-            print(f"DELETING FILE: {deleted_rec.file_location.path}")
             os.remove(deleted_rec.file_location.path)
-    else:
-        print(f"{deleted_rec.file_location.path} WAS NOT A FILE")

--- a/DataRepo/tests/models/test_archive_file.py
+++ b/DataRepo/tests/models/test_archive_file.py
@@ -1,11 +1,17 @@
+import os
 from pathlib import Path
 
 from django.conf import settings
 from django.core.files import File
+from django.db import transaction
 from django.test import override_settings
 
 from DataRepo.models import ArchiveFile, DataFormat, DataType
-from DataRepo.tests.tracebase_test_case import TracebaseTestCase
+from DataRepo.models.utilities import exists_in_db
+from DataRepo.tests.tracebase_test_case import (
+    TracebaseArchiveTestCase,
+    TracebaseTestCase,
+)
 
 
 @override_settings(CACHES=settings.TEST_CACHES)
@@ -59,6 +65,97 @@ class ArchiveFileTests(TracebaseTestCase):
         fn = "DataRepo/data/tests/small_obob/small_obob_maven_6eaas_inf_lactate_mzxmls/BAT-xz971.mzXML"
         self.assertFalse(ArchiveFile.file_is_binary(fn))
 
+
+class ArchiveFileArchiveTests(TracebaseArchiveTestCase):
+    record_id = None
+    fixtures = ["data_types.yaml", "data_formats.yaml"]
+
+    @classmethod
+    def setUpTestData(cls):
+        path = Path("DataRepo/data/tests/small_obob/small_obob_maven_6eaas_inf.xlsx")
+        with path.open(mode="rb") as f:
+            myfile = File(f, name=path.name)
+        ms_peak_annotation = DataType.objects.get(code="ms_peak_annotation")
+        accucor_format = DataFormat.objects.get(code="accucor")
+        cls.rec_dict = {
+            "filename": "small_obob_maven_6eaas_inf.xlsx",
+            "file_location": myfile,
+            "checksum": "558ea654d7f2914ca4527580edf4fac11bd151c3",
+            "data_type": ms_peak_annotation,
+            "data_format": accucor_format,
+        }
+        super().setUpTestData()
+
+    def setUp(self):
+        super().setUp()
+        self.rec = None
+
+    def create_archive_file(self):
+        path = Path("DataRepo/data/tests/small_obob/small_obob_maven_6eaas_inf.xlsx")
+        with path.open(mode="rb") as f:
+            myfile = File(f, name=path.name)
+            ms_peak_annotation = DataType.objects.get(code="ms_peak_annotation")
+            accucor_format = DataFormat.objects.get(code="accucor")
+            rec_dict = {
+                "filename": "small_obob_maven_6eaas_inf.xlsx",
+                "file_location": myfile,
+                "checksum": "558ea654d7f2914ca4527580edf4fac11bd151c3",
+                "data_type": ms_peak_annotation,
+                "data_format": accucor_format,
+            }
+            self.rec = ArchiveFile.objects.create(**rec_dict)
+            self.rec.full_clean()
+        self.assertTrue(
+            os.path.isfile(self.rec.file_location.path),
+            msg="Asserts created file was saved to disk.",
+        )
+
+    @transaction.atomic
+    def delete_during_transaction_failure(self):
+        self.create_archive_file()
+        self.rec.delete()
+        self.assertTrue(
+            os.path.isfile(self.rec.file_location.path),
+            msg="Asserts created file does not delete during transaction.",
+        )
+        raise ValueError("TEST")
+
+    @transaction.atomic
+    def delete_during_transaction_success(self):
+        self.create_archive_file()
+        self.rec.delete()
+        self.assertTrue(
+            os.path.isfile(self.rec.file_location.path),
+            msg="Asserts created file does not delete during transaction.",
+        )
+
+    def test_post_delete_commit_failure(self):
+        """Tests that archive files are cleaned up after rollback."""
+        try:
+            self.delete_during_transaction_failure()
+        except ValueError:
+            pass
+        self.assertIsNotNone(self.rec)
+        self.assertIsNotNone(self.rec.file_location)
+        self.assertIn(self.ARCHIVE_DIR, str(self.rec.file_location.path))
+        self.assertTrue(
+            os.path.isfile(self.rec.file_location.path),
+            msg="Asserts created file was not deleted due to transaction rollback.",
+        )
+        self.assertFalse(exists_in_db(self.rec))
+
+    def test_post_delete_commit_success(self):
+        """Tests that archive files are cleaned up after rollback."""
+        self.delete_during_transaction_success()
+        self.assertIsNotNone(self.rec)
+        self.assertIsNotNone(self.rec.file_location)
+        self.assertIn(self.ARCHIVE_DIR, str(self.rec.file_location.path))
+        self.assertFalse(
+            os.path.isfile(self.rec.file_location.path),
+            msg="Asserts created file was deleted after transaction commit due to call to record delete.",
+        )
+        self.assertFalse(exists_in_db(self.rec))
+
     def test_get_or_create_override(self):
         """This tests the essential functionality of the get_or_create method override, which is to ignore the
         randomized hash string appended to file_location.  but it also tests the conveniences (takes a path string,
@@ -82,10 +179,16 @@ class ArchiveFileTests(TracebaseTestCase):
         self.assertEqual("mzxml", created_rec.data_format.code)
         self.assertEqual("ms_data", created_rec.data_type.code)
         self.assertEqual("BAT-xz971.mzXML", created_rec.filename)
+        self.assertTrue(
+            os.path.isfile(created_rec.file_location.path),
+            msg="Asserts mzXML file was created in the archive.",
+        )
 
         # Called a second time to "get"
         gotten_rec, second_created = ArchiveFile.objects.get_or_create(**rec_dict)
         self.assertFalse(second_created)
         self.assertEqual(created_rec.id, gotten_rec.id)
-
-        # TODO: Figure out how to test that the file_location is an actual stored file
+        self.assertTrue(
+            os.path.isfile(gotten_rec.file_location.path),
+            msg="Asserts mzXML file still exists.",
+        )

--- a/DataRepo/tests/models/test_archive_file.py
+++ b/DataRepo/tests/models/test_archive_file.py
@@ -131,10 +131,8 @@ class ArchiveFileArchiveTests(TracebaseArchiveTestCase):
 
     def test_post_delete_commit_failure(self):
         """Tests that archive files are cleaned up after rollback."""
-        try:
+        with self.assertRaises(ValueError):
             self.delete_during_transaction_failure()
-        except ValueError:
-            pass
         self.assertIsNotNone(self.rec)
         self.assertIsNotNone(self.rec.file_location)
         self.assertIn(self.ARCHIVE_DIR, str(self.rec.file_location.path))


### PR DESCRIPTION
## Summary Change Description

`ArchiveFile` now has a post_delete signal that queues up a `transaction.on_commit` signal for every record that is deleted.  It deletes the file from the archive directory using those signals, but it won't do the deletion if there's an exception before it leaves its atomic block.

This also moved the test of `get_or_create` into a new test class that inherits from the new `TracebaseArchivetestCase` and tests if files are actually created.  If we don't keep the `post_delete` cleanup of the archive, we should edit this to keep that moved test.

## Affected Issues/Pull Requests

- Resolves no issue

## Review Notes
<!--
For added context for reviewers, add comments to relevant lines of code.  Use
this space to describe any general areas of concern not linked to a specific
line of code that reviewers should pay particular attention to, e.g. please
make sure I have accounted for all possible inputs.
-->
See comments in-line.

## Checklist
<!--
If any of the checkbox requirements are not met, uncheck them and add an
explanation. E.g. Linting errors pre-date this PR.
-->
This pull request will be merged once the following requirements are met.  The
author and/or reviewers should uncheck any unmet requirements:

- Review requirements
  - Minimum approvals: 1 <!-- Edit as desired (e.g. based on complexity) -->
  - No changes requested
  - All blocking issues resolved by reviewers
  - Specific reviewers: @__add_username_here__
    <!--
    Require reviewers with specific expertise to be included among the minimum
    number of reviewers by tagging them.  Also please send them a message.
    -->
  - Review period: 2 days <!-- Edit as desired (e.g. based on complexity) -->
- Associated issue/pull request requirements:
  <!--
  Assert that all requirements in issues marked "resolved" are done and that
  all required pull requests are merged.  If any are not done, either edit or
  split the issue or explain the unmerged affected pull requests.
  -->
  - [x] All requirements in affected issues marked "resolved" are satisfied
  - [x] All required pull requests are merged *(or none)*
- Basic requirements
  <!--
  Uncheck items to acknowledge failures/conflicts you intend to address.
  Add an explanation if any won't be addressed before merge.
  -->
  - [x] [All linters pass](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#linting)
  - [x] [All tests pass](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#quality-control)
  - [x] All conflicts resolved
- Overhead requirements
  <!--
  These are additional requirements that are not directly associated with
  resolving the affected issue(s).
  -->
  - [x] [New/changed method tests implemented/updated *(or no change)*](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#test-implementation)
  - [ ] [Updated *Unreleased* section of `changelog.md` *(or no change)*](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/changelog.md)
  - [x] [Migrations created & committed *(or no change)*](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#migration-process)
