### PR TITLE
`TableLoader` updates for the submission refactor

### DIFF
--- a/DataRepo/tests/loaders/base/test_table_loader.py
+++ b/DataRepo/tests/loaders/base/test_table_loader.py
@@ -654,8 +654,7 @@ class TableLoaderTests(TracebaseTestCase):
                 "\tattribute [TestInvalidLoader.DataRequiredValues] N-dimensional list of strings required, "
                 "but contains ['NoneType']\n"
                 "\tattribute [TestInvalidLoader.DataUniqueColumnConstraints] list required, NoneType set\n"
-                "\tattribute [TestInvalidLoader.FieldToDataHeaderKey] dict required, NoneType set\n"
-                "\tModels is required to have at least 1 Model class"
+                "\tattribute [TestInvalidLoader.FieldToDataHeaderKey] dict required, NoneType set"
             ),
             str(aes.exceptions[0]),
         )

--- a/DataRepo/tests/management/test_load_animals.py
+++ b/DataRepo/tests/management/test_load_animals.py
@@ -269,7 +269,6 @@ class LoadAnimalsAutoupdateTests(TracebaseTestCase):
                 infile="DataRepo/data/tests/small_obob/study_missing_rqd_vals.xlsx",
             )
         aes = ar.exception
-        # TODO: After rebase for neighboring PRs, change 5 to 2, bec. the missing record errors will be summarized as 1
         self.assertEqual(1, len(aes.exceptions))
         self.assertTrue(isinstance(aes.exceptions[0], RequiredColumnValues))
         self.assertEqual(


### PR DESCRIPTION
## Summary Change Description

Cherry-picked necessary updates to `TableLoader` to support the coming `StudyLoader` class.

`StudyLoader` does not directly update any models.  It just calls other loaders, so `TableLoader` needed to be able to:
1. have an empty `Models` class attribute.
2. Allow `StudyLoader` to be able to raise 2 new exceptions: `AggregatedErrorsSet` and `MultiLoadStatus` instead of stuffing them into the member `AggregatedErrors` object.  The `AggregatedErrorsSet` exception is unchanged and its usage in `StudyLoader` is the same exact usage in the old `load_study.py` script.  Basically, it organizes all of the `AggregatedErrors` objects from all the different loaders into a dict keyed on study sheet name (`load_study.py` keyed them on file name).  And `TableLoader` just needs to raise `AggregatedErrorsSet` and `MultiLoadStatus` when it sees them

I also added a bunch of `is_error` and `is_fatal` arguments to the methods that handle exceptions, though I didn't end up actually using them.  The purpose at the time was to resolve an issue where animal loader warnings were somehow resulting in a rollback when it shouldn't have rolled back and the next loader (in order) couldn't access the records from the previous loader it depends on.  That problem however turned out to be that I wasn't supplying `defer_rollback=True` in `StudyLoader` when it was calling the individual loaders, so I didn't actually need to pass those new arguments.  But, it didn't hurt anything and it left the option open to treat exceptions how you want, so I left those changes in.

## Affected Issues/Pull Requests

- Partially addresses #829
- Merges into #1007
- Next PR: #1009

## Review Notes
<!--
For added context for reviewers, add comments to relevant lines of code.  Use
this space to describe any general areas of concern not linked to a specific
line of code that reviewers should pay particular attention to, e.g. please
make sure I have accounted for all possible inputs.
-->
See comments in-line.

## Checklist
<!--
If any of the checkbox requirements are not met, uncheck them and add an
explanation. E.g. Linting errors pre-date this PR.
-->
This pull request will be merged once the following requirements are met.  The
author and/or reviewers should uncheck any unmet requirements:

- Review requirements
  - Minimum approvals: 1 <!-- Edit as desired (e.g. based on complexity) -->
  - No changes requested
  - All blocking issues resolved by reviewers
  - Specific reviewers: @__add_username_here__
    <!--
    Require reviewers with specific expertise to be included among the minimum
    number of reviewers by tagging them.  Also please send them a message.
    -->
  - Review period: 2 days <!-- Edit as desired (e.g. based on complexity) -->
- Associated issue/pull request requirements:
  <!--
  Assert that all requirements in issues marked "resolved" are done and that
  all required pull requests are merged.  If any are not done, either edit or
  split the issue or explain the unmerged affected pull requests.
  -->
  - [x] All requirements in affected issues marked "resolved" are satisfied
  - [x] All required pull requests are merged *(or none)*
- Basic requirements
  <!--
  Uncheck items to acknowledge failures/conflicts you intend to address.
  Add an explanation if any won't be addressed before merge.
  -->
  - [x] [All linters pass](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#linting)
  - [x] [All tests pass](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#quality-control)
  - [x] All conflicts resolved
- Overhead requirements
  <!--
  These are additional requirements that are not directly associated with
  resolving the affected issue(s).
  -->
  - [x] [New/changed method tests implemented/updated *(or no change)*](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#test-implementation)
  - [ ] [Updated *Unreleased* section of `changelog.md` *(or no change)*](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/changelog.md)
  - [x] [Migrations created & committed *(or no change)*](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#migration-process)
