### PR TITLE
Add a study sheet to the returned "build a submission" doc

### DIFF
--- a/DataRepo/loaders/study_table_loader.py
+++ b/DataRepo/loaders/study_table_loader.py
@@ -1,4 +1,5 @@
 from collections import namedtuple
+from typing import Dict
 
 from django.db import transaction
 
@@ -44,7 +45,13 @@ class StudyTableLoader(TableLoader):
     DataRequiredValues = DataRequiredHeaders
 
     # No DataDefaultValues needed
-    # No DataColumnTypes needed
+
+    # The type of data in each column (used by pandas to not, for example, turn "1" into an integer then str is set)
+    DataColumnTypes: Dict[str, type] = {
+        CODE_KEY: str,
+        NAME_KEY: str,
+        DESC_KEY: str,
+    }
 
     # Combinations of columns whose values must be unique in the file
     DataUniqueColumnConstraints = [[CODE_KEY], [NAME_KEY]]

--- a/DataRepo/tests/loaders/test_study_loader.py
+++ b/DataRepo/tests/loaders/test_study_loader.py
@@ -113,6 +113,8 @@ class StudyLoaderTests(TracebaseTestCase):
                 "TISSUES": "Tissues",
                 "TRACERS": "Tracers",
                 "TREATMENTS": "Treatments",
+                "DEFAULTS": "Defaults",
+                "ERRORS": "Errors",
             },
             snt._asdict(),
         )

--- a/DataRepo/tests/views/upload/test_validation.py
+++ b/DataRepo/tests/views/upload/test_validation.py
@@ -9,6 +9,7 @@ from django.urls import reverse
 from DataRepo.loaders import ProtocolsLoader, TissuesLoader
 from DataRepo.loaders.compounds_loader import CompoundsLoader
 from DataRepo.loaders.samples_loader import SamplesLoader
+from DataRepo.loaders.study_table_loader import StudyTableLoader
 from DataRepo.models import Protocol, Tissue
 from DataRepo.models.compound import Compound
 from DataRepo.models.infusate import Infusate
@@ -118,6 +119,11 @@ class DataValidationViewTests1(TracebaseTransactionTestCase):
                 "Formula": {},
                 "HMDB ID": {},
                 "Synonyms": {},
+            },
+            "Study": {
+                "Description": {},
+                "Name": {},
+                "Study ID": {},
             },
         }
 
@@ -275,6 +281,11 @@ class DataValidationViewTests1(TracebaseTransactionTestCase):
                 "File Format": {},
                 "Default Sequence Name": {},
             },
+            "Study": {
+                "Description": {},
+                "Name": {},
+                "Study ID": {},
+            },
             "Infusions": None,  # Ignoring this one
         }
 
@@ -333,6 +344,11 @@ class DataValidationViewTests1(TracebaseTransactionTestCase):
             "Tissues": {
                 "Description": str,
                 "Tissue": str,
+            },
+            "Study": {
+                "Description": str,
+                "Name": str,
+                "Study ID": str,
             },
             "Compounds": None,  # Not yet in the infile
         }
@@ -426,6 +442,7 @@ class DataValidationViewTests1(TracebaseTransactionTestCase):
                     "wined-and-dined": {"Animal Treatment": "wined-and-dined"}
                 },
                 "Compounds": {},
+                "Study": {},
             },
             vo.autofill_dict,
         )
@@ -446,7 +463,7 @@ class DataValidationViewTests1(TracebaseTransactionTestCase):
 
     def test_extract_all_missing_samples(self):
         vo = DataValidationView()
-        vo.extract_all_missing_samples(
+        vo.extract_all_missing_values(
             AllMissingSamples(
                 [
                     RecordDoesNotExist(Sample, {"name": "s1"}, file="accucor1.xlsx"),
@@ -455,7 +472,9 @@ class DataValidationViewTests1(TracebaseTransactionTestCase):
                     RecordDoesNotExist(Sample, {"name": "s3"}, file="accucor3.xlsx"),
                     RecordDoesNotExist(Sample, {"name": "s1"}, file="accucor4.xlsx"),
                 ]
-            )
+            ),
+            "Samples",
+            "Sample",
         )
         expected = {
             SamplesLoader.DataSheetName: {
@@ -466,18 +485,21 @@ class DataValidationViewTests1(TracebaseTransactionTestCase):
             ProtocolsLoader.DataSheetName: {},
             TissuesLoader.DataSheetName: {},
             CompoundsLoader.DataSheetName: {},
+            StudyTableLoader.DataSheetName: {},
         }
         self.assertDictEqual(expected, vo.autofill_dict)
 
     def test_extract_all_missing_tissues(self):
         vo = DataValidationView()
-        vo.extract_all_missing_tissues(
+        vo.extract_all_missing_values(
             AllMissingTissues(
                 [
                     RecordDoesNotExist(Tissue, {"name": "elbow pit"}),
                     RecordDoesNotExist(Tissue, {"name": "earlobe"}),
                 ]
-            )
+            ),
+            "Tissues",
+            "Tissue",
         )
         expected = {
             CompoundsLoader.DataSheetName: {},
@@ -487,18 +509,21 @@ class DataValidationViewTests1(TracebaseTransactionTestCase):
                 "elbow pit": {TissuesLoader.DataHeaders.NAME: "elbow pit"},
                 "earlobe": {TissuesLoader.DataHeaders.NAME: "earlobe"},
             },
+            StudyTableLoader.DataSheetName: {},
         }
         self.assertDictEqual(expected, vo.autofill_dict)
 
     def test_extract_all_missing_treatments(self):
         vo = DataValidationView()
