### PR TITLE
Submission flow phase 2 (adding the sequence form fields)

### DIFF
--- a/DataRepo/management/commands/profile_submission_page.py
+++ b/DataRepo/management/commands/profile_submission_page.py
@@ -4,7 +4,7 @@ from typing import Optional
 
 from django.core.management import BaseCommand
 
-from DataRepo.views.upload.submission import DataValidationView
+from DataRepo.views.upload.submission import BuildSubmissionView
 
 
 def profile(study_doc, peak_annot_files: Optional[list] = None):
@@ -12,7 +12,7 @@ def profile(study_doc, peak_annot_files: Optional[list] = None):
     # Set up all the input files
     study_doc_name = None
     peak_annot_filenames = []
-    dvv = DataValidationView()
+    dvv = BuildSubmissionView()
     if study_doc is not None:
         _, study_doc_name = os.path.split(study_doc)
     if peak_annot_files is None:

--- a/DataRepo/models/msrun_sequence.py
+++ b/DataRepo/models/msrun_sequence.py
@@ -131,3 +131,51 @@ class MSRunSequence(Model):
             instrument,
             date,
         )
+
+    @classmethod
+    def get_most_used_protocol(cls):
+        """Retrieves the name of the most used LCMethod in the database.
+
+        Args:
+            None
+        Exceptions:
+            None
+        Returns:
+            LCMethod name (str) [LCMethod.create_name(LCMethod.DEFAULT_TYPE)]
+        """
+        from django.db.models import Count
+
+        from DataRepo.models import LCMethod
+
+        max_lc_dict = (
+            cls.objects.values("lc_method_id")
+            .annotate(count=Count("lc_method_id"))
+            .order_by("-count")
+            .first()
+        )
+        if max_lc_dict is None:
+            return LCMethod.create_name(LCMethod.DEFAULT_TYPE)
+        return LCMethod.objects.get(id=max_lc_dict["lc_method_id"]).name
+
+    @classmethod
+    def get_most_used_instrument(cls):
+        """Retrieves the name of the most used instrument in the database.
+
+        Args:
+            None
+        Exceptions:
+            None
+        Returns:
+            instrument (str) [cls.INSTRUMENT_DEFAULT]
+        """
+        from django.db.models import Count
+
+        max_instrument_dict = (
+            cls.objects.values("instrument")
+            .annotate(count=Count("instrument"))
+            .order_by("-count")
+            .first()
+        )
+        if max_instrument_dict is None:
+            return cls.INSTRUMENT_DEFAULT
+        return max_instrument_dict["instrument"]

--- a/DataRepo/templates/submission/includes/1_start.html
+++ b/DataRepo/templates/submission/includes/1_start.html
@@ -4,32 +4,54 @@
 <div>
     <h3>Start a Submission</h3>
     <span class="small text-muted">Generate a Study Submission Template with auto-filled samples and compounds extracted from your peak annotation files (e.g. AccuCor) along with other supporting data from the database.</span><br><br>
-    <form action="{% url 'submission' %}" id="submission-validation" method="POST" enctype="multipart/form-data">
+    <form action="{% url 'submission' %}" id="submission-validation" method="POST" enctype="multipart/form-data" class="tbform-control">
         {% csrf_token %}
 
         {{ form.mode }}
 
-        <label for="peak_annotation_files" class="tight-form-label">
+        <label for="peak_annotation_file" class="tight-form-label">
             Peak Annotation Files:
             <span class="small"><span class="small text-muted">(e.g. AccuCor, IsoCorr, and/or IsoAutoCorr files)</span></span>
         </label>
