### PR TITLE
Samples and Animals Loader fixes

### DIFF
--- a/DataRepo/loaders/animals_loader.py
+++ b/DataRepo/loaders/animals_loader.py
@@ -428,7 +428,7 @@ class AnimalsLoader(TableLoader):
             # Package errors (like IntegrityError and ValidationError) with relevant details
             # This also updates the skip row indexes
             self.handle_load_db_errors(e, Protocol, query_dict)
-            self.add_skip_row_index()
+            # Treatment is not a required field, so no need to add to skip rows
 
         return rec
 

--- a/DataRepo/loaders/samples_loader.py
+++ b/DataRepo/loaders/samples_loader.py
@@ -10,6 +10,7 @@ from DataRepo.loaders.base.table_loader import TableLoader
 from DataRepo.loaders.tissues_loader import TissuesLoader
 from DataRepo.models import Animal, MaintainedModel, Sample, Tissue
 from DataRepo.models.fcirc import FCirc
+from DataRepo.models.fcirc import FCirc
 from DataRepo.models.researcher import (
     could_be_variant_researcher,
     get_researchers,

--- a/DataRepo/loaders/samples_loader.py
+++ b/DataRepo/loaders/samples_loader.py
@@ -10,7 +10,6 @@ from DataRepo.loaders.base.table_loader import TableLoader
 from DataRepo.loaders.tissues_loader import TissuesLoader
 from DataRepo.models import Animal, MaintainedModel, Sample, Tissue
 from DataRepo.models.fcirc import FCirc
-from DataRepo.models.fcirc import FCirc
 from DataRepo.models.researcher import (
     could_be_variant_researcher,
     get_researchers,

--- a/DataRepo/models/fcirc.py
+++ b/DataRepo/models/fcirc.py
@@ -59,6 +59,7 @@ class FCirc(MaintainedModel, HierCachedModel):
             )
         ]
 
