### PR TITLE
PeakAnnotationsLoader 5 - Model `get_or_create` methods

### DIFF
--- a/DataRepo/models/peak_data.py
+++ b/DataRepo/models/peak_data.py
@@ -1,5 +1,6 @@
 from django.core.validators import MinValueValidator
 from django.db import models
+from django.db.models import Q
 from django.utils.functional import cached_property
 
 
@@ -61,3 +62,78 @@ class PeakData(models.Model):
         verbose_name = "peak data"
         verbose_name_plural = "peak data"
         ordering = ["peak_group", "-corrected_abundance"]
+
+    @classmethod
+    def get_or_create(cls, label_obs: list, **kwargs):
+        """Get or create a PeakData record.
+
+        PeakData has no unique fields or unique constraints.  There can be records that are essentially duplicates,
+        however when taken together with PeakDataLabel records, they can be uniquely managed manually.  So this method
+        provides get_or_create functionality by assessing uniqueness in the context of PeakDataLabel records.  It
+        searches for a PeakData record either with no associated PeakDataLabel records or PeakData records with the
+        associated label.  Note that PeakDataLabel records have a unique constraint that only allows a single instance
+        of a particular element associated with a PeakData record, i.e. only a single count.  That's because it
+        represents a single observation.  There cannot be multiple counts of an element.  Theoretically, there could be
+        multiple mass numbers, but that's just something Tracebase currently does not support.
+
+        NOTE: It should go without saying, but since it uses the create() method, it does a save(), but does not call
+        full_clean().  That is up to the caller, just like with any get_cor_create method.
+
+        Args:
+            label_obs (List[ObservedIsotopeData]): List of isotope observations all associated with the same PeakData
+                record.
+            kwargs (dict): PeakData field values keyed on PeakData field names.
+        Exceptions:
+            None
+        Returns:
+            rec (PeakData)
+            created (bool)
+        """
+        rec_dict = kwargs
+        matching_recs = []
+        orphan_recs = []
+
+        # A PeakData record with identical values (e.g. med_mz=0, med_rt=0, raw_abundance=0, and corrected_abundance=0)
+        # could exist, but have a different set of labels associated with it.  The only way to tell them apart is by
+        # their associated labels (PeakDataLabel records), so we will be comparing associated labels to get or create
+        # the record we want.
+
+        # First, see if there are any records matching the basic criteria
+        recs = PeakData.objects.filter(**kwargs)
+
+        # If there are none, it's easy:
+        if len(recs) == 0:
+            return PeakData.objects.create(**kwargs), True
+
+        for potential_rec in recs:
+            # If there end up being no matches, we will return a lone orphan if one exists
+            if potential_rec.labels.count() == 0:
+                orphan_recs.append(potential_rec)
+                continue
+            # Build a Q expression for matching PeakDataLabel records
+            labels_q = Q()
+            for label in label_obs:
+                labels_q |= Q(
+                    peak_data=potential_rec,
+                    element=label["element"],
+                    count=label["count"],
+                    mass_number=label["mass_number"],
+                )
+            matching_labels = potential_rec.labels.filter(labels_q)
+            if potential_rec.labels.count() == len(label_obs) and set(
+                potential_rec.labels.all()
+            ) == set(matching_labels.all()):
+                matching_recs.append(potential_rec)
+
+        if len(matching_recs) == 1:
+            return matching_recs[0], False
+        elif len(matching_recs) > 1:
+            raise PeakData.MultipleObjectsReturned()
+        elif len(orphan_recs) == 0:
+            return PeakData.objects.create(**rec_dict), True
+        elif len(orphan_recs) == 1:
+            # Even though this doesn't have the labels in the query, we will return the orphan.  This isn't a method
+            # meant to create PeakDataLabel records.  It's up to the caller to do the create.
+            return orphan_recs[0], False
+        else:
+            raise PeakData.MultipleObjectsReturned()