-        vo.extract_all_missing_treatments(
+        vo.extract_all_missing_values(
             AllMissingTreatments(
                 [
                     RecordDoesNotExist(Protocol, {"name": "berated"}),
                     RecordDoesNotExist(Protocol, {"name": "wined-and-dined"}),
                 ]
-            )
+            ),
+            "Treatments",
+            "Animal Treatment",
         )
         expected = {
             CompoundsLoader.DataSheetName: {},
@@ -510,6 +535,7 @@ class DataValidationViewTests1(TracebaseTransactionTestCase):
                 },
             },
             TissuesLoader.DataSheetName: {},
+            StudyTableLoader.DataSheetName: {},
         }
         self.assertDictEqual(expected, vo.autofill_dict)
 
@@ -549,6 +575,11 @@ class DataValidationViewTests1(TracebaseTransactionTestCase):
                 "Formula": {},
                 "HMDB ID": {},
                 "Synonyms": {},
+            },
+            "Study": {
+                "Description": {},
+                "Name": {},
+                "Study ID": {},
             },
         }
 
@@ -621,6 +652,7 @@ class DataValidationViewTests1(TracebaseTransactionTestCase):
                 },
                 "Tissues": {},
                 "Treatments": {},
+                "Study": {},
             },
             dvv.autofill_dict,
         )

--- a/DataRepo/utils/exceptions.py
+++ b/DataRepo/utils/exceptions.py
@@ -2908,6 +2908,16 @@ class AllMissingTissues(MissingModelRecordsByFile):
     RecordName = ModelName
 
 
+class MissingStudies(MissingModelRecords):
+    ModelName = "Study"
+    RecordName = ModelName
+
+
+class AllMissingStudies(MissingModelRecordsByFile):
+    ModelName = "Study"
+    RecordName = ModelName
+
+
 # TODO: Delete when sample_table_loader is removed
 class MissingTreatment(InfileError):
     def __init__(self, treatment_name, message=None, **kwargs):


### PR DESCRIPTION
## Summary Change Description

Updates to the DataValidationView that reads a peak annotation file and fills in missing data into a study doc.

Added the study sheet, missing study errors, and did some streamlining.

Details:

- Moved the get_study_sheet_column_display_order method to StudyLoader.
- Created a class attribute in StudyLoader to hold the sheet display order.
- Added the defaults sheet and created an errors sheet placeholder.
- Made a generic version of all the extract_all_missing_* methods.
- Defined the DataColumnTypes class attribute in the StudyTableLoader.

I changed what was initially (in the previous PR?) an instance attribute named `CustomLoaderKwargs` into a class attribute and in the instance, I copy it and modify the copy to occlude the class version, because I needed to set `kwargs` for the protocols loader in such a way that it was accessible from the class level, but also have a way to set kwargs from the instance level for the `PeakAnnotationFilesLoader` so it could have access to the `annot_files_dict` passed into the constructor.

I also filled in a couple of missing namedtuple keys.

## Affected Issues/Pull Requests

- Partially addresses #829
- Merges into: #1015
- Next PR: #1017

## Review Notes
<!--
For added context for reviewers, add comments to relevant lines of code.  Use
this space to describe any general areas of concern not linked to a specific
line of code that reviewers should pay particular attention to, e.g. please
make sure I have accounted for all possible inputs.
-->
See comments in-line.

## Checklist
<!--
If any of the checkbox requirements are not met, uncheck them and add an
explanation. E.g. Linting errors pre-date this PR.
-->
This pull request will be merged once the following requirements are met.  The
author and/or reviewers should uncheck any unmet requirements:

- Review requirements
  - Minimum approvals: 1 <!-- Edit as desired (e.g. based on complexity) -->
  - No changes requested
  - All blocking issues resolved by reviewers
  - Specific reviewers: @__add_username_here__
    <!--
    Require reviewers with specific expertise to be included among the minimum
    number of reviewers by tagging them.  Also please send them a message.
    -->
  - Review period: 2 days <!-- Edit as desired (e.g. based on complexity) -->
- Associated issue/pull request requirements:
  <!--
  Assert that all requirements in issues marked "resolved" are done and that
  all required pull requests are merged.  If any are not done, either edit or
  split the issue or explain the unmerged affected pull requests.
  -->
  - [x] All requirements in affected issues marked "resolved" are satisfied
  - [x] All required pull requests are merged *(or none)*
- Basic requirements
  <!--
  Uncheck items to acknowledge failures/conflicts you intend to address.
  Add an explanation if any won't be addressed before merge.
  -->
  - [x] [All linters pass](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#linting)
  - [x] [All tests pass](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#quality-control)
  - [x] All conflicts resolved
- Overhead requirements
  <!--
  These are additional requirements that are not directly associated with
  resolving the affected issue(s).
  -->
  - [x] [New/changed method tests implemented/updated *(or no change)*](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#test-implementation)
  - [ ] [Updated *Unreleased* section of `changelog.md` *(or no change)*](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/changelog.md)
  - [x] [Migrations created & committed *(or no change)*](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#migration-process)
