### PR TITLE
Load stats improvement

### DIFF
--- a/DataRepo/loaders/base/table_loader.py
+++ b/DataRepo/loaders/base/table_loader.py
@@ -2425,7 +2425,7 @@ class TableLoader(ABC):
         This is intended for loaders that call multiple other loaders.
 
         Args:
-            None
+            record_counts (Dict[str, Dict[str, int]]): A dict of counts keyed on model name and count type.
         Exceptions:
             None
         Returns:

--- a/DataRepo/loaders/base/table_loader.py
+++ b/DataRepo/loaders/base/table_loader.py
@@ -1064,12 +1064,18 @@ class TableLoader(ABC):
 
         self.record_counts = defaultdict(lambda: defaultdict(int))
         for mdl in self.Models:
-            self.record_counts[mdl.__name__]["created"] = 0
-            self.record_counts[mdl.__name__]["existed"] = 0
-            self.record_counts[mdl.__name__]["updated"] = 0
-            self.record_counts[mdl.__name__]["skipped"] = 0
-            self.record_counts[mdl.__name__]["errored"] = 0
-            self.record_counts[mdl.__name__]["warned"] = 0
+            self.record_counts[mdl.__name__] = self.initial_counts
+
+    @property
+    def initial_counts(self):
+        return {
+            "created": 0,
+            "existed": 0,
+            "updated": 0,
+            "skipped": 0,
+            "errored": 0,
+            "warned": 0,
+        }
 
     @staticmethod
     def isnamedtuple(obj) -> bool:
@@ -2411,6 +2417,27 @@ class TableLoader(ABC):
         Returns:
             record_counts (dict of dicts of ints): Counts by model and status
         """
+        return self.record_counts
+
+    def update_load_stats(self, record_counts):
+        """Adds model record status counts to existing counts.
+
+        This is intended for loaders that call multiple other loaders.
+
+        Args:
+            None
+        Exceptions:
+            None
+        Returns:
+            record_counts (dict of dicts of ints): Counts by model and status
+        """
+        for model_name in record_counts.keys():
+            if model_name not in self.record_counts.keys():
+                self.record_counts[model_name] = self.initial_counts
+            for stat_name in record_counts[model_name].keys():
+                self.record_counts[model_name][stat_name] += record_counts[model_name][
+                    stat_name
+                ]
         return self.record_counts
 
     def check_for_inconsistencies(

--- a/DataRepo/loaders/peak_annotation_files_loader.py
+++ b/DataRepo/loaders/peak_annotation_files_loader.py
@@ -488,3 +488,5 @@ class PeakAnnotationFilesLoader(TableLoader):
         except AggregatedErrors as aes:
             # Log the peak annot loader's exceptions by file
             self.aggregated_errors_dict[filename] = aes
+        finally:
+            self.update_load_stats(peak_annot_loader.get_load_stats())

--- a/DataRepo/loaders/study_loader.py
+++ b/DataRepo/loaders/study_loader.py
@@ -420,6 +420,8 @@ class StudyLoader(ConvertedTableLoader, ABC):
                 loader.load_data()
             except Exception as e:
                 self.package_group_exceptions(e)
+            finally:
+                self.update_load_stats(loader.get_load_stats())
 
         enable_caching_updates()
 

--- a/DataRepo/management/commands/load_table.py
+++ b/DataRepo/management/commands/load_table.py
@@ -467,22 +467,20 @@ class LoadTableCommand(ABC, BaseCommand):
             msg = "Dry-run complete.  The following would occur during a real load:\n"
 
         load_stats = self.loader.get_load_stats()
-        for mdl in self.loader_class.get_models():
-            mdl_name = mdl.__name__
-            if mdl_name in load_stats.keys():
-                msg += (
-                    "%s records created: [%i], existed: [%i], updated: [%i], skipped [%i], errored: [%i], and warned: "
-                    "[%i].\n"
-                    % (
-                        mdl_name,
-                        load_stats[mdl_name]["created"],
-                        load_stats[mdl_name]["existed"],
-                        load_stats[mdl_name]["updated"],
-                        load_stats[mdl_name]["skipped"],
-                        load_stats[mdl_name]["errored"],
-                        load_stats[mdl_name]["warned"],
-                    )
+        for mdl_name in load_stats.keys():
+            msg += (
+                "%s records created: [%i], existed: [%i], updated: [%i], skipped [%i], errored: [%i], and warned: "
+                "[%i].\n"
+                % (
+                    mdl_name,
+                    load_stats[mdl_name]["created"],
+                    load_stats[mdl_name]["existed"],
+                    load_stats[mdl_name]["updated"],
+                    load_stats[mdl_name]["skipped"],
+                    load_stats[mdl_name]["errored"],
+                    load_stats[mdl_name]["warned"],
                 )
+            )
 
         if self.saved_aes is not None and self.saved_aes.get_num_errors() > 0:
             status = self.style.ERROR(msg)

--- a/DataRepo/tests/loaders/base/test_table_loader.py
+++ b/DataRepo/tests/loaders/base/test_table_loader.py
@@ -1615,8 +1615,73 @@ class TableLoaderTests(TracebaseTestCase):
         pass
 
     def test_update_load_stats(self):
-        # TODO: Implement test
-        pass
+        tl = self.TestLoader()
+        counts = {
+            "UndocumentedModel": {  # Adding a model that's not in tl.Models (to support child loaders)
+                "created": 10,
+                "existed": 0,
+                "updated": 0,
+                "skipped": 0,
+                "errored": 0,
+                "warned": 0,
+            },
+            "TestModel": {
+                "created": 0,
+                "existed": 5,
+                "updated": 1,
+                "skipped": 2,
+                "errored": 3,
+                "warned": 4,
+            },
+        }
+        tl.update_load_stats(counts)
+        self.assertDictEqual(counts, tl.record_counts)
+        new_counts = {
+            "NewUndocumentedModel": {  # Adding a new model
+                "created": 10,
+                "existed": 0,
+                "updated": 0,
+                "skipped": 0,
+                "errored": 0,
+                "warned": 0,
+            },
+            "TestModel": {
+                "created": 1,
+                "existed": 2,
+                "updated": 3,
+                "skipped": 4,
+                "errored": 5,
+                "warned": 0,
+            },
+        }
+        tl.update_load_stats(new_counts)
+        expected = {
+            "UndocumentedModel": {
+                "created": 10,
+                "existed": 0,
+                "updated": 0,
+                "skipped": 0,
+                "errored": 0,
+                "warned": 0,
+            },
+            "NewUndocumentedModel": {
+                "created": 10,
+                "existed": 0,
+                "updated": 0,
+                "skipped": 0,
+                "errored": 0,
+                "warned": 0,
+            },
+            "TestModel": {
+                "created": 1,
+                "existed": 7,
+                "updated": 4,
+                "skipped": 6,
+                "errored": 8,
+                "warned": 4,
+            },
+        }
+        self.assertDictEqual(expected, tl.record_counts)
 
 
 class TableLoaderUtilitiesTests(TracebaseTestCase):

--- a/DataRepo/tests/loaders/base/test_table_loader.py
+++ b/DataRepo/tests/loaders/base/test_table_loader.py
@@ -1614,6 +1614,10 @@ class TableLoaderTests(TracebaseTestCase):
         # TODO: Implement test
         pass
 
+    def test_update_load_stats(self):
+        # TODO: Implement test
+        pass
+
 
 class TableLoaderUtilitiesTests(TracebaseTestCase):
     def test_flatten(self):


### PR DESCRIPTION
## Summary Change Description

While working on Michael's water study, I wanted to see how many compound and synonym records were being created, but when I ran `load_study` in dry-run mode on an excel file containing only the Compounds sheet, there were no stats - just the dry run complete message.  I quickly realized that this is because the stats are not accumulated from the nested loader calls.  This PR adds that ability to accumulate stats from each loader call, so that now at the end of a `load_study` call, (for a compounds only load), you get something like this:

![recordcounts](https://github.com/user-attachments/assets/4d585085-d0dc-4d82-987c-875925d826ee)

Added the ability to track load stats of calls to nested loaders.

Details:

- Checked the outer loop from using self.loader_class.get_models to using load_stats.keys()
- Added method to TableLoader: update_load_stats, to sum stats from different loaders.
- Added property to TableLoader: initial_counts, for initializing stats consistently, given the need for it in multiple spots in the code now.
- Called the update_load_stats method in both study_loader and peak_annotation_files_loader, which both call other loaders.

## Affected Issues/Pull Requests

- Resolves no documented issue
- Merges into main

## Review Notes
<!--
For added context for reviewers, add comments to relevant lines of code.  Use
this space to describe any general areas of concern not linked to a specific
line of code that reviewers should pay particular attention to, e.g. please
make sure I have accounted for all possible inputs.
-->
See comments in-line.

## Checklist
<!--
If any of the checkbox requirements are not met, uncheck them and add an
explanation. E.g. Linting errors pre-date this PR.
-->
This pull request will be merged once the following requirements are met.  The
author and/or reviewers should uncheck any unmet requirements:

- Review requirements
  - Minimum approvals: 1 <!-- Edit as desired (e.g. based on complexity) -->
  - No changes requested
  - All blocking issues resolved by reviewers
  - Specific reviewers: @__add_username_here__
    <!--
    Require reviewers with specific expertise to be included among the minimum
    number of reviewers by tagging them.  Also please send them a message.
    -->
  - Review period: 2 days <!-- Edit as desired (e.g. based on complexity) -->
- Associated issue/pull request requirements:
  <!--
  Assert that all requirements in issues marked "resolved" are done and that
  all required pull requests are merged.  If any are not done, either edit or
  split the issue or explain the unmerged affected pull requests.
  -->
  - [x] All requirements in affected issues marked "resolved" are satisfied
  - [x] All required pull requests are merged *(or none)*
- Basic requirements
  <!--
  Uncheck items to acknowledge failures/conflicts you intend to address.
  Add an explanation if any won't be addressed before merge.
  -->
  - [x] [All linters pass](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#linting)
  - [x] [All tests pass](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#quality-control)
  - [x] All conflicts resolved
- Overhead requirements
  <!--
  These are additional requirements that are not directly associated with
  resolving the affected issue(s).
  -->
  - [x] [New/changed method tests implemented/updated *(or no change)*](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#test-implementation)
  - [ ] [Updated *Unreleased* section of `changelog.md` *(or no change)*](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/changelog.md)
  - [x] [Migrations created & committed *(or no change)*](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#migration-process)