--- a/DataRepo/models/peak_data_label.py
+++ b/DataRepo/models/peak_data_label.py
@@ -67,17 +67,18 @@ class PeakDataLabel(models.Model, ElementLabel):
         )
         # Ensure isotope elements exist in compound formula
         if atom_count == 0:
+            compounds = [str(cpd) for cpd in self.peak_data.peak_group.compounds.all()]
             raise ValidationError(
-                f"Labeled element {self.element} does not exist in {self.tracer.compound} formula "
-                f"({self.tracer.compound.formula})"
+                f"Labeled element {self.element} does not exist in compound(s): {compounds} with formula "
+                f"({self.peak_data.peak_group.formula})."
             )
 
         # Ensure isotope count does not exceed count of that element in formula
         if self.count > atom_count:
+            compounds = [str(cpd) for cpd in self.peak_data.peak_group.compounds.all()]
             raise ValidationError(
-                f"Count of labeled element {self.element} exceeds the number of "
-                f"{self.element} atoms in compound(s): [{', '.join(self.peak_data.peak_group.compounds)}] with "
-                f"formula ({self.peak_data.peak_group.formula})."
+                f"Count of labeled element {self.element} exceeds the number of {self.element} atoms in compound(s): "
+                f"{compounds} with formula ({self.peak_data.peak_group.formula})."
             )
 
         # Ensure that the mass number is at least the number of nuetrons (which is the same as the number of protons)

--- a/DataRepo/models/protocol.py
+++ b/DataRepo/models/protocol.py
@@ -25,50 +25,6 @@ class Protocol(models.Model):
         help_text="Classification of the protocol, " "e.g. an animal treatment.",
     )
 
-    @classmethod
-    def retrieve_or_create_protocol(
-        cls,
-        protocol_input,
-        category=None,
-        provisional_description=None,
-    ):
-        """
-        retrieve or create a protocol, based on input.
-        protocol_input can either be a name or an integer (protocol_id)
-        """
-
-        if protocol_input is None:
-            raise ValueError("protocol_input cannot be None.")
-
-        created = False
-
-        try:
-            protocol = Protocol.objects.get(id=protocol_input)
-        except ValueError:
-            # protocol_input must not be an integer; try the name
-            try:
-                protocol, created = Protocol.objects.get_or_create(
-                    name=protocol_input,
-                    category=category,
-                )
-                if created:
-                    # add the provisional description
-                    if provisional_description is not None:
-                        protocol.description = provisional_description
-                        protocol.full_clean()
-                        protocol.save()
-
-            except Protocol.DoesNotExist as e:
-                raise Protocol.DoesNotExist(
-                    f"Protocol ID {protocol_input} does not exist."
-                ) from e
-
-        except Protocol.DoesNotExist as e:
-            # protocol_input was an integer, but was not found
-            print(f"Protocol ID {protocol_input} does not exist.")
-            raise e
-        return (protocol, created)
-
     class Meta:
         verbose_name = "protocol"
         verbose_name_plural = "protocols"

--- a/DataRepo/tests/models/test_peak_data.py
+++ b/DataRepo/tests/models/test_peak_data.py
@@ -20,6 +20,7 @@ from DataRepo.models import (
     Tissue,
 )
 from DataRepo.tests.tracebase_test_case import TracebaseTestCase
+from DataRepo.utils.infusate_name_parser import ObservedIsotopeData
 
 
 class PeakDataData(TracebaseTestCase):
@@ -98,7 +99,7 @@ class PeakDataData(TracebaseTestCase):
             )
             accucor_file.save()
 
