### PR TITLE
Disable caching during maintained field rebuild

### DIFF
--- a/DataRepo/management/commands/rebuild_maintained_fields.py
+++ b/DataRepo/management/commands/rebuild_maintained_fields.py
@@ -1,5 +1,12 @@
 from django.core.management import BaseCommand
 
+from DataRepo.models.hier_cached_model import (
+    delete_all_caches,
+    disable_caching_retrievals,
+    disable_caching_updates,
+    enable_caching_retrievals,
+    enable_caching_updates,
+)
 from DataRepo.models.maintained_model import MaintainedModel
 
 
@@ -26,8 +33,15 @@ class Command(BaseCommand):
         )
 
     def handle(self, *args, **options):
-        MaintainedModel.rebuild_maintained_fields(
-            "DataRepo.models",  # optional - should work without this, but supplying anyway
-            label_filters=options["labels"],
-            filter_in=not options["exclude"],
-        )
+        try:
+            disable_caching_retrievals()
+            disable_caching_updates()
+            MaintainedModel.rebuild_maintained_fields(
+                "DataRepo.models",  # optional - should work without this, but supplying anyway
+                label_filters=options["labels"],
+                filter_in=not options["exclude"],
+            )
+            delete_all_caches()
+        finally:
+            enable_caching_updates()
+            enable_caching_retrievals()


### PR DESCRIPTION
## Summary Change Description

Disable caching during maintained field rebuild.  Also clears all cache after a rebuild.

I used this branch to fix stale maintained fields on dev in 4 minutes.  Before this change, the script ran all day and everything rolled back when my GlobalProtect session went stale.  The maintained field values had somehow gotten cleared out when we were mucking with the database manually a few days ago, and this fixed them all (6,310 field values).

## Affected Issues/Pull Requests

- Indirectly related to #985 - makes `rebuild_maintained_field` multiple orders of magnitude faster, with the side-effect of deleting all cached values

## Review Notes
<!--
For added context for reviewers, add comments to relevant lines of code.  Use
this space to describe any general areas of concern not linked to a specific
line of code that reviewers should pay particular attention to, e.g. please
make sure I have accounted for all possible inputs.
-->
See comments in-line.

## Checklist
<!--
If any of the checkbox requirements are not met, uncheck them and add an
explanation. E.g. Linting errors pre-date this PR.
-->
This pull request will be merged once the following requirements are met.  The
author and/or reviewers should uncheck any unmet requirements:

- Review requirements
  - Minimum approvals: 1 <!-- Edit as desired (e.g. based on complexity) -->
  - No changes requested
  - All blocking issues resolved by reviewers
  - Specific reviewers: @__add_username_here__
    <!--
    Require reviewers with specific expertise to be included among the minimum
    number of reviewers by tagging them.  Also please send them a message.
    -->
  - Review period: 2 days <!-- Edit as desired (e.g. based on complexity) -->
- Associated issue/pull request requirements:
  <!--
  Assert that all requirements in issues marked "resolved" are done and that
  all required pull requests are merged.  If any are not done, either edit or
  split the issue or explain the unmerged affected pull requests.
  -->
  - [x] All requirements in affected issues marked "resolved" are satisfied
  - [x] All required pull requests are merged *(or none)*
- Basic requirements
  <!--
  Uncheck items to acknowledge failures/conflicts you intend to address.
  Add an explanation if any won't be addressed before merge.
  -->
  - [x] [All linters pass](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#linting)
  - [x] [All tests pass](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#quality-control)
  - [x] All conflicts resolved
- Overhead requirements
  <!--
  These are additional requirements that are not directly associated with
  resolving the affected issue(s).
  -->
  - [x] [New/changed method tests implemented/updated *(or no change)*](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#test-implementation)
  - [ ] [Updated *Unreleased* section of `changelog.md` *(or no change)*](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/changelog.md)
  - [x] [Migrations created & committed *(or no change)*](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#migration-process)