-        {{ form.peak_annotation_files }}
-        <span class="text-danger">{{ form.peak_annotation_files.errors }}</span>
-        <pre id="pending_peak_annot_files" class="drop-area-list-indent"></pre>
+        <table>
+            <tr>
+                <td>
+                    {{ form.peak_annotation_file }}
+                    <span class="text-danger">{{ form.peak_annotation_file.errors }}</span>
+                </td>
+                <td>
+                    {{ form.operator }}
+                    <span class="text-danger">{{ form.operator.errors }}</span>
+                </td>
+                <td>
+                    {{ form.instrument }}
+                    <span class="text-danger">{{ form.instrument.errors }}</span>
+                </td>
+                <td>
+                    {{ form.protocol }}
+                    <span class="text-danger">{{ form.protocol.errors }}</span>
+                </td>
+                <td>
+                    {{ form.run_date }}
+                    <span class="text-danger">{{ form.run_date.errors }}</span>
+                </td>
+            </tr>
+        </table>
+        {% if not form.peak_annotation_file.errors and not form.operator.errors and not form.instrument.errors and not form.protocol.errors and not form.run_date.errors %}<br>{% endif %}
 
         <div style="display: none;">
-            <label for="animal_sample_table" class="tight-form-label">
+            <label for="study_doc" class="tight-form-label">
                 Study doc:
                 <span class="small"><span class="small text-muted">(OPTIONAL <span class="fst-italic">excel</span>, if exists)</span></span>
             </label>
-            {{ form.animal_sample_table }}<span class="text-danger">{{ form.animal_sample_table.errors }}</span>
+            {{ form.study_doc }}<span class="text-danger">{{ form.study_doc.errors }}</span>
             <!-- Errors, if they exist, add an extra like which makes the spacing off -->
-            {% if not form.animal_sample_table.errors %}<br>{% endif %}
+            {% if not form.study_doc.errors %}<br>{% endif %}
         </div>
 
         <span class="text-danger">{{ form.non_field_errors }}</span>
         <button type="submit" class="btn btn-primary" id="validate">Download Template</button>
-        <button type="reset" class="btn btn-secondary" id="clear" onclick="showPeakAnnotFiles([]);">Clear</button>
+        <button type="reset" class="btn btn-secondary" id="clear">Clear</button>
         {% if results %}
             <a class="btn {% if valid %}btn-success{% elif state == 'FAILED' %}btn-danger{% elif state == 'WARNING' %}btn-warning{% else %}btn-secondary{% endif %}" href="{% url 'submission' %}?page=Fill%20In" role="button" style="float: right;">Next</a>
         {% endif %}

--- a/DataRepo/templates/submission/includes/3_validate.html
+++ b/DataRepo/templates/submission/includes/3_validate.html
@@ -14,28 +14,43 @@
 
         {{ form.mode }}
 
-        <div style="display: none;">
-            <label for="peak_annotation_files" class="tight-form-label">
-                Peak Annotation Files:
-                <span class="small"><span class="small text-muted">(e.g. AccuCor, IsoCorr, and/or IsoAutoCorr files)</span></span></span>
-            </label>
-            {{ form.peak_annotation_files }}
-            <span class="text-danger">{{ form.peak_annotation_files.errors }}</span>
-            <pre id="pending_peak_annot_files" class="drop-area-list-indent"></pre>
-        </div>
+        <table style="display: none;">
+            <tr>
+                <td>
+                    {{ form.peak_annotation_file }}
+                    <span class="text-danger">{{ form.peak_annotation_file.errors }}</span>
+                </td>
+                <td>
+                    {{ form.operator }}
+                    <span class="text-danger">{{ form.operator.errors }}</span>
+                </td>
+                <td>
+                    {{ form.instrument }}
+                    <span class="text-danger">{{ form.instrument.errors }}</span>
+                </td>
+                <td>
+                    {{ form.protocol }}
+                    <span class="text-danger">{{ form.protocol.errors }}</span>
+                </td>
+                <td>
+                    {{ form.run_date }}
+                    <span class="text-danger">{{ form.run_date.errors }}</span>
+                </td>
+            </tr>
+        </table>
 
-        <label for="animal_sample_table" class="tight-form-label">
+        <label for="study_doc" class="tight-form-label">
             Study doc:
             <span class="small"><span class="small text-muted">(excel)</span></span>
         </label>
-        {{ form.animal_sample_table }}<span class="text-danger">{{ form.animal_sample_table.errors }}</span>
+        {{ form.study_doc }}<span class="text-danger">{{ form.study_doc.errors }}</span>
         <!-- Errors, if they exist, add an extra like which makes the spacing off -->
