### PR TITLE
PeakAnnotationsLoader 2 - MSRunsLoader updates

### DIFF
--- a/DataRepo/loaders/__init__.py
+++ b/DataRepo/loaders/__init__.py
@@ -17,6 +17,7 @@ from DataRepo.loaders.tissues_loader import TissuesLoader
 from DataRepo.loaders.tracers_loader import TracersLoader
 
 __all__ = [
+    "MSRunsLoader",
     "AccuCorDataLoader",
     "IsotopeObservationData",
     "lcms_headers_are_valid",

--- a/DataRepo/loaders/__init__.py
+++ b/DataRepo/loaders/__init__.py
@@ -5,6 +5,7 @@ from DataRepo.loaders.accucor_data_loader import (
 )
 from DataRepo.loaders.base.table_loader import TableLoader
 from DataRepo.loaders.compounds_loader import CompoundsLoader
+from DataRepo.loaders.msruns_loader import MSRunsLoader
 from DataRepo.loaders.protocols_loader import ProtocolsLoader
 from DataRepo.loaders.sample_table_loader import (
     LCMSDBSampleMissing,

--- a/DataRepo/loaders/sample_table_loader.py
+++ b/DataRepo/loaders/sample_table_loader.py
@@ -687,7 +687,7 @@ class SampleTableLoader:
         if animal_rec and infusate_rec:
             # Animal Label - Load each unique labeled element among the tracers for this animal
             # This is where enrichment_fraction, enrichment_abundance, and normalized_labeling functions live
-            for labeled_element in infusate_rec.tracer_labeled_elements():
+            for labeled_element in infusate_rec.tracer_labeled_elements:
                 if self.verbosity >= 2:
                     print(
                         f"Finding or inserting animal label '{labeled_element}' for '{animal_rec}'..."

--- a/DataRepo/management/commands/load_study.py
+++ b/DataRepo/management/commands/load_study.py
@@ -63,7 +63,7 @@ class Command(BaseCommand):
             "files_missing_all": defaultdict(list),
             "files_missing_some": defaultdict(list),
             "all_missing_samples": defaultdict(list),
-        }  # For NoSamplesError and MissingSamplesError
+        }  # For NoSamples and MissingSamples
         self.missing_tissue_errors = []
         self.missing_treatment_errors = []
         self.missing_compounds = defaultdict(dict)

--- a/DataRepo/models/archive_file.py
+++ b/DataRepo/models/archive_file.py
@@ -115,6 +115,11 @@ class ArchiveFileQuerySet(models.QuerySet):
 
         Args:
             kwargs (dict): The field names (keys) and values.
+                file_location (str|Path|File): Required.
+                filename (str): Optional.  Can be derived from file_location.
+                checksum (str): Optional.  Can be derived from file_location
+                data_type (str|DataType): Required.
+                data_format (str|DataFormat): Required.
             is_binary (boolean): An optional way to indicate if the file is binary or not, overriding the automatic
                 guess/determination.
         Exceptions:

--- a/DataRepo/models/compound.py
+++ b/DataRepo/models/compound.py
@@ -100,7 +100,7 @@ class Compound(models.Model):
 
         # find the distinct union of these queries
         matching_compounds = cls.objects.filter(
-            Q(name__iexact=name) | Q(synonyms__name__iexact=name)
+            cls.get_name_query_expression(name)
         ).distinct()
         if matching_compounds.count() > 1:
             raise ValidationError(
@@ -109,7 +109,11 @@ class Compound(models.Model):
             )
         elif matching_compounds.count() == 0:
             raise cls.DoesNotExist(f"Compound [{name}] not found.")
-        return matching_compounds.first()
+        return matching_compounds.get()
+
+    @classmethod
+    def get_name_query_expression(cls, name):
+        return Q(name__iexact=name) | Q(synonyms__name__iexact=name)
 
     class Meta:
         verbose_name = "compound"

--- a/DataRepo/models/hier_cached_model.py
+++ b/DataRepo/models/hier_cached_model.py
@@ -90,7 +90,7 @@ def set_cache(rec, cache_func_name, value):
                 cache.set(rep_cachekey, rep_result, timeout=None, version=1)
     except Exception as e:
         # Allow tracebase to still work, just without caching
-        print(e)
+        print(f"{type(e).__name__}: {e}")
         if throw_cache_errors:
             raise CacheError(f"{rec.__class__.__name__}.{cache_func_name} ERROR: {e}")
         return False

--- a/DataRepo/models/infusate.py
+++ b/DataRepo/models/infusate.py
@@ -5,6 +5,7 @@ from typing import TYPE_CHECKING, Optional
 from django.core.exceptions import ValidationError
 from django.db import models, transaction
 
+from DataRepo.models.hier_cached_model import HierCachedModel, cached_function
 from DataRepo.models.maintained_model import MaintainedModel
 from DataRepo.models.utilities import get_model_by_name
 
@@ -81,7 +82,7 @@ class InfusateQuerySet(models.QuerySet):
         return matching_infusate
 
 
-class Infusate(MaintainedModel):
+class Infusate(MaintainedModel, HierCachedModel):
     objects = InfusateQuerySet().as_manager()
 
     id = models.AutoField(primary_key=True)
@@ -260,6 +261,8 @@ class Infusate(MaintainedModel):
         if len(problems) > 0:
             raise ValidationError("\n".join(problems))
 
+    @property
+    @cached_function
     def tracer_labeled_elements(self):
         """
         This method returns a unique list of the labeled elements that exist among the tracers.

--- a/DataRepo/models/peak_group.py
+++ b/DataRepo/models/peak_group.py
@@ -87,10 +87,18 @@ class PeakGroup(HierCachedModel, MaintainedModel):
         included in the returned list.
         """
         peak_labeled_elements = []
-        for atom in self.msrun_sample.sample.animal.infusate.tracer_labeled_elements():
+        for atom in self.tracer_labeled_elements:
             if atom_count_in_formula(self.formula, atom) > 0:
                 peak_labeled_elements.append(atom)
         return peak_labeled_elements
+
+    @property
+    @cached_function
+    def tracer_labeled_elements(self):
+        """
+        This method returns a unique list of the labeled elements that exist among the tracers.
+        """
+        return self.msrun_sample.sample.animal.infusate.tracer_labeled_elements
 
     # @cached_function is *slower* than uncached
     @cached_property

--- a/DataRepo/models/researcher.py
+++ b/DataRepo/models/researcher.py
@@ -1,3 +1,5 @@
+from typing import Optional
+
 import pandas as pd
 from django.core.exceptions import ObjectDoesNotExist
 from django.utils.functional import cached_property
@@ -25,7 +27,7 @@ def get_researchers():
             )
         )
     unique_researchers = list(pd.unique(list(filter(None, researchers))))
