### PR TITLE
Changed sample name derivation heuristic from suffix to internal scan labels

### DIFF
--- a/DataRepo/tests/loaders/test_msruns_loader.py
+++ b/DataRepo/tests/loaders/test_msruns_loader.py
@@ -254,21 +254,25 @@ class MSRunsLoaderTests(TracebaseTestCase):
 
         super().setUpTestData()
 
-    def test_guess_sample_name_default(self):
+    def test_guess_sample_name_default_end(self):
         samplename = MSRunsLoader.guess_sample_name("mysample_neg_pos_scan2")
         self.assertEqual("mysample", samplename)
+
+    def test_guess_sample_name_default_middle(self):
+        samplename = MSRunsLoader.guess_sample_name("His-pos-M3-T08-small-intes")
+        self.assertEqual("His-M3-T08-small-intes", samplename)
 
     def test_guess_sample_name_add_custom(self):
         samplename = MSRunsLoader.guess_sample_name(
             "mysample_pos_blah_scan1",
-            suffix_patterns=[r"_blah"],
+            scan_patterns=[r"_blah"],
         )
         self.assertEqual("mysample", samplename)
 
     def test_guess_sample_name_just_custom(self):
         samplename = MSRunsLoader.guess_sample_name(
             "mysample_pos_blah",
-            suffix_patterns=[r"_blah"],
+            scan_patterns=[r"_blah"],
             add_patterns=False,
         )
         self.assertEqual("mysample_pos", samplename)

--- a/DataRepo/tests/loaders/test_msruns_loader.py
+++ b/DataRepo/tests/loaders/test_msruns_loader.py
@@ -265,14 +265,14 @@ class MSRunsLoaderTests(TracebaseTestCase):
     def test_guess_sample_name_add_custom(self):
         samplename = MSRunsLoader.guess_sample_name(
             "mysample_pos_blah_scan1",
-            scan_patterns=[r"_blah"],
+            scan_patterns=[r"blah"],
         )
         self.assertEqual("mysample", samplename)
 
     def test_guess_sample_name_just_custom(self):
         samplename = MSRunsLoader.guess_sample_name(
             "mysample_pos_blah",
-            scan_patterns=[r"_blah"],
+            scan_patterns=[r"blah"],
             add_patterns=False,
         )
         self.assertEqual("mysample_pos", samplename)


### PR DESCRIPTION
## Summary Change Description

When working on the previous 2 PRs, I was testing with this isoautocorr sample data: [col013a_tracebase_studydoc.xlsx](https://github.com/user-attachments/files/16474172/col013a_tracebase_studydoc.xlsx).

The samples use dash delimiters instead of underscores, and the scan labels were in the middle of the sample names, so even though, for example `His-neg-M3-T02-liv` and `His-pos-M3-T02-liv` were from the same sample (and were just different mzXML files), they would be generated as different samples in the database, which we don't want.

This happens because the heuristic used up until now required the scan labels to be suffixes and for the delimiters to be underscores.

This PR updates the heuristic to allow dashes as delimiters and for the scan label to be anywhere inside the sample name/header.

Note though that it does not solve the case where a user has manually created a sample sheet, like the one linked above.  However, this change affect the autofill functionality of the start-a-submission page, so if they start composing their samples sheet using that interface, the sample names will get the heuristic applied.

It's also notable that in that instance (manual creation of the samples sheet - even if they get it right), there will be an issue with matching the sample name to the peak annotation file sample headers.  The previous PR that allows matching of the headers to the mzXML files, despite the difference in underscores versus dashes, does not apply to the matching of database sample names to peak annotation file sample headers.  I will address that in the next PR.

## Affected Issues/Pull Requests

- Resolves no documented issue - see **Summary Change Description** above.
- Merges into PR #1081
- Next PR: #1083

## Review Notes
<!--
For added context for reviewers, add comments to relevant lines of code.  Use
this space to describe any general areas of concern not linked to a specific
line of code that reviewers should pay particular attention to, e.g. please
make sure I have accounted for all possible inputs.
-->
See comments in-line.

## Checklist
<!--
If any of the checkbox requirements are not met, uncheck them and add an
explanation. E.g. Linting errors pre-date this PR.
-->
This pull request will be merged once the following requirements are met.  The
author and/or reviewers should uncheck any unmet requirements:

- Review requirements
  - Minimum approvals: 1 <!-- Edit as desired (e.g. based on complexity) -->
  - No changes requested
  - All blocking issues resolved by reviewers
  - Specific reviewers: @__add_username_here__
    <!--
    Require reviewers with specific expertise to be included among the minimum
    number of reviewers by tagging them.  Also please send them a message.
    -->
  - Review period: 2 days <!-- Edit as desired (e.g. based on complexity) -->
- Associated issue/pull request requirements:
  <!--
  Assert that all requirements in issues marked "resolved" are done and that
  all required pull requests are merged.  If any are not done, either edit or
  split the issue or explain the unmerged affected pull requests.
  -->
  - [x] All requirements in affected issues marked "resolved" are satisfied
  - [x] All required pull requests are merged *(or none)*
- Basic requirements
  <!--
  Uncheck items to acknowledge failures/conflicts you intend to address.
  Add an explanation if any won't be addressed before merge.
  -->
  - [x] [All linters pass](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#linting)
  - [x] [All tests pass](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#quality-control)
  - [x] All conflicts resolved
- Overhead requirements
  <!--
  These are additional requirements that are not directly associated with
  resolving the affected issue(s).
  -->
  - [x] [New/changed method tests implemented/updated *(or no change)*](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#test-implementation)
  - [ ] [Updated *Unreleased* section of `changelog.md` *(or no change)*](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/changelog.md)
  - [x] [Migrations created & committed *(or no change)*](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#migration-process)
