### PR TITLE
Added compounds with matching formulas to the Compounds autofill

### DIFF
--- a/DataRepo/views/upload/submission.py
+++ b/DataRepo/views/upload/submission.py
@@ -5,6 +5,7 @@ from collections import defaultdict
 from io import BytesIO
 from typing import Dict, Optional, Type
 
+import numpy as np
 import pandas as pd
 import xlsxwriter
 import xlsxwriter.worksheet
@@ -1567,6 +1568,25 @@ class DataValidationView(FormView):
                         CompoundsLoader.DataHeaders.NAME: compound_name,
                         CompoundsLoader.DataHeaders.FORMULA: formula,
                     }
+
+            print("EXTRACTING AND INCLUDING ALL COMPOUNDS WITH MATCHING FORMULAS")
+            for formula in np.unique(formulas):
+                if formula in self.none_vals:
+                    continue
+                for compound_rec in Compound.objects.filter(formula__iexact=formula):
+                    if (
+                        compound_rec.name
+                        not in self.autofill_dict[CompoundsLoader.DataSheetName].keys()
+                    ):
+                        print(
+                            f"ADDING COMPOUND (BY FORMULA) {compound_rec.name} {compound_rec.formula}"
+                        )
+                        self.autofill_dict[CompoundsLoader.DataSheetName][
+                            compound_rec.name
+                        ] = {
+                            CompoundsLoader.DataHeaders.NAME: compound_rec.name,
+                            CompoundsLoader.DataHeaders.FORMULA: compound_rec.formula,
+                        }
 
     def extract_autofill_from_exceptions(self, retain_as_warnings=True):
         """Remove exceptions related to references to missing underlying data and extract their data.


### PR DESCRIPTION
## Summary Change Description

The issue mentions adding "all compounds", but given Michael's concern about identifying the compounds from the peak annotation files and the large number of compounds in tracebase, I decided to only add those with matching formulas, which should both be easier for the researcher to pour through and remain scalable as tracebase grows.

That also solves the original problem, which was there was no way to add a missing synonym if the compound to add it to wasn't present in the sheet.

## Affected Issues/Pull Requests

- Resolves #1153
- Merges into main

## Review Notes
<!--
For added context for reviewers, add comments to relevant lines of code.  Use
this space to describe any general areas of concern not linked to a specific
line of code that reviewers should pay particular attention to, e.g. please
make sure I have accounted for all possible inputs.
-->
See comments in-line.

## Checklist
<!--
If any of the checkbox requirements are not met, uncheck them and add an
explanation. E.g. Linting errors pre-date this PR.
-->
This pull request will be merged once the following requirements are met.  The
author and/or reviewers should uncheck any unmet requirements:

- Review requirements
  - Minimum approvals: 1 <!-- Edit as desired (e.g. based on complexity) -->
  - No changes requested
  - All blocking issues resolved by reviewers
  - Specific reviewers: @__add_username_here__
    <!--
    Require reviewers with specific expertise to be included among the minimum
    number of reviewers by tagging them.  Also please send them a message.
    -->
  - Review period: 2 days <!-- Edit as desired (e.g. based on complexity) -->
- Associated issue/pull request requirements:
  <!--
  Assert that all requirements in issues marked "resolved" are done and that
  all required pull requests are merged.  If any are not done, either edit or
  split the issue or explain the unmerged affected pull requests.
  -->
  - [x] All requirements in affected issues marked "resolved" are satisfied
  - [x] All required pull requests are merged *(or none)*
- Basic requirements
  <!--
  Uncheck items to acknowledge failures/conflicts you intend to address.
  Add an explanation if any won't be addressed before merge.
  -->
  - [x] [All linters pass](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#linting)
  - [x] [All tests pass](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#quality-control)
  - [x] All conflicts resolved
- Overhead requirements
  <!--
  These are additional requirements that are not directly associated with
  resolving the affected issue(s).
  -->
  - [x] [New/changed method tests implemented/updated *(or no change)*](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#test-implementation)
  - [ ] [Updated *Unreleased* section of `changelog.md` *(or no change)*](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/changelog.md)
  - [x] [Migrations created & committed *(or no change)*](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#migration-process)
