### PR TITLE
Submission start - Create and autofill the peak group conflicts sheet

### DIFF
--- a/DataRepo/loaders/base/table_loader.py
+++ b/DataRepo/loaders/base/table_loader.py
@@ -1242,13 +1242,9 @@ class TableLoader(ABC):
 
         hidden_column_names = []
         for key in self.DataHiddenColumns:
-            hdr = getattr(headers, key)
-            if hdr is None:
-                # This is in case the custom-supplied headers are incomplete (they should not be if they came from the
-                # instance - only if this is called externally)
-                hidden_column_names.append(getattr(self.DataHeaders, key))
-            else:
-                hidden_column_names.append(hdr)
+            default_header = getattr(self.DataHeaders, key)
+            header = getattr(headers, key, default_header)
+            hidden_column_names.append(header)
 
         return hidden_column_names
 

--- a/DataRepo/loaders/base/table_loader.py
+++ b/DataRepo/loaders/base/table_loader.py
@@ -3,7 +3,7 @@ import re
 from abc import ABC, abstractmethod
 from collections import defaultdict, namedtuple
 from collections.abc import Iterable
-from typing import Dict, Optional, Type
+from typing import Dict, List, Optional, Type
 
 from django.core.exceptions import (
     MultipleObjectsReturned,
@@ -62,6 +62,7 @@ class TableLoader(ABC):
             values must be unique in the file.
         FieldToDataHeaderKey (dict): Header keys by field name.
         DataColumnTypes (Optional[dict]): Column value types by header key.
+        DataHiddenColumns (Optional[list]): Header keys
         DataDefaultValues (Optional[DataTableHeaders of objects]): Column default values by header key.  Auto-filled.
         Models (list of Models): List of model classes.
         DataColumnMetadata (DataTableHeaders of TableColumns): TableColumn objects by header key.
@@ -163,6 +164,11 @@ class TableLoader(ABC):
     # (converted to by-header-name in get_column_types)
     # dict of types by header key
     DataColumnTypes: Optional[Dict[str, Type[str]]] = None
+
+    # DataHiddenColumns is optional unless there is an error associated with the column
+    # (converted to by-header-name in get_column_types)
+    # dict of types by header key
+    DataHiddenColumns: Optional[List[str]] = None
 
     # FieldToDataValueConverter is a dict of (lambda) functions keyed on model and field names
     # Use this for exporting the database field values to the value in the column
@@ -834,6 +840,7 @@ class TableLoader(ABC):
             DataUniqueColumnConstraints (class attribute, list of lists of strings): Sets of unique column combinations
             FieldToDataHeaderKey (class attribute, dict): Header keys by field name
             DataColumnTypes (class attribute, Optional[dict]): Column value types by header key
+            DataHiddenColumns (class attribute, Optional[list]): Header keys
             DataDefaultValues (Optional[namedtuple of DataTableHeaders of objects]): Column default values by header key
             DataColumnMetadata (class attribute, namedtuple of DataTableHeaders of TableColumns)
 
@@ -946,6 +953,24 @@ class TableLoader(ABC):
                                 f"must be one of {list(cls.DataHeaders._asdict().keys())}"
                             )
                             valid_types = False
+
+            if cls.DataHiddenColumns is not None:
+                if not isinstance(cls.DataHiddenColumns, list):
+                    typeerrs.append(
+                        f"attribute [{cls.__name__}.DataHiddenColumns] must be a list of strings"
+                    )
+                else:
+                    for hk in cls.DataHiddenColumns:
+                        if not isinstance(hk, str):
+                            typeerrs.append(
+                                f"list attribute [{cls.__name__}.DataHiddenColumns] must have string values, "
+                                f"but type [{type(hk).__name__}] encountered"
+                            )
+                        elif hk not in cls.DataHeaders._asdict().keys():
+                            typeerrs.append(
+                                f"list attribute [{cls.__name__}.DataHiddenColumns] has an invalid key: [{hk}].  Keys "
+                                f"must be one of {list(cls.DataHeaders._asdict().keys())}"
+                            )
 
             if cls.DataDefaultValues is None:
                 # DataDefaultValues is optional (not often used/needed). Set all to None using DataHeaders
@@ -1178,6 +1203,54 @@ class TableLoader(ABC):
                 dtypes[hdr] = self.DataColumnTypes[key]
 
         return dtypes
