### PR TITLE
Msruns loader rollback cleanup

### DIFF
--- a/DataRepo/loaders/msruns_loader.py
+++ b/DataRepo/loaders/msruns_loader.py
@@ -5,8 +5,9 @@ from pathlib import Path
 from typing import Dict, Optional
 
 import xmltodict
-from django.db import transaction
+from django.db import ProgrammingError, transaction
 from django.db.models import Max, Min, Q
+from django.forms import model_to_dict
 
 from DataRepo.loaders.sequences_loader import SequencesLoader
 from DataRepo.loaders.table_column import ColumnReference, TableColumn
@@ -14,7 +15,7 @@ from DataRepo.loaders.table_loader import TableLoader
 from DataRepo.models import MSRunSample, MSRunSequence, PeakGroup
 from DataRepo.models.archive_file import ArchiveFile, DataFormat, DataType
 from DataRepo.models.sample import Sample
-from DataRepo.models.utilities import update_rec
+from DataRepo.models.utilities import exists_in_db, update_rec
 from DataRepo.utils.exceptions import (
     AggregatedErrors,
     InfileError,

--- a/DataRepo/loaders/msruns_loader.py
+++ b/DataRepo/loaders/msruns_loader.py
@@ -384,6 +384,10 @@ class MSRunsLoader(TableLoader):
                             # Continue processing rows to find more errors
                             pass
 
+        # If there were any exceptions (i.e. a rollback of everything will be triggered)
+        if self.aggregated_errors_object.should_raise():
+            self.clean_up_created_mzxmls_in_archive()
+
     @transaction.atomic
     def get_or_create_mzxml_and_raw_archive_files(self, mzxml_file):
         """Get or create ArchiveFile records for an mzXML file and a record for its raw file.  Updates self.mzxml_dict.
@@ -414,6 +418,8 @@ class MSRunsLoader(TableLoader):
             mzaf_rec, mzaf_created = ArchiveFile.objects.get_or_create(**mz_rec_dict)
             if mzaf_created:
                 self.created(ArchiveFile.__name__)
+                # Save the path to the file in the archive in case of rollback
+                self.created_mzxml_archive_file_recs.append(mzaf_rec)
             else:
                 self.existed(ArchiveFile.__name__)
         except (DataType.DoesNotExist, DataFormat.DoesNotExist) as dne:
@@ -1448,3 +1454,63 @@ class MSRunsLoader(TableLoader):
             suffix_patterns=suffix_patterns, add_patterns=add_patterns
         )
         return re.sub(pattern, "", mzxml_bamename)
+
+    def clean_up_created_mzxmls_in_archive(self):
+        """Call this method when rollback did/will happen in order to delete mzXML files added to the archive on disk.
+
+        Args:
+            None
+        Exceptions:
+            Buffers:
+                NotImplementedError
+                ProgrammingError
+                OSError
+            Raises:
+                None
+        Returns:
+            None
+        """
+        if not self.aggregated_errors_object.should_raise():
+            self.aggregated_errors_object.buffer_error(
+                NotImplementedError(
+                    "clean_up_created_mzxmls_in_archive is not intended for use when an exception has not been raised."
+                )
+            )
+            return
+
+        deleted = 0
+        failures = 0
+        skipped = 0
+        for rec in self.created_mzxml_archive_file_recs:
+            # If there was no associated file, or the file wasn't actually created, there's nothing to delete, so
+            # continue
+            if not rec.file_location or not os.path.isfile(rec.file_location.path):
+                skipped += 1
+                continue
+
+            # To be extra safe, we will confirm that the record does not exist in the database before deleting
+            if exists_in_db(rec):
+                self.aggregated_errors_object.buffer_error(
+                    ProgrammingError(
+                        f"Cannot delete a file [{rec.file_location.path}] from the os that is associated with "
+                        f"existing {ArchiveFile.__name__} database record: {model_to_dict(rec)}."
+                    )
+                )
+            else:
+                try:
+                    os.remove(rec.file_location.path)
+                    deleted += 1
+                except Exception as e:
+                    self.aggregated_errors_object.buffer_error(
+                        OSError(
+                            f"Unable to delete created mzXML archive file: [{rec.file_location.path}] during "
+                            f"rollback due to {type(e).__name__}: {e}"
+                        ),
+                        orig_exception=e,
+                    )
+                    failures += 1
+
+        print(
+            f"mzXML file rollback disk archive clean up stats: {deleted} deleted, {failures} failed to be deleted, and "
+            f"{skipped} expected files did not exist."
+        )


### PR DESCRIPTION
## Summary Change Description

This code buffers created `ArchiveFile` records and very cautiously deletes the files in the archive that were created in the event of a rollback.

The issue originally was to only exit if the default sequence records could not be found, but I quickly realized that there are all sorts of common exceptions that could happen and leave behind orphaned files: missing sample record (very common), missing sequence detailed in the infile (common), duplicates, missing headers... the list goes on and on.  And when I started thinking about having the add a front-loaded loop to handle the infile exceptions for missing sequence records, I started to think of the strategy and eventually creating messy spaghetti code, so I decided a cleaner solution was to simply rollback the directory using a buffer of created ArchiveFile records.

I pointed out in the original PR though that there's a potentially better strategy that avoids file deletion: buffer the creation of the files `on_commit` after a `post_save` signal (for each record).  I have to think more about this, but in theory, it should work, and be a more comfortable change for those that worry about unintended deletions.  however, I for one am very confident in this code.  I think that post-save-on-commit would be better, because it's more efficient, but it's the same basic mechanism, which was intended for this express purpose.  We should use it IMO.

## Affected Issues/Pull Requests

- Resolves #976

## Review Notes
<!--
For added context for reviewers, add comments to relevant lines of code.  Use
this space to describe any general areas of concern not linked to a specific
line of code that reviewers should pay particular attention to, e.g. please
make sure I have accounted for all possible inputs.
-->
See comments in-line.

## Checklist
<!--
If any of the checkbox requirements are not met, uncheck them and add an
explanation. E.g. Linting errors pre-date this PR.
-->
This pull request will be merged once the following requirements are met.  The
author and/or reviewers should uncheck any unmet requirements:

- Review requirements
  - Minimum approvals: 1 <!-- Edit as desired (e.g. based on complexity) -->
  - No changes requested
  - All blocking issues resolved by reviewers
  - Specific reviewers: @__add_username_here__
    <!--
    Require reviewers with specific expertise to be included among the minimum
    number of reviewers by tagging them.  Also please send them a message.
    -->
  - Review period: 2 days <!-- Edit as desired (e.g. based on complexity) -->
- Associated issue/pull request requirements:
  <!--
  Assert that all requirements in issues marked "resolved" are done and that
  all required pull requests are merged.  If any are not done, either edit or
  split the issue or explain the unmerged affected pull requests.
  -->
  - [x] All requirements in affected issues marked "resolved" are satisfied
  - [x] All required pull requests are merged *(or none)*
- Basic requirements
  <!--
  Uncheck items to acknowledge failures/conflicts you intend to address.
  Add an explanation if any won't be addressed before merge.
  -->
  - [x] [All linters pass](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#linting)
  - [x] [All tests pass](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#quality-control)
  - [x] All conflicts resolved
- Overhead requirements
  <!--
  These are additional requirements that are not directly associated with
  resolving the affected issue(s).
  -->
  - [x] [New/changed method tests implemented/updated *(or no change)*](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#test-implementation)
  - [ ] [Updated *Unreleased* section of `changelog.md` *(or no change)*](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/changelog.md)
  - [x] [Migrations created & committed *(or no change)*](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#migration-process)
