### PR TITLE
`DataValidationView` (the `Build a Submission` view) Refactor 7 - `StudyLoader`

### DIFF
--- a/DataRepo/loaders/study_loader.py
+++ b/DataRepo/loaders/study_loader.py
@@ -1,6 +1,5 @@
-import traceback
 from collections import namedtuple
-from typing import Dict, List
+from typing import Dict, List, Type
 
 from django.db.models import Model
 
@@ -27,18 +26,21 @@ from DataRepo.models.hier_cached_model import (
 from DataRepo.models.maintained_model import MaintainedModel
 from DataRepo.utils.exceptions import (
     AggregatedErrors,
+    AggregatedErrorsSet,
     AllMissingCompounds,
     AllMissingSamples,
     AllMissingTissues,
     AllMissingTreatments,
     MissingCompounds,
+    MissingRecords,
     MissingSamples,
     MissingTissues,
     MissingTreatments,
     MultiLoadStatus,
     NoSamples,
+    RecordDoesNotExist,
 )
-from DataRepo.utils.file_utils import get_sheet_names, read_from_file
+from DataRepo.utils.file_utils import get_sheet_names, is_excel, read_from_file
 
 
 class StudyLoader(TableLoader):
@@ -146,12 +148,13 @@ class StudyLoader(TableLoader):
                 dry_run (Optional[boolean]) [False]: Dry run mode.
                 defer_rollback (Optional[boolean]) [False]: Defer rollback mode.  DO NOT USE MANUALLY - A PARENT SCRIPT
                     MUST HANDLE THE ROLLBACK.
-                data_sheet (Optional[str]) [None]: Sheet name (for error reporting).
-                defaults_sheet (Optional[str]) [None]: Sheet name (for error reporting).
-                file (Optional[str]) [None]: File name (for error reporting).
+                data_sheet (Optional[str]): Sheet name (for error reporting).
+                defaults_sheet (Optional[str]): Sheet name (for error reporting).
+                file (Optional[str]): File path.
+                filename (Optional[str]): Filename (for error reporting).
                 user_headers (Optional[dict]): Header names by header key.
                 defaults_df (Optional[pandas dataframe]): Default values data from a table-like file.
-                defaults_file (Optional[str]) [None]: Defaults file name (None if the same as infile).
+                defaults_file (Optional[str]): Defaults file name (None if the same as infile).
                 headers (Optional[DefaultsTableHeaders namedtuple]): headers by header key.
                 defaults (Optional[DefaultsTableHeaders namedtuple]): default values by header key.
                 extra_headers (Optional[List[str]]): Use for dynamic headers (different in every file).  To allow any
@@ -161,7 +164,11 @@ class StudyLoader(TableLoader):
                     commits anything, but it also raises warnings as fatal (so they can be reported through the web
                     interface and seen by researchers, among other behaviors specific to non-privileged users).
             Derived (this) class Args:
-                None
+                annot_files_dict (Optional[Dict[str, str]]): This is a dict of peak annotation file paths keyed on peak
+                    annotation file basename.  This is not necessary on the command line.  It is only provided for the
+                    purpose of web forms, where the name of the actual file is a randomized hash string at the end of a
+                    temporary path.  This dict associates the user's readable filename parsed from the infile (the key)
+                    with the actual file (the value).
         Exceptions:
             Raises:
                 AggregatedErrors
@@ -170,6 +177,7 @@ class StudyLoader(TableLoader):
         Returns:
             None
         """
+        # NOTE: self.load_data() requires the file argument to have been provided to this constructor.
         if (
             kwargs.get("df") is not None
             or kwargs.get("defaults_df") is not None
@@ -180,6 +188,23 @@ class StudyLoader(TableLoader):
                 "defaults_df, defer_rollback]."
             )
 
+        self.annot_files_dict = kwargs.pop("annot_files_dict", {})
+
+        self.CustomLoaderKwargs = self.DataTableHeaders(
+            STUDY={},
+            ANIMALS={},
+            SAMPLES={},
+            TREATMENTS={},
+            TISSUES={},
+            INFUSATES={},
+            TRACERS={},
+            COMPOUNDS={},
+            LCPROTOCOLS={},
+            SEQUENCES={},
+            HEADERS={},
+            FILES={"annot_files_dict": self.annot_files_dict},
+        )
+
         super().__init__(*args, **kwargs)
 
         self.missing_sample_record_exceptions = []
@@ -187,7 +212,13 @@ class StudyLoader(TableLoader):
         self.missing_tissue_record_exceptions = []
         self.missing_treatment_record_exceptions = []
         self.missing_compound_record_exceptions = []
-        self.load_statuses = MultiLoadStatus()
+        self.load_statuses = MultiLoadStatus(
+            # Tell the MultiLoadStatus object we're going to try to load these files
+            load_keys=[
+                self.get_friendly_filename(),
+                *list(self.annot_files_dict.keys()),
+            ]
+        )
 
     @MaintainedModel.defer_autoupdates(
         disable_opt_names=["validate", "dry_run"],
@@ -214,16 +245,36 @@ class StudyLoader(TableLoader):
                     f"The [file] argument to {type(self).__name__}() is required."
                 )
             )
+        elif not is_excel(self.file):
+            raise AggregatedErrors().buffer_error(
+                ValueError(
+                    f"'{self.file}' is not an excel file.  StudyLoader's file argument requires excel."
+                )
+            )
 
         file_sheets = get_sheet_names(self.file)
         sheet_names = self.get_sheet_names_tuple()
         loaders = self.Loaders
+
+        if (
+            len(self.annot_files_dict.keys()) > 0
+            and PeakAnnotationFilesLoader.DataSheetName not in file_sheets
+        ):
+            self.buffer_infile_exception(
+                (
+                    f"Peak annotation files [{list(self.annot_files_dict.keys())}] were provided without a "
+                    f"{PeakAnnotationFilesLoader.DataSheetName} sheet in {self.get_friendly_filename()}.  A "
+                    f"{PeakAnnotationFilesLoader.DataSheetName} sheet is required to load peak annotation files."
+                )
+            )
+            raise self.aggregated_errors_object
 
         common_args = {
             "dry_run": self.dry_run,
             "defer_rollback": True,
             "defaults_sheet": self.defaults_sheet,
             "file": self.file,
+            "filename": self.get_friendly_filename(),
             "defaults_file": self.defaults_file,
             "_validate": self.validate,
         }
@@ -242,11 +293,10 @@ class StudyLoader(TableLoader):
         # This cycles through the loaders in the order in which they were defined in the namedtuple
         for loader_key in loaders._fields:
             sheet = getattr(sheet_names, loader_key)
-            loader_class = getattr(loaders, loader_key)
+            loader_class: Type[TableLoader] = getattr(loaders, loader_key)
+            custom_args = getattr(self.CustomLoaderKwargs, loader_key)
 
             if sheet in file_sheets:
-                # Tell the MultiLoadStatus object we're going to try to load this sheet
-                self.load_statuses.init_load(sheet)
 
                 try:
                     # Build the keyword arguments to read_from_file
@@ -260,12 +310,13 @@ class StudyLoader(TableLoader):
                         df=read_from_file(self.file, **rffkwargs),
                         data_sheet=sheet,
                         **common_args,
+                        **custom_args,
                     )
                     # Load its data
                     loader.load_data()
 
                 except Exception as e:
-                    self.package_group_exceptions(e, sheet)
+                    self.package_group_exceptions(e)
 
         enable_caching_updates()
 
@@ -290,7 +341,7 @@ class StudyLoader(TableLoader):
 
         # dry_run and defer_rollback are handled by the load_data wrapper
 
-    def get_loader_class_dtypes(self, loader_class, headers=None):
+    def get_loader_class_dtypes(self, loader_class: Type[TableLoader], headers=None):
         """Retrieve a dtypes dict from the loader_class.
 
         Args:
@@ -301,26 +352,14 @@ class StudyLoader(TableLoader):
         Returns:
             dtypes (dict): Types keyed on header names (not keys)
         """
-        # TODO: Make this support custom headers
-        if (
-            not hasattr(loader_class, "DataColumnTypes")
-            or loader_class.DataColumnTypes is None
-            or len(loader_class.DataColumnTypes.keys()) == 0
-        ):
-            return None
+        if headers is not None:
+            return loader_class._get_column_types(headers)
 
-        if headers is None:
-            # TODO Git rid of (/refactor) the ProtocolsLoader to not use this "DataHeadersExcel" class attribute
-            if hasattr(loader_class, "DataHeadersExcel"):
-                headers = loader_class.DataHeadersExcel
-            else:
-                headers = loader_class.DataHeaders
-        dtypes = {}
+        # TODO Git rid of (/refactor) the ProtocolsLoader to not use this "DataHeadersExcel" class attribute
+        if hasattr(loader_class, "DataHeadersExcel"):
+            return loader_class._get_column_types(loader_class.DataHeadersExcel)
 
-        for key, val in loader_class.DataColumnTypes.items():
-            hdr = getattr(headers, key)
-            dtypes[hdr] = val
-        return dtypes
+        return loader_class._get_column_types()
 
     def get_sheet_names_tuple(self):
         """Retrieve a tuple containing all of the loaders' sheet names.
@@ -338,7 +377,7 @@ class StudyLoader(TableLoader):
         # This class does not take or use a dataframe with headers.  It only takes a file and calls other loaders.
         return self.get_headers()
 
-    def package_group_exceptions(self, exception, sheet):
+    def package_group_exceptions(self, exception):
         """Repackages an exception for consolidated reporting.
 
         Compile group-level errors/warnings relevant specifically to a study load that should be reported in one
@@ -346,7 +385,18 @@ class StudyLoader(TableLoader):
         individual load file statuses from fatal errors to non-fatal warnings.  This is because the consolidated
         representation will be the "fatal error" and the errors in the files will be kept to cross-reference with the
         group level error.  See handle_exceptions.
+
+        Args:
+            exception (Exception)
+        Exceptions:
+            None
+        Returns:
+            None
         """
+        # load_data (from which this is called) requires that self.file is not None, so we're assuming that here.  This
+        # will be used as the load_key in the MultiLoadStatus object - for errors that arise from the file being
+        # directly processed by this loader.  The PeakAnnotationsLoader calls will get their own file load keys.
+        parent_file = self.get_friendly_filename()
 
         # Compile group-level errors/warnings relevant specifically to a study load that should be reported in one
         # consolidated error based on exceptions contained in AggregatedErrors.  Note, this could potentially change
@@ -354,44 +404,63 @@ class StudyLoader(TableLoader):
         # representation will be the "fatal error" and the errors in the files will be kept to cross-reference with the
         # group level error.  See handle_exceptions.
         if isinstance(exception, AggregatedErrors):
-            # Consolidate related cross-file exceptions, like missing samples
-            # Note, this can change whether the AggregatedErrors for this file are fatal or not
 
-            mses = exception.modify_exception_type(
-                MissingSamples, is_fatal=False, is_error=False
-            )
-            for mse in mses:
-                self.missing_sample_record_exceptions.extend(mse.exceptions)
+            self.extract_repeated_exceptions(exception)
+            self.load_statuses.set_load_exception(exception, parent_file)
 
-            nses = exception.modify_exception_type(
-                NoSamples, is_fatal=False, is_error=False
-            )
-            for nse in nses:
-                self.no_sample_record_exceptions.extend(nse.exceptions)
+        elif isinstance(exception, AggregatedErrorsSet):
 
-            mties = exception.modify_exception_type(
-                MissingTissues, is_fatal=False, is_error=False
-            )
-            for mtie in mties:
-                self.missing_tissue_record_exceptions.extend(mtie.exceptions)
+            for load_key, aes in exception.aggregated_errors_dict.items():
+                self.extract_repeated_exceptions(aes)
+                self.load_statuses.set_load_exception(aes, load_key)
 
-            mtres = exception.modify_exception_type(
-                MissingTreatments, is_fatal=False, is_error=False
-            )
-            for mtre in mtres:
-                self.missing_treatment_record_exceptions.extend(mtre.exceptions)
-
-            mces = exception.modify_exception_type(
-                MissingCompounds, is_fatal=False, is_error=False
-            )
-            for mce in mces:
-                self.missing_compound_record_exceptions.extend(mce.exceptions)
         else:
-            # Print the trace
-            print("".join(traceback.format_tb(exception.__traceback__)))
-            print(f"EXCEPTION: {type(exception).__name__}: {str(exception)}")
+            self.load_statuses.set_load_exception(exception, parent_file)
 
-        self.load_statuses.set_load_exception(exception, sheet)
+    def extract_repeated_exceptions(self, aes: AggregatedErrors):
+        """This method takes selected exceptions (currently just missing records of Samples, Tissues,
+        Protocols(/Treatments), and Compounds) and extracts their contained RecordDoesNotExist exceptions and puts them
+        in lists of exceptions to be repackaged later.  The purpose is to consolidate errors about the same missing
+        records that come from multiple different files in order to later collate them.
+
+        Args:
+            aes (AggregatedErrors)
+        Exceptions:
+            None
+        Returns:
+            None
+        """
+        for exc_cls, buffer in [
+            (MissingSamples, self.missing_sample_record_exceptions),
+            (NoSamples, self.no_sample_record_exceptions),
+            (MissingTissues, self.missing_tissue_record_exceptions),
+            (MissingTreatments, self.missing_treatment_record_exceptions),
+            (MissingCompounds, self.missing_compound_record_exceptions),
+        ]:
+            self.extract_missing_records_exception(aes, exc_cls, buffer)
+
+    def extract_missing_records_exception(
+        self,
+        aes: AggregatedErrors,
+        missing_class: Type[MissingRecords],
+        buffer: List[RecordDoesNotExist],
+    ):
+        """This extracts RecordDoesNotExist exceptions from exceptions derived from MissingRecords exceptions.
+
+        Args:
+            aes (AggregatedErrors)
+            missing_class (MissingRecords)
+            buffer (List[RecordDoesNotExist])
+        Exceptions:
+            None
+        Returns:
+            None
+        """
+        mrecs_excs = aes.modify_exception_type(
+            missing_class, is_fatal=False, is_error=False
+        )
+        for mrecs_exc in mrecs_excs:
+            buffer.extend(mrecs_exc.exceptions)
 
     def create_grouped_exceptions(self):
         """

--- a/DataRepo/tests/loaders/test_study_loader.py
+++ b/DataRepo/tests/loaders/test_study_loader.py
@@ -151,34 +151,37 @@ class StudyLoaderTests(TracebaseTestCase):
         aess = ar.exception
 
         # Make sure all the exceptions are categorized correctly per sheet and special category
-        self.assertEqual(7, len(aess.aggregated_errors_dict.keys()))
-        self.assertEqual(1, len(aess.aggregated_errors_dict["Animals"].exceptions))
-        self.assertTrue(
-            aess.aggregated_errors_dict["Animals"].exception_type_exists(
-                MissingTreatments
-            )
-        )
-        self.assertEqual(1, len(aess.aggregated_errors_dict["Samples"].exceptions))
-        self.assertTrue(
-            aess.aggregated_errors_dict["Samples"].exception_type_exists(MissingTissues)
+        self.assertEqual(
+            5,
+            len(aess.aggregated_errors_dict.keys()),
+            msg=f"AES keys: {list(aess.aggregated_errors_dict.keys())}",
         )
         self.assertEqual(
-            1, len(aess.aggregated_errors_dict["Peak Annotation Details"].exceptions)
+            3,
+            len(aess.aggregated_errors_dict["study_missing_data.xlsx"].exceptions),
+            msg=f"Exceptions: {list(aess.aggregated_errors_dict['study_missing_data.xlsx'].get_exception_types())}",
         )
-
-        # TODO: Change this to MissingSamples
         self.assertTrue(
             aess.aggregated_errors_dict[
-                "Peak Annotation Details"
+                "study_missing_data.xlsx"
+            ].exception_type_exists(MissingTreatments)
+        )
+        self.assertTrue(
+            aess.aggregated_errors_dict[
+                "study_missing_data.xlsx"
+            ].exception_type_exists(MissingTissues)
+        )
+        self.assertTrue(
+            aess.aggregated_errors_dict[
+                "study_missing_data.xlsx"
             ].exception_type_exists(MissingRecords)
         )
 
-        # TODO: It would be nice if every file got its own category
         self.assertEqual(
-            1, len(aess.aggregated_errors_dict["Peak Annotation Files"].exceptions)
+            1, len(aess.aggregated_errors_dict["alaglu_cor.xlsx"].exceptions)
         )
         self.assertTrue(
-            aess.aggregated_errors_dict["Peak Annotation Files"].exception_type_exists(
+            aess.aggregated_errors_dict["alaglu_cor.xlsx"].exception_type_exists(
                 NoSamples
             )
         )
@@ -222,10 +225,15 @@ class StudyLoaderTests(TracebaseTestCase):
             RecordDoesNotExist(Compound, {"name": "titanium"})
         ]
         sl.create_grouped_exceptions()
-        self.assertEqual(2, len(sl.load_statuses.statuses.keys()))
+        self.assertEqual(
+            3,
+            len(sl.load_statuses.statuses.keys()),
+            msg=f"Load status keys: {list(sl.load_statuses.statuses.keys())}",
+        )
         self.assertIn(
             "All Samples Exist in the Database", sl.load_statuses.statuses.keys()
         )
         self.assertIn(
             "All Compounds Exist in the Database", sl.load_statuses.statuses.keys()
         )
+        self.assertIn("study_missing_data.xlsx", sl.load_statuses.statuses.keys())


### PR DESCRIPTION
## Summary Change Description

This adds a loader class that does what the old `load_study.py` script did.  The `DataValidationView` will call this instead.

## Affected Issues/Pull Requests

- Partially addresses #829
- Merges into PR #1024
- Next PR: #1026

## Review Notes
<!--
For added context for reviewers, add comments to relevant lines of code.  Use
this space to describe any general areas of concern not linked to a specific
line of code that reviewers should pay particular attention to, e.g. please
make sure I have accounted for all possible inputs.
-->
See comments in-line.

## Checklist
<!--
If any of the checkbox requirements are not met, uncheck them and add an
explanation. E.g. Linting errors pre-date this PR.
-->
This pull request will be merged once the following requirements are met.  The
author and/or reviewers should uncheck any unmet requirements:

- Review requirements
  - Minimum approvals: 1 <!-- Edit as desired (e.g. based on complexity) -->
  - No changes requested
  - All blocking issues resolved by reviewers
  - Specific reviewers: @__add_username_here__
    <!--
    Require reviewers with specific expertise to be included among the minimum
    number of reviewers by tagging them.  Also please send them a message.
    -->
  - Review period: 2 days <!-- Edit as desired (e.g. based on complexity) -->
- Associated issue/pull request requirements:
  <!--
  Assert that all requirements in issues marked "resolved" are done and that
  all required pull requests are merged.  If any are not done, either edit or
  split the issue or explain the unmerged affected pull requests.
  -->
  - [x] All requirements in affected issues marked "resolved" are satisfied
  - [x] All required pull requests are merged *(or none)*
- Basic requirements
  <!--
  Uncheck items to acknowledge failures/conflicts you intend to address.
  Add an explanation if any won't be addressed before merge.
  -->
  - [x] [All linters pass](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#linting)
  - [x] [All tests pass](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#quality-control)
  - [x] All conflicts resolved
- Overhead requirements
  <!--
  These are additional requirements that are not directly associated with
  resolving the affected issue(s).
  -->
  - [x] [New/changed method tests implemented/updated *(or no change)*](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#test-implementation)
  - [ ] [Updated *Unreleased* section of `changelog.md` *(or no change)*](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/changelog.md)
  - [x] [Migrations created & committed *(or no change)*](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#migration-process)