-    return unique_researchers
+    return sorted(unique_researchers)
 
 
 def validate_researchers(input_researchers, known_researchers=None, skip_flag=None):
@@ -50,6 +52,18 @@ def validate_researchers(input_researchers, known_researchers=None, skip_flag=No
                 known_researchers,
                 skip_flag,
             )
+
+
+def could_be_variant_researcher(
+    researcher: str, known_researchers: Optional[list] = None
+) -> bool:
+    """Check if a researcher could potentially be a variant of one already existing in the database.
+
+    Known can be supplied for efficiency.
+    """
+    if known_researchers is None:
+        known_researchers = get_researchers()
+    return len(known_researchers) > 0 and researcher not in known_researchers
 
 
 class Researcher:

--- a/DataRepo/tests/loaders/test_sequences_loader.py
+++ b/DataRepo/tests/loaders/test_sequences_loader.py
@@ -43,7 +43,7 @@ class SequencesLoaderTests(TracebaseTestCase):
         _, row = next(self.TEST_DF.iterrows())
         sl = SequencesLoader()
         lcrec = LCMethod.objects.get(name="polar-HILIC-25-min")
-        rec, created = sl.get_or_create_sequence(row, lcrec)
+        rec, created = sl.get_or_create_sequence(row, lcrec, "Xianfeng Zeng")
         self.assertEqual(0, len(sl.aggregated_errors_object.exceptions))
         self.assertTrue(created)
         self.assertEqual("polar-HILIC-25-min", rec.lc_method.name)

--- a/DataRepo/tests/management/test_load_msruns.py
+++ b/DataRepo/tests/management/test_load_msruns.py
@@ -2,12 +2,14 @@ from datetime import datetime, timedelta
 
 from django.core.management import call_command
 
-from DataRepo.models.animal import Animal
-from DataRepo.models.infusate import Infusate
-from DataRepo.models.lc_method import LCMethod
-from DataRepo.models.msrun_sequence import MSRunSequence
-from DataRepo.models.sample import Sample
-from DataRepo.models.tissue import Tissue
+from DataRepo.models import (
+    Animal,
+    Infusate,
+    LCMethod,
+    MSRunSequence,
+    Sample,
+    Tissue,
+)
 from DataRepo.tests.tracebase_test_case import TracebaseTestCase
 from DataRepo.utils.exceptions import (
     AggregatedErrors,

--- a/DataRepo/tests/management/test_load_protocols.py
+++ b/DataRepo/tests/management/test_load_protocols.py
@@ -120,7 +120,11 @@ class ProtocolLoadingTests(TracebaseTestCase):
         aes = ar.exception
         self.assertEqual(1, aes.num_errors)
         self.assertEqual(0, aes.num_warnings)
-        self.assertEqual(InfileDatabaseError, type(aes.exceptions[0]))
+        self.assertEqual(
+            InfileDatabaseError,
+            type(aes.exceptions[0]),
+            msg=f"Expected InfileDatabaseError, got: {type(aes.exceptions[0]).__name__}: {aes.exceptions[0]}",
+        )
         self.assertIn("category", str(aes.exceptions[0]))
         self.assertIn("is not a valid choice", str(aes.exceptions[0]))
         # If errors are found, no records should be loaded

--- a/DataRepo/tests/models/test_compounds.py
+++ b/DataRepo/tests/models/test_compounds.py
@@ -40,6 +40,13 @@ class CompoundTests(TracebaseTestCase):
         with self.assertWarns(UserWarning):
             self.assertEqual(alanine.atom_count("Abc"), None)
 
+    def test_get_name_query_expression(self):
+        q_exp = Compound.get_name_query_expression("alanine")
+        self.assertEqual(
+            "(OR: ('name__iexact', 'alanine'), ('synonyms__name__iexact', 'alanine'))",
+            str(q_exp),
+        )
+
 
 @override_settings(CACHES=settings.TEST_CACHES)
 class CompoundSynonymTests(TracebaseTestCase):

--- a/DataRepo/tests/models/test_hier_cached_model.py
+++ b/DataRepo/tests/models/test_hier_cached_model.py
@@ -260,7 +260,11 @@ class GlobalCacheTests(TracebaseTestCase):
                 "last_tracer_peak_groups",
                 "is_last_serum_sample",
             ],
