### PR TITLE
Removed the sequence from the multiple representation choice logic

### DIFF
--- a/DataRepo/data/tests/multiple_representations/mult_reps.tsv
+++ b/DataRepo/data/tests/multiple_representations/mult_reps.tsv
@@ -1,6 +1,6 @@
-Peak Group Conflict	Sequence Name	Selected Peak Annotation File
-Lysine	Anonymous, polar-HILIC-25-min, Exploris480, 2024-01-19	accucor_pos.xlsx
-lysine	Anonymous, polar-HILIC-25-min, Exploris480, 2024-01-19	parentdir/samefilename/casediff/accucor_pos.xlsx
-asparagine	Anonymous, polar-HILIC-25-min, Exploris480, 2024-01-20	ok/nextday/isocorr1.xlsx
-L-aspartame/R-aspartame	Anonymous, polar-HILIC-25-min, Exploris480, 2024-01-20	v1/isocorr1.xlsx
-r-aspartame/l-aspartame	Anonymous, polar-HILIC-25-min, Exploris480, 2024-01-20	v2/difforder/diffcase/difffile/bad/isocorr2.xlsx
+Peak Group Conflict	Common Samples	Selected Peak Annotation File	Common Sample Count	Example Samples
+Lysine	sample1;sample2;sample3	accucor_pos.xlsx	3	sample1;sample2;sample3
+lysine	sample1;sample2;sample3	parentdir/samefilename/casediff/accucor_pos.xlsx	3	sample1;sample2;sample3
+asparagine	sampleA;sampleB	ok/nextday/isocorr1.xlsx	2	sampleA;sampleB
+L-aspartame/R-aspartame	sampleA;sampleB	v1/isocorr1.xlsx	2	sampleA;sampleB
+r-aspartame/l-aspartame	sampleA;sampleB	v2/difforder/diffcase/difffile/bad/isocorr2.xlsx	2	sampleA;sampleB

--- a/DataRepo/data/tests/multiple_representations/mult_reps.tsv
+++ b/DataRepo/data/tests/multiple_representations/mult_reps.tsv
@@ -1,6 +1,6 @@
 Peak Group Conflict	Common Samples	Selected Peak Annotation File	Common Sample Count	Example Samples
-Lysine	sample1;sample2;sample3	accucor_pos.xlsx	3	sample1;sample2;sample3
-lysine	sample1;sample2;sample3	parentdir/samefilename/casediff/accucor_pos.xlsx	3	sample1;sample2;sample3
-asparagine	sampleA;sampleB	ok/nextday/isocorr1.xlsx	2	sampleA;sampleB
-L-aspartame/R-aspartame	sampleA;sampleB	v1/isocorr1.xlsx	2	sampleA;sampleB
-r-aspartame/l-aspartame	sampleA;sampleB	v2/difforder/diffcase/difffile/bad/isocorr2.xlsx	2	sampleA;sampleB
+Lysine	sample1;sample2;sample3	accucor_pos.xlsx	3	sample1
+lysine	sample1;sample2;sample3	parentdir/samefilename/casediff/accucor_pos.xlsx	3	sample1
+asparagine	sampleA;sampleB	ok/nextday/isocorr1.xlsx	2	sampleA
+L-aspartame/R-aspartame	sampleA;sampleB	v1/isocorr1.xlsx	2	sampleA
+r-aspartame/l-aspartame	sampleA;sampleB	v2/difforder/diffcase/difffile/bad/isocorr2.xlsx	2	sampleA

