### PR TITLE
Fixed download limit of 200 on the compounds page

### DIFF
--- a/DataRepo/formats/dataformat_group.py
+++ b/DataRepo/formats/dataformat_group.py
@@ -774,6 +774,15 @@ class FormatGroup:
             )
         return qry_list
 
+    def getDownloadQry(self, format):
+        """Returns a dict where the keys are name and json and the values are the format name and the json-stringified
+        qry object with the target format selected.
+        """
+        root_group = self.getRootGroup(format)
+        name = root_group["searches"][format]["name"]
+        qry = {"name": name, "json": json.dumps(root_group)}
+        return qry
+
     def createNewBasicQuery(
         self, mdl, fld, cmp, val, fmt, units="identity", search_again=True
     ):

--- a/DataRepo/templates/DataRepo/compound_list.html
+++ b/DataRepo/templates/DataRepo/compound_list.html
@@ -1,12 +1,49 @@
 {% extends "base.html" %}
 {% load customtags %}
 
+{% block head_extras %}
+    <!-- This adds a custom download button to the bootstrap-table toolbar.  It uses the custom_download form in the template below.  It is based on:
+        https://live.bootstrap-table.com/code/UtechtDustin/4195
+        https://github.com/wenzhixin/bootstrap-table/pull/5227
+        https://github.com/wenzhixin/bootstrap-table/issues/5208
+    And is a solution for:
+        https://github.com/Princeton-LSI-ResearchComputing/tracebase/issues/1038
+    -->
+    <script>
+        function buttonsFunction() {
+            return {
+                btnCustomDownload: {
+                    'text': 'btnCustomDownload',
+                    'icon': 'bi-download',
+                    'event': function customDownloadButton () {
+                        var myform = document.getElementById("custom_download")
+                        myform.submit();
+                    },
+                    'attributes': {
+                        "title": "All Compound Data",
+                        "data-test": "btnCustomDownload"
+                    }
+                }
+            }
+        }
+    </script>
+{% endblock %}
+
 {% block title %}Compounds{% endblock %}
 
 {% block content %}
 <div>
     <h4>List of Compounds</h4>
     {% if df %}
+    <!-- This renders a download button that always downloads all compound data (regardless of what is displayed in the table from the search) -->
+    <div style="float: right;">
+        {% getDownloadQry "cptemplate" as qry %}
+        <form action="/DataRepo/search_advanced_tsv/" id="custom_download" method="POST">
+            {% csrf_token %}
+            <input type="hidden" name="qryjson" value="{{ qry.json }}">
+            <button type="submit" style="display: none;"></button>
+        </form>
+    </div>
     <table class="table table-sm table-hover table-bordered table-responsive-xl table-striped"
         id="comp_tracer_list"
         data-toggle="table"
@@ -20,8 +57,7 @@
         data-show-columns="true"
         data-show-columns-toggle-all="true"
         data-show-fullscreen="true"
-        data-show-export="true"
-        data-export-types="['csv', 'txt', 'excel']"
+        data-buttons="buttonsFunction"
         data-height="1200"
         data-virtual-scroll="true"
         data-pagination="true"

--- a/DataRepo/templatetags/customtags.py
+++ b/DataRepo/templatetags/customtags.py
@@ -113,6 +113,12 @@ def getDownloadQrys():
 
 
 @register.simple_tag
+def getDownloadQry(format):
+    basv = SearchGroup()
+    return basv.getDownloadQry(format)
+
+
+@register.simple_tag
 def obj_hyperlink(id_name_list, obj, newline=False):
     """
     returns a comma-separated list of hyperlinks.


### PR DESCRIPTION
## Summary Change Description

This  fixes the download limit of 200 rows by replacing the bootstrap download button with a custom button.  I figured out how to do it inside the bootstrap toolbar itself.  Only tsv is supported.  See the discussion in the comments in the issue for details on the problem and the fix.

This still needs to be done for every template.  It represents just over a day's work, so if we want to go a different route, that's fine with me.

Details:

- Added a new template tag: `getDownloadQry`
- Added a download form and javascript to trigger it in the compound list page.
- Removed the export attributes and added a data-buttons attribute to put the custom button in the bootstrap toolbar.
- Added a method to `FormatGroup`: `getDownloadQry` that takes a format name and returns a dict with the download name and the root qry object.

## Affected Issues/Pull Requests

- Partially addresses #1038
- Merges into PR #1154

## Review Notes
<!--
For added context for reviewers, add comments to relevant lines of code.  Use
this space to describe any general areas of concern not linked to a specific
line of code that reviewers should pay particular attention to, e.g. please
make sure I have accounted for all possible inputs.
-->
See comments in-line.

## Checklist
<!--
If any of the checkbox requirements are not met, uncheck them and add an
explanation. E.g. Linting errors pre-date this PR.
-->
This pull request will be merged once the following requirements are met.  The
author and/or reviewers should uncheck any unmet requirements:

- Review requirements
  - Minimum approvals: 1 <!-- Edit as desired (e.g. based on complexity) -->
  - No changes requested
  - All blocking issues resolved by reviewers
  - Specific reviewers: @__add_username_here__
    <!--
    Require reviewers with specific expertise to be included among the minimum
    number of reviewers by tagging them.  Also please send them a message.
    -->
  - Review period: 2 days <!-- Edit as desired (e.g. based on complexity) -->
- Associated issue/pull request requirements:
  <!--
  Assert that all requirements in issues marked "resolved" are done and that
  all required pull requests are merged.  If any are not done, either edit or
  split the issue or explain the unmerged affected pull requests.
  -->
  - [x] All requirements in affected issues marked "resolved" are satisfied
  - [x] All required pull requests are merged *(or none)*
- Basic requirements
  <!--
  Uncheck items to acknowledge failures/conflicts you intend to address.
  Add an explanation if any won't be addressed before merge.
  -->
  - [x] [All linters pass](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#linting)
  - [x] [All tests pass](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#quality-control)
  - [x] All conflicts resolved
- Overhead requirements
  <!--
  These are additional requirements that are not directly associated with
  resolving the affected issue(s).
  -->
  - [x] [New/changed method tests implemented/updated *(or no change)*](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#test-implementation)
  - [ ] [Updated *Unreleased* section of `changelog.md` *(or no change)*](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/changelog.md)
  - [x] [Migrations created & committed *(or no change)*](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#migration-process)