-        {% if not form.animal_sample_table.errors %}<br>{% endif %}
+        {% if not form.study_doc.errors %}<br>{% endif %}
 
         <span class="text-danger">{{ form.non_field_errors }}</span>
         <button type="submit" class="btn btn-primary" id="validate">Validate &amp; Repair</button>
         <!-- "Clear" is only needed for -->
-        <button type="reset" class="btn btn-secondary" id="clear" onclick="showPeakAnnotFiles([]);" style="display:none;">Clear</button>
+        <button type="reset" class="btn btn-secondary" id="clear" style="display:none;">Clear</button>
         <a class="btn {% if valid %}btn-success{% elif state == 'FAILED' %}btn-danger{% elif state == 'WARNING' %}btn-warning{% else %}btn-secondary{% endif %}" href="{% url 'submission' %}?page=Submit" role="button" style="float: right;">{% if results %}Next{% else %}Skip{% endif %}</a>
         {{ form.management_form }}
     </form>

--- a/DataRepo/templates/submission/submission.html
+++ b/DataRepo/templates/submission/submission.html
@@ -7,6 +7,7 @@
     <link href="{% static 'css/tabbar.css' %}" rel="stylesheet">
     {% if page == 'Start' or page is None %}
         <link href="{% static 'css/hierarchical_formsets.css' %}" rel="stylesheet">
+        <link href="{% static 'css/tbforms.css' %}" rel="stylesheet">
         <link href="{% static 'css/drop_area.css' %}" rel="stylesheet">
         <script src="{% static 'js/browser_download.js' %}"></script>
         <script src="{% static 'js/file_list_drop_area.js' %}"></script>
@@ -20,6 +21,7 @@
         </script>
     {% elif page == 'Validate' %}
         <link href="{% static 'css/hierarchical_formsets.css' %}" rel="stylesheet">
+        <link href="{% static 'css/tbforms.css' %}" rel="stylesheet">
         <script src="{% static 'js/browser_download.js' %}"></script>
         <script src="{% static 'js/submission.js' %}"></script>
     {% elif page == 'Submit' %}

--- a/DataRepo/tests/views/upload/test_submission.py
+++ b/DataRepo/tests/views/upload/test_submission.py
@@ -36,7 +36,7 @@ from DataRepo.utils.exceptions import (
     RecordDoesNotExist,
 )
 from DataRepo.utils.infusate_name_parser import parse_infusate_name_with_concs
-from DataRepo.views.upload.submission import DataValidationView
+from DataRepo.views.upload.submission import BuildSubmissionView
 
 
 class DataValidationViewTests1(TracebaseTransactionTestCase):
@@ -83,7 +83,7 @@ class DataValidationViewTests1(TracebaseTransactionTestCase):
             name="test", category="animal_treatment", description="test description"
         )
 
-        dvv = DataValidationView()
+        dvv = BuildSubmissionView()
         dvv.study_file = None
 
         dfs_dict = dvv.get_or_create_dfs_dict()
