### PR TITLE
Gracefully handle stale maintained `Animal.last_serum_sample` maintained field

### DIFF
--- a/DataRepo/tests/models/test_fcirc.py
+++ b/DataRepo/tests/models/test_fcirc.py
@@ -217,7 +217,7 @@ class FCircTests(TracebaseTestCase):
                 "No significant problems found", fcr.serum_validity["message"]
             )
             self.assertEqual("good", fcr.serum_validity["level"])
-            self.assertEqual("000000000", fcr.serum_validity["bitcode"])
+            self.assertEqual("00000000", fcr.serum_validity["bitcode"])
 
     def test_serum_validity_no_peakgroup(self):
         self.create_newlss_fcirc_recs()
@@ -246,7 +246,7 @@ class FCircTests(TracebaseTestCase):
             #                                          a time collected.
             # 0 - msr_date_is_none_but_only1_msr_for_smpl - 0 = There are either many MSRunSamples for this serum sample
             #                                                   or there is 1 & it has a date.
-            self.assertEqual("100000100", fcr.serum_validity["bitcode"])
+            self.assertEqual("10000010", fcr.serum_validity["bitcode"])
 
     def test_serum_validity_no_time_collected(self):
         # When we null the time collected for lss, newlss is still the last serun sample, but the fcirc record for the
@@ -283,7 +283,7 @@ class FCircTests(TracebaseTestCase):
             #                                          a time collected.
             # 0 - msr_date_is_none_but_only1_msr_for_smpl - 0 = There are either many MSRunSamples for this serum sample
             #                                                   or there is 1 & it has a date.
-            self.assertEqual("011000100", fcr.serum_validity["bitcode"])
+            self.assertEqual("01100010", fcr.serum_validity["bitcode"])
 
         self.lss.time_collected = tcbak
         self.lss.save()
@@ -326,7 +326,7 @@ class FCircTests(TracebaseTestCase):
             #                                          a time collected.
             # 0 - msr_date_is_none_but_only1_msr_for_smpl - 0 = There are either many MSRunSamples for this serum sample
             #                                                   or there is 1 & it has a date.
-            self.assertEqual("000100100", fcr.serum_validity["bitcode"])
+            self.assertEqual("00010010", fcr.serum_validity["bitcode"])
 
         self.newlss.time_collected = tcbak
         self.newlss.save()
@@ -417,7 +417,7 @@ class FCircTests(TracebaseTestCase):
             #                                          a time collected.
             # 0 - msr_date_is_none_but_only1_msr_for_smpl - 0 = There are either many MSRunSamples for this serum sample
             #                                                   or there is 1 & it has a date.
-            self.assertEqual("000010100", fcr.serum_validity["bitcode"])
+            self.assertEqual("00001010", fcr.serum_validity["bitcode"])
 
         self.newlss.time_collected = tcbak
         self.newlss.save()


### PR DESCRIPTION
## Summary Change Description

Caught a situation where the `Animal.last_serum_sample` maintained field value can be invalid due to manual data manipulation and added an error status with a message suggesting that maintained fields be rebuilt.

While I was at it, I addressed a TODO item in the same serum_validity code:

> `TODO: MSRunSequence.date can no longer be null, so these warnings can probably be removed`

An example of the exception previously encountered is in the issue's current behavior section.  This is now what the user gets from this PR when the maintained field value is incorrect:

![stalemtf](https://github.com/Princeton-LSI-ResearchComputing/tracebase/assets/2300532/34aaa036-438a-4994-8ee2-3edd0a90b404)

This is what caused the exception to occur:  The `last_serum_sample` should be on dev, which is still what it is in my sandbox:
```
In [1]: from DataRepo.models import Animal

In [2]: anml = Animal.objects.get(name="20220818M1")

In [3]: anml._last_serum_sample()

Out[3]: <Sample: 20220818_M1_mix1_T150>

In [4]: anml.last_serum_sample
Out[4]: <Sample: 20220818_M1_mix1_T150>
```

This is what it became on dev:
```
In [1]: from DataRepo.models import Animal

In [2]: anml = Animal.objects.get(name="20220818M1")
Adding propagation handler to Animal.studies.through

In [3]: anml._last_serum_sample()
Out[3]: <Sample: 20220818_M1_mix1_T150>

In [4]: anml.last_serum_sample
```

I believe that manual database manipulations caused the value to become `None`.  As you can see, the method that generates the value, still generates the correct value.  It's just that the value saved got wiped out.

Just calling:
```
In [4]: anml.save()
```
automatically fixes the maintained fields:

![mntfldfixd](https://github.com/Princeton-LSI-ResearchComputing/tracebase/assets/2300532/5012d1be-4823-43a2-8efc-ab1b0838d28e)

This PR doesn't fix the values, it just makes it fail gracefully and tell us what needs to be done to fix the problem (in the tooltip).

Note, I should have started a screen session yesterday when I ran `rebuild_maintained_fields`, because my session went stale and the rebuild was rolled back.  I'm going to take a quick look at the script.  I think it has a surgical option to make it only apply to certain labeled autoupdate routes.  I may also reintroduce the ability to suspend cache updates.  I'd previously eliminated that to make it better encapsulated, but I can add it to the management command...

## Affected Issues/Pull Requests

- Resolves #985

## Review Notes
<!--
For added context for reviewers, add comments to relevant lines of code.  Use
this space to describe any general areas of concern not linked to a specific
line of code that reviewers should pay particular attention to, e.g. please
make sure I have accounted for all possible inputs.
-->
See comments in-line.

## Checklist
<!--
If any of the checkbox requirements are not met, uncheck them and add an
explanation. E.g. Linting errors pre-date this PR.
-->
This pull request will be merged once the following requirements are met.  The
author and/or reviewers should uncheck any unmet requirements:

- Review requirements
  - Minimum approvals: 1 <!-- Edit as desired (e.g. based on complexity) -->
  - No changes requested
  - All blocking issues resolved by reviewers
  - Specific reviewers: @__add_username_here__
    <!--
    Require reviewers with specific expertise to be included among the minimum
    number of reviewers by tagging them.  Also please send them a message.
    -->
  - Review period: 2 days <!-- Edit as desired (e.g. based on complexity) -->
- Associated issue/pull request requirements:
  <!--
  Assert that all requirements in issues marked "resolved" are done and that
  all required pull requests are merged.  If any are not done, either edit or
  split the issue or explain the unmerged affected pull requests.
  -->
  - [x] All requirements in affected issues marked "resolved" are satisfied
  - [x] All required pull requests are merged *(or none)*
- Basic requirements
  <!--
  Uncheck items to acknowledge failures/conflicts you intend to address.
  Add an explanation if any won't be addressed before merge.
  -->
  - [x] [All linters pass](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#linting)
  - [x] [All tests pass](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#quality-control)
  - [x] All conflicts resolved
- Overhead requirements
  <!--
  These are additional requirements that are not directly associated with
  resolving the affected issue(s).
  -->
  - [x] [New/changed method tests implemented/updated *(or no change)*](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#test-implementation)
  - [x] [Updated *Unreleased* section of `changelog.md` *(or no change)*](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/changelog.md)
  - [x] [Migrations created & committed *(or no change)*](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#migration-process)
