### PR TITLE
Infusate parsing updates for intersheet relations in `StudyLoader`

### DIFF
--- a/DataRepo/loaders/samples_loader.py
+++ b/DataRepo/loaders/samples_loader.py
@@ -9,7 +9,6 @@ from DataRepo.loaders.base.table_column import ColumnReference, TableColumn
 from DataRepo.loaders.base.table_loader import TableLoader
 from DataRepo.loaders.tissues_loader import TissuesLoader
 from DataRepo.models import Animal, MaintainedModel, Sample, Tissue
-from DataRepo.models.fcirc import FCirc
 from DataRepo.models.researcher import (
     could_be_variant_researcher,
     get_researchers,

--- a/DataRepo/models/infusate.py
+++ b/DataRepo/models/infusate.py
@@ -209,7 +209,9 @@ class Infusate(MaintainedModel, HierCachedModel):
         """
         from DataRepo.utils.infusate_name_parser import (
             InfusateParsingError,
+            TracerParsingError,
             parse_infusate_name,
+            parse_infusate_name_with_concs,
         )
 
         # Any infusate name string (e.g. as supplied from a file) may not have the tracers in the same order
@@ -218,6 +220,8 @@ class Infusate(MaintainedModel, HierCachedModel):
         rec_data = parse_infusate_name(rec_name, rec_concentrations)
         try:
             sup_data = parse_infusate_name(supplied_name, supplied_concs)
+        except TracerParsingError:
+            sup_data = parse_infusate_name_with_concs(supplied_name)
         except InfusateParsingError as ipe:
             # If the name and concs is invalid due to unmatching numbers of tracers and concentrations, return False
             if (

--- a/DataRepo/tests/utils/test_infusate_parser.py
+++ b/DataRepo/tests/utils/test_infusate_parser.py
@@ -295,7 +295,8 @@ class InfusateParsingTests(InfusateTest):
 
     def test_parse_tracer_with_conc_string(self):
         tcr_data, conc = parse_tracer_with_conc_string("lactate-[13C3][148.88]")
-        self.assertEqual("lactate-[13C3][148.88]", tcr_data["unparsed_string"])
+        self.assertEqual("lactate-[13C3]", tcr_data["unparsed_string"])
+        self.assertEqual(148.88, conc)
         self.assertEqual("lactate", tcr_data["compound_name"])
         self.assertEqual(1, len(tcr_data["isotopes"]))
         self.assertIsNotNone(tcr_data["isotopes"][0])

--- a/DataRepo/utils/infusate_name_parser.py
+++ b/DataRepo/utils/infusate_name_parser.py
@@ -28,7 +28,7 @@ TRACER_ENCODING_PATTERN = re.compile(
     r"^(?P<compound_name>.*?)-\[(?P<isotopes>[^\[\]]+)\]$"
 )
 TRACER_WITH_CONC_ENCODING_PATTERN = re.compile(
-    r"^(?P<compound_name>.*?)-\[(?P<isotopes>[^\[\]]+)\]\[(?P<concentration>[^\[\]]+)\]$"
+    r"^(?P<tracer_str>(?P<compound_name>.*?)-\[(?P<isotopes>[^\[\]]+)\])\[(?P<concentration>[^\[\]]+)\]$"
 )
 ISOTOPE_ENCODING_JOIN = ","
 ISOTOPE_ENCODING_PATTERN = re.compile(
@@ -241,13 +241,14 @@ def parse_tracer_with_conc_string(tracer_string: str) -> Tuple[TracerData, float
         concentration (float)
     """
     tracer_data: TracerData = {
-        "unparsed_string": tracer_string,
+        "unparsed_string": "",  # Conc removed below to be compatible with the patterns that omit concentrations...
         "compound_name": "",
         "isotopes": list(),
     }
     concentration = 0.0
     match = re.search(TRACER_WITH_CONC_ENCODING_PATTERN, tracer_string)
     if match:
+        tracer_data["unparsed_string"] = match.group("tracer_str").strip()
         tracer_data["compound_name"] = match.group("compound_name").strip()
         tracer_data["isotopes"] = parse_isotope_string(match.group("isotopes").strip())
         concentration = float(match.group("concentration").strip())


### PR DESCRIPTION
## Summary Change Description

Made updates to the infusate and tracer name parsing - specifically the construction of the data objects. The new unparsed tracer strings have a concentration on them which is incompatible with code elsewhere, specifically in the check method inside the Infusate class. The check also relies on the name field, as does code in the infusates loader. Once I added the defer_autoupdates decorator from maintainedmodel, those method would fail because the names were not there. So I just changed them to use the generator methods instead of the field. This only affects loading and validation - not the operation of the database in production.

## Affected Issues/Pull Requests

- Partially addresses #829
- Merges into #1009
- Next PR: #1011

## Review Notes
<!--
For added context for reviewers, add comments to relevant lines of code.  Use
this space to describe any general areas of concern not linked to a specific
line of code that reviewers should pay particular attention to, e.g. please
make sure I have accounted for all possible inputs.
-->
See comments in-line.

## Checklist
<!--
If any of the checkbox requirements are not met, uncheck them and add an
explanation. E.g. Linting errors pre-date this PR.
-->
This pull request will be merged once the following requirements are met.  The
author and/or reviewers should uncheck any unmet requirements:

- Review requirements
  - Minimum approvals: 1 <!-- Edit as desired (e.g. based on complexity) -->
  - No changes requested
  - All blocking issues resolved by reviewers
  - Specific reviewers: @__add_username_here__
    <!--
    Require reviewers with specific expertise to be included among the minimum
    number of reviewers by tagging them.  Also please send them a message.
    -->
  - Review period: 2 days <!-- Edit as desired (e.g. based on complexity) -->
- Associated issue/pull request requirements:
  <!--
  Assert that all requirements in issues marked "resolved" are done and that
  all required pull requests are merged.  If any are not done, either edit or
  split the issue or explain the unmerged affected pull requests.
  -->
  - [x] All requirements in affected issues marked "resolved" are satisfied
  - [x] All required pull requests are merged *(or none)*
- Basic requirements
  <!--
  Uncheck items to acknowledge failures/conflicts you intend to address.
  Add an explanation if any won't be addressed before merge.
  -->
  - [x] [All linters pass](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#linting)
  - [x] [All tests pass](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#quality-control)
  - [x] All conflicts resolved
- Overhead requirements
  <!--
  These are additional requirements that are not directly associated with
  resolving the affected issue(s).
  -->
  - [x] [New/changed method tests implemented/updated *(or no change)*](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#test-implementation)
  - [ ] [Updated *Unreleased* section of `changelog.md` *(or no change)*](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/changelog.md)
  - [x] [Migrations created & committed *(or no change)*](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#migration-process)