@@ -192,7 +192,7 @@ class DataValidationViewTests1(TracebaseTransactionTestCase):
 
         This also indirectly tests get_study_dfs_dict and fill_in_missing_columns.
         """
-        dvv = DataValidationView()
+        dvv = BuildSubmissionView()
         dvv.study_file = (
             "DataRepo/data/tests/small_obob/small_obob_animal_and_sample_table.xlsx"
         )
@@ -394,7 +394,7 @@ class DataValidationViewTests1(TracebaseTransactionTestCase):
         self.assert_dfs_dicts(expected, dfs_dict)
 
     def test_get_study_dtypes_dict(self):
-        dvv = DataValidationView()
+        dvv = BuildSubmissionView()
         # TODO: Eliminate the need for a dummy file (with an xls extension).  The protocol headers change for the
         # treatments sheet if it's an excel file.  The data is not needed - just the headers.
         dvv.study_file = "dummy.xlsx"
@@ -485,7 +485,7 @@ class DataValidationViewTests1(TracebaseTransactionTestCase):
         self.assertDictEqual(expected, dvv.get_study_dtypes_dict())
 
     def get_data_validation_object_with_errors(self):
-        vo = DataValidationView()
+        vo = BuildSubmissionView()
         vo.load_status_data = MultiLoadStatus(
             load_keys=[
                 "All Samples present",
@@ -608,7 +608,7 @@ class DataValidationViewTests1(TracebaseTransactionTestCase):
         self.assertEqual("WARNING", vo.load_status_data.statuses["file2.xlsx"]["state"])
 
     def test_extract_all_missing_samples(self):
-        vo = DataValidationView()
+        vo = BuildSubmissionView()
         vo.extract_all_missing_values(
             AllMissingSamples(
                 [
@@ -643,7 +643,7 @@ class DataValidationViewTests1(TracebaseTransactionTestCase):
         self.assertDictEqual(expected, vo.autofill_dict)
 
     def test_extract_all_missing_tissues(self):
-        vo = DataValidationView()
+        vo = BuildSubmissionView()
         vo.extract_all_missing_values(
             AllMissingTissues(
                 [
@@ -674,7 +674,7 @@ class DataValidationViewTests1(TracebaseTransactionTestCase):
         self.assertDictEqual(expected, vo.autofill_dict)
 
     def test_extract_all_missing_treatments(self):
-        vo = DataValidationView()
+        vo = BuildSubmissionView()
         vo.extract_all_missing_values(
             AllMissingTreatments(
                 [
@@ -838,7 +838,7 @@ class DataValidationViewTests1(TracebaseTransactionTestCase):
         )
 
     def test_extract_autofill_from_peak_annotation_files(self):
-        dvv = DataValidationView()
+        dvv = BuildSubmissionView()
         dvv.set_files(
             peak_annot_files=["DataRepo/data/tests/data_submission/accucor1.xlsx"]
         )
@@ -898,7 +898,7 @@ class DataValidationViewTests1(TracebaseTransactionTestCase):
         )
 
     def test_determine_study_file_readiness_no_peak_files(self):
-        dvv = DataValidationView()
+        dvv = BuildSubmissionView()
         dvv.set_files(
             study_file="DataRepo/data/tests/small_obob/small_obob_animal_and_sample_table.xlsx",
             study_filename=None,
@@ -909,7 +909,7 @@ class DataValidationViewTests1(TracebaseTransactionTestCase):
         self.assertTrue(dvv.determine_study_file_validation_readiness())
 
     def test_determine_study_file_readiness_study_file_with_sample_names_only(self):
-        dvv = DataValidationView()
+        dvv = BuildSubmissionView()
         dvv.study_file = "study.xlsx"  # Invalid, but does not matter
         dvv.peak_annot_files = ["accucor.xlsx"]  # Invalid, but does not matter
         dvv.dfs_dict = self.get_autofilled_study_dfs_dict()
@@ -917,7 +917,7 @@ class DataValidationViewTests1(TracebaseTransactionTestCase):
         self.assertFalse(dvv.determine_study_file_validation_readiness())
 
     def test_determine_study_file_readiness_fleshed_study_file(self):
-        dvv = DataValidationView()
+        dvv = BuildSubmissionView()
         dvv.study_file = "study.xlsx"  # Invalid, but does not matter
         dvv.peak_annot_files = ["accucor.xlsx"]  # Invalid, but does not matter
         dvv.dfs_dict = self.get_autofilled_study_dfs_dict()
@@ -928,7 +928,7 @@ class DataValidationViewTests1(TracebaseTransactionTestCase):
 
     def test_create_study_file_writer(self):
         # This also tests annotate_study_excel and dfs_dict_is_valid (indirectly)
-        dvv = DataValidationView()
+        dvv = BuildSubmissionView()
         study_stream = BytesIO()
         xlsxwriter = dvv.create_study_file_writer(study_stream)
         dvv.annotate_study_excel(xlsxwriter)
@@ -936,7 +936,7 @@ class DataValidationViewTests1(TracebaseTransactionTestCase):
         self.assertEqual(0, len(base64.b64encode(study_stream.read()).decode("utf-8")))
 
     def test_header_to_cell(self):
-        dvv = DataValidationView()
+        dvv = BuildSubmissionView()
 
         # Get cell location success
         result = dvv.header_to_cell("Animals", "Age")
@@ -1377,7 +1377,7 @@ class DataValidationViewTests2(TracebaseTransactionTestCase):
 
     def validate_some_files(self, sample_file, accucor_files):
         # Test the get_validation_results function
-        vo = DataValidationView()
+        vo = BuildSubmissionView()
         vo.set_files(study_file=sample_file, peak_annot_files=accucor_files)
         # Now try validating the load files
         vo.validate_study()

--- a/DataRepo/urls.py
+++ b/DataRepo/urls.py
@@ -4,7 +4,7 @@ from . import views
 
 urlpatterns = [
     path("", views.home, name="home"),
-    path("submission", views.DataValidationView.as_view(), name="submission"),
+    path("submission", views.BuildSubmissionView.as_view(), name="submission"),
     path(
         "search_basic/<str:mdl>/<str:fld>/<str:cmp>/<str:val>/<str:fmt>/",
         views.search_basic,

--- a/DataRepo/utils/file_utils.py
+++ b/DataRepo/utils/file_utils.py
@@ -1,6 +1,6 @@
+import datetime
 import pathlib
 from collections import defaultdict
-from datetime import datetime
 from typing import Optional
 from zipfile import BadZipFile
 
@@ -19,6 +19,8 @@ from DataRepo.utils.exceptions import (
     InvalidDtypeKeys,
     InvalidHeaders,
 )
+
+date_format = "%Y-%m-%d"
 
 
 def read_from_file(
@@ -625,7 +627,7 @@ def string_to_date(
         date_str = date_str.replace(" 00:00:00", "")
 
     try:
-        dt = datetime.strptime(date_str.strip(), format_str).date()
+        dt = datetime.datetime.strptime(date_str.strip(), format_str).date()
     except ValueError as ve:
         try:
             # Fallback to try dateutil
@@ -649,6 +651,11 @@ def string_to_date(
     return dt
 
 
-def datetime_to_string(date_in: datetime, format_str: Optional[str] = None):
-    format = "%Y-%m-%d" if format_str is None else format_str
+def datetime_to_string(date_in: datetime.datetime, format_str: Optional[str] = None):
+    format = date_format if format_str is None else format_str
     return date_in.strftime(format)
+
+
+def date_to_string(date_in: datetime.date, format_str: Optional[str] = None):
+    format = date_format if format_str is None else format_str
+    return datetime.date.strftime(date_in, format)

--- a/DataRepo/views/__init__.py
+++ b/DataRepo/views/__init__.py
@@ -33,11 +33,11 @@ from .search import (
     search_basic,
     view_search_results,
 )
-from .upload import DataValidationView
+from .upload import BuildSubmissionView
 
 __all__ = [
     "home",
-    "DataValidationView",
+    "BuildSubmissionView",
     "search_basic",
     "view_search_results",
     "AdvancedSearchView",

--- a/DataRepo/views/upload/__init__.py
+++ b/DataRepo/views/upload/__init__.py
@@ -1,5 +1,5 @@
-from .submission import DataValidationView
+from .submission import BuildSubmissionView
 
 __all__ = [
-    "DataValidationView",
+    "BuildSubmissionView",
 ]

--- a/DataRepo/views/upload/submission.py
+++ b/DataRepo/views/upload/submission.py
@@ -76,7 +76,6 @@ from DataRepo.utils.text_utils import autowrap
 
 
 class BuildSubmissionView(FormView):
-    form_class = create_BuildSubmissionForm()
     template_name = "submission/submission.html"
     success_url = ""
     submission_url = settings.SUBMISSION_FORM_URL
@@ -305,6 +304,9 @@ class BuildSubmissionView(FormView):
                 "dict": {"bg_color": "#F2F2F2"},
             },
         }
+
+    def get_form_class(self):
+        return create_BuildSubmissionForm()
 
     def set_files(
         self,

--- a/DataRepo/views/upload/submission.py
+++ b/DataRepo/views/upload/submission.py
@@ -15,7 +15,7 @@ from django.db.utils import ProgrammingError
 from django.forms import ValidationError
 from django.views.generic.edit import FormView
 
-from DataRepo.forms import DataSubmissionValidationForm
+from DataRepo.forms import BuildSubmissionForm
 from DataRepo.loaders.animals_loader import AnimalsLoader
 from DataRepo.loaders.base.table_column import ColumnReference
 from DataRepo.loaders.base.table_loader import TableLoader
@@ -75,8 +75,8 @@ from DataRepo.utils.infusate_name_parser import (
 from DataRepo.utils.text_utils import autowrap
 
 
-class DataValidationView(FormView):
-    form_class = DataSubmissionValidationForm
+class BuildSubmissionView(FormView):
+    form_class = BuildSubmissionForm
     template_name = "submission/submission.html"
     success_url = ""
     submission_url = settings.SUBMISSION_FORM_URL
@@ -565,7 +565,7 @@ class DataValidationView(FormView):
         return context
 
     def dispatch(self, request, *args, **kwargs):
-        return super(DataValidationView, self).dispatch(request, *args, **kwargs)
+        return super(BuildSubmissionView, self).dispatch(request, *args, **kwargs)
 
     def post(self, request, *args, **kwargs):
         form_class = self.get_form_class()
@@ -574,16 +574,16 @@ class DataValidationView(FormView):
         if not form.is_valid():
             return self.form_invalid(form)
 
-        if "animal_sample_table" in request.FILES:
-            sample_file = request.FILES["animal_sample_table"]
-            tmp_study_file = sample_file.temporary_file_path()
+        if "study_doc" in request.FILES:
+            study_doc = request.FILES["study_doc"]
+            tmp_study_file = study_doc.temporary_file_path()
         else:
             # Ignore missing study file (allow user to validate just the accucor/isocorr file(s))
-            sample_file = None
+            study_doc = None
             tmp_study_file = None
 
-        if "peak_annotation_files" in request.FILES:
-            peak_annotation_files = request.FILES.getlist("peak_annotation_files")
+        if "peak_annotation_file" in request.FILES:
+            peak_annotation_files = [request.FILES["peak_annotation_file"]]
         else:
             # Ignore missing accucor files (allow user to validate just the sample file)
             peak_annotation_files = []
@@ -592,7 +592,7 @@ class DataValidationView(FormView):
 
         self.set_files(
             tmp_study_file,
-            study_filename=str(sample_file) if sample_file is not None else None,
+            study_filename=str(study_doc) if study_doc is not None else None,
             peak_annot_files=[fp.temporary_file_path() for fp in peak_annotation_files],
             peak_annot_filenames=[str(fp) for fp in peak_annotation_files],
         )

--- a/DataRepo/views/upload/submission.py
+++ b/DataRepo/views/upload/submission.py
@@ -15,7 +15,7 @@ from django.db.utils import ProgrammingError
 from django.forms import ValidationError
 from django.views.generic.edit import FormView
 
-from DataRepo.forms import BuildSubmissionForm
+from DataRepo.forms import create_BuildSubmissionForm
 from DataRepo.loaders.animals_loader import AnimalsLoader
 from DataRepo.loaders.base.table_column import ColumnReference
 from DataRepo.loaders.base.table_loader import TableLoader
@@ -76,7 +76,7 @@ from DataRepo.utils.text_utils import autowrap
 
 
 class BuildSubmissionView(FormView):
-    form_class = BuildSubmissionForm
+    form_class = create_BuildSubmissionForm()
     template_name = "submission/submission.html"
     success_url = ""
     submission_url = settings.SUBMISSION_FORM_URL

--- a/DataRepo/widgets.py
+++ b/DataRepo/widgets.py
@@ -1,0 +1,66 @@
+from typing import List
+
+from django.db import ProgrammingError
+from django.forms.widgets import TextInput
+from django.utils.safestring import mark_safe
+
+
+class AutoCompleteTextInput(TextInput):
+    """This defines a widget for text form input with autocomplete using an HTML5 datalist element."""
+
+    def __init__(
+        self,
+        datalist_id: str,
+        datalist_values: List[str],
+        *args,
+        datalist_manual=False,
+        **kwargs,
+    ):
+        """Constructor for the widget.
+
+        Args:
+            attrs (dict) with the following recognized (additional) keys:
+                datalist_id (str): Required ID for the datalist element and the "list" attribute of the input element.
+                datalist_values (List[str]): Required list of values for the datalist element.
+                datalist_manual (bool): Whther to automatically include the datalist element in the rendered html.
+                    Note, if this is true, you must call the datalist method in your template to render its html.
+        Exceptions:
+            ProgrammingError
+        Returns:
+            object (AutoCompleteTextInput)
+        """
+        super().__init__(*args, **kwargs)
+        if (
+            datalist_id is not None
+            and "list" in self.attrs.keys()
+            and self.attrs["list"] != datalist_id
+        ):
+            raise ProgrammingError(
+                "A 'list' attribute must not be supplied if 'datalist_id' is provided."
+            )
+
+        self.datalist_id = datalist_id
+        self.datalist_values = datalist_values
+        self.attrs["list"] = self.datalist_id
+        self.datalist_manual = datalist_manual
+        # This makes tabbing to the field reveal the dropdown.  Without this, it only ever drops down on click.
+        self.attrs["onfocus"] = "this.click();"
+
+    def render(self, *args, **kwargs):
+        """This renders the HTML for the widget (the input element and an associated datalist element).
+
+        Args:
+            None
+        Exceptions:
+            None
+        Returns:
+            html (str)
+        """
+        html = super().render(*args, **kwargs)
+        if not self.datalist_manual:
+            html += self.datalist()
+        return html
+
+    def datalist(self):
+        vals = " ".join([f"<option>{val}</option>" for val in self.datalist_values])
+        return mark_safe(f'<datalist id="{self.datalist_id}">{vals}</datalist>')

--- a/static/css/tbforms.css
+++ b/static/css/tbforms.css
@@ -1,0 +1,16 @@
+.tbform-control ::placeholder { /* Chrome, Firefox, Opera, Safari 10.1+ */
+  color: #a9a9a9;
+  opacity: 1; /* Firefox */
+}
+
+input[type="text"] {
+  width: 20ch;
+}
+
+input[type="file"] {
+  width: 50ch;
+}
+
+table td {
+  vertical-align:top;
+}

--- a/static/js/submission.js
+++ b/static/js/submission.js
@@ -1,11 +1,8 @@
-// TODO: Figure out how to import methods from other files: browserDownloadExcel, getFileNamesString, DataTransfer
+// TODO: Figure out how to import methods from other files: browserDownloadExcel
 // See https://stackoverflow.com/questions/950087/
 document.addEventListener('DOMContentLoaded', function () {
-  const peakAnnotInput = document.getElementById('peak_annotation_files_field')
-  const peakAnnotList = document.getElementById('pending_peak_annot_files')
   const studyFileContentTag = document.getElementById('output_study_file')
   const studyFileNameTag = document.getElementById('output_study_file_name')
-  let currentPeakAnnotFiles = null
 
   // If there is a study file that was produced
   if (typeof studyFileContentTag !== 'undefined' && studyFileContentTag) {
@@ -13,39 +10,5 @@ document.addEventListener('DOMContentLoaded', function () {
       studyFileNameTag.innerHTML,
       studyFileContentTag.innerHTML
     )
-  }
-
-  // Note that the reset button does not trigger a change event, so see its onclick code
-  peakAnnotInput.addEventListener(
-    'change',
-    function () { handlePeakAnnotFiles(peakAnnotInput.files) },
-    false
-  )
-
-  function showPeakAnnotFiles (files) {
-    peakAnnotList.innerHTML = getFileNamesString(files) // eslint-disable-line no-undef
-  }
-
-  function handlePeakAnnotFiles (files, add) {
-    if (typeof add === 'undefined' || add === null) {
-      add = true
-    }
-    // If we're adding files, oreviously selected files exist, and the field isn't being cleared
-    if (add && typeof currentPeakAnnotFiles !== 'undefined' && currentPeakAnnotFiles && files.length > 0) {
-      // DataTransfer comes from browsers
-      const dT = new DataTransfer() // eslint-disable-line no-undef
-      // Add previously added files to the DataTranfer object
-      for (let i = 0; i < currentPeakAnnotFiles.length; i++) {
-        dT.items.add(currentPeakAnnotFiles[i])
-      }
-      // Add newly selected files to the DataTranfer object
-      for (let i = 0; i < files.length; i++) {
-        dT.items.add(files[i])
-      }
-      // Set the file input element to the combined (previously added and new) files
-      peakAnnotInput.files = dT.files
-    }
-    currentPeakAnnotFiles = peakAnnotInput.files
-    showPeakAnnotFiles(peakAnnotInput.files)
   }
 })


### PR DESCRIPTION
## Summary Change Description

This is an incremental step toward changing the submission start page to include sequence details for each input peak annotation file.  It replaces the multi-file picker with a single-file picker that will be cloned in javascript using +/- buttons, like in the advanced search.

The resulting start page (temporarily) looks like this:

![seqins](https://github.com/user-attachments/assets/9372b47a-4541-478f-87f4-325e7ee9b4c9)

It implements dropdowns for 3 of the sequence metadata fields, e.g.:

![dropdownseq](https://github.com/user-attachments/assets/9fcd1f35-73d4-4c9d-9107-decbaf0be891)

Details:

- Renamed the form and view classes involved from including "validation" to "submission".
- Removed the javascript code that rendered the peak annotation file list (because it will no longer be used).
- Changed the names of the study doc and peak annotation form fields (and made the necessary changes for changing the multi-file picker to a single file picker).  I kept the list variables in the view (and statically coded a single element list for now, as this WILL turn back into a multi-file list).
- I had to create a date_to_string method in the file utils.  This needs to change, but figuring that out is not a part of this work.
- I created static/css/tbforms.css to handle the css for the form.  Mainly, I just wanted a lighter gray for the placeholders, but I couldn't figure out how I'd done it for the advanced search page, despite looking for quite some time.
- I added get_most_used_protocol and get_most_used_instrument to MSRunSequence for convenience.
- Each added sequence field uses a drop-down of current values in the DB.
- There is a new widgets.py file for the drop-down rendering.  I made the datalist element optionally rendered, in anticipation of wanting to only render it once for all of the cloned forms.
- I updated the form class's clean method and added an is_valid method (both with the same logic).

## Affected Issues/Pull Requests

- Partially addresses #1097 (this satisfies all of requirement `1.` in that issue)
- Merges into main

## Review Notes
<!--
For added context for reviewers, add comments to relevant lines of code.  Use
this space to describe any general areas of concern not linked to a specific
line of code that reviewers should pay particular attention to, e.g. please
make sure I have accounted for all possible inputs.
-->
See comments in-line.

## Checklist
<!--
If any of the checkbox requirements are not met, uncheck them and add an
explanation. E.g. Linting errors pre-date this PR.
-->
This pull request will be merged once the following requirements are met.  The
author and/or reviewers should uncheck any unmet requirements:

- Review requirements
  - Minimum approvals: 1 <!-- Edit as desired (e.g. based on complexity) -->
  - No changes requested
  - All blocking issues resolved by reviewers
  - Specific reviewers: @__add_username_here__
    <!--
    Require reviewers with specific expertise to be included among the minimum
    number of reviewers by tagging them.  Also please send them a message.
    -->
  - Review period: 2 days <!-- Edit as desired (e.g. based on complexity) -->
- Associated issue/pull request requirements:
  <!--
  Assert that all requirements in issues marked "resolved" are done and that
  all required pull requests are merged.  If any are not done, either edit or
  split the issue or explain the unmerged affected pull requests.
  -->
  - [x] All requirements in affected issues marked "resolved" are satisfied
  - [x] All required pull requests are merged *(or none)*
- Basic requirements
  <!--
  Uncheck items to acknowledge failures/conflicts you intend to address.
  Add an explanation if any won't be addressed before merge.
  -->
  - [x] [All linters pass](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#linting)
  - [x] [All tests pass](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#quality-control)
  - [x] All conflicts resolved
- Overhead requirements
  <!--
  These are additional requirements that are not directly associated with
  resolving the affected issue(s).
  -->
  - [x] [New/changed method tests implemented/updated *(or no change)*](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#test-implementation)
  - [ ] [Updated *Unreleased* section of `changelog.md` *(or no change)*](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/changelog.md)
  - [x] [Migrations created & committed *(or no change)*](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#migration-process)
