### PR TITLE
Sped up the submission page autofill when numerous compounds are missing

### DIFF
--- a/DataRepo/loaders/peak_annotations_loader.py
+++ b/DataRepo/loaders/peak_annotations_loader.py
@@ -602,11 +602,12 @@ class PeakAnnotationsLoader(ConvertedTableLoader, ABC):
         Returns:
             rec (Compound)
         """
+        rec = None
+        exc = None
+        query = None
         if name in self.compound_lookup.keys():
             rec, exc, query = self.compound_lookup[name]
         else:
-            exc = None
-            query = None
             try:
                 rec = Compound.compound_matching_name_or_synonym(name)
             except (ValidationError, ObjectDoesNotExist) as cmpderr:

--- a/DataRepo/tests/loaders/test_peak_annotations_loader.py
+++ b/DataRepo/tests/loaders/test_peak_annotations_loader.py
@@ -392,7 +392,7 @@ class PeakAnnotationsLoaderTests(DerivedPeakAnnotationsLoaderTestCase):
         )
         row = pd.Series({AccucorLoader.DataHeaders.COMPOUND: "isocitrate/citrate"})
         al = AccucorLoader()
-        pgname, recs = al.get_peak_group_name_and_compounds(row)
+        pgname, recs = al.get_peak_group_name_and_compounds(row=row)
         self.assertEqual("citrate/isocitrate", pgname)
         self.assertEqual([cit, iso], recs)
 
@@ -401,7 +401,7 @@ class PeakAnnotationsLoaderTests(DerivedPeakAnnotationsLoaderTestCase):
         CompoundSynonym.objects.create(name="ser", compound=self.SERINE)
         row = pd.Series({AccucorLoader.DataHeaders.COMPOUND: "ser"})
         al = AccucorLoader()
-        pgname, recs = al.get_peak_group_name_and_compounds(row)
+        pgname, recs = al.get_peak_group_name_and_compounds(row=row)
         self.assertEqual("Serine", pgname)
         self.assertEqual([self.SERINE], recs)
 


### PR DESCRIPTION
## Summary Change Description

Made dramatic running time improvements to the autofill-only mode of the build-a-submission page (when numerous compounds don't exist in the database).

It turns out that there were a number of aspects of the code that, when these combined changes are implemented, there is a dramatic improvement to data-specific lag (e.g. when there are numerous repeated lookups of missing compounds).

One thing I learned during this effort is that pandas' `iterrows` method is very slow.  So when the peak annotations file is large (many samples and many compounds), the unicorr format has the drawback that it hits pandas' iterrows pretty hard.  The time that pandas spends instantiating pd.Series objects becomes rather large.  I had initially just mimicked existing code when I utilized iterrows, so I imagine that a future refactor could address the iterrows usage later more holistically.

Combine that with the fact that `Compound.compound_matching_name_or_synonym` has a worst-case running time when the compound is not found, so when the peak annotations file has numerous not-before-loaded compounds, that method also hits the overall running time pretty hard.

Lastly, you get a not insignificant running time hit when the `PeakAnnotationsLoader` buffers all those excessive exceptions.  For the purposes of the autofill-only mode, we don't need those exceptions.  We only need them in validation mode, so I did 2 things to address this aspect:

1. Skip compounds we've seen before (so not failed lookup or exception occurs.
2. Added an argument to the methods involved to turn off error buffering.

It's probably not necessary to skip the exception buffering given the skipping of already seen compound strings, but it did improve running time a noticeable amount.

It's also notable that, after the autofill step, the user will likely fill in the missing information in the Compounds sheet, so even if we buffer errors in the validation step, there shouldn't be (as many) missing compounds, so the problem should mostly go away at validation anyway.  Besides, in the validation step, we're only going to validate the study doc, so we won't be hitting these repeated exceptions anyway in the PeakAnnotationsLoader, so even if they don't fill the compounds sheet in, we won't hit this lag in the validation step.

I also added a debug print that prints the compounds added to the compounds sheet.

The files which demonstrate the slowness are:

- [col013a_negative_cor.xlsx](https://github.com/user-attachments/files/16480769/col013a_negative_cor.xlsx)
- [col013a_pos-highmz_cor.xlsx](https://github.com/user-attachments/files/16480771/col013a_pos-highmz_cor.xlsx)

Combined, they now get processed in about 30 seconds, and the vast majority of that is simply reading the files (now).

## Affected Issues/Pull Requests

- Resolves no documented issue.  See the **Summary Change Description** above)
- Merges into PR #1083
- Next PR: #1085

## Review Notes
<!--
For added context for reviewers, add comments to relevant lines of code.  Use
this space to describe any general areas of concern not linked to a specific
line of code that reviewers should pay particular attention to, e.g. please
make sure I have accounted for all possible inputs.
-->
See comments in-line.

## Checklist
<!--
If any of the checkbox requirements are not met, uncheck them and add an
explanation. E.g. Linting errors pre-date this PR.
-->
This pull request will be merged once the following requirements are met.  The
author and/or reviewers should uncheck any unmet requirements:

- Review requirements
  - Minimum approvals: 1 <!-- Edit as desired (e.g. based on complexity) -->
  - No changes requested
  - All blocking issues resolved by reviewers
  - Specific reviewers: @__add_username_here__
    <!--
    Require reviewers with specific expertise to be included among the minimum
    number of reviewers by tagging them.  Also please send them a message.
    -->
  - Review period: 2 days <!-- Edit as desired (e.g. based on complexity) -->
- Associated issue/pull request requirements:
  <!--
  Assert that all requirements in issues marked "resolved" are done and that
  all required pull requests are merged.  If any are not done, either edit or
  split the issue or explain the unmerged affected pull requests.
  -->
  - [x] All requirements in affected issues marked "resolved" are satisfied
  - [x] All required pull requests are merged *(or none)*
- Basic requirements
  <!--
  Uncheck items to acknowledge failures/conflicts you intend to address.
  Add an explanation if any won't be addressed before merge.
  -->
  - [x] [All linters pass](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#linting)
  - [x] [All tests pass](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#quality-control)
  - [x] All conflicts resolved
- Overhead requirements
  <!--
  These are additional requirements that are not directly associated with
  resolving the affected issue(s).
  -->
  - [x] [New/changed method tests implemented/updated *(or no change)*](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#test-implementation)
  - [ ] [Updated *Unreleased* section of `changelog.md` *(or no change)*](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/changelog.md)
  - [x] [Migrations created & committed *(or no change)*](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#migration-process)
