### PR TITLE
Fixed an uncaught exception on the validate page

### DIFF
--- a/DataRepo/loaders/msruns_loader.py
+++ b/DataRepo/loaders/msruns_loader.py
@@ -773,6 +773,10 @@ class MSRunsLoader(TableLoader):
                 else False
             )
 
+            if self.is_skip_row():
+                self.skipped(MSRunSample.__name__)
+                return rec, created, updated
+
             if skip is True:
                 self.skipped(MSRunSample.__name__)
                 mzxml_dir, mzxml_filename = os.path.split(mzxml_path)
@@ -801,7 +805,7 @@ class MSRunsLoader(TableLoader):
                     )
                     self.warned(MSRunSample.__name__)
 
-            if sample is None or msrun_sequence is None or self.is_skip_row():
+            if sample is None or msrun_sequence is None:
                 self.skipped(MSRunSample.__name__)
                 return rec, created, updated
 

--- a/DataRepo/loaders/msruns_loader.py
+++ b/DataRepo/loaders/msruns_loader.py
@@ -779,9 +779,16 @@ class MSRunsLoader(TableLoader):
 
             if skip is True:
                 self.skipped(MSRunSample.__name__)
-                mzxml_dir, mzxml_filename = os.path.split(mzxml_path)
-                mzxml_name = self.get_sample_header_from_mzxml_name(mzxml_filename)
-                self.skip_msrunsample_by_mzxml[mzxml_name][mzxml_dir] = True
+                if mzxml_path is not None:
+                    mzxml_dir, mzxml_filename = os.path.split(mzxml_path)
+                    mzxml_name = self.get_sample_header_from_mzxml_name(mzxml_filename)
+                    self.skip_msrunsample_by_mzxml[mzxml_name][mzxml_dir] = True
+                else:
+                    # If there happen to be mzXMLs supplied, but not in the mzXML column, add the sample header to cause
+                    # the skip (fingers crossed, there's not some difference - but we can't necessarily know that).
+                    # TODO: Account for the dash/underscore issue here.  Isocorr changes dashes in the mzXML name to
+                    # underscores, and we haven't accounted for that here...
+                    self.skip_msrunsample_by_mzxml[sample_header][""] = True
                 return rec, created, updated
 
             sample = self.get_sample_by_name(sample_name)

