### PR TITLE
Fix for un-raised `MultiplePeakGroupRepresentations` errors and made `NoTracerLabeledElements` a warning/skip

### DIFF
--- a/DataRepo/loaders/base/table_loader.py
+++ b/DataRepo/loaders/base/table_loader.py
@@ -2735,6 +2735,7 @@ class TableLoader(ABC):
                                     )
                             # Whether we buffered or not, the error was identified and handled (by either buffering or
                             # ignoring a duplicate)
+                            # TODO: Handle all errors. This returns on the first one (there currently only ever is one).
                             return True
 
                 elif issubclass(
@@ -2759,6 +2760,7 @@ class TableLoader(ABC):
                             is_error=is_error,
                             is_fatal=is_fatal,
                         )
+                    # TODO: Handle all errors. This returns on the first one (there currently only ever is one).
                     return True
 
         elif isinstance(exception, RequiredColumnValue):

--- a/DataRepo/loaders/peak_annotations_loader.py
+++ b/DataRepo/loaders/peak_annotations_loader.py
@@ -38,6 +38,7 @@ from DataRepo.utils.exceptions import (
     IsotopeStringDupe,
     MissingCompounds,
     MissingSamples,
+    MultiplePeakGroupRepresentations,
     NoSamples,
     NoTracerLabeledElements,
     NoTracers,
@@ -694,6 +695,10 @@ class PeakAnnotationsLoader(ConvertedTableLoader, ABC):
                 self.created(PeakGroup.__name__)
             else:
                 self.existed(PeakGroup.__name__)
+        except MultiplePeakGroupRepresentations as mpgr:
+            self.aggregated_errors_object.buffer_error(mpgr)
+            self.errored(PeakGroup.__name__)
+            raise RollbackException()
         except Exception as e:
             self.handle_load_db_errors(e, PeakGroup, rec_dict)
             self.errored(PeakGroup.__name__)
@@ -941,8 +946,9 @@ class PeakAnnotationsLoader(ConvertedTableLoader, ABC):
                 sheet=self.sheet,
                 column=self.headers.COMPOUND,
                 rownum=self.rownum,
+                suggestion="This compound / peak group link will be skipped.",
             )
-            self.aggregated_errors_object.buffer_error(ntle)
+            self.aggregated_errors_object.buffer_warning(ntle)
             # Subsequent record creations from this row should be skipped.
             self.add_skip_row_index()
             self.errored(PeakGroupCompound.__name__)
@@ -1049,15 +1055,18 @@ class PeakAnnotationsLoader(ConvertedTableLoader, ABC):
         num_possible_isotope_observations = 1
         if pgrec is not None:
             if pgrec.compounds.count() == 0:
