### PR TITLE
Archive cleanup exception fix

### DIFF
--- a/DataRepo/loaders/msruns_loader.py
+++ b/DataRepo/loaders/msruns_loader.py
@@ -1763,7 +1763,6 @@ class MSRunsLoader(TableLoader):
         Exceptions:
             Buffers:
                 NotImplementedError
-                ProgrammingError
                 OSError
             Raises:
                 None

--- a/DataRepo/loaders/msruns_loader.py
+++ b/DataRepo/loaders/msruns_loader.py
@@ -1790,6 +1790,7 @@ class MSRunsLoader(TableLoader):
 
             try:
                 os.remove(rec.file_location.path)
+                print(f"DELETED (due to rollback): {rec.file_location.path}")
                 deleted += 1
             except Exception as e:
                 self.aggregated_errors_object.buffer_error(

--- a/DataRepo/loaders/msruns_loader.py
+++ b/DataRepo/loaders/msruns_loader.py
@@ -5,9 +5,8 @@ from pathlib import Path
 from typing import Dict, Optional
 
 import xmltodict
-from django.db import ProgrammingError, transaction
+from django.db import transaction
 from django.db.models import Max, Min, Q
-from django.forms import model_to_dict
 
 from DataRepo.loaders.base.table_column import ColumnReference, TableColumn
 from DataRepo.loaders.base.table_loader import TableLoader
@@ -28,7 +27,7 @@ from DataRepo.models.hier_cached_model import (
     disable_caching_updates,
     enable_caching_updates,
 )
-from DataRepo.models.utilities import exists_in_db, update_rec
+from DataRepo.models.utilities import update_rec
 from DataRepo.utils.exceptions import (
     AggregatedErrors,
     InfileError,
@@ -1789,27 +1788,18 @@ class MSRunsLoader(TableLoader):
                 skipped += 1
                 continue
 
-            # To be extra safe, we will confirm that the record does not exist in the database before deleting
-            if exists_in_db(rec):
+            try:
+                os.remove(rec.file_location.path)
+                deleted += 1
+            except Exception as e:
                 self.aggregated_errors_object.buffer_error(
-                    ProgrammingError(
-                        f"Cannot delete a file [{rec.file_location.path}] from the os that is associated with "
-                        f"existing {ArchiveFile.__name__} database record: {model_to_dict(rec)}."
-                    )
+                    OSError(
+                        f"Unable to delete created mzXML archive file: [{rec.file_location.path}] during "
+                        f"rollback due to {type(e).__name__}: {e}"
+                    ),
+                    orig_exception=e,
                 )
-            else:
-                try:
-                    os.remove(rec.file_location.path)
-                    deleted += 1
-                except Exception as e:
-                    self.aggregated_errors_object.buffer_error(
-                        OSError(
-                            f"Unable to delete created mzXML archive file: [{rec.file_location.path}] during "
-                            f"rollback due to {type(e).__name__}: {e}"
-                        ),
-                        orig_exception=e,
-                    )
-                    failures += 1
+                failures += 1
 
         print(
             f"mzXML file rollback disk archive clean up stats: {deleted} deleted, {failures} failed to be deleted, and "


### PR DESCRIPTION
## Summary Change Description

Removed circular conditional logic that was preventing clean-up of created archive files upon exception.

## Affected Issues/Pull Requests

- Resolves #990
- Merges into main

## Review Notes
<!--
For added context for reviewers, add comments to relevant lines of code.  Use
this space to describe any general areas of concern not linked to a specific
line of code that reviewers should pay particular attention to, e.g. please
make sure I have accounted for all possible inputs.
-->
See comments in-line.

## Checklist
<!--
If any of the checkbox requirements are not met, uncheck them and add an
explanation. E.g. Linting errors pre-date this PR.
-->
This pull request will be merged once the following requirements are met.  The
author and/or reviewers should uncheck any unmet requirements:

- Review requirements
  - Minimum approvals: 1 <!-- Edit as desired (e.g. based on complexity) -->
  - No changes requested
  - All blocking issues resolved by reviewers
  - Specific reviewers: @__add_username_here__
    <!--
    Require reviewers with specific expertise to be included among the minimum
    number of reviewers by tagging them.  Also please send them a message.
    -->
  - Review period: 2 days <!-- Edit as desired (e.g. based on complexity) -->
- Associated issue/pull request requirements:
  <!--
  Assert that all requirements in issues marked "resolved" are done and that
  all required pull requests are merged.  If any are not done, either edit or
  split the issue or explain the unmerged affected pull requests.
  -->
  - [x] All requirements in affected issues marked "resolved" are satisfied
  - [x] All required pull requests are merged *(or none)*
- Basic requirements
  <!--
  Uncheck items to acknowledge failures/conflicts you intend to address.
  Add an explanation if any won't be addressed before merge.
  -->
  - [x] [All linters pass](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#linting)
  - [x] [All tests pass](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#quality-control)
  - [x] All conflicts resolved
- Overhead requirements
  <!--
  These are additional requirements that are not directly associated with
  resolving the affected issue(s).
  -->
  - [x] [New/changed method tests implemented/updated *(or no change)*](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#test-implementation)
  - [ ] [Updated *Unreleased* section of `changelog.md` *(or no change)*](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/changelog.md)
  - [x] [Migrations created & committed *(or no change)*](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#migration-process)
