### PR TITLE
Match underscores in sample headers with dashes in mzXMLs

### DIFF
--- a/DataRepo/management/commands/load_msruns.py
+++ b/DataRepo/management/commands/load_msruns.py
@@ -78,6 +78,16 @@ class Command(LoadTableCommand):
             ),
             required=False,
         )
+        parser.add_argument(
+            "--exact-mode",
+            action="store_true",
+            default=False,
+            help=(
+                f"When the {MSRunsLoader.DataHeaders.MZXMLNAME} column is empty, consider underscores and dashes to be "
+                "equivalent when matching mzXML files with peak annotation file sample headers.  When true, only allow "
+                "exact matches."
+            ),
+        )
 
     def handle(self, *args, **options):
         """Code to run when the command is called from the command line.
@@ -135,5 +145,6 @@ class Command(LoadTableCommand):
             date=options.get("date"),
             lc_protocol_name=options.get("lc_protocol_name"),
             instrument=options.get("instrument"),
+            exact_mode=options.get("exact_mode"),
         )
         self.load_data()

--- a/DataRepo/tests/loaders/test_msruns_loader.py
+++ b/DataRepo/tests/loaders/test_msruns_loader.py
@@ -218,7 +218,7 @@ class MSRunsLoaderTests(TracebaseTestCase):
                     }
                 ],
             },
-            "Br-xz971": {
+            "Br_xz971": {
                 "DataRepo/data/tests/small_obob/small_obob_maven_6eaas_inf_glucose_mzxmls": [
                     {
                         "added": True,
@@ -234,7 +234,7 @@ class MSRunsLoaderTests(TracebaseTestCase):
                     }
                 ],
             },
-            "BAT-xz971": {
+            "BAT_xz971": {
                 "DataRepo/data/tests/small_obob/small_obob_maven_6eaas_inf_glucose_mzxmls": [
                     {
                         "added": False,
@@ -287,7 +287,7 @@ class MSRunsLoaderTests(TracebaseTestCase):
         """
         msrl = MSRunsLoader()
         msrl.mzxml_dict = deepcopy(self.MOCK_MZXML_DICT)