-        pg = PeakGroup.objects.create(
+        self.pg = PeakGroup.objects.create(
             name="gluc",
             formula="C6H12O6",
             msrun_sample=msr,
@@ -107,7 +108,7 @@ class PeakDataData(TracebaseTestCase):
         PeakData.objects.create(
             raw_abundance=1000.0,
             corrected_abundance=1000.0,
-            peak_group=pg,
+            peak_group=self.pg,
             med_mz=1.0,
             med_rt=1.0,
         )
@@ -133,6 +134,28 @@ class PeakDataTests(PeakDataData):
             mass_number=17,
         )
         self.assertEqual(pd.labels.count(), 2)
+
+    def test_peak_data_get_or_create(self):
+        label_obs = [
+            ObservedIsotopeData(
+                element="C",
+                count=1,
+                mass_number=13,
+            )
+        ]
+        rec_dict = {
+            "raw_abundance": 900.0,
+            "corrected_abundance": 900.0,
+            "peak_group": self.pg,
+            "med_mz": 1.2,
+            "med_rt": 1.2,
+        }
+        rec, cre = PeakData.get_or_create(label_obs, **rec_dict)
+        self.assertTrue(cre)
+        self.assertIsNotNone(rec)
+        rec, cre = PeakData.get_or_create(label_obs, **rec_dict)
+        self.assertFalse(cre)
+        self.assertIsNotNone(rec)
 
 
 class PeakDataLabelTests(PeakDataData):

--- a/DataRepo/tests/models/test_peak_group.py
+++ b/DataRepo/tests/models/test_peak_group.py
@@ -1,6 +1,7 @@
 from datetime import datetime, timedelta
 from pathlib import Path
 
+from django.core.exceptions import ValidationError
 from django.core.files import File
 
 from DataRepo.models import (
@@ -17,7 +18,10 @@ from DataRepo.models import (
     Sample,
     Tissue,
 )
+from DataRepo.models.compound import Compound
 from DataRepo.tests.tracebase_test_case import TracebaseTestCase
+from DataRepo.utils.exceptions import MultiplePeakGroupRepresentations
+from DataRepo.utils.infusate_name_parser import parse_infusate_name
 
 
 class PeakGroupTests(TracebaseTestCase):
@@ -25,8 +29,11 @@ class PeakGroupTests(TracebaseTestCase):
 
     @classmethod
     def setUpTestData(cls):
-        inf = Infusate()
-        inf.save()
+        Compound.objects.create(
+            name="Leucine", formula="C6H13NO2", hmdb_id="HMDB0000687"
+        )
+        trcr = parse_infusate_name("Leucine-[1,2-13C2]", [1.0])
+        inf, _ = Infusate.objects.get_or_create_infusate(trcr)
         anml = Animal.objects.create(
             name="test_animal",
             age=timedelta(weeks=int(13)),
@@ -38,7 +45,7 @@ class PeakGroupTests(TracebaseTestCase):
             infusate=inf,
         )
         tsu = Tissue.objects.create(name="Brain")
-        smpl = Sample.objects.create(
+        cls.smpl = Sample.objects.create(
             name="Sample Name",
             tissue=tsu,
             animal=anml,
@@ -47,54 +54,51 @@ class PeakGroupTests(TracebaseTestCase):
         )
         lcm = LCMethod.objects.get(name__exact="polar-HILIC-25-min")
 
-        seq = MSRunSequence(
+        cls.seq = MSRunSequence.objects.create(
             researcher="John Doe",
             date=datetime.now(),
             instrument=MSRunSequence.INSTRUMENT_CHOICES[0][0],
             lc_method=lcm,
         )
-        seq.full_clean()
-        seq.save()
-        mstype = DataType.objects.get(code="ms_data")
-        rawfmt = DataFormat.objects.get(code="ms_raw")
-        mzxfmt = DataFormat.objects.get(code="mzxml")
+        cls.seq.full_clean()
+        cls.mstype = DataType.objects.get(code="ms_data")
+        cls.rawfmt = DataFormat.objects.get(code="ms_raw")
+        cls.mzxfmt = DataFormat.objects.get(code="mzxml")
         rawrec = ArchiveFile.objects.create(
             filename="test.raw",
             file_location=None,
             checksum="558ea654d7f2914ca4527580edf4fac11bd151c5",
-            data_type=mstype,
-            data_format=rawfmt,
+            data_type=cls.mstype,
+            data_format=cls.rawfmt,
         )
         mzxrec = ArchiveFile.objects.create(
             filename="test.mzxml",
             file_location=None,
             checksum="558ea654d7f2914ca4527580edf4fac11bd151c4",
-            data_type=mstype,
-            data_format=mzxfmt,
+            data_type=cls.mstype,
+            data_format=cls.mzxfmt,
         )
-        msr = MSRunSample(
-            msrun_sequence=seq,
-            sample=smpl,
+        msr = MSRunSample.objects.create(
+            msrun_sequence=cls.seq,
+            sample=cls.smpl,
             polarity=MSRunSample.POSITIVE_POLARITY,
             ms_raw_file=rawrec,
             ms_data_file=mzxrec,
         )
         msr.full_clean()
-        msr.save()
 
+        cls.ms_peak_annotation = DataType.objects.get(code="ms_peak_annotation")
+        cls.accucor_format = DataFormat.objects.get(code="accucor")
         path = Path("DataRepo/data/tests/small_obob/small_obob_maven_6eaas_inf.xlsx")
         with path.open(mode="rb") as f:
             myfile = File(f, name=path.name)
-            ms_peak_annotation = DataType.objects.get(code="ms_peak_annotation")
-            accucor_format = DataFormat.objects.get(code="accucor")
             accucor_file = ArchiveFile.objects.create(
                 filename="small_obob_maven_6eaas_inf.xlsx",
                 file_location=myfile,
                 checksum="558ea654d7f2914ca4527580edf4fac11bd151c3",
-                data_type=ms_peak_annotation,
-                data_format=accucor_format,
+                data_type=cls.ms_peak_annotation,
+                data_format=cls.accucor_format,
             )
-            accucor_file.save()
 
         cls.pg = PeakGroup.objects.create(
             name="gluc",
@@ -123,3 +127,65 @@ class PeakGroupTests(TracebaseTestCase):
 
     def test_max_med_mz(self):
         self.assertEqual(4.0, self.pg.max_med_mz)
+
+    def test_clean_raises_MultiplePeakGroupRepresentations(self):
+        rawrec = ArchiveFile.objects.create(
+            filename="test.raw",
+            file_location=None,
+            checksum="558ea654d7f2914ca4527580edf4fac11bd151c6",
+            data_type=self.mstype,
+            data_format=self.rawfmt,
+        )
+        mzxrec = ArchiveFile.objects.create(
+            filename="test.mzxml",
+            file_location=None,
+            checksum="558ea654d7f2914ca4527580edf4fac11bd151c7",
+            data_type=self.mstype,
+            data_format=self.mzxfmt,
+        )
+        msr = MSRunSample.objects.create(
+            msrun_sequence=self.seq,
+            sample=self.smpl,
+            polarity="negative",
+            ms_raw_file=rawrec,
+            ms_data_file=mzxrec,
+        )
+        msr.full_clean()
+        accucor_file = ArchiveFile.objects.create(
+            filename="small_obob_maven_6eaas_inf2.xlsx",
+            file_location=None,
+            checksum="558ea654d7f2914ca4527580edf4fac11bd151c8",
+            data_type=self.ms_peak_annotation,
+            data_format=self.accucor_format,
+        )
+        pg = PeakGroup.objects.create(
+            name="gluc",
+            formula="C6H12O6",
+            msrun_sample=msr,
+            peak_annotation_file=accucor_file,
+        )
+
+        # The clean method should raise a MultiplePeakGroupRepresentations exception (derived from ValidationError)
+        with self.assertRaises(ValidationError) as ar:
+            pg.full_clean()
+
+        # Make sure it's a MultiplePeakGroupRepresentations exception
+        self.assertTrue(
+            isinstance(
+                ar.exception.error_dict["__all__"][0],
+                MultiplePeakGroupRepresentations,
+            ),
+        )
+
+    def test_get_or_create_compound_link(self):
+        cmpd = Compound.objects.create(
+            name="glucose",
+            formula="C6H12O6",
+            hmdb_id="HMDB0000122",
+        )
+        rec, cre = self.pg.get_or_create_compound_link(cmpd)
+        self.assertTrue(cre)
+        self.assertIsNotNone(rec)
+        rec, cre = self.pg.get_or_create_compound_link(cmpd)
+        self.assertFalse(cre)
+        self.assertIsNotNone(rec)

--- a/DataRepo/tests/test_models.py
+++ b/DataRepo/tests/test_models.py
@@ -1061,7 +1061,7 @@ class PropertyTests(TracebaseTestCase):
                 "element C (from the tracers in the infusate [methionine-(15N1)[200]])."
             ),
         ):
-            pg.labels.first().enrichment_fraction
+            pg.labels.first().enrichment_fraction  # pylint: disable=no-member
 
     def test_enrichment_fraction_missing_peak_group_formula(self):
         peak_group = (

--- a/DataRepo/tests/utils/test_exceptions.py
+++ b/DataRepo/tests/utils/test_exceptions.py
@@ -1199,6 +1199,8 @@ class ExceptionTests(TracebaseTestCase):
         self.assertIn("Sample header:       [sample]", str(exc))
         self.assertIn("mzXML Base Filename: [sample_neg]", str(exc))
 
+    # NOTE: MultiplePeakGroupRepresentations is tested in the peak group tests, because it needs records
+
     def test_RequiredHeadersError(self):
         exc = RequiredHeadersError(["A"])
         self.assertIn("header(s) missing: ['A']", str(exc))


### PR DESCRIPTION
## Summary Change Description

Much of the code that was/is in the accucor data loader are methods that could go inside the model classes, and doing so simplifies the peak annotations loader.  I used a strategy of always using get_or_create.  I had to go a bit extra to make that work with the PeakData model, because there is no unique constraint.  Taken together with PeakDataLabel, however, it could be implemented as a get_or_create.

I also added a clean method to PeakGroup to check for multiple representations.

## Affected Issues/Pull Requests

- Partially addresses #825
- Merges into #995
- Next PR: #997

## Review Notes
<!--
For added context for reviewers, add comments to relevant lines of code.  Use
this space to describe any general areas of concern not linked to a specific
line of code that reviewers should pay particular attention to, e.g. please
make sure I have accounted for all possible inputs.
-->
See comments in-line.

## Checklist
<!--
If any of the checkbox requirements are not met, uncheck them and add an
explanation. E.g. Linting errors pre-date this PR.
-->
This pull request will be merged once the following requirements are met.  The
author and/or reviewers should uncheck any unmet requirements:

- Review requirements
  - Minimum approvals: 1 <!-- Edit as desired (e.g. based on complexity) -->
  - No changes requested
  - All blocking issues resolved by reviewers
  - Specific reviewers: @__add_username_here__
    <!--
    Require reviewers with specific expertise to be included among the minimum
    number of reviewers by tagging them.  Also please send them a message.
    -->
  - Review period: 2 days <!-- Edit as desired (e.g. based on complexity) -->
- Associated issue/pull request requirements:
  <!--
  Assert that all requirements in issues marked "resolved" are done and that
  all required pull requests are merged.  If any are not done, either edit or
  split the issue or explain the unmerged affected pull requests.
  -->
  - [x] All requirements in affected issues marked "resolved" are satisfied
  - [x] All required pull requests are merged *(or none)*
- Basic requirements
  <!--
  Uncheck items to acknowledge failures/conflicts you intend to address.
  Add an explanation if any won't be addressed before merge.
  -->
  - [x] [All linters pass](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#linting)
  - [x] [All tests pass](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#quality-control)
  - [x] All conflicts resolved
- Overhead requirements
  <!--
  These are additional requirements that are not directly associated with
  resolving the affected issue(s).
  -->
  - [x] [New/changed method tests implemented/updated *(or no change)*](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#test-implementation)
  - [ ] [Updated *Unreleased* section of `changelog.md` *(or no change)*](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/changelog.md)
  - [x] [Migrations created & committed *(or no change)*](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#migration-process)
