### PR TITLE
Added returns of decorated methods and added suggestions to the `AutoUpdateFailed` exception

### DIFF
--- a/DataRepo/models/maintained_model.py
+++ b/DataRepo/models/maintained_model.py
@@ -635,7 +635,7 @@ class MaintainedModel(Model):
         # Custom argument: propagate - Whether to propagate updates to related model objects - default True
         # Used internally. Do not supply unless you know what you're doing.
         propagate = kwargs.pop("propagate", True)
-        # Custom argument: mass_updates - Whether auto-updating biffered model objects - default False
+        # Custom argument: mass_updates - Whether auto-updating buffered model objects - default False
         # Used internally. Do not supply unless you know what you're doing.
         mass_updates = kwargs.pop("mass_updates", False)
 
@@ -1238,7 +1238,7 @@ class MaintainedModel(Model):
                     pre_mass_update_func=pre_mass_update_func,
                     post_mass_update_func=post_mass_update_func,
                 ):
-                    fn(*args, **kwargs)
+                    return fn(*args, **kwargs)
 
             return wrapper
 
@@ -1257,7 +1257,7 @@ class MaintainedModel(Model):
             def wrapper(*args, **kwargs):
                 coordinator = MaintainedModelCoordinator(auto_update_mode="disabled")
                 with cls.custom_coordinator(coordinator):
-                    fn(*args, **kwargs)
+                    return fn(*args, **kwargs)
 
             return wrapper
 
@@ -1987,19 +1987,25 @@ class AutoUpdateFailed(Exception):
         updater_flds = [
             d["update_field"] for d in updaters if d["update_field"] is not None
         ]
+        if len(updater_flds) == 0:
+            message = f"Propagation of autoupdates from the {model_object.__class__.__name__} model "
+        else:
+            message = f"Autoupdate of the {model_object.__class__.__name__} model's fields [{', '.join(updater_flds)}] "
         try:
             obj_str = str(model_object)
         except Exception:
             # Displaying the offending object is optional, so catch any error
             obj_str = "unknown"
-        message = (
-            f"Autoupdate of the {model_object.__class__.__name__} model's fields [{', '.join(updater_flds)}] in the "
-            f"database failed for record {obj_str}.  Potential causes:\n"
+        message += (
+            f"in the database failed for record {obj_str}.  Potential causes:\n"
             "\t1. The record was created and deleted before the buffered update (a catch for the exception should be "
             "added and ignored).\n"
-            "\t2. The autoupdate buffer is stale and auto-updates are being attempted on non-existent records.  Find "
-            "a previous call to a loader that performs mass auto-updates and ensure that clear_update_buffer() is "
-            "called.\n"
+            "\t2. The autoupdate buffer is stale and auto-updates are being attempted on non-existent records.  There "
+            "are multiple possible resolutions to this case.  If deletions of parent and child records are occurring "
+            "together, a `no_autoupdates` decorator/context-manager can be applied to the deletion of the child "
+            "records so that the mass autoupdates do not get called on the deleted parent records, or you can apply a "
+            "`no_autoupdates` decorator to the entire model modification method (or call clear_update_buffer() at the "
+            "end of the method), and run `rebuild_maintained_fields` afterwards.\n"
             f"The triggering {err.__class__.__name__} exception: [{err}]."
         )
         super().__init__(message)


### PR DESCRIPTION
## Summary Change Description

During the work on `clean_reps` in #1167, I discovered that I needed the return value of decorated methods, and the `MaintainedModel` decorators weren't passing the return value(s) along, so I added that, and I added more/better suggestions in the `AutoUpdateFailed` exception.

## Affected Issues/Pull Requests

- Resolves no issue
- Merges into main

## Review Notes
<!--
For added context for reviewers, add comments to relevant lines of code.  Use
this space to describe any general areas of concern not linked to a specific
line of code that reviewers should pay particular attention to, e.g. please
make sure I have accounted for all possible inputs.
-->
See comments in-line.

## Checklist
<!--
If any of the checkbox requirements are not met, uncheck them and add an
explanation. E.g. Linting errors pre-date this PR.
-->
This pull request will be merged once the following requirements are met.  The
author and/or reviewers should uncheck any unmet requirements:

- Review requirements
  - Minimum approvals: 1 <!-- Edit as desired (e.g. based on complexity) -->
  - No changes requested
  - All blocking issues resolved by reviewers
  - Specific reviewers: @__add_username_here__
    <!--
    Require reviewers with specific expertise to be included among the minimum
    number of reviewers by tagging them.  Also please send them a message.
    -->
  - Review period: 2 days <!-- Edit as desired (e.g. based on complexity) -->
- Associated issue/pull request requirements:
  <!--
  Assert that all requirements in issues marked "resolved" are done and that
  all required pull requests are merged.  If any are not done, either edit or
  split the issue or explain the unmerged affected pull requests.
  -->
  - [x] All requirements in affected issues marked "resolved" are satisfied
  - [x] All required pull requests are merged *(or none)*
- Basic requirements
  <!--
  Uncheck items to acknowledge failures/conflicts you intend to address.
  Add an explanation if any won't be addressed before merge.
  -->
  - [x] [All linters pass](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#linting)
  - [x] [All tests pass](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#quality-control)
  - [x] All conflicts resolved
- Overhead requirements
  <!--
  These are additional requirements that are not directly associated with
  resolving the affected issue(s).
  -->
  - [x] [New/changed method tests implemented/updated *(or no change)*](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#test-implementation)
  - [ ] [Updated *Unreleased* section of `changelog.md` *(or no change)*](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/changelog.md)
  - [x] [Migrations created & committed *(or no change)*](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#migration-process)
