### PR TITLE
Fixed dry-run mode in `load_study`

### DIFF
--- a/DataRepo/loaders/base/table_loader.py
+++ b/DataRepo/loaders/base/table_loader.py
@@ -28,6 +28,7 @@ from DataRepo.utils.exceptions import (
     InfileError,
     InvalidHeaderCrossReferenceError,
     MultiLoadStatus,
+    MutuallyExclusiveArgs,
     NoLoadData,
     RecordDoesNotExist,
     RequiredColumnValue,
@@ -265,6 +266,14 @@ class TableLoader(ABC):
         # Running Modes
         self.dry_run = dry_run
         self.defer_rollback = defer_rollback
+
+        if dry_run and defer_rollback:
+            raise MutuallyExclusiveArgs(
+                "dry_run and defer_rollback are mutually exclusive.  A DryRun exception will be raised for rollback if "
+                "supplied, but defer_rollback is intended to not raise an exception for rollback.  defer_rollback "
+                "should only be used in a loader that calls other loaders, in which case, it should not also pass "
+                "along the dry_run value."
+            )
 
         # Error tracking
         self.skip_row_indexes = []

--- a/DataRepo/loaders/study_loader.py
+++ b/DataRepo/loaders/study_loader.py
@@ -461,7 +461,10 @@ class StudyLoader(ConvertedTableLoader, ABC):
         sheets_present = [] if self.file is None else list(self.df_dict.keys())
 
         common_args = {
-            "dry_run": self.dry_run,
+            # Do not pass dry-run.  That raises FOR rollback.  It should only be raised from THIS loader, not the
+            # loaders it calls.  If you want to run in dry-run mode, that's fine.  Just don't pass that argument to the
+            # child loaders.
+            # "dry_run": self.dry_run,
             "defer_rollback": True,
             "defaults_sheet": self.defaults_sheet,
             "file": self.file,

--- a/DataRepo/loaders/study_loader.py
+++ b/DataRepo/loaders/study_loader.py
@@ -283,7 +283,7 @@ class StudyLoader(ConvertedTableLoader, ABC):
             None
         """
         # NOTE: self.load_data() requires the file argument to have been provided to this constructor.
-        if kwargs.get("defer_rollback") is False:
+        if kwargs.get("defer_rollback") is True:
             raise ProgrammingError(
                 "Modifying the following superclass constructor arguments is prohibited by StudyLoader: "
                 "[defer_rollback]."

--- a/DataRepo/management/commands/load_study.py
+++ b/DataRepo/management/commands/load_study.py
@@ -31,7 +31,6 @@ class Command(LoadTableCommand):
         # Don't require any options (i.e. don't require the --infile option)
         super().__init__(
             *args,
-            opt_defaults={"defer_rollback": True},
             custom_loader_init=True,
             **kwargs,
         )

--- a/DataRepo/models/hier_cached_model.py
+++ b/DataRepo/models/hier_cached_model.py
@@ -53,8 +53,6 @@ def get_cache(rec, cache_func_name):
         if result is uncached:
             result = None
             good_cache = False
-        if settings.DEBUG:
-            print(f"Getting cache {cachekey}")
     except Exception as e:
         # Allow tracebase to still work, just without caching
         print(e)

--- a/DataRepo/tests/loaders/test_study_loader.py
+++ b/DataRepo/tests/loaders/test_study_loader.py
@@ -241,7 +241,7 @@ class StudyLoaderTests(TracebaseTestCase):
         self.assertIn("study_missing_data.xlsx", sl.load_statuses.statuses.keys())
 
     def test_get_loader_instances(self):
-        sl = StudyV3Loader(dry_run=True)
+        sl = StudyV3Loader(_validate=True)
         loaders: Dict[str, TableLoader] = sl.get_loader_instances()
         self.assertIsInstance(loaders, dict)
         self.assertEqual(
@@ -249,7 +249,7 @@ class StudyLoaderTests(TracebaseTestCase):
             set(list(loaders.keys()) + ["DEFAULTS", "ERRORS"]),
         )
         # Make sure that the loaders were instantiated using the common args
-        self.assertTrue(loaders["STUDY"].dry_run)
+        self.assertTrue(loaders["STUDY"].validate)
         # Make sure that the loaders were instantiated using the custom args
         self.assertEqual(
             ProtocolsLoader.DataHeadersExcel, loaders["TREATMENTS"].get_headers()

--- a/DataRepo/tests/management/commands/test_load_table.py
+++ b/DataRepo/tests/management/commands/test_load_table.py
@@ -254,7 +254,7 @@ class LoadTableCommandTests(TracebaseTestCase):
         tc.init_loader(
             df=None,
             dry_run=True,  # Diff from default False
-            defer_rollback=True,  # Diff from default False
+            defer_rollback=False,  # Same as default (mutex with dry_run)
             file="DataRepo/data/tests/load_table/test.xlsx",  # Diff from default None
             data_sheet="Test",  # Diff from default None
             defaults_df=None,
@@ -277,7 +277,7 @@ class LoadTableCommandTests(TracebaseTestCase):
 
         # Assert that the loader has the custom values we set
         self.assertTrue(tc.loader.dry_run)
-        self.assertTrue(tc.loader.defer_rollback)
+        self.assertFalse(tc.loader.defer_rollback)
         self.assertEqual("DataRepo/data/tests/load_table/test.xlsx", tc.loader.file)
         self.assertEqual("Test", tc.loader.sheet)
 


### PR DESCRIPTION
## Summary Change Description

Been working on Michael's water study.  Fixed all the issues using the validate page and tried running `load_study` on the command line on dev.  Turns out that there was a bug with dry-run mode (which I tried first).  It was running each child loader in dry-run, which was wrong.  Only the outer loader `StudyLoader` should run `load_data` in dry-run and defer rollback exceptions until all child loaders are done, THEN raise the DryRun exception inside the outer atomic transaction block.

## Affected Issues/Pull Requests

- Resolves no documented issue
- Merges into PR #1175

## Review Notes
<!--
For added context for reviewers, add comments to relevant lines of code.  Use
this space to describe any general areas of concern not linked to a specific
line of code that reviewers should pay particular attention to, e.g. please
make sure I have accounted for all possible inputs.
-->
See comments in-line.

## Checklist
<!--
If any of the checkbox requirements are not met, uncheck them and add an
explanation. E.g. Linting errors pre-date this PR.
-->
This pull request will be merged once the following requirements are met.  The
author and/or reviewers should uncheck any unmet requirements:

- Review requirements
  - Minimum approvals: 1 <!-- Edit as desired (e.g. based on complexity) -->
  - No changes requested
  - All blocking issues resolved by reviewers
  - Specific reviewers: @__add_username_here__
    <!--
    Require reviewers with specific expertise to be included among the minimum
    number of reviewers by tagging them.  Also please send them a message.
    -->
  - Review period: 2 days <!-- Edit as desired (e.g. based on complexity) -->
- Associated issue/pull request requirements:
  <!--
  Assert that all requirements in issues marked "resolved" are done and that
  all required pull requests are merged.  If any are not done, either edit or
  split the issue or explain the unmerged affected pull requests.
  -->
  - [x] All requirements in affected issues marked "resolved" are satisfied
  - [x] All required pull requests are merged *(or none)*
- Basic requirements
  <!--
  Uncheck items to acknowledge failures/conflicts you intend to address.
  Add an explanation if any won't be addressed before merge.
  -->
  - [x] [All linters pass](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#linting)
  - [x] [All tests pass](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#quality-control)
  - [x] All conflicts resolved
- Overhead requirements
  <!--
  These are additional requirements that are not directly associated with
  resolving the affected issue(s).
  -->
  - [x] [New/changed method tests implemented/updated *(or no change)*](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#test-implementation)
  - [ ] [Updated *Unreleased* section of `changelog.md` *(or no change)*](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/changelog.md)
  - [x] [Migrations created & committed *(or no change)*](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#migration-process)