-                self.aggregated_errors_object.buffer_error(
-                    ProgrammingError(
-                        "PeakGroup record has no linked compounds.  A peak group must have associated compounds in "
-                        "order to confirm label observations."
+                # There had to have been errors when trying to retrieve compounds to link, which means that this error
+                # is unnecessary (i.e. fixing the previous error would make this error go away), but just to be safe,
+                # error if there have been no errors buffered.
+                if self.aggregated_errors_object.num_errors == 0:
+                    self.aggregated_errors_object.buffer_error(
+                        ProgrammingError(
+                            "PeakGroup record has no linked compounds.  A peak group must have associated compounds in "
+                            "order to confirm label observations."
+                        )
                     )
-                )
-            else:
-                possible_isotope_observations = pgrec.possible_isotope_observations
-                num_possible_isotope_observations = len(possible_isotope_observations)
+            possible_isotope_observations = pgrec.possible_isotope_observations
+            num_possible_isotope_observations = len(possible_isotope_observations)
 
         # For the exceptions below (for convenience)
         infile_err_args = {

--- a/DataRepo/loaders/study_loader.py
+++ b/DataRepo/loaders/study_loader.py
@@ -12,6 +12,7 @@
 
 from __future__ import annotations
 
+import warnings
 from abc import ABC, abstractmethod
 from collections import defaultdict, namedtuple
 from copy import deepcopy
@@ -90,6 +91,12 @@ from DataRepo.utils.file_utils import (
 from DataRepo.utils.infusate_name_parser import (
     parse_infusate_name,
     parse_tracer_concentrations,
+)
+
+# See: https://stackoverflow.com/q/9134795/2057516 and https://stackoverflow.com/q/53965596/2057516
+# This is just warning us that it doesn't read in the data validation formulas, but we don't need them anyway.
+warnings.filterwarnings(
+    "ignore", message="Data Validation extension is not supported and will be removed"
 )
 
 

--- a/DataRepo/loaders/study_loader.py
+++ b/DataRepo/loaders/study_loader.py
@@ -772,13 +772,13 @@ class StudyLoader(ConvertedTableLoader, ABC):
                 AllMissingCompounds,
                 self.missing_compound_record_exceptions,
                 "Compounds Check",
-                False,
+                True,
             ),
             (
                 AllMultiplePeakGroupRepresentations,
                 self.multiple_pg_reps_exceptions,
                 "Peak Groups Check",
-                False,
+                True,
             ),
         ]:
             # Add this load key (if not already present anong the load keys).

--- a/DataRepo/models/peak_group.py
+++ b/DataRepo/models/peak_group.py
@@ -210,7 +210,7 @@ class PeakGroup(HierCachedModel, MaintainedModel):
             None
         """
         from DataRepo.models.utilities import exists_in_db
-        from DataRepo.utils.exceptions import MultiplePeakGroupRepresentations
+        from DataRepo.utils.exceptions import MultiplePeakGroupRepresentation
 
         conflicts = PeakGroup.objects.filter(
             name=self.name,
@@ -223,7 +223,7 @@ class PeakGroup(HierCachedModel, MaintainedModel):
             conflicts = conflicts.exclude(pk=self.pk)
 
         if conflicts.count() > 0:
-            raise MultiplePeakGroupRepresentations(self, conflicts)
+            raise MultiplePeakGroupRepresentation(self, conflicts)
 
     def clean(self, *args, **kwargs):
         """This checks to ensure that the compound(s) associated with the PeakGroup HAVE an element that is labeled

--- a/DataRepo/models/peak_group.py
+++ b/DataRepo/models/peak_group.py
@@ -212,6 +212,13 @@ class PeakGroup(HierCachedModel, MaintainedModel):
         from DataRepo.models.utilities import exists_in_db
         from DataRepo.utils.exceptions import MultiplePeakGroupRepresentation
 
+        if (
+            not hasattr(self, "peak_annotation_file")
+            or self.peak_annotation_file is None
+        ):
+            # This cannot be a multiple representation issue if no peak annotation file is provided
+            return None
+
         conflicts = PeakGroup.objects.filter(
             name=self.name,
             msrun_sample__sample__pk=self.msrun_sample.sample.pk,
@@ -236,7 +243,13 @@ class PeakGroup(HierCachedModel, MaintainedModel):
         Returns:
             None
         """
-        from DataRepo.utils.exceptions import NoTracerLabeledElements
+        from DataRepo.utils.exceptions import (
+            NoTracerLabeledElements,
+            NoTracers,
+        )
+
+        if len(self.tracer_labeled_elements) == 0:
+            raise NoTracers(self.animal)
 
         if len(self.peak_labeled_elements) == 0:
             raise NoTracerLabeledElements(

--- a/DataRepo/tests/loaders/test_study_loader.py
+++ b/DataRepo/tests/loaders/test_study_loader.py
@@ -232,7 +232,7 @@ class StudyLoaderTests(TracebaseTestCase):
         ]
         sl.create_grouped_exceptions()
         self.assertEqual(
-            7,
+            8,
             len(sl.load_statuses.statuses.keys()),
             msg=f"Load status keys: {list(sl.load_statuses.statuses.keys())}",
         )

--- a/DataRepo/tests/management/commands/test_load_peak_annotations.py
+++ b/DataRepo/tests/management/commands/test_load_peak_annotations.py
@@ -22,8 +22,8 @@ from DataRepo.models.study import Study
 from DataRepo.tests.tracebase_test_case import TracebaseTestCase
 from DataRepo.utils.exceptions import (
     AggregatedErrors,
-    ConflictingValueErrors,
     DuplicateFileHeaders,
+    MultiplePeakGroupRepresentations,
 )
 from DataRepo.utils.infusate_name_parser import parse_infusate_name_with_concs
 
@@ -246,10 +246,10 @@ class LoadAccucorSmallObobCommandTests(TracebaseTestCase):
 
         aes = ar.exception
         self.assertEqual(1, aes.num_errors)
-        self.assertEqual(ConflictingValueErrors, type(aes.exceptions[0]))
+        self.assertEqual(MultiplePeakGroupRepresentations, type(aes.exceptions[0]))
         # 1 compounds, 2 samples -> 2 PeakGroups
         # This error occurs on each of 7 rows, twice (once for each sample)
-        self.assertEqual(14, len(aes.exceptions[0].conflicting_value_errors))
+        self.assertEqual(14, len(aes.exceptions[0].mpgr_errors))
 
 
 class LoadAccucorSmallObob2CommandTests(TracebaseTestCase):

--- a/DataRepo/tests/management/commands/test_load_peak_annotations.py
+++ b/DataRepo/tests/management/commands/test_load_peak_annotations.py
@@ -249,7 +249,7 @@ class LoadAccucorSmallObobCommandTests(TracebaseTestCase):
         self.assertEqual(MultiplePeakGroupRepresentations, type(aes.exceptions[0]))
         # 1 compounds, 2 samples -> 2 PeakGroups
         # This error occurs on each of 7 rows, twice (once for each sample)
-        self.assertEqual(14, len(aes.exceptions[0].mpgr_errors))
+        self.assertEqual(14, len(aes.exceptions[0].exceptions))
 
 
 class LoadAccucorSmallObob2CommandTests(TracebaseTestCase):

--- a/DataRepo/tests/models/test_peak_group.py
+++ b/DataRepo/tests/models/test_peak_group.py
@@ -1,7 +1,6 @@
 from datetime import datetime, timedelta
 from pathlib import Path
 
-from django.core.exceptions import ValidationError
 from django.core.files import File
 
 from DataRepo.models import (
@@ -20,7 +19,10 @@ from DataRepo.models import (
 )
 from DataRepo.models.compound import Compound
 from DataRepo.tests.tracebase_test_case import TracebaseTestCase
-from DataRepo.utils.exceptions import MultiplePeakGroupRepresentation
+from DataRepo.utils.exceptions import (
+    MultiplePeakGroupRepresentation,
+    NoTracerLabeledElements,
+)
 from DataRepo.utils.infusate_name_parser import parse_infusate_name
 
 
@@ -128,7 +130,7 @@ class PeakGroupTests(TracebaseTestCase):
     def test_max_med_mz(self):
         self.assertEqual(4.0, self.pg.max_med_mz)
 
-    def test_clean_raises_MultiplePeakGroupRepresentations(self):
+    def prepare_peak_group_creation(self):
         rawrec = ArchiveFile.objects.create(
             filename="test.raw",
             file_location=None,
@@ -158,24 +160,32 @@ class PeakGroupTests(TracebaseTestCase):
             data_type=self.ms_peak_annotation,
             data_format=self.accucor_format,
         )
+        return msr, accucor_file
+
+    def test_save_raises_MultiplePeakGroupRepresentations(self):
+        msr, accucor_file = self.prepare_peak_group_creation()
+
+        # The save method should raise a MultiplePeakGroupRepresentation exception
+        with self.assertRaises(MultiplePeakGroupRepresentation):
+            PeakGroup.objects.create(
+                name="gluc",
+                formula="C6H12O6",
+                msrun_sample=msr,
+                peak_annotation_file=accucor_file,
+            )
+
+    def test_clean_raises_NoTracerLabeledElements(self):
+        msr, accucor_file = self.prepare_peak_group_creation()
         pg = PeakGroup.objects.create(
-            name="gluc",
-            formula="C6H12O6",
+            name="water",
+            formula="H2O",
             msrun_sample=msr,
             peak_annotation_file=accucor_file,
         )
 
-        # The clean method should raise a MultiplePeakGroupRepresentations exception (derived from ValidationError)
-        with self.assertRaises(ValidationError) as ar:
+        # The clean method should raise a NoTracerLabeledElements exception
+        with self.assertRaises(NoTracerLabeledElements):
             pg.full_clean()
-
-        # Make sure it's a MultiplePeakGroupRepresentations exception
-        self.assertTrue(
-            isinstance(
-                ar.exception.error_dict["__all__"][0],
-                MultiplePeakGroupRepresentation,
-            ),
-        )
 
     def test_get_or_create_compound_link(self):
         cmpd = Compound.objects.create(

--- a/DataRepo/tests/models/test_peak_group.py
+++ b/DataRepo/tests/models/test_peak_group.py
@@ -20,7 +20,7 @@ from DataRepo.models import (
 )
 from DataRepo.models.compound import Compound
 from DataRepo.tests.tracebase_test_case import TracebaseTestCase
-from DataRepo.utils.exceptions import MultiplePeakGroupRepresentations
+from DataRepo.utils.exceptions import MultiplePeakGroupRepresentation
 from DataRepo.utils.infusate_name_parser import parse_infusate_name
 
 
@@ -173,7 +173,7 @@ class PeakGroupTests(TracebaseTestCase):
         self.assertTrue(
             isinstance(
                 ar.exception.error_dict["__all__"][0],
-                MultiplePeakGroupRepresentations,
+                MultiplePeakGroupRepresentation,
             ),
         )
 

--- a/DataRepo/tests/views/upload/test_submission.py
+++ b/DataRepo/tests/views/upload/test_submission.py
@@ -1366,11 +1366,11 @@ class DataValidationViewTests2(TracebaseTransactionTestCase):
         self.assertEqual("AllMissingSamples", exceptions[groupkey][0]["type"])
         self.assertEqual(0, num_warnings[groupkey])
 
-        self.assertEqual(8, len(results.keys()), msg=f"Keys: {results.keys()}")
-        self.assertEqual(8, len(exceptions.keys()), msg=f"Keys: {exceptions.keys()}")
-        self.assertEqual(8, len(num_errors.keys()), msg=f"Keys: {num_errors.keys()}")
+        self.assertEqual(9, len(results.keys()), msg=f"Keys: {results.keys()}")
+        self.assertEqual(9, len(exceptions.keys()), msg=f"Keys: {exceptions.keys()}")
+        self.assertEqual(9, len(num_errors.keys()), msg=f"Keys: {num_errors.keys()}")
         self.assertEqual(
-            8, len(num_warnings.keys()), msg=f"Keys: {num_warnings.keys()}"
+            9, len(num_warnings.keys()), msg=f"Keys: {num_warnings.keys()}"
         )
 
         self.assertFalse(valid)

--- a/DataRepo/utils/exceptions.py
+++ b/DataRepo/utils/exceptions.py
@@ -3899,7 +3899,10 @@ class MultiplePeakGroupRepresentations(Exception):
                 mpgr_dict[str(mpgr.sequence)][files_str]["compounds"].append(
                     mpgr.compound
                 )
-            if mpgr.sample not in mpgr_dict[str(mpgr.sequence)][files_str]["samples"]:
+            if (
+                mpgr.sample.name
+                not in mpgr_dict[str(mpgr.sequence)][files_str]["samples"]
+            ):
                 mpgr_dict[str(mpgr.sequence)][files_str]["samples"].append(
                     mpgr.sample.name
                 )

--- a/DataRepo/utils/exceptions.py
+++ b/DataRepo/utils/exceptions.py
@@ -3806,7 +3806,9 @@ class MultiplePeakGroupRepresentations(Exception):
                     mpgr.compound
                 )
             if mpgr.sample not in mpgr_dict[str(mpgr.sequence)][files_str]["samples"]:
-                mpgr_dict[str(mpgr.sequence)][files_str]["samples"].append(mpgr.sample)
+                mpgr_dict[str(mpgr.sequence)][files_str]["samples"].append(
+                    mpgr.sample.name
+                )
             mpgr_dict[str(mpgr.sequence)][files_str]["exceptions"].append(mpgr)
 
         message = (
@@ -3826,7 +3828,9 @@ class MultiplePeakGroupRepresentations(Exception):
                     files = mpgr_dict[sequence][files_set]["files"]
                     message += "\n\t\tFiles:\n\t\t\t" + "\n\t\t\t".join(sorted(files))
                     compounds = mpgr_dict[sequence][files_set]["compounds"]
-                    message += "\n\t\tFiles:\n\t\t\t" + "\n\t\t\t".join(sorted(files))
+                    message += "\n\t\tCompounds:\n\t\t\t" + "\n\t\t\t".join(
+                        sorted(compounds)
+                    )
             else:
                 files = list(mpgr_dict[sequence].values())[0]["files"]
                 message += "\n\t\tFiles:\n\t\t\t" + "\n\t\t\t".join(sorted(files))

--- a/DataRepo/utils/exceptions.py
+++ b/DataRepo/utils/exceptions.py
@@ -3741,7 +3741,7 @@ class AmbiguousMSRuns(Exception):
         self.infile = infile
 
 
-class MultiplePeakGroupRepresentations(ValidationError):
+class MultiplePeakGroupRepresentations(Exception):
     def __init__(self, new_rec, existing_recs):
         """MultiplePeakGroupRepresentations constructor.
 
@@ -3749,20 +3749,20 @@ class MultiplePeakGroupRepresentations(ValidationError):
             new_rec (PeakGroup): An uncommitted record.
             existing_recs (PeakGroup.QuerySet)
         """
-        leader = "Existing: "
         from_files = [r.peak_annotation_file.filename for r in existing_recs.all()]
-        from_str = f"\n\t{leader}".join(from_files)
+        from_str = "\n\t".join(from_files)
         message = (
             f"Multiple representations of this peak group were encountered:\n"
             f"\tcompound: {new_rec.name}\n"
             f"\tMSRunSequence: {new_rec.msrun_sample.msrun_sequence}\n"
             f"\tSample: {new_rec.msrun_sample.sample}\n"
             "Each peak group originated from:\n"
-            f"\tProposed: {new_rec.peak_annotation_file.filename}\n"
-            f"\t{leader}{from_str}\n"
-            "Only 1 representation of a compound per sequence and sample is allowed.  "
+            f"\t{new_rec.peak_annotation_file.filename} (already loaded)\n"
+            f"\t{from_str}\n"
+            "Only 1 representation of a compound per sequence and sample is allowed.  Please remove this compound from "
+            "all but one of the above files, or check to make sure the correct sequence is assigned to each file."
         )
-        super().__init__(message, code="MultiplePeakGroupRepresentations")
+        super().__init__(message)
         self.new_rec = new_rec
         self.existing_recs = existing_recs
 

--- a/DataRepo/utils/exceptions.py
+++ b/DataRepo/utils/exceptions.py
@@ -891,10 +891,12 @@ class MissingModelRecordsByFile(MissingRecords, ABC):
                 self.ModelName
             ].items():
                 summary += "\n\t"
+                summary += f"{terms}{nltt}"
                 if succinct:
-                    summary += "\n\t".join(loc_dict.keys())
+                    # Every exception is from the same file, given the loc_dict key is the file location
+                    files = [exc_lst[0].file for exc_lst in loc_dict.values()]
+                    summary += nltt.join(files)
                 else:
-                    summary += f"{terms}\n\t\t"
                     summary += nltt.join(
                         [
                             f"{loc}, row(s): ["
@@ -906,7 +908,10 @@ class MissingModelRecordsByFile(MissingRecords, ABC):
                         ]
                     )
             if succinct:
-                message = f"{len(exceptions)} {self.ModelName}s missing in the database:{summary}\nwhile processing %s."
+                message = (
+                    f"{len(exceptions)} {self.ModelName} records missing in the database:{summary}\nwhile processing "
+                    "%s."
+                )
             else:
                 message = (
                     f"{len(exceptions)} {self.ModelName}s matching the following values were not found in the "
@@ -3825,8 +3830,15 @@ class AllMultiplePeakGroupRepresentations(Exception):
                         message += "\n\t\t\tFiles:\n\t\t\t\t"
                         message += "\n\t\t\t\t".join(sorted(files))
             else:
-                files = list(mpgr_dict[compound].values())[0]["files"]
-                message += "\n\t\t" + "\n\t\t".join(sorted(files))
+                if succinct:
+                    files = list(mpgr_dict[compound].values())[0]["files"]
+                    message += "\n\t\t" + "\n\t\t".join(sorted(files))
+                else:
+                    samples = list(mpgr_dict[compound].values())[0]["samples"]
+                    message += "\n\t\tSamples:\n\t\t\t"
+                    message += "\n\t\t\t".join(sorted(samples))
+                    message += "\n\t\tFiles:\n\t\t\t\t"
+                    message += "\n\t\t\t".join(sorted(files))
         message += (
             "\nPlease make sure that the files do in fact belong to the same sequence and if so, remove each compound "
             "(row) from all but one of the listed files."

--- a/DataRepo/utils/exceptions.py
+++ b/DataRepo/utils/exceptions.py
@@ -888,7 +888,8 @@ class MissingModelRecordsByFile(MissingRecords, ABC):
             nltt = "\n\t\t"
             summary = ""
             for terms in sorted(
-                self.exceptions_by_model_query_and_loc[self.ModelName].keys()
+                self.exceptions_by_model_query_and_loc[self.ModelName].keys(),
+                key=str.casefold,
             ):
                 loc_dict = self.exceptions_by_model_query_and_loc[self.ModelName][terms]
                 summary += "\n\t"
@@ -896,10 +897,14 @@ class MissingModelRecordsByFile(MissingRecords, ABC):
                 if succinct:
                     # Every exception is from the same file, given the loc_dict key is the file location
                     files = [
-                        (os.path.split(exc_lst[0].file))[1]
+                        (
+                            (os.path.split(exc_lst[0].file))[1]
+                            if exc_lst[0].file is not None
+                            else None
+                        )
                         for exc_lst in loc_dict.values()
                     ]
-                    summary += nltt.join(sorted(files))
+                    summary += nltt.join(sorted(files, key=str.casefold))
                 else:
                     summary += nltt.join(
                         [
@@ -910,7 +915,7 @@ class MissingModelRecordsByFile(MissingRecords, ABC):
                                 )
                             )
                             + "]"
-                            for loc in sorted(loc_dict.keys())
+                            for loc in sorted(loc_dict.keys(), key=str.casefold)
                         ]
                     )
             if succinct:
@@ -3821,32 +3826,35 @@ class AllMultiplePeakGroupRepresentations(Exception):
             "The following compounds are present in multiple peak annotation files (derived from the same sequence for "
             "the same samples)."
         )
-        for compound in sorted(mpgr_dict.keys()):
+        for compound in sorted(mpgr_dict.keys(), key=str.casefold):
             message += f"\n\t{compound}"
             if len(mpgr_dict[compound].keys()) > 1:
-                for sequence in sorted(mpgr_dict[compound].keys()):
+                for sequence in sorted(mpgr_dict[compound].keys(), key=str.casefold):
                     files = mpgr_dict[compound][sequence]["files"]
                     if succinct:
                         message += f"\n\t\t{sequence} ({len(mpgr_dict[compound][sequence]['samples'])} samples)\n\t\t\t"
-                        message += "\n\t\t\t".join(sorted(files))
+                        message += "\n\t\t\t".join(sorted(files, key=str.casefold))
                     else:
                         message += f"\n\t\t{sequence}"
                         message += "\n\t\t\tSamples:\n\t\t\t\t"
                         message += "\n\t\t\t\t".join(
-                            sorted(mpgr_dict[compound][sequence]["samples"])
+                            sorted(
+                                mpgr_dict[compound][sequence]["samples"],
+                                key=str.casefold,
+                            )
                         )
                         message += "\n\t\t\tFiles:\n\t\t\t\t"
-                        message += "\n\t\t\t\t".join(sorted(files))
+                        message += "\n\t\t\t\t".join(sorted(files, key=str.casefold))
             else:
                 if succinct:
                     files = list(mpgr_dict[compound].values())[0]["files"]
-                    message += "\n\t\t" + "\n\t\t".join(sorted(files))
+                    message += "\n\t\t" + "\n\t\t".join(sorted(files, key=str.casefold))
                 else:
                     samples = list(mpgr_dict[compound].values())[0]["samples"]
                     message += "\n\t\tSamples:\n\t\t\t"
-                    message += "\n\t\t\t".join(sorted(samples))
+                    message += "\n\t\t\t".join(sorted(samples, key=str.casefold))
                     message += "\n\t\tFiles:\n\t\t\t\t"
-                    message += "\n\t\t\t".join(sorted(files))
+                    message += "\n\t\t\t".join(sorted(files, key=str.casefold))
         message += (
             "\nPlease make sure that the files do in fact belong to the same sequence and if so, remove each compound "
             "(row) from all but one of the listed files."

--- a/DataRepo/utils/exceptions.py
+++ b/DataRepo/utils/exceptions.py
@@ -900,10 +900,11 @@ class MissingModelRecordsByFile(MissingRecords, ABC):
                         (
                             (os.path.split(exc_lst[0].file))[1]
                             if exc_lst[0].file is not None
-                            else None
+                            else ""
                         )
                         for exc_lst in loc_dict.values()
                     ]
+                    # Cannot use casefold when a file can be None
                     summary += nltt.join(sorted(files, key=str.casefold))
                 else:
                     summary += nltt.join(
@@ -3830,7 +3831,10 @@ class AllMultiplePeakGroupRepresentations(Exception):
             message += f"\n\t{compound}"
             if len(mpgr_dict[compound].keys()) > 1:
                 for sequence in sorted(mpgr_dict[compound].keys(), key=str.casefold):
-                    files = mpgr_dict[compound][sequence]["files"]
+                    files = [
+                        f if f is not None else ""
+                        for f in mpgr_dict[compound][sequence]["files"]
+                    ]
                     if succinct:
                         message += f"\n\t\t{sequence} ({len(mpgr_dict[compound][sequence]['samples'])} samples)\n\t\t\t"
                         message += "\n\t\t\t".join(sorted(files, key=str.casefold))
@@ -3847,9 +3851,16 @@ class AllMultiplePeakGroupRepresentations(Exception):
                         message += "\n\t\t\t\t".join(sorted(files, key=str.casefold))
             else:
                 if succinct:
-                    files = list(mpgr_dict[compound].values())[0]["files"]
+                    files = [
+                        f if f is not None else ""
+                        for f in list(mpgr_dict[compound].values())[0]["files"]
+                    ]
                     message += "\n\t\t" + "\n\t\t".join(sorted(files, key=str.casefold))
                 else:
+                    files = [
+                        f if f is not None else ""
+                        for f in list(mpgr_dict[compound].values())[0]["files"]
+                    ]
                     samples = list(mpgr_dict[compound].values())[0]["samples"]
                     message += "\n\t\tSamples:\n\t\t\t"
                     message += "\n\t\t\t".join(sorted(samples, key=str.casefold))

--- a/DataRepo/utils/infusate_name_parser.py
+++ b/DataRepo/utils/infusate_name_parser.py
@@ -342,7 +342,7 @@ def parse_isotope_label(
 
     The isotope label string only includes elements observed in the peak reported on the row and a row only exists
     if at least 1 isotope was detected.  However, when an isotope is present, we want to report 0 counts for
-    elements present (as labeled) in the tracers when the compound being recorded on has an element that is labeled
+    elements present (as labeled) in the tracers when the compound being recorded has an element that is labeled
     in the tracers, so to include these 0 counts, supply possible_observations.
 
     NOTE: The isotope label string only includes elements whose label count is greater than 0.  If the tracers


### PR DESCRIPTION
## Summary Change Description

Fixed various issues revealed by Michael's water study that were preventing loading and making error navigation difficult.

Details:

- Made the `MultiplePeakGroupRepresentations` error not inherit from `ValidationError`
- Added a check for `NoTracerLabeledElements` in `PeakGroup.clean()`
- Added a check for `NoTracers` in `PeakGroup.clean()`
- Created `PeakGroup.check_for_multiple_representations()` to encapsulate the logic.
- Created an override of `PeakGroup.save()` to check for multiple representations (because otherwise, a cryptic `IntegrityError` results).

## Affected Issues/Pull Requests

- Resolves #1194
- Resolves #1189
- Merges into main (previously merged into PR #1190)

## Review Notes
<!--
For added context for reviewers, add comments to relevant lines of code.  Use
this space to describe any general areas of concern not linked to a specific
line of code that reviewers should pay particular attention to, e.g. please
make sure I have accounted for all possible inputs.
-->
See comments in-line.

## Checklist
<!--
If any of the checkbox requirements are not met, uncheck them and add an
explanation. E.g. Linting errors pre-date this PR.
-->
This pull request will be merged once the following requirements are met.  The
author and/or reviewers should uncheck any unmet requirements:

- Review requirements
  - Minimum approvals: 1 <!-- Edit as desired (e.g. based on complexity) -->
  - No changes requested
  - All blocking issues resolved by reviewers
  - Specific reviewers: @__add_username_here__
    <!--
    Require reviewers with specific expertise to be included among the minimum
    number of reviewers by tagging them.  Also please send them a message.
    -->
  - Review period: 2 days <!-- Edit as desired (e.g. based on complexity) -->
- Associated issue/pull request requirements:
  <!--
  Assert that all requirements in issues marked "resolved" are done and that
  all required pull requests are merged.  If any are not done, either edit or
  split the issue or explain the unmerged affected pull requests.
  -->
  - [x] All requirements in affected issues marked "resolved" are satisfied
  - [x] All required pull requests are merged *(or none)*
- Basic requirements
  <!--
  Uncheck items to acknowledge failures/conflicts you intend to address.
  Add an explanation if any won't be addressed before merge.
  -->
  - [x] [All linters pass](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#linting)
  - [x] [All tests pass](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#quality-control)
  - [x] All conflicts resolved
- Overhead requirements
  <!--
  These are additional requirements that are not directly associated with
  resolving the affected issue(s).
  -->
  - [x] [New/changed method tests implemented/updated *(or no change)*](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#test-implementation)
  - [ ] [Updated *Unreleased* section of `changelog.md` *(or no change)*](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/changelog.md)
  - [x] [Migrations created & committed *(or no change)*](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#migration-process)