+    # TODO: Make this into a clean method
     def save(self, *args, **kwargs):
         """
         This checks to make sure that self.serum_sample is in fact a serum sample.

--- a/DataRepo/tests/loaders/test_samples_loader.py
+++ b/DataRepo/tests/loaders/test_samples_loader.py
@@ -35,7 +35,7 @@ class SamplesLoaderTests(TracebaseTestCase):
             name=cls.anml1nm, genotype="WT", infusate=cls.infusate
         )
 
-        cls.tiss1nm = "test tissue"
+        cls.tiss1nm = "serum"
         cls.tiss1 = Tissue.objects.create(name=cls.tiss1nm)
 
         cls.row = pd.Series(

--- a/DataRepo/tests/loaders/test_samples_loader.py
+++ b/DataRepo/tests/loaders/test_samples_loader.py
@@ -5,6 +5,7 @@ import pandas as pd
 
 from DataRepo.loaders.samples_loader import SamplesLoader
 from DataRepo.models import Animal, Compound, Infusate
+from DataRepo.models.fcirc import FCirc
 from DataRepo.models.sample import Sample
 from DataRepo.models.tissue import Tissue
 from DataRepo.tests.tracebase_test_case import TracebaseTestCase
@@ -54,7 +55,15 @@ class SamplesLoaderTests(TracebaseTestCase):
                 "errored": 0,
                 "warned": 0,
                 "updated": 0,
-            }
+            },
+            FCirc.__name__: {
+                "created": 0,
+                "existed": 0,
+                "skipped": 0,
+                "errored": 0,
+                "warned": 0,
+                "updated": 0,
+            },
         }
 
         super().setUpTestData()
@@ -84,6 +93,7 @@ class SamplesLoaderTests(TracebaseTestCase):
         self.assertEqual(0, len(sl.aggregated_errors_object.exceptions))
         counts = deepcopy(self.rec_counts)
         counts[Sample.__name__]["created"] = 1
+        counts[FCirc.__name__]["created"] = 1
         self.assertDictEqual(counts, sl.record_counts)
 
     def test_get_or_create_sample_success(self):
@@ -285,3 +295,20 @@ class SamplesLoaderTests(TracebaseTestCase):
         sl.repackage_exceptions()
         self.assertEqual(1, len(sl.aggregated_errors_object.exceptions))
         self.assertIsInstance(sl.aggregated_errors_object.exceptions[0], MissingTissues)
+
+    def test_get_or_create_fcirc(self):
+        sample = Sample.objects.create(
+            name="s1",
+            researcher="Ralph",
+            date=string_to_datetime("2024-6-15"),
+            time_collected=timedelta(minutes=90),
+            animal=self.anml1,
+            tissue=self.tiss1,
+        )  # No exception = successful test
+        tracer = self.infusate.tracers.first()
+        sl = SamplesLoader()
+        sl.get_or_create_fcirc(sample, tracer, "C")
+        self.assertEqual(0, len(sl.aggregated_errors_object.exceptions))
+        counts = deepcopy(self.rec_counts)
+        counts[FCirc.__name__]["created"] = 1
+        self.assertDictEqual(counts, sl.record_counts)

--- a/DataRepo/utils/exceptions.py
+++ b/DataRepo/utils/exceptions.py
@@ -2659,8 +2659,10 @@ class NoTracerLabeledElements(InfileError):
 
 
 class NoTracers(InfileError):
-    def __init__(self, animal: Animal, **kwargs):
-        message = f"The Animal [{animal}] associated with %s, has no tracers."
+    def __init__(self, animal: Optional[Animal] = None, message=None, **kwargs):
+        if message is None:
+            animal_str = f" [{animal}]"
+            message = f"The Animal{animal_str} associated with %s, has no tracers."
         super().__init__(message, **kwargs)
         self.animal = animal
 


### PR DESCRIPTION
## Summary Change Description

Added loading of the FCirc model to the SamplesLoader. This was overlooked in the first go-round.

I removed the call to add_skip_row_index in the animal loader's get or create protocol method because the samples loader wasn't getting the required animal records and there should have been no issue.  The treatment field is optional and it was just a warning.

## Affected Issues/Pull Requests

- Partially addresses #829
- Merges into #1010
- Next PR: #1012

## Review Notes
<!--
For added context for reviewers, add comments to relevant lines of code.  Use
this space to describe any general areas of concern not linked to a specific
line of code that reviewers should pay particular attention to, e.g. please
make sure I have accounted for all possible inputs.
-->
See comments in-line.

## Checklist
<!--
If any of the checkbox requirements are not met, uncheck them and add an
explanation. E.g. Linting errors pre-date this PR.
-->
This pull request will be merged once the following requirements are met.  The
author and/or reviewers should uncheck any unmet requirements:

- Review requirements
  - Minimum approvals: 1 <!-- Edit as desired (e.g. based on complexity) -->
  - No changes requested
  - All blocking issues resolved by reviewers
  - Specific reviewers: @__add_username_here__
    <!--
    Require reviewers with specific expertise to be included among the minimum
    number of reviewers by tagging them.  Also please send them a message.
    -->
  - Review period: 2 days <!-- Edit as desired (e.g. based on complexity) -->
- Associated issue/pull request requirements:
  <!--
  Assert that all requirements in issues marked "resolved" are done and that
  all required pull requests are merged.  If any are not done, either edit or
  split the issue or explain the unmerged affected pull requests.
  -->
  - [x] All requirements in affected issues marked "resolved" are satisfied
  - [x] All required pull requests are merged *(or none)*
- Basic requirements
  <!--
  Uncheck items to acknowledge failures/conflicts you intend to address.
  Add an explanation if any won't be addressed before merge.
  -->
  - [x] [All linters pass](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#linting)
  - [x] [All tests pass](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#quality-control)
  - [x] All conflicts resolved
- Overhead requirements
  <!--
  These are additional requirements that are not directly associated with
  resolving the affected issue(s).
  -->
  - [x] [New/changed method tests implemented/updated *(or no change)*](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#test-implementation)
  - [ ] [Updated *Unreleased* section of `changelog.md` *(or no change)*](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/changelog.md)
  - [x] [Migrations created & committed *(or no change)*](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#migration-process)