+
+    def get_hidden_columns(self):
+        """Returns a list of hidden columns by header name (not header key).
+
+        Args:
+            None
+        Exceptions:
+            None
+        Returns:
+            hidden_column_names (list): Header names
+        """
+        if self.DataHiddenColumns is None:
+            return []
+
+        if hasattr(self, "headers") and self.headers is not None:
+            return self._get_hidden_columns(self.headers)
+
+        return self._get_hidden_columns()
+
+    @classmethod
+    def _get_hidden_columns(self, headers=None):
+        """Returns a list of hidden columns by header name (not header key).
+
+        Args:
+            headers (namedtuple)
+        Exceptions:
+            None
+        Returns:
+            hidden_column_names (list): Header names
+        """
+        # TODO: Make optional mode have the ability to consider the required state for the column
+        if self.DataHiddenColumns is None:
+            return []
+
+        if headers is None:
+            headers = self.DataHeaders
+
+        hidden_column_names = []
+        for key in self.DataHiddenColumns:
+            hdr = getattr(headers, key)
+            if hdr is None:
+                # This is in case the custom-supplied headers are incomplete (they should not be if they came from the
+                # instance - only if this is called externally)
+                hidden_column_names.append(getattr(self.DataHeaders, key))
+            else:
+                hidden_column_names.append(hdr)
+
+        return hidden_column_names
 
     @classmethod
     def header_key_to_name(cls, indict, headers=None):

--- a/DataRepo/loaders/peak_group_conflicts.py
+++ b/DataRepo/loaders/peak_group_conflicts.py
@@ -84,6 +84,8 @@ class PeakGroupConflicts(TableLoader):
 
     # No FieldToDataValueConverter needed
 
+    DataHiddenColumns = [SAMPLES_KEY]
+
     DataColumnMetadata = DataTableHeaders(
         PEAKGROUP=TableColumn.init_flat(
             name=DataHeaders.PEAKGROUP,

--- a/DataRepo/loaders/study_loader.py
+++ b/DataRepo/loaders/study_loader.py
@@ -39,6 +39,7 @@ from DataRepo.loaders.peak_annotations_loader import (
     PeakAnnotationsLoader,
     UnicorrLoader,
 )
+from DataRepo.loaders.peak_group_conflicts import PeakGroupConflicts
 from DataRepo.loaders.protocols_loader import ProtocolsLoader
 from DataRepo.loaders.samples_loader import SamplesLoader
 from DataRepo.loaders.sequences_loader import SequencesLoader
@@ -127,6 +128,7 @@ class StudyLoader(ConvertedTableLoader, ABC):
     SEQUENCES_SHEET = "SEQUENCES"
     HEADERS_SHEET = "HEADERS"
     FILES_SHEET = "FILES"
+    PGCONFLICTS_SHEET = "PGCONFLICTS"
     DEFAULTS_SHEET = "DEFAULTS"
     ERRORS_SHEET = "ERRORS"
 
@@ -146,6 +148,7 @@ class StudyLoader(ConvertedTableLoader, ABC):
             "SEQUENCES",
             "HEADERS",
             "FILES",
+            "PGCONFLICTS",
             "DEFAULTS",
             "ERRORS",
         ],
@@ -165,6 +168,7 @@ class StudyLoader(ConvertedTableLoader, ABC):
         SEQUENCES=SequencesLoader.DataSheetName,
         HEADERS=MSRunsLoader.DataSheetName,
         FILES=PeakAnnotationFilesLoader.DataSheetName,
+        PGCONFLICTS=PeakGroupConflicts.DataSheetName,
         DEFAULTS="Defaults",
         ERRORS="Errors",
     )
@@ -190,6 +194,7 @@ class StudyLoader(ConvertedTableLoader, ABC):
         SEQUENCES=None,
         HEADERS=None,
         FILES=None,
+        PGCONFLICTS=None,
         DEFAULTS=None,
         ERRORS=None,
     )
@@ -213,6 +218,7 @@ class StudyLoader(ConvertedTableLoader, ABC):
         SEQUENCES=SequencesLoader,
         HEADERS=MSRunsLoader,
         FILES=PeakAnnotationFilesLoader,
+        PGCONFLICTS=PeakGroupConflicts,
         DEFAULTS=None,
         ERRORS=None,
     )
@@ -231,19 +237,21 @@ class StudyLoader(ConvertedTableLoader, ABC):
         SEQUENCES={},
         HEADERS={},
         FILES={},