-            "PeakGroup": ["peak_labeled_elements"],
+            "Infusate": ["tracer_labeled_elements"],
+            "PeakGroup": [
+                "peak_labeled_elements",
+                "tracer_labeled_elements",
+            ],
             "FCirc": [
                 "last_peak_group_in_animal",
                 "last_peak_group_in_sample",
@@ -483,7 +487,10 @@ class HierCachedModelTests(TracebaseTestCase):
 
     def test_get_my_cached_method_names(self):
         pg = PeakGroup.objects.all().first()
-        expected = ["peak_labeled_elements"]
+        expected = [
+            "peak_labeled_elements",
+            "tracer_labeled_elements",
+        ]
         self.assertEqual(
             expected,
             pg.get_my_cached_method_names(),

--- a/DataRepo/tests/models/test_researcher.py
+++ b/DataRepo/tests/models/test_researcher.py
@@ -1,0 +1,13 @@
+from DataRepo.models.researcher import could_be_variant_researcher
+from DataRepo.tests.tracebase_test_case import TracebaseTestCase
+
+
+class ResearcherTests(TracebaseTestCase):
+    def test_could_be_variant_researcher_none_exist(self):
+        self.assertFalse(could_be_variant_researcher("Gail"))
+
+    def test_could_be_variant_researcher_match_exists(self):
+        self.assertFalse(could_be_variant_researcher("Gail", ["Gail"]))
+
+    def test_could_be_variant_researcher_no_match(self):
+        self.assertTrue(could_be_variant_researcher("Gail", ["Gus"]))

--- a/DataRepo/tests/test_models.py
+++ b/DataRepo/tests/test_models.py
@@ -1043,7 +1043,7 @@ class PropertyTests(TracebaseTestCase):
         # make sure we get only 1 labeled element of nitrogen
         self.assertEqual(
             ["N"],
-            sample.animal.infusate.tracer_labeled_elements(),
+            sample.animal.infusate.tracer_labeled_elements,
             msg="Make sure the tracer labeled elements are set for the animal this peak group is linked to.",
         )
 
@@ -1116,7 +1116,7 @@ class PropertyTests(TracebaseTestCase):
 
         self.assertEqual(
             ["C"],
-            peak_group.msrun_sample.sample.animal.infusate.tracer_labeled_elements(),
+            peak_group.msrun_sample.sample.animal.infusate.tracer_labeled_elements,
         )
 
     def test_normalized_labeling_latest_serum(self):
@@ -1665,7 +1665,7 @@ class MultiTracerLabelPropertyTests(TracebaseTestCase):
     def test_tracer_labeled_elements(self):
         anml = Animal.objects.get(name="xzl1")
         expected = ["C", "N"]
-        output = anml.infusate.tracer_labeled_elements()
+        output = anml.infusate.tracer_labeled_elements
         self.assertEqual(expected, output)
 
     def test_serum_tracers_enrichment_fraction(self):

--- a/DataRepo/tests/utils/test_exceptions.py
+++ b/DataRepo/tests/utils/test_exceptions.py
@@ -6,6 +6,7 @@ from DataRepo.utils.exceptions import (
     AllMissingTreatments,
     CompoundDoesNotExist,
     DateParseError,
+    DuplicateCompoundIsotopes,
     DuplicateValueErrors,
     DuplicateValues,
     ExcelSheetNotFound,
@@ -30,6 +31,7 @@ from DataRepo.utils.exceptions import (
     NoSamples,
     OptionsNotAvailable,
     RecordDoesNotExist,
+    RequiredArgument,
     RequiredColumnValue,
     RequiredColumnValues,
     RequiredColumnValuesWhenNovel,
@@ -1108,6 +1110,12 @@ class ExceptionTests(TracebaseTestCase):
     def test_NewResearcher(self):
         exc = NewResearcher("Thelma")
         self.assertIn("new researcher [Thelma] is being added", str(exc))
+
+    def test_RequiredArgument(self):
+        exc = RequiredArgument("val", methodname="do_stuff")
+        self.assertEqual(
+            "do_stuff requires a non-None value for argument 'val'.", str(exc)
+        )
 
     def test_DuplicateCompoundIsotope(self):
         dvs = [

--- a/DataRepo/tests/utils/test_exceptions.py
+++ b/DataRepo/tests/utils/test_exceptions.py
@@ -40,8 +40,10 @@ from DataRepo.utils.exceptions import (
     RequiredValueErrors,
     ResearcherNotNew,
     UnexpectedIsotopes,
+    UnexpectedSamples,
     UnitsWrong,
     UnknownHeaderError,
+    UnskippedBlanks,
     generate_file_location_string,
     summarize_int_list,
 )

--- a/DataRepo/utils/exceptions.py
+++ b/DataRepo/utils/exceptions.py
@@ -946,6 +946,18 @@ class MissingSamples(MissingRecords):
 
 
 
+class RequiredArgument(Exception):
+    def __init__(self, argname, methodname=None, message=None):
+        if message is None:
+            if methodname is None:
+                message = f"A non-None value for argument '{argname}' is required."
+            else:
+                message = (
+                    f"{methodname} requires a non-None value for argument '{argname}'."
+                )
+        super().__init__(message)
+        self.argname = argname
+        self.methodname = methodname
 
 
 # TODO: Remove this class when the accucor loader is deleted
@@ -1003,7 +1015,6 @@ class NoSamplesError(MissingSamplesError):
             "before they can be loaded from the mass spec data files."
         )
         super().__init__(sample_names, message=message, **kwargs)
-        self.missing_samples = missing_samples
 
 
 class NoSamples(MissingSamples):

--- a/DataRepo/utils/exceptions.py
+++ b/DataRepo/utils/exceptions.py
@@ -4,7 +4,7 @@ import traceback
 import warnings
 from abc import ABC, abstractmethod
 from collections import defaultdict
-from typing import TYPE_CHECKING, Dict, Optional
+from typing import TYPE_CHECKING, Dict, List, Optional
 
 from django.core.exceptions import (
     MultipleObjectsReturned,
@@ -12,8 +12,11 @@ from django.core.exceptions import (
     ValidationError,
 )
 from django.core.management import CommandError
+from django.db.models import Q
 from django.db.utils import ProgrammingError
 from django.forms.models import model_to_dict
+
+from DataRepo.models.researcher import get_researchers
 
 if TYPE_CHECKING:
     from DataRepo.models.archive_file import ArchiveFile
@@ -103,21 +106,79 @@ class InfileError(Exception):
     def __init__(
         self,
         message,
+        file=None,
+        sheet=None,
+        column: Optional[object] = None,
+        rownum: Optional[object] = None,
+        order=None,
+    ):
+        self.location_args = ["rownum", "column", "file", "sheet"]
+        self.loc = generate_file_location_string(
+            rownum=rownum, sheet=sheet, file=file, column=column
+        )
+        self.message = message
+        self.orig_message = message
+        self.set_formatted_message(
+            rownum=rownum,
+            sheet=sheet,
+            file=file,
+            column=column,
+            order=order,
+        )
+        super().__init__(self.message)
+
+    def set_formatted_message(
+        self,
         rownum: Optional[object] = None,
         sheet=None,
         file=None,
         column=None,
         order=None,
     ):
-        location_args = ["rownum", "column", "file", "sheet"]
+        """This method allows one to change the string that will be returned when the exception is in string context.
+
+        Sets instance attributes:
+            rownum
+            sheet
+            file
+            column
+            order
+            message
+            loc
+
+        The purpose is so that a class independent of the file-processing code/script can raise an exception and be
+        caught by the file loading script, and the debug info (location of the data in the file that caused the error)
+        can be added to the exception.
+
+        Args:
+            rownum (Optional[int or str]): The row number in the file (where the header row is row 1) where the
+                offending data is located.  A row "name" can alternatively be supplied.
+            sheet (Optional[str]): If the file is an excel file, this is the sheet where the offending data is.
+            file (Optional[str]): File name or path where the offending data is located.
+            column (Optional[str]): Column name where the offending data is located.
+            order (Optional(List[str])) {"loc", "file", "sheet", "column", "rownum"} ["loc"]: List of 1-5 strings
+                corresponding the the '%s' placeholders in the message that was supplied to the constructor (i.e.
+                self.orig_message).  The effective default is ["loc"], which is a dynamically built string of all the
+                location information (rownum, column, sheet, and file).  The size of the list must equal the number of
+                placeholders in the message.  Note that if '%s' is not in the message, the generated value for "loc" is
+                appended to the message.
+        Exceptions:
+            Raises:
+                ProgrammingError
+            Buffers:
+                None
+        Returns:
+            None
+        """
         self.rownum = rownum
         self.sheet = sheet
         self.file = file
         self.column = column
-        loc = generate_file_location_string(
+        self.order = order
+        self.loc = generate_file_location_string(
             rownum=rownum, sheet=sheet, file=file, column=column
         )
-        self.loc = loc
+        message = self.orig_message
 
         if "%s" not in message:
             # The purpose of this (base) class is to provide file location context of erroneous data to exception
@@ -126,12 +187,17 @@ class InfileError(Exception):
             message += "  Location: %s."
 
         if order is not None:
-            if "loc" not in order and len(order) != len(location_args):
+            missing_loc_arg_placeholders = []
+            for locarg in self.location_args:
+                if getattr(self, locarg) is not None and locarg not in order:
+                    missing_loc_arg_placeholders.append(locarg)
+            if "loc" not in order and len(order) != len(self.location_args):
                 order.append("loc")
                 if message.count("%s") != len(order):
-                    raise ValueError(
-                        f"You must either provide all location arguments in your order list: {location_args} or "
-                        "provide an extra '%s' in your message for the leftover location information."
+                    raise ProgrammingError(
+                        f"You must either provide all location arguments in your order list: {self.location_args} or "
+                        "provide an extra '%s' in your message for the leftover location information "
+                        f"({missing_loc_arg_placeholders})."
                     )
             # Save the arguments in a dict
             vdict = {
@@ -149,16 +215,19 @@ class InfileError(Exception):
                 column = None
             if "rownum" in order:
                 rownum = None
-            loc = generate_file_location_string(
+            self.loc = generate_file_location_string(
                 rownum=rownum, sheet=sheet, file=file, column=column
             )
-            vdict["loc"] = loc
-            self.loc = loc
+            vdict["loc"] = self.loc
             insertions = [vdict[k] for k in order]
             message = message % tuple(insertions)
         else:
-            message = message % loc
-        super().__init__(message)
+            message = message % self.loc
+
+        self.message = message
+
+    def __str__(self):
+        return self.message
 
 
 class HeaderError(Exception):
@@ -466,11 +535,316 @@ class ResearcherNotNew(Exception):
         self.existing_researchers = existing_researchers
 
 
+class NewResearchers(Exception):
+    """Summarization exception of NewResearcher exceptions.
+
+    Example output:
+
+    New researchers encountered.  Please check the existing researchers:
+        George
+        Frank
+    to ensure that the following researchers (parsed from the indicated file locations) are not variants of existing
+    names:
+        Edith (in column [Operator] of sheet [Sequences] in study.xlsx, on rows: '1-10')
+    """
+
+    def __init__(self, new_researcher_exceptions: List[NewResearcher]):
+        existing = "\n\t".join(get_researchers())
+        nre_dict: Dict[str, dict] = defaultdict(lambda: defaultdict(list))
+        for nre in new_researcher_exceptions:
+            file_loc = generate_file_location_string(
+                file=nre.file, sheet=nre.sheet, column=nre.column
+            )
+            if nre.rownum is not None:
+                nre_dict[nre.researcher][file_loc].append(nre.rownum)
+            elif "unreported rows" not in nre_dict[file_loc]:
+                nre_dict[nre.researcher][file_loc].append("unreported rows")
+        message = "New researchers encountered"
+        if existing == "":
+            message += ":"
+        else:
+            message += (
+                f".  Please check the existing researchers:\n\t{existing}\nto ensure that the following researchers "
+                "(parsed from the indicated file locations) are not variants of existing names:"
+            )
+        for nr in sorted(nre_dict.keys()):
+            for loc in sorted(nre_dict[nr].keys()):
+                message += f"\n\t{nr} (in {loc}, on rows: {summarize_int_list(nre_dict[nr][loc])})"
+        super().__init__(message)
+        self.new_researcher_exceptions = new_researcher_exceptions
+        self.existing = existing
+
+
+class NewResearcher(InfileError, SummarizableError):
+    SummarizerExceptionClass = NewResearchers
+
+    def __init__(self, researcher: str, message=None, **kwargs):
+        existing = "\n\t".join(get_researchers())
+        message = f"A new researcher [{researcher}] is being added (parsed from %s)."
+        if existing != "":
+            message += (
+                "  Please check the existing researchers to ensure this researcher name isn't a variant of an existing "
+                f"name:\n\t{existing}"
+            )
+        super().__init__(message, **kwargs)
+        self.researcher = researcher
+        self.existing = existing
+
+
+class MissingRecords(InfileError):
+    def __init__(
+        self,
+        exceptions: List[RecordDoesNotExist],
+        message=None,
+        suggestion=None,
+        **kwargs,
+    ):
+        # Initialize the remaining kwargs
+        msg = "" if message is None else message
+        super().__init__(msg, **kwargs)
+
+        if not message:
+            message = ""
+            exceptions_by_query_type: Dict[str, dict] = defaultdict(
+                lambda: defaultdict(list)
+            )
+            for inst in exceptions:
+                q_str = inst._get_query_stub()
+                exceptions_by_query_type[inst.model.__name__][q_str].append(inst)
+
+            for mdl_name in exceptions_by_query_type.keys():
+                for categorized_exceptions in exceptions_by_query_type[
+                    mdl_name
+                ].values():
+                    loc_args, flds_str, vals_dict = (
+                        RecordDoesNotExist.get_failed_searches_dict(
+                            categorized_exceptions
+                        )
+                    )
+
+                    loc_str = generate_file_location_string(**loc_args)
+
+                    # Summarize the values and the rows on which they occurred
+                    nltab = "\n\t"
+                    search_terms_str = nltab.join(
+                        list(
+                            map(
+                                lambda key: f"{key} from row(s): {summarize_int_list(vals_dict[key])}",
+                                vals_dict.keys(),
+                            )
+                        )
+                    )
+                    message += (
+                        f"{len(categorized_exceptions)} {mdl_name} records were not found (using search field(s): "
+                        f"{flds_str}) with values found in {loc_str}:{nltab}{search_terms_str}\n"
+                    )
+
+        if suggestion is not None:
+            if message.endswith("\n"):
+                message += suggestion
+            else:
+                message += f"  {suggestion}"
+
+        self.message = message
+
+
+class RecordDoesNotExist(InfileError, ObjectDoesNotExist, SummarizableError):
+    SummarizerExceptionClass = MissingRecords
+
+    def __init__(
+        self, model, query_obj: dict | Q, message=None, suggestion=None, **kwargs
+    ):
+        """General use DoesNotExist exception constructor for errors retrieving Model records.
+
+        Args:
+            model: (Model)
+            query_obj (dict or Q): A representation of the query parameters, to provide context for the user.
+            message (Optional[str])
+            suggestion (str): An addendum as to how to possibly fix this issue.
+        Exceptions:
+            None
+        Returns:
+            instance
+        """
+        if message is None:
+            message = (
+                f"{model.__name__} record matching {query_obj} from %s does not exist."
+            )
+        if suggestion is not None:
+            message += f"  {suggestion}"
+        super().__init__(message, **kwargs)
+        self.query_obj = query_obj
+        self.model = model
+        self.suggestion = suggestion
+
+    @classmethod
+    def get_failed_searches_dict(cls, instances: List[RecordDoesNotExist]):
+        """Given a list of RecordDoesNotExist instances, a field description and dict like the following example is
+        returned:
+
+            {"George": [1, 2, 3, 4]}
+
+        Where the first key is the search term, and the value is a list of row numbers from an input file where the term
+        was found.
+
+        Args:
+            instances (List[RecordDoesNotExist]): RecordDoesNotExist exceptions
+        Exceptions:
+            ProgrammingError
+        Returns:
+            loc_args (dict): file, sheet, and column values
+            fields_stub (str): Search field/column and comparator
+            search_valuecombos_rows_dict (defaultdict(list))
+        """
+        search_valuecombos_rows_dict = defaultdict(list)
+        model = None
+        fields_str = None
+        loc_args: Dict[str, str] = {}
+        for inst in instances:
+            if model is None:
+                model = inst.model
+            elif inst.model != model:
+                raise ProgrammingError(
+                    "instances must be a list of RecordDoesNotExist exceptions generated from queries of the same "
+                    f"model.  {inst.model} != {model}"
+                )
+
+            cur_loc_args = {
+                "column": inst.column,
+                "file": inst.file,
+                "sheet": inst.sheet,
+            }
+            if len(loc_args.keys()) == 0:
+                loc_args = cur_loc_args
+            elif cur_loc_args != loc_args:
+                raise ProgrammingError(
+                    "instances must be a list of RecordDoesNotExist exceptions generated from queries of the same "
+                    f"file/column.  {cur_loc_args} != {loc_args}"
+                )
+
+            query_fields_str = inst._get_query_stub()
+
+            if fields_str is None:
+                fields_str = query_fields_str
+            elif fields_str != query_fields_str:
+                raise ProgrammingError(
+                    "instances must be a list of RecordDoesNotExist exceptions generated from queries using the same "
+                    f"search fields (and comparators).  {fields_str} != {query_fields_str}"
+                )
+
+            query_values_str = inst._get_query_values_str()
+            rownum = (
+                inst.rownum if inst.rownum is not None else "no row number supplied"
+            )
+            search_valuecombos_rows_dict[query_values_str].append(rownum)
+
+        return loc_args, fields_str, search_valuecombos_rows_dict
+
+    def _get_query_stub(self, _query_obj: Optional[dict | Q] = None) -> str:
+        """This takes an instance and returns a string describing the fields (and comparators) the query operates on.
+        The values(/search terms) are replaced with numeric labels.  If there is only a single field/comparator, it will
+        be retendered as a single string (instead of a string version of a list or Q object).
+
+        The purpose of this method is to be able to generate strings that can be used as keys, so that a series of
+        failed searches using the same fields but different values can be grouped together.
+
+        Both arguments are private.  Do not supply manually.
+
+        Args:
+            _query_obj (Optional[dict|Q]): An object supplied to Model.objects.get/get_or_create/create/...
+        Exceptions:
+            None
+        Returns:
+            new_q (str|Q): The original call returns a string describing the search fields and comparators.  Recursive
+                calls return Q objects.
+        """
+        if _query_obj is None:
+            _query_obj = self.query_obj
+
+        # Not recursive when given a dict
+        if isinstance(_query_obj, dict):
+            return ", ".join(_query_obj.keys())
+
+        # Must be a Q instance
+        search_fields_str = ""
+        if _query_obj.negated:
+            search_fields_str += "NOT "
+        if len(_query_obj.children) > 1:
+            search_fields_str += f"({_query_obj.connector}: "
+        search_fields_str += ", ".join(
+            [
+                (
+                    self._get_query_stub(_query_obj=sub_q)
+                    if isinstance(sub_q, Q)
+                    else str(sub_q[0])
+                )
+                for sub_q in _query_obj.children
+            ]
+        )
+        if len(_query_obj.children) > 1:
+            search_fields_str += ")"
+
+        return search_fields_str
+
+    def _get_query_values_str(
+        self, _query_obj: Optional[dict | Q] = None, _uniq_vals: Optional[list] = None
+    ) -> list | str:
+        """This takes an instance and returns a string of comma-delimited search terms from the query_obj.
+
+        The purpose of this method is to be able to generate strings that can be used as keys, so that a series of
+        failed searches using the same values from multiple rownums can be grouped together.
+
+        NOTE: The values(/search terms) will either be the values from every query field from the query_obj (unique or
+        not) or will only be the unique values if self.column is defined.  A column value can be used in multiple field
+        matches.  This is intended to reduce redundancy.  For example, if searching for a compound and looking in
+        Compound.name or CompoundSynonym.name, the same value from 1 column is used.  We don't need to include it twice.
+
+        Limitations:
+            This is a simple heuristic.  If values are ever manipulated or static terms are added, the only result will
+            be a different number of values compared to the listed column.
+
+        Args:
+            _query_obj (Optional[dict|Q]): An object supplied to Model.objects.get/get_or_create/create/...
+            _label (int): 1 for first call, not 1 otherwise
+        Exceptions:
+            None
+        Returns:
+            _uniq_vals (list|str): The original call returns a string describing the search fields and comparators.
+                Recursive calls return a list.
+        """
+        first_call = False
+        if _query_obj is None:
+            first_call = True
+            _query_obj = self.query_obj
+
+        if isinstance(_query_obj, dict):
+            return ", ".join([str(val) for val in _query_obj.values()])
+
+        if _uniq_vals is None:
+            _uniq_vals = []
+
+        for sub_q in _query_obj.children:
+            if isinstance(sub_q, Q):
+                _uniq_vals.extend(
+                    self._get_query_values_str(_query_obj=sub_q, _uniq_vals=_uniq_vals)
+                )
+            else:
+                val = str(sub_q[1])
+                # We are only returning unique values if self.column is defined.  See doc string.
+                if self.column is None or val not in _uniq_vals:
+                    _uniq_vals.append(val)
+
+        if first_call:
+            return ", ".join(_uniq_vals)
+
+        return _uniq_vals
+
+
 class AllMissingSamplesError(Exception):
-    """This is a summary of the MissingSamplesError and NoSamplesError classes."""
+    """This is a summary of the MissingSamples and NoSamples classes."""
 
     def __init__(self, missing_samples_dict, message=None):
-        """An exception for all missing samples errors (MissingSampelsError and NoSamplesError).
+        """An exception for all missing samples errors (MissingSamples and NoSamples).
 
         Args:
             missing_samples_dict (dict): Example:
@@ -524,8 +898,15 @@ class AllMissingSamplesError(Exception):
         self.missing_samples_dict = missing_samples_dict
 
 
+# TODO: Remove this class when the accucor loader is deleted
 class MissingSamplesError(Exception):
-    def __init__(self, missing_samples, message=None):
+    def __init__(
+        self,
+        missing_samples,
+        suggestion="Samples must be loaded prior to loading mass spec data.",
+        message=None,
+        exceptions: Optional[List[RecordDoesNotExist]] = None,
+    ):
         if missing_samples is None:
             missing_samples = []
         if not message:
@@ -534,45 +915,132 @@ class MissingSamplesError(Exception):
             message = (
                 f"{num_missing} samples are missing in the database/sample-table-file:{nltab}"
                 f"{nltab.join(missing_samples)}\n"
-                "Samples must be loaded prior to loading mass spec data."
             )
+        if suggestion is not None:
+            message += suggestion
         super().__init__(message)
+        self.missing_samples = missing_samples
+        self.suggestion = suggestion
+        self.exceptions = exceptions
+
+
+class MissingSamples(MissingRecords):
+    def __init__(
+        self,
+        exceptions: List[RecordDoesNotExist],
+        **kwargs,
+    ):
+        super().__init__(exceptions, **kwargs)
+        # Add a custom attribute listing the missing sample headers
+        self.missing_samples = self.get_sample_names(exceptions)
+
+    @classmethod
+    def get_sample_names(cls, exceptions):
+        missing_samples = []
+        for exc in exceptions:
+            if exc.query_obj["name"] not in missing_samples:
+                missing_samples.append(exc.query_obj["name"])
+        return missing_samples
+
+
+
+
+
+
+# TODO: Remove this class when the accucor loader is deleted
+class UnskippedBlanksError(MissingSamplesError):
+    def __init__(self, sample_names, **kwargs):
+        if sample_names is None or len(sample_names) == 0:
+            raise RequiredArgument(
+                "sample_names",
+                type(self).__name__,
+                message="A non-zero sized list is required.",
+            )
+        message = (
+            f"{len(sample_names)} samples that appear to possibly be blanks are missing in the database: "
+            f"[{', '.join(sample_names)}].  Blank samples should be skipped."
+        )
+        super().__init__(sample_names, message=message, **kwargs)
+
+
+class UnskippedBlanks(MissingSamples):
+    def __init__(
+        self,
+        exceptions: List[RecordDoesNotExist],
+        **kwargs,
+    ):
+        sample_names = self.get_sample_names(exceptions)
+        message = kwargs.pop("message", None)
+        if message is None:
+            message = (
+                f"{len(sample_names)} samples that appear to possibly be blanks are missing in the database: "
+                f"[{', '.join(sample_names)}]."
+            )
+        suggestion = kwargs.pop("suggestion", None)
+        if suggestion is None:
+            suggestion = (
+                "Be sure to set the skip column in the PeakAnnotation Details sheet to 'true' for blank "
+                "samples."
+            )
+        super().__init__(exceptions, message=message, suggestion=suggestion, **kwargs)
+
+
+# TODO: Remove this class when the accucor loader is deleted
+class NoSamplesError(MissingSamplesError):
+    def __init__(self, sample_names, **kwargs):
+        """An error to abbreviate an error about all samples."""
+        if sample_names is None or len(sample_names) == 0:
+            raise RequiredArgument(
+                "sample_names",
+                type(self).__name__,
+                message="A non-zero sized list is required.",
+            )
+        num_samples = len(sample_names)
+        message = (
+            f"None of the {num_samples} samples were found in the database/sample table file.  Samples "
+            "in the peak annotation files must be present in the sample table file and loaded into the database "
+            "before they can be loaded from the mass spec data files."
+        )
+        super().__init__(sample_names, message=message, **kwargs)
         self.missing_samples = missing_samples
 
 
-class UnskippedBlanksError(MissingSamplesError):
-    def __init__(self, samples):
-        message = (
-            f"{len(samples)} samples that appear to possibly be blanks are missing in the database: "
-            f"[{', '.join(samples)}].  Blank samples should be skipped."
-        )
-        super().__init__(samples, message)
+class NoSamples(MissingSamples):
+    def __init__(
+        self,
+        exceptions: List[RecordDoesNotExist],
+        **kwargs,
+    ):
+        num_samples = len(exceptions)
+        message = kwargs.pop("message", None)
+        if message is None:
+            message = f"None of the {num_samples} samples were found in the database/sample table file."
+        suggestion = kwargs.pop("suggestion", None)
+        if suggestion is None:
+            suggestion = (
+                "Samples in the peak annotation files must be present in the sample table file and loaded into the "
+                "database before they can be loaded from the mass spec data files."
+            )
+        super().__init__(exceptions, message=message, suggestion=suggestion, **kwargs)
 
 
-class NoSamplesError(Exception):
-    def __init__(self, missing_samples):
-        """An error to abbreviate an error about all samples.
-
-        Args:
-            missing_samples (list of strings): Missing samples (with prefixes) that are not likely blanks (e.g. not
-                containing "blank").
-
-        Exceptions:
-            None
-
-        Returns:
-            instance containing:
-                missing_samples (list of strings): See args above
-        """
-        if missing_samples is None:
-            raise ValueError("A non-zero sized list of missing_samples is required.")
-        num_samples = len(missing_samples)
-        message = (
-            f"None of the {num_samples} samples were found in the database/sample table file.  Samples "
-            "in the accucor/isocorr files must be present in the sample table file and loaded into the database "
-            "before they can be loaded from the mass spec data files."
-        )
-        super().__init__(message)
+class UnexpectedSamples(InfileError):
+    def __init__(self, missing_samples, suggestion=None, **kwargs):
+        if missing_samples is None or len(missing_samples) == 0:
+            raise RequiredArgument(
+                "missing_samples",
+                type(self).__name__,
+                message="A non-zero sized list is required.",
+            )
+        message = kwargs.pop("message", None)
+        if message is None:
+            message = (
+                "The following sample data headers from the Peak Annotation Details sheet were not among the headers "
+                f"in %s: {missing_samples}."
+            )
+        if suggestion is not None:
+            message += f"  {suggestion}"
+        super().__init__(message, **kwargs)
         self.missing_samples = missing_samples
 
 
@@ -1204,7 +1672,7 @@ class AggregatedErrors(Exception):
 
         # Look for exceptions to remove and recompute new object values
         for exception in self.exceptions:
-            if isinstance(exception, exception_class):
+            if self.exception_matches(exception, exception_class):
                 if remove and modify:
                     # Change every removed exception to a non-fatal warning
                     exception.is_error = False
@@ -1254,7 +1722,7 @@ class AggregatedErrors(Exception):
 
         # Look for exceptions to remove and recompute new object values
         for exception in self.exceptions:
-            if isinstance(exception, exception_class):
+            if self.exception_matches(exception, exception_class):
                 if is_error is not None:
                     exception.is_error = is_error
                 if is_fatal is not None:
@@ -1506,6 +1974,93 @@ class AggregatedErrors(Exception):
 
     def exception_type_exists(self, exc_cls):
         return exc_cls in [type(exc) for exc in self.exceptions]
+
+    def exception_matches(self, exception, cls, attr_name=None, attr_val=None):
+        return isinstance(exception, cls) and (
+            attr_name is None
+            or (
+                hasattr(exception, attr_name)
+                and (
+                    (
+                        not type(attr_val).__name__ == "function"
+                        and getattr(exception, attr_name) == attr_val
+                    )
+                    or (
+                        type(attr_val).__name__ == "function"
+                        and attr_val(getattr(exception, attr_name))
+                    )
+                )
+            )
+        )
+
+    def exception_exists(self, cls, attr_name, attr_val):
+        """Returns True if an exception of type cls, containing an attribute with the supplied value has been buffered.
+
+        Args:
+            cls (Exception): The Exception class to look for.
+            attr_name (str): An attribute the buffered exception class has.
+            attr_val (object): The value of the attribute the buffered exception class has.  If this is a function, it
+                must take a single argument (the value of the attribute) and return a boolean.
+        Exceptions:
+            None
+        Returns:
+            bool
+        """
+        for exc in self.exceptions:
+            if self.exception_matches(exc, cls, attr_name, attr_val):
+                return True
+        return False
+
+    def remove_matching_exceptions(self, cls, attr_name, attr_val):
+        """
+        To support consolidation of errors across files (like MissingCompounds, MissingSamples, etc), this method
+        is provided to remove such exceptions (if they exist in the exceptions list) from this object and return them
+        for consolidation.
+
+        Args:
+            cls (Type): The class of exceptions to remove
+            attr_name (str): An attribute the buffered exception class has.
+            attr_val (object): The value of the attribute the buffered exception class has.  If this is a function, it
+                must take a single argument (the value of the attribute) and return a boolean.
+        Exceptions:
+            None
+        Returns (List[Exception]): A list of exceptions of the supplied type, and containing the supplied attribute with
+            the supplied value (or with a value that yields true from the supplied value function).
+        """
+        matched_exceptions = []
+        unmatched_exceptions = []
+        is_fatal = False
+        is_error = False
+        num_errors = 0
+        num_warnings = 0
+
+        # Look for exceptions to remove and recompute new object values
+        for exception in self.exceptions:
+            if self.exception_matches(exception, cls, attr_name, attr_val):
+                matched_exceptions.append(exception)
+            else:
+                if exception.is_error:
+                    num_errors += 1
+                else:
+                    num_warnings += 1
+                if exception.is_fatal:
+                    is_fatal = True
+                if exception.is_error:
+                    is_error = True
+                unmatched_exceptions.append(exception)
+
+        self.num_errors = num_errors
+        self.num_warnings = num_warnings
+        self.is_fatal = is_fatal
+        self.is_error = is_error
+
+        # Reinitialize this object
+        self.exceptions = unmatched_exceptions
+        if not self.custom_message:
+            super().__init__(self.get_default_message())
+
+        # Return removed exceptions
+        return matched_exceptions
 
 
 class ConflictingValueErrors(Exception):
@@ -2190,6 +2745,21 @@ class MismatchedSampleHeaderMZXML(Exception):
         self.mismatching_mzxmls = mismatching_mzxmls
 
 
+class MzxmlSampleHeaderMismatch(InfileError):
+    def __init__(self, header, mzxml_file, **kwargs):
+        mzxml_basename, _ = os.path.splitext(os.path.basename(mzxml_file))
+        message = (
+            f"The sample header does not match the base name of the mzXML file [{mzxml_file}], as listed in %s:\n"
+            f"\tSample header:       [{header}]\n"
+            f"\tmzXML Base Filename: [{mzxml_basename}]"
+        )
+        super().__init__(message, **kwargs)
+        self.header = header
+        self.mzxml_basename = mzxml_basename
+        self.mzxml_file = mzxml_file
+
+
+# TODO: Delete once the accucor and accompanying lcms code is deleted
 class DuplicateSampleDataHeaders(Exception):
     def __init__(self, dupes, lcms_metadata, samples):
         cs = ", "
@@ -2739,17 +3309,6 @@ class CompoundDoesNotExist(InfileError, ObjectDoesNotExist):
         message = f"Compound [{name}] from %s does not exist as either a primary compound name or synonym."
         super().__init__(message, **kwargs)
         self.name = name
-
-
-class RecordDoesNotExist(InfileError, ObjectDoesNotExist):
-    def __init__(self, model, query_dict, message=None, **kwargs):
-        if message is None:
-            message = (
-                f"{model.__name__} record matching {query_dict} from %s does not exist."
-            )
-        super().__init__(message, **kwargs)
-        self.query_dict = query_dict
-        self.model = model
 
 
 class MultipleRecordsReturned(InfileError, MultipleObjectsReturned):

--- a/DataRepo/utils/exceptions.py
+++ b/DataRepo/utils/exceptions.py
@@ -944,8 +944,6 @@ class MissingSamples(MissingRecords):
         return missing_samples
 
 
-
-
 class RequiredArgument(Exception):
     def __init__(self, argname, methodname=None, message=None):
         if message is None:

--- a/DataRepo/utils/exceptions.py
+++ b/DataRepo/utils/exceptions.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import os
 import traceback
 import warnings
 from abc import ABC, abstractmethod

--- a/DataRepo/views/upload/validation.py
+++ b/DataRepo/views/upload/validation.py
@@ -567,7 +567,7 @@ class DataValidationView(FormView):
                                 f"{len(exc.missing_treatment_errors)} treatment names"
                             )
                             self.extract_all_missing_treatments(exc)
-                        # We're only removing NoSamplesErrors. All their samples are added to the AllMissingSamplesError
+                        # We're only removing NoSamples. All their samples are added to the AllMissingSamplesError
 
                     elif retain_as_warnings:
                         self.extracted_exceptions[exc_class.__name__][
@@ -1531,7 +1531,9 @@ class DataValidationView(FormView):
                 "Cannot call create_study_file_writer when dfs_dict is not valid/created."
             )
 
-        xlsxwriter = pd.ExcelWriter(stream_obj, engine="xlsxwriter")
+        xlsxwriter = pd.ExcelWriter(  # pylint: disable=abstract-class-instantiated
+            stream_obj, engine="xlsxwriter"
+        )
 
         for order_spec in self.get_study_sheet_column_display_order():
             sheet = order_spec[0]


### PR DESCRIPTION
## Summary Change Description

The MSRunsLoader was updated to add a method for the PeakAnnotationsLoader to retrieve the MSRunSample records associated with samples gotten from peak annotations files. The ability to skip samples was added, and updates were made to the associated MSRunSequence loader.

Exceptions were also improved to take advantage of the new summarizable errors, so that missing samples and MSRunSample records could be summarized without custom code needed in the loaders.  This included various sample errors and researcher wanrings.

Details:

- MSRunsLoader (TableLoader)
  - Data files where I added a "Skip" column (looks to be none??)
  - MSRunSequencesLoader
  - Researcher (could_be_variant_researcher & get_researchers)
  - Exceptions:
    - MzxmlSampleHeaderMismatch
    - RecordDoesNotExist
    - MissingRecords
    - MissingSamples
    - NewResearcher/NewResearchers

A few other changes were pulled in due to the complexity of the patch.

## Affected Issues/Pull Requests

- Partially addresses #825
- Merges into #992
- Next PR: #994

## Review Notes
<!--
For added context for reviewers, add comments to relevant lines of code.  Use
this space to describe any general areas of concern not linked to a specific
line of code that reviewers should pay particular attention to, e.g. please
make sure I have accounted for all possible inputs.
-->
See comments in-line.

## Checklist
<!--
If any of the checkbox requirements are not met, uncheck them and add an
explanation. E.g. Linting errors pre-date this PR.
-->
This pull request will be merged once the following requirements are met.  The
author and/or reviewers should uncheck any unmet requirements:

- Review requirements
  - Minimum approvals: 1 <!-- Edit as desired (e.g. based on complexity) -->
  - No changes requested
  - All blocking issues resolved by reviewers
  - Specific reviewers: @__add_username_here__
    <!--
    Require reviewers with specific expertise to be included among the minimum
    number of reviewers by tagging them.  Also please send them a message.
    -->
  - Review period: 2 days <!-- Edit as desired (e.g. based on complexity) -->
- Associated issue/pull request requirements:
  <!--
  Assert that all requirements in issues marked "resolved" are done and that
  all required pull requests are merged.  If any are not done, either edit or
  split the issue or explain the unmerged affected pull requests.
  -->
  - [x] All requirements in affected issues marked "resolved" are satisfied
  - [x] All required pull requests are merged *(or none)*
- Basic requirements
  <!--
  Uncheck items to acknowledge failures/conflicts you intend to address.
  Add an explanation if any won't be addressed before merge.
  -->
  - [x] [All linters pass](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#linting)
  - [x] [All tests pass](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#quality-control)
  - [x] All conflicts resolved
- Overhead requirements
  <!--
  These are additional requirements that are not directly associated with
  resolving the affected issue(s).
  -->
  - [x] [New/changed method tests implemented/updated *(or no change)*](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#test-implementation)
  - [ ] [Updated *Unreleased* section of `changelog.md` *(or no change)*](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/changelog.md)
  - [x] [Migrations created & committed *(or no change)*](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#migration-process)