-        msrl.mzxml_dict["BAT-xz971"][
+        msrl.mzxml_dict["BAT_xz971"][
             "DataRepo/data/tests/small_obob/small_obob_maven_6eaas_inf_glucose_mzxmls"
         ][0]["added"] = True
         self.assertFalse(msrl.leftover_mzxml_files_exist())
@@ -430,12 +430,12 @@ class MSRunsLoaderTests(TracebaseTestCase):
         msrl = MSRunsLoader()
         msrl.set_row_index(2)
         msrl.mzxml_dict = deepcopy(self.MOCK_MZXML_DICT)
-        expected = self.MOCK_MZXML_DICT["Br-xz971"][
+        expected = self.MOCK_MZXML_DICT["Br_xz971"][
             "DataRepo/data/tests/small_obob/small_obob_maven_6eaas_inf_glucose_mzxmls"
         ][0]
         mzxml_metadata = msrl.get_matching_mzxml_metadata(
             "mysample",  # Sample name - does not match
-            "Br-xz971",  # Sample header - does match
+            "Br_xz971",  # Sample header - does match
             "Br-xz971.mzXML",  # file name or path
         )
         self.assertDictEqual(expected, mzxml_metadata)
@@ -535,7 +535,7 @@ class MSRunsLoaderTests(TracebaseTestCase):
 
         # Copy the metadata, because the method will modify it
         mzxml_metadata = deepcopy(
-            self.MOCK_MZXML_DICT["BAT-xz971"][
+            self.MOCK_MZXML_DICT["BAT_xz971"][
                 "DataRepo/data/tests/small_obob/small_obob_maven_6eaas_inf_glucose_mzxmls"
             ][0]
         )
@@ -552,7 +552,7 @@ class MSRunsLoaderTests(TracebaseTestCase):
         # Test get
         # Copy the metadata again
         mzxml_metadata2 = deepcopy(
-            self.MOCK_MZXML_DICT["BAT-xz971"][
+            self.MOCK_MZXML_DICT["BAT_xz971"][
                 "DataRepo/data/tests/small_obob/small_obob_maven_6eaas_inf_glucose_mzxmls"
             ][0]
         )
@@ -568,7 +568,7 @@ class MSRunsLoaderTests(TracebaseTestCase):
         msrun_sequence = self.msr.msrun_sequence
         # Copy the metadata, because the method will modify it
         mzxml_metadata = deepcopy(
-            self.MOCK_MZXML_DICT["Br-xz971"][
+            self.MOCK_MZXML_DICT["Br_xz971"][
                 "DataRepo/data/tests/small_obob/small_obob_maven_6eaas_inf_glucose_mzxmls"
             ][0]
         )
@@ -754,7 +754,7 @@ class MSRunsLoaderTests(TracebaseTestCase):
         # Check that the existing placeholder now has the mzXML
         self.assertEqual(
             rec.ms_data_file,
-            self.MOCK_MZXML_DICT["BAT-xz971"][
+            self.MOCK_MZXML_DICT["BAT_xz971"][
                 "DataRepo/data/tests/small_obob/small_obob_maven_6eaas_inf_glucose_mzxmls"
             ][0]["mzaf_record"],
         )
@@ -812,7 +812,7 @@ class MSRunsLoaderTests(TracebaseTestCase):
         # Check that the record has the mzXML
         self.assertEqual(
             rec.ms_data_file,
-            self.MOCK_MZXML_DICT["BAT-xz971"][
+            self.MOCK_MZXML_DICT["BAT_xz971"][
                 "DataRepo/data/tests/small_obob/small_obob_maven_6eaas_inf_glucose_mzxmls"
             ][0]["mzaf_record"],
         )
@@ -867,7 +867,7 @@ class MSRunsLoaderTests(TracebaseTestCase):
         self.assertEqual(self.msr.id, rec.id)
         self.assertEqual(
             rec.ms_data_file,
-            self.MOCK_MZXML_DICT["BAT-xz971"][
+            self.MOCK_MZXML_DICT["BAT_xz971"][
                 "DataRepo/data/tests/small_obob/small_obob_maven_6eaas_inf_glucose_mzxmls"
             ][0]["mzaf_record"],
         )
@@ -899,7 +899,7 @@ class MSRunsLoaderTests(TracebaseTestCase):
         self.pg2.save()
 
         # Create an empty concrete MSRunSample record (i.e. it has an mzXML file and no peak groups link to it)
-        concrete_mzxml_dict = self.MOCK_MZXML_DICT["BAT-xz971"][
+        concrete_mzxml_dict = self.MOCK_MZXML_DICT["BAT_xz971"][
             "DataRepo/data/tests/small_obob/small_obob_maven_6eaas_inf_glucose_mzxmls"
         ][0]
         empty_concrete_rec_dict = {
@@ -943,7 +943,7 @@ class MSRunsLoaderTests(TracebaseTestCase):
         self.assertEqual(self.msr.id, rec.id)
         self.assertEqual(
             rec.ms_data_file,
-            self.MOCK_MZXML_DICT["BAT-xz971"][
+            self.MOCK_MZXML_DICT["BAT_xz971"][
                 "DataRepo/data/tests/small_obob/small_obob_maven_6eaas_inf_glucose_mzxmls"
             ][0]["mzaf_record"],
         )
@@ -975,7 +975,7 @@ class MSRunsLoaderTests(TracebaseTestCase):
         #                 else:
 
         # Create an empty concrete MSRunSample record (i.e. it has an mzXML file and no peak groups link to it)
-        concrete_mzxml_dict = self.MOCK_MZXML_DICT["BAT-xz971"][
+        concrete_mzxml_dict = self.MOCK_MZXML_DICT["BAT_xz971"][
             "DataRepo/data/tests/small_obob/small_obob_maven_6eaas_inf_glucose_mzxmls"
         ][0]
         concrete_rec_dict = {
@@ -1035,7 +1035,7 @@ class MSRunsLoaderTests(TracebaseTestCase):
         self.assertEqual(concrete_rec.id, rec.id)
         self.assertEqual(
             rec.ms_data_file,
-            self.MOCK_MZXML_DICT["BAT-xz971"][
+            self.MOCK_MZXML_DICT["BAT_xz971"][
                 "DataRepo/data/tests/small_obob/small_obob_maven_6eaas_inf_glucose_mzxmls"
             ][0]["mzaf_record"],
         )
@@ -1097,7 +1097,7 @@ class MSRunsLoaderTests(TracebaseTestCase):
         self.assertNotEqual(self.msr.id, rec.id)
         self.assertEqual(
             rec.ms_data_file,
-            self.MOCK_MZXML_DICT["BAT-xz971"][
+            self.MOCK_MZXML_DICT["BAT_xz971"][
                 "DataRepo/data/tests/small_obob/small_obob_maven_6eaas_inf_glucose_mzxmls"
             ][0]["mzaf_record"],
         )
@@ -1135,7 +1135,7 @@ class MSRunsLoaderTests(TracebaseTestCase):
         self.pg2.save()
 
         # Create a concrete MSRunSample record (i.e. it has an mzXML file and no peak groups link to it)
-        concrete_mzxml_dict = self.MOCK_MZXML_DICT["BAT-xz971"][
+        concrete_mzxml_dict = self.MOCK_MZXML_DICT["BAT_xz971"][
             "DataRepo/data/tests/small_obob/small_obob_maven_6eaas_inf_glucose_mzxmls"
         ][0]
         concrete_rec_dict = {
@@ -1178,7 +1178,7 @@ class MSRunsLoaderTests(TracebaseTestCase):
         self.assertNotEqual(self.msr.id, rec.id)
         self.assertEqual(
             rec.ms_data_file,
-            self.MOCK_MZXML_DICT["BAT-xz971"][
+            self.MOCK_MZXML_DICT["BAT_xz971"][
                 "DataRepo/data/tests/small_obob/small_obob_maven_6eaas_inf_glucose_mzxmls"
             ][0]["mzaf_record"],
         )
@@ -1235,7 +1235,7 @@ class MSRunsLoaderTests(TracebaseTestCase):
         self.assertNotEqual(self.msr.id, rec.id)
         self.assertEqual(
             rec.ms_data_file,
-            self.MOCK_MZXML_DICT["BAT-xz971"][
+            self.MOCK_MZXML_DICT["BAT_xz971"][
                 "DataRepo/data/tests/small_obob/small_obob_maven_6eaas_inf_glucose_mzxmls"
             ][0]["mzaf_record"],
         )
@@ -1276,7 +1276,7 @@ class MSRunsLoaderTests(TracebaseTestCase):
         msrl.mzxml_dict = deepcopy(self.MOCK_MZXML_DICT)
 
         # Create a concrete MSRunSample record (i.e. it has an mzXML file and no peak groups link to it)
-        concrete_mzxml_dict = self.MOCK_MZXML_DICT["BAT-xz971"][
+        concrete_mzxml_dict = self.MOCK_MZXML_DICT["BAT_xz971"][
             "DataRepo/data/tests/small_obob/small_obob_maven_6eaas_inf_glucose_mzxmls"
         ][0]
         concrete_rec_dict = {
@@ -1315,7 +1315,7 @@ class MSRunsLoaderTests(TracebaseTestCase):
         self.assertNotEqual(self.msr.id, rec.id)
         self.assertEqual(
             rec.ms_data_file,
-            self.MOCK_MZXML_DICT["BAT-xz971"][
+            self.MOCK_MZXML_DICT["BAT_xz971"][
                 "DataRepo/data/tests/small_obob/small_obob_maven_6eaas_inf_glucose_mzxmls"
             ][0]["mzaf_record"],
         )


### PR DESCRIPTION
## Summary Change Description

This adds the ability for the msruns loader to equate peak annotation sample headers with mzXML file names if they differ by dashes and underscores.

An option to only allow exact matches can revert to the original behavior.

## Affected Issues/Pull Requests

- Resolves #991
- Merges into: #1079
- Next PR: #1081

## Review Notes

I originally branched this off main, but I needed fixes in the outstanding PRs to be able to test using the submission interface.

## Checklist
<!--
If any of the checkbox requirements are not met, uncheck them and add an
explanation. E.g. Linting errors pre-date this PR.
-->
This pull request will be merged once the following requirements are met.  The
author and/or reviewers should uncheck any unmet requirements:

- Review requirements
  - Minimum approvals: 1 <!-- Edit as desired (e.g. based on complexity) -->
  - No changes requested
  - All blocking issues resolved by reviewers
  - Specific reviewers: @__add_username_here__
    <!--
    Require reviewers with specific expertise to be included among the minimum
    number of reviewers by tagging them.  Also please send them a message.
    -->
  - Review period: 2 days <!-- Edit as desired (e.g. based on complexity) -->
- Associated issue/pull request requirements:
  <!--
  Assert that all requirements in issues marked "resolved" are done and that
  all required pull requests are merged.  If any are not done, either edit or
  split the issue or explain the unmerged affected pull requests.
  -->
  - [x] All requirements in affected issues marked "resolved" are satisfied
  - [x] All required pull requests are merged *(or none)*
- Basic requirements
  <!--
  Uncheck items to acknowledge failures/conflicts you intend to address.
  Add an explanation if any won't be addressed before merge.
  -->
  - [x] [All linters pass](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#linting)
  - [x] [All tests pass](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#quality-control)
  - [x] All conflicts resolved
- Overhead requirements
  <!--
  These are additional requirements that are not directly associated with
  resolving the affected issue(s).
  -->
  - [x] [New/changed method tests implemented/updated *(or no change)*](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#test-implementation)
  - [ ] [Updated *Unreleased* section of `changelog.md` *(or no change)*](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/changelog.md)
  - [x] [Migrations created & committed *(or no change)*](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#migration-process)