+        PGCONFLICTS={},
         DEFAULTS=None,
         ERRORS=None,
     )
 
     DataSheetDisplayOrder = [
         STUDY_SHEET,
+        TRACERS_SHEET,
+        INFUSATES_SHEET,
         ANIMALS_SHEET,
         SAMPLES_SHEET,
+        SEQUENCES_SHEET,
         FILES_SHEET,
         HEADERS_SHEET,
-        SEQUENCES_SHEET,
-        INFUSATES_SHEET,
-        TRACERS_SHEET,
+        PGCONFLICTS_SHEET,
         TREATMENTS_SHEET,
         TISSUES_SHEET,
         COMPOUNDS_SHEET,

--- a/DataRepo/tests/loaders/test_study_loader.py
+++ b/DataRepo/tests/loaders/test_study_loader.py
@@ -109,6 +109,7 @@ class StudyLoaderTests(TracebaseTestCase):
                 "HEADERS": "Peak Annotation Details",
                 "INFUSATES": "Infusates",
                 "LCPROTOCOLS": "LC Protocols",
+                "PGCONFLICTS": "Peak Group Conflicts",
                 "SAMPLES": "Samples",
                 "SEQUENCES": "Sequences",
                 "STUDY": "Study",

--- a/DataRepo/tests/views/upload/test_submission.py
+++ b/DataRepo/tests/views/upload/test_submission.py
@@ -481,6 +481,12 @@ class DataValidationViewTests1(TracebaseTransactionTestCase):
                 "File Format": str,
                 "Peak Annotation File": str,
             },
+            "Peak Group Conflicts": {
+                "Common Samples": str,
+                "Example Samples": str,
+                "Peak Group Conflict": str,
+                "Selected Peak Annotation File": str,
+            },
         }
         self.assertDictEqual(expected, dvv.get_study_dtypes_dict())
 

--- a/DataRepo/tests/views/upload/test_submission.py
+++ b/DataRepo/tests/views/upload/test_submission.py
@@ -14,6 +14,7 @@ from DataRepo.loaders.msruns_loader import MSRunsLoader
 from DataRepo.loaders.peak_annotation_files_loader import (
     PeakAnnotationFilesLoader,
 )
+from DataRepo.loaders.peak_group_conflicts import PeakGroupConflicts
 from DataRepo.loaders.samples_loader import SamplesLoader
 from DataRepo.loaders.sequences_loader import SequencesLoader
 from DataRepo.loaders.studies_loader import StudiesLoader
@@ -169,6 +170,13 @@ class DataValidationViewTests1(TracebaseTransactionTestCase):
                 "Default Sequence Name": str,
                 "File Format": str,
                 "Peak Annotation File": str,
+            },
+            "Peak Group Conflicts": {
+                "Peak Group Conflict": str,
+                "Selected Peak Annotation File": str,
+                "Common Sample Count": int,
+                "Example Samples": str,
+                "Common Samples": str,
             },
         }
 
@@ -370,6 +378,13 @@ class DataValidationViewTests1(TracebaseTransactionTestCase):
                 "Peak Annotation File": {},
             },
             "Infusions": None,  # Ignoring this one
+            "Peak Group Conflicts": {
+                "Peak Group Conflict": {},
+                "Selected Peak Annotation File": {},
+                "Common Sample Count": {},
+                "Example Samples": {},
+                "Common Samples": {},
+            },
         }
 
         # The following is to avoid a JSCPD error.  Silly hoop jumping...
@@ -595,6 +610,7 @@ class DataValidationViewTests1(TracebaseTransactionTestCase):
                 "Sequences": {},
                 "Peak Annotation Details": {},
                 "Peak Annotation Files": {},
+                "Peak Group Conflicts": {},
             },
             vo.autofill_dict,
         )
@@ -645,6 +661,7 @@ class DataValidationViewTests1(TracebaseTransactionTestCase):
             SequencesLoader.DataSheetName: {},
             MSRunsLoader.DataSheetName: {},
             PeakAnnotationFilesLoader.DataSheetName: {},
+            PeakGroupConflicts.DataSheetName: {},
         }
         self.assertDictEqual(expected, vo.autofill_dict)
 
@@ -676,6 +693,7 @@ class DataValidationViewTests1(TracebaseTransactionTestCase):
             SequencesLoader.DataSheetName: {},
             MSRunsLoader.DataSheetName: {},
             PeakAnnotationFilesLoader.DataSheetName: {},
+            PeakGroupConflicts.DataSheetName: {},
         }
         self.assertDictEqual(expected, vo.autofill_dict)
 
@@ -709,6 +727,7 @@ class DataValidationViewTests1(TracebaseTransactionTestCase):
             SequencesLoader.DataSheetName: {},
             MSRunsLoader.DataSheetName: {},
             PeakAnnotationFilesLoader.DataSheetName: {},
+            PeakGroupConflicts.DataSheetName: {},
         }
         self.assertDictEqual(expected, vo.autofill_dict)
 
@@ -795,6 +814,13 @@ class DataValidationViewTests1(TracebaseTransactionTestCase):
                 "Default Sequence Name": {},
                 "File Format": {},
                 "Peak Annotation File": {},
+            },
+            "Peak Group Conflicts": {
+                "Peak Group Conflict": {},
+                "Selected Peak Annotation File": {},
+                "Common Sample Count": {},
+                "Example Samples": {},
+                "Common Samples": {},
             },
         }
 