--- a/DataRepo/loaders/peak_group_conflicts.py
+++ b/DataRepo/loaders/peak_group_conflicts.py
@@ -123,12 +123,12 @@ class PeakGroupConflicts(TableLoader):
         ANNOTFILE=TableColumn.init_flat(
             name=DataHeaders.ANNOTFILE,
             help_text=(
-                "There must exist only one peak group compound for every sample.  Sometimes a compound can show up in "
-                "multiple scans (e.g. in positive and negative mode scans).  You must select the file containing the "
-                "best representation of each compound.  Using the provided drop-downs, select the peak annotation file "
-                "from which this peak group should be loaded for the listed samples.  That compound in the remaining "
-                "files will be skipped for those samples.  Note, each drop-down contains only the peak annotation "
-                "files containing the peak group compound for that row."
+                "TraceBase will accept only one peak group measurement for each compound in a given sample.  Sometimes "
+                "a compound can show up in multiple scans (e.g. in positive and negative mode scans).  You must select "
+                "the file containing the best representation of each compound.  Using the provided drop-downs, select "
+                "the peak annotation file from which this peak group should be loaded for the listed samples.  That "
+                "compound in the remaining files will be skipped for those samples.  Note, each drop-down contains "
+                "only the peak annotation files containing the peak group compound for that row."
             ),
             reference=ColumnReference(
                 loader_class=PeakAnnotationFilesLoader,

--- a/DataRepo/tests/loaders/test_peak_group_conflicts.py
+++ b/DataRepo/tests/loaders/test_peak_group_conflicts.py
@@ -13,10 +13,22 @@ class PeakGroupConflictsTests(TracebaseTestCase):
         selected_dict = pgc.get_selected_representations()
         expected = {
             # Duplicates that only issue a warning and still skip
-            "Anonymous, polar-HILIC-25-min, Exploris480, 2024-01-19": {
+            "sample1": {
                 "lysine": "accucor_pos.xlsx",
             },
-            "Anonymous, polar-HILIC-25-min, Exploris480, 2024-01-20": {
+            "sample2": {
+                "lysine": "accucor_pos.xlsx",
+            },
+            "sample3": {
+                "lysine": "accucor_pos.xlsx",
+            },
+            "sampleA": {
+                # Version with no issues
+                "asparagine": "isocorr1.xlsx",
+                # Differing conflict resolutions because equivalent names (despite case and order differences)
+                "l-aspartame/r-aspartame": None,
+            },
+            "sampleB": {
                 # Version with no issues
                 "asparagine": "isocorr1.xlsx",
                 # Differing conflict resolutions because equivalent names (despite case and order differences)


### PR DESCRIPTION
## Summary Change Description

Removed the Sequence Name column and added a Common Samples column (along with 2 other metadata columns for sample count and a short set of example samples).

This supports only 1 peak group compound representation per sample as opposed to 1 per sample and sequence.  I could have left sequence and made it a delimited column, but decided that I could add it back later.  Right now, the priority is the basic functionality.

I changed the returned dict to be keyed on individual sample name instead of the combo and instead of the sequence.  It will make the lookup easier.

I intend to hide the common samples column, because it will be a mess to look at for the user, but it's utility is for the unique constraint (and to support multiple sequences in a file with difference sets of samples).

Files checked in: DataRepo/data/tests/multiple_representations/mult_reps.tsv DataRepo/loaders/peak_group_conflicts.py DataRepo/tests/loaders/test_peak_group_conflicts.py

## Affected Issues/Pull Requests

- Resolves #1199
- Merges into PR #1202

## Review Notes
<!--
For added context for reviewers, add comments to relevant lines of code.  Use
this space to describe any general areas of concern not linked to a specific
line of code that reviewers should pay particular attention to, e.g. please
make sure I have accounted for all possible inputs.
-->
See comments in-line.

## Checklist
<!--
If any of the checkbox requirements are not met, uncheck them and add an
explanation. E.g. Linting errors pre-date this PR.
-->
This pull request will be merged once the following requirements are met.  The
author and/or reviewers should uncheck any unmet requirements:

- Review requirements
  - Minimum approvals: 1 <!-- Edit as desired (e.g. based on complexity) -->
  - No changes requested
  - All blocking issues resolved by reviewers
  - Specific reviewers: @__add_username_here__
    <!--
    Require reviewers with specific expertise to be included among the minimum
    number of reviewers by tagging them.  Also please send them a message.
    -->
  - Review period: 2 days <!-- Edit as desired (e.g. based on complexity) -->
- Associated issue/pull request requirements:
  <!--
  Assert that all requirements in issues marked "resolved" are done and that
  all required pull requests are merged.  If any are not done, either edit or
  split the issue or explain the unmerged affected pull requests.
  -->
  - [x] All requirements in affected issues marked "resolved" are satisfied
  - [x] All required pull requests are merged *(or none)*
- Basic requirements
  <!--
  Uncheck items to acknowledge failures/conflicts you intend to address.
  Add an explanation if any won't be addressed before merge.
  -->
  - [x] [All linters pass](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#linting)
  - [x] [All tests pass](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#quality-control)
  - [x] All conflicts resolved
- Overhead requirements
  <!--
  These are additional requirements that are not directly associated with
  resolving the affected issue(s).
  -->
  - [x] [New/changed method tests implemented/updated *(or no change)*](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#test-implementation)
  - [ ] [Updated *Unreleased* section of `changelog.md` *(or no change)*](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/changelog.md)
  - [x] [Migrations created & committed *(or no change)*](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#migration-process)
