### PR TITLE
Suppress errors about missing peak annotation files during study-doc only validation

### DIFF
--- a/DataRepo/views/upload/submission.py
+++ b/DataRepo/views/upload/submission.py
@@ -55,6 +55,7 @@ from DataRepo.utils.exceptions import (
     AllMissingTissues,
     AllMissingTreatments,
     DuplicatePeakAnnotationFileName,
+    FileFromInputNotFound,
     InvalidPeakAnnotationFileFormat,
     InvalidStudyDocVersion,
     MissingDataAdded,
@@ -2639,6 +2640,12 @@ class DataValidationView(FormView):
             )
         except MultiLoadStatus as mls:
             load_status_data = mls
+
+        # Remove exceptions about missing peak annotation files when the peak annotation files were not submitted
+        if len(self.annot_files_dict.keys()) == 0:
+            load_status_data.remove_exception_type(
+                self.study_filename, FileFromInputNotFound
+            )
 
         self.load_status_data = load_status_data
 


### PR DESCRIPTION
## Summary Change Description

Suppressed errors about missing peak annotation files when validating only the study doc.

You can test with [MASTER STUDY DOC FOR TRACEBASE_exp011b3_240816.xlsx](https://github.com/user-attachments/files/16662101/MASTER.STUDY.DOC.FOR.TRACEBASE_exp011b3_240816.xlsx).  It produces lots of errors, but `FileFromInputNotFound` is no longer one of them.

## Affected Issues/Pull Requests

- Resolves #1169
- Merges into main

## Review Notes
<!--
For added context for reviewers, add comments to relevant lines of code.  Use
this space to describe any general areas of concern not linked to a specific
line of code that reviewers should pay particular attention to, e.g. please
make sure I have accounted for all possible inputs.
-->
See comments in-line.

## Checklist
<!--
If any of the checkbox requirements are not met, uncheck them and add an
explanation. E.g. Linting errors pre-date this PR.
-->
This pull request will be merged once the following requirements are met.  The
author and/or reviewers should uncheck any unmet requirements:

- Review requirements
  - Minimum approvals: 1 <!-- Edit as desired (e.g. based on complexity) -->
  - No changes requested
  - All blocking issues resolved by reviewers
  - Specific reviewers: @__add_username_here__
    <!--
    Require reviewers with specific expertise to be included among the minimum
    number of reviewers by tagging them.  Also please send them a message.
    -->
  - Review period: 2 days <!-- Edit as desired (e.g. based on complexity) -->
- Associated issue/pull request requirements:
  <!--
  Assert that all requirements in issues marked "resolved" are done and that
  all required pull requests are merged.  If any are not done, either edit or
  split the issue or explain the unmerged affected pull requests.
  -->
  - [x] All requirements in affected issues marked "resolved" are satisfied
  - [x] All required pull requests are merged *(or none)*
- Basic requirements
  <!--
  Uncheck items to acknowledge failures/conflicts you intend to address.
  Add an explanation if any won't be addressed before merge.
  -->
  - [x] [All linters pass](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#linting)
  - [x] [All tests pass](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#quality-control)
  - [x] All conflicts resolved
- Overhead requirements
  <!--
  These are additional requirements that are not directly associated with
  resolving the affected issue(s).
  -->
  - [x] [New/changed method tests implemented/updated *(or no change)*](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#test-implementation)
  - [ ] [Updated *Unreleased* section of `changelog.md` *(or no change)*](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/changelog.md)
  - [x] [Migrations created & committed *(or no change)*](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#migration-process)