--- a/DataRepo/loaders/study_loader.py
+++ b/DataRepo/loaders/study_loader.py
@@ -732,7 +732,7 @@ class StudyLoader(ConvertedTableLoader, ABC):
             (
                 AllMissingSamples,
                 self.no_sample_record_exceptions,
-                "Peak Annotation Files Check",
+                "Peak Annotation Samples Check",
                 True,
             ),
             (

--- a/DataRepo/tests/loaders/test_study_loader.py
+++ b/DataRepo/tests/loaders/test_study_loader.py
@@ -206,11 +206,13 @@ class StudyLoaderTests(TracebaseTestCase):
 
         self.assertEqual(
             1,
-            len(aess.aggregated_errors_dict["Peak Annotation Files Check"].exceptions),
+            len(
+                aess.aggregated_errors_dict["Peak Annotation Samples Check"].exceptions
+            ),
         )
         self.assertTrue(
             aess.aggregated_errors_dict[
-                "Peak Annotation Files Check"
+                "Peak Annotation Samples Check"
             ].exception_type_exists(AllMissingSamples)
         )
 

--- a/DataRepo/tests/views/upload/test_submission.py
+++ b/DataRepo/tests/views/upload/test_submission.py
@@ -797,7 +797,7 @@ class DataValidationViewTests1(TracebaseTransactionTestCase):
         # Obtain a DataValidationView object containing errors
         vo = self.get_data_validation_object_with_errors()
         # Create the dfs_dict (to which data will be added)
-        vo.dfs_dict = vo.create_study_dfs_dict()
+        vo.dfs_dict = vo.create_or_repair_study_dfs_dict()
         # Extract the errors into the autofill_dict (in the object)
         vo.extract_autofill_from_exceptions()
 
@@ -1354,7 +1354,7 @@ class DataValidationViewTests2(TracebaseTransactionTestCase):
         self.assertTrue(exceptions[afkey][1]["is_error"])
 
         # All samples in sample table combined error
-        groupkey = "Peak Annotation Files Check"
+        groupkey = "Peak Annotation Samples Check"
         self.assertTrue(groupkey in results)
         self.assertEqual("FAILED", results[groupkey])
 

--- a/DataRepo/views/upload/submission.py
+++ b/DataRepo/views/upload/submission.py
@@ -231,7 +231,7 @@ class DataValidationView(FormView):
 
         self.output_study_filename = "study.xlsx"
         self.autofill_only_mode = True
-        self.dfs_dict = self.create_study_dfs_dict()
+        self.dfs_dict = self.create_or_repair_study_dfs_dict()
         self.init_row_group_nums()
         self.study_file = None
         self.study_filename = None
@@ -2232,22 +2232,24 @@ class DataValidationView(FormView):
             dict of dicts: dataframes-style dicts dict keyed on sheet name
         """
         if self.study_file is None:
-            return self.create_study_dfs_dict()
+            return self.create_or_repair_study_dfs_dict()
         dfs_dict = self.get_study_dfs_dict()
         # If there was a conversion issue, the dfs_dict will be empty
         if dfs_dict is None or len(dfs_dict.keys()) == 0:
             # There will have been an exception buffered, so let's just fall back to a default template for them to use
-            return self.create_study_dfs_dict()
-        return dfs_dict
+            return self.create_or_repair_study_dfs_dict()
+        # This fills in missing sheets and columns
+        return self.create_or_repair_study_dfs_dict(dfs_dict)
 
-    def create_study_dfs_dict(self, dfs_dict: Optional[Dict[str, dict]] = None):
+    def create_or_repair_study_dfs_dict(
+        self, dfs_dict: Optional[Dict[str, dict]] = None
+    ):
         """Create dataframe template dicts for each sheet in self.animal_sample_file as a dict keyed on sheet.
 
         Treatments and tissues dataframes are populated using all of the data in the database for their models.
         Animals and Samples dataframes are not populated.
 
-        In neither case, is missing data attempted to be auto-filled by this method.  Nor are unrecognized sheets or
-        columns removed.
+        Missing data is not attempted to be auto-filled by this method.  Nor are unrecognized sheets or columns removed.
 
         Args:
             dfs_dict (dict of dicts): Supply this if you want to "fill in" missing sheets only.
@@ -2501,8 +2503,9 @@ class DataValidationView(FormView):
             for k, v in dict_of_dataframes.items():
                 dfs_dict[k] = v.to_dict()
 
-            # create_study_dfs_dict, if given a dict, will fill in any missing sheets and columns with empty row values
-            self.create_study_dfs_dict(dfs_dict=dfs_dict)
+            # create_or_repair_study_dfs_dict, if given a dict, will fill in any missing sheets and columns with empty
+            # row values
+            self.create_or_repair_study_dfs_dict(dfs_dict=dfs_dict)
         except (
             InvalidStudyDocVersion,
             UnknownStudyDocVersion,
@@ -2663,11 +2666,6 @@ class DataValidationView(FormView):
         Returns:
             xlsx_writer (xlsxwriter)
         """
-        if not self.dfs_dict_is_valid():
-            raise ValueError(
-                "Cannot call create_study_file_writer when dfs_dict is not valid/created."
-            )
-
         xlsx_writer = pd.ExcelWriter(  # pylint: disable=abstract-class-instantiated
             stream_obj, engine="xlsxwriter"
         )
@@ -2775,13 +2773,12 @@ class DataValidationView(FormView):
         Returns:
             valid (boolean)
         """
-        if self.dfs_dict is None or set(
-            [
-                s[0]
-                for s in StudyLoader.get_study_sheet_column_display_order()
-                if s[0] in self.dfs_dict.keys()
-            ]
-        ) < set(self.build_sheets):
+        existing_sheets = [
+            s[0]
+            for s in StudyLoader.get_study_sheet_column_display_order()
+            if s[0] in self.dfs_dict.keys()
+        ]
+        if self.dfs_dict is None or set(existing_sheets) < set(self.build_sheets):
             return False
 
         return (


### PR DESCRIPTION
## Summary Change Description

Fixed an uncaught exception on the validate page when an invalid study doc is submitted.

It turned out that I had overlooked the removal of one of the `dfs_dict_is_valid` calls.  It could be that the existing call was (re-)introduced by a maerge, but regardless, the validation is not handled by the study_loader, which buffers errors about missing or unexpected columns.

I also neglected to call `create_study_dfs_dict` and supply it the dict derived from the uploaded file.  It has the ability to add missing sheets and columns, and when I created the validate page (and the start page), I had made changes to statically set the mode (autofill or validate), and in doing so, I should have realized that in validate mode, I needed to call that method.  I renamed the method to `create_or_repair_study_dfs_dict` to make it clearer.

I also made a couple other fixes.

Details:

- Tweaked some doc strings.
- Newer linters made some linting changes.
- Changed the check heading "Peak Annotation Files Check" to "Peak Annotation Samples Check" to make it clear that it's not the same as checking the "Peak Annotation Files" sheet.
- Made a minor fix to the `MSRunsLoader` to avoid errors associated with `NoneType` on skip rows.

## Affected Issues/Pull Requests

- Resolves #1173
- Merges into main

## Review Notes
<!--
For added context for reviewers, add comments to relevant lines of code.  Use
this space to describe any general areas of concern not linked to a specific
line of code that reviewers should pay particular attention to, e.g. please
make sure I have accounted for all possible inputs.
-->
See comments in-line.

## Checklist
<!--
If any of the checkbox requirements are not met, uncheck them and add an
explanation. E.g. Linting errors pre-date this PR.
-->
This pull request will be merged once the following requirements are met.  The
author and/or reviewers should uncheck any unmet requirements:

- Review requirements
  - Minimum approvals: 1 <!-- Edit as desired (e.g. based on complexity) -->
  - No changes requested
  - All blocking issues resolved by reviewers
  - Specific reviewers: @__add_username_here__
    <!--
    Require reviewers with specific expertise to be included among the minimum
    number of reviewers by tagging them.  Also please send them a message.
    -->
  - Review period: 2 days <!-- Edit as desired (e.g. based on complexity) -->
- Associated issue/pull request requirements:
  <!--
  Assert that all requirements in issues marked "resolved" are done and that
  all required pull requests are merged.  If any are not done, either edit or
  split the issue or explain the unmerged affected pull requests.
  -->
  - [x] All requirements in affected issues marked "resolved" are satisfied
  - [x] All required pull requests are merged *(or none)*
- Basic requirements
  <!--
  Uncheck items to acknowledge failures/conflicts you intend to address.
  Add an explanation if any won't be addressed before merge.
  -->
  - [x] [All linters pass](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#linting)
  - [x] [All tests pass](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#quality-control)
  - [x] All conflicts resolved
- Overhead requirements
  <!--
  These are additional requirements that are not directly associated with
  resolving the affected issue(s).
  -->
  - [x] [New/changed method tests implemented/updated *(or no change)*](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#test-implementation)
  - [ ] [Updated *Unreleased* section of `changelog.md` *(or no change)*](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/changelog.md)
  - [x] [Migrations created & committed *(or no change)*](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#migration-process)