@@ -899,6 +925,7 @@ class DataValidationViewTests1(TracebaseTransactionTestCase):
                         "Peak Annotation File": "accucor1.xlsx",
                     },
                 },
+                "Peak Group Conflicts": {},
             },
             dvv.autofill_dict,
         )

--- a/DataRepo/views/upload/submission.py
+++ b/DataRepo/views/upload/submission.py
@@ -1049,7 +1049,7 @@ class DataValidationView(FormView):
                 for rowindex, validation_dict in self.validation_autofill_dict[sheet][
                     header
                 ].items():
-                    rownum = rowindex + 1
+                    rownum = rowindex + 2  # Indexed from 1, and skip the header
                     worksheet.data_validation(
                         f"{letter}{rownum}",
                         validation_dict,

--- a/DataRepo/views/upload/submission.py
+++ b/DataRepo/views/upload/submission.py
@@ -1742,7 +1742,7 @@ class DataValidationView(FormView):
                         }
 
         db_samples_exist = (
-            Sample.objects.filter(name__in=list(all_samples.keys())).first() is not None
+            Sample.objects.filter(name__in=list(all_samples.keys())).count() > 0
         )
         multiple_files = len(self.peak_annot_files) > 1
 


### PR DESCRIPTION
## Summary Change Description

Create and autofill the peak group conflicts sheet.

~Unfortunately, while this works, it triples the amount of time it takes to process peak annotation files, but I decided to check in this working version and then try and optimize it, perhaps using pandas operations on the data instead of loops...~ Added running time is now negligible.  I optimized it in the last commit, though I'm not sure how it will behave when adding to a study, but I can say that if the study does not exist in the DB, this adds virtually no time.  The largest study now finishes in about 45s.

Details:

- Added the PeakGroupConflicts loader and sheet to the BuildSubmissionView.
- Added the ability to autofill 1-cell dropdowns from the autofill_dict by setting the autofill value to the dict needed by xlsxwriter's data_validation method.  When autofill is added, these dicts are saved in a validation_autofill_dict.  When that dict is processed, it supplies the dropdown dict to xlsxwriter.data_validation with the sheet, column, and row of where it should go.
- Added a search for multiple representations by first recording all representations, adding representations that already exist in the DB, grouping them by file set, then grouping the file sets by common samples.
- Added the ability to hide columns by creating a new optional class attribute to TableLoader, with associated methods, and added the common samples column to PeakGroupConflicts as a hidden column.  A new corresponding method in submission.py was added and called from the add_annotations method.
- Changed the display order of the sheets to represent the order in which sheets should be filled out: Study, Tracers, Infusates, Animals, Samples, Sequences, Files, Details, Conflicts...

## Affected Issues/Pull Requests

- Resolves #1095
- Resolves #1092
- Merges into PR #1209

## Review Notes
<!--
For added context for reviewers, add comments to relevant lines of code.  Use
this space to describe any general areas of concern not linked to a specific
line of code that reviewers should pay particular attention to, e.g. please
make sure I have accounted for all possible inputs.
-->
See comments in-line.

## Checklist
<!--
If any of the checkbox requirements are not met, uncheck them and add an
explanation. E.g. Linting errors pre-date this PR.
-->
This pull request will be merged once the following requirements are met.  The
author and/or reviewers should uncheck any unmet requirements:

- Review requirements
  - Minimum approvals: 1 <!-- Edit as desired (e.g. based on complexity) -->
  - No changes requested
  - All blocking issues resolved by reviewers
  - Specific reviewers: @__add_username_here__
    <!--
    Require reviewers with specific expertise to be included among the minimum
    number of reviewers by tagging them.  Also please send them a message.
    -->
  - Review period: 2 days <!-- Edit as desired (e.g. based on complexity) -->
- Associated issue/pull request requirements:
  <!--
  Assert that all requirements in issues marked "resolved" are done and that
  all required pull requests are merged.  If any are not done, either edit or
  split the issue or explain the unmerged affected pull requests.
  -->
  - [x] All requirements in affected issues marked "resolved" are satisfied
  - [x] All required pull requests are merged *(or none)*
- Basic requirements
  <!--
  Uncheck items to acknowledge failures/conflicts you intend to address.
  Add an explanation if any won't be addressed before merge.
  -->
  - [x] [All linters pass](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#linting)
  - [x] [All tests pass](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#quality-control)
  - [x] All conflicts resolved
- Overhead requirements
  <!--
  These are additional requirements that are not directly associated with
  resolving the affected issue(s).
  -->
  - [x] [New/changed method tests implemented/updated *(or no change)*](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#test-implementation)
  - [ ] [Updated *Unreleased* section of `changelog.md` *(or no change)*](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/changelog.md)
  - [x] [Migrations created & committed *(or no change)*](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#migration-process)
