### PR TITLE
`DataValidationView` (the `Build a Submission` view) Refactor 2 - Necessary improvements to `TableLoader` and `PeakAnnotationFilesLoader`

### DIFF
--- a/DataRepo/loaders/peak_annotation_files_loader.py
+++ b/DataRepo/loaders/peak_annotation_files_loader.py
@@ -213,7 +213,7 @@ class PeakAnnotationFilesLoader(TableLoader):
                 lc_protocol_name=lc_protocol_name,
                 instrument=instrument,
                 date=date,
-                filename=filename,
+                filename=os.path.basename(filepath),
             )
 
     def get_file_and_format(self, row):

--- a/DataRepo/tests/loaders/base/test_table_loader.py
+++ b/DataRepo/tests/loaders/base/test_table_loader.py
@@ -1621,3 +1621,7 @@ class TableLoaderUtilitiesTests(TracebaseTestCase):
             ]
         )
         self.assertEqual("['one', 'two', 'three']", str(ve))
+
+    def test__get_column_types(self):
+        # TODO: Implement test
+        pass

--- a/DataRepo/tests/loaders/test_peak_annotation_files_loader.py
+++ b/DataRepo/tests/loaders/test_peak_annotation_files_loader.py
@@ -213,13 +213,15 @@ class PeakAnnotationFilesLoaderTests(TracebaseTestCase):
             file="DataRepo/data/tests/small_obob/study.xlsx"
         )
         file = "DataRepo/data/tests/small_obob2/obob_maven_c160_inf.xlsx"
-        row = pd.Series(
-            {
-                PeakAnnotationFilesLoader.DataHeaders.SEQNAME: "Dick, polar-HILIC-25-min, QE2, 1991-5-7"
-            }
-        )
         fmt = "accucor"
-        pafl.load_peak_annotations(row, file, fmt)
+        pafl.load_peak_annotations(
+            file,
+            fmt,
+            operator="Dick",
+            lc_protocol_name="polar-HILIC-25-min",
+            instrument="QE2",
+            date="1991-5-7",
+        )
 
         self.assert_test_peak_annotations_loaded()
 
@@ -286,3 +288,7 @@ class PeakAnnotationFilesLoaderTests(TracebaseTestCase):
         pafl.load_data()
 
         self.assert_test_peak_annotations_loaded()
+
+    def test_get_default_sequence_details(self):
+        # TODO: Implement test
+        pass


### PR DESCRIPTION
## Summary Change Description

This is the second PR split off from #1015.

Various improvements to support the build-a-submission interface.

Details:

- `PeakAnnotationFilesLoader`
  - To support auto-fill of compounds parsed from the peak annotation files without loading, `None` records were included in the compound return from the parsing of the compound column so that the interface could decide whether to use the given string for the peak group name or the primary compound names.
  - Added a `get_default_sequence_details` method split off from `load_peak_annotations` method on the `PeakAnnotationFilesLoader`, so that other code could re-use the parsing code for the sequence name columns loacated in different sheets.
- `TableLoader`
  - Added an option to `TableLoader`'s methods: `check_dataframe_headers` and `check_dataframe_values` to be able to return the status without raising or buffering an error.  This allows us to just read the file without buffering errors or loading anything, which facilitates the autofill-only mode.
  - Added a private class version of `TableLoader`'s `get_column_types` so that files could be read with types without having to build an object just to get the types for the pandas' reading methods.

## Affected Issues/Pull Requests

- Partially addresses #829
- Merges into: #1019
- Next PR: #1021

## Review Notes
<!--
For added context for reviewers, add comments to relevant lines of code.  Use
this space to describe any general areas of concern not linked to a specific
line of code that reviewers should pay particular attention to, e.g. please
make sure I have accounted for all possible inputs.
-->
See comments in-line.

## Checklist
<!--
If any of the checkbox requirements are not met, uncheck them and add an
explanation. E.g. Linting errors pre-date this PR.
-->
This pull request will be merged once the following requirements are met.  The
author and/or reviewers should uncheck any unmet requirements:

- Review requirements
  - Minimum approvals: 1 <!-- Edit as desired (e.g. based on complexity) -->
  - No changes requested
  - All blocking issues resolved by reviewers
  - Specific reviewers: @__add_username_here__
    <!--
    Require reviewers with specific expertise to be included among the minimum
    number of reviewers by tagging them.  Also please send them a message.
    -->
  - Review period: 2 days <!-- Edit as desired (e.g. based on complexity) -->
- Associated issue/pull request requirements:
  <!--
  Assert that all requirements in issues marked "resolved" are done and that
  all required pull requests are merged.  If any are not done, either edit or
  split the issue or explain the unmerged affected pull requests.
  -->
  - [x] All requirements in affected issues marked "resolved" are satisfied
  - [x] All required pull requests are merged *(or none)*
- Basic requirements
  <!--
  Uncheck items to acknowledge failures/conflicts you intend to address.
  Add an explanation if any won't be addressed before merge.
  -->
  - [x] [All linters pass](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#linting)
  - [x] [All tests pass](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#quality-control)
  - [x] All conflicts resolved
- Overhead requirements
  <!--
  These are additional requirements that are not directly associated with
  resolving the affected issue(s).
  -->
  - [x] [New/changed method tests implemented/updated *(or no change)*](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#test-implementation)
  - [ ] [Updated *Unreleased* section of `changelog.md` *(or no change)*](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/changelog.md)
  - [x] [Migrations created & committed *(or no change)*](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#migration-process)
