### PR TITLE
Fixed `mzXML`-related exceptions related to walking the directory to find all `mzXML` files

### DIFF
--- a/DataRepo/loaders/msruns_loader.py
+++ b/DataRepo/loaders/msruns_loader.py
@@ -504,15 +504,22 @@ class MSRunsLoader(TableLoader):
                                 skip_files.append(
                                     os.path.join(dr, dct["mzxml_filename"])
                                 )
-                        self.aggregated_errors_object.buffer_error(
+                        self.aggregated_errors_object.buffer_warning(
                             MzXMLSkipRowError(
                                 mzxml_name,
-                                dirs,
-                                self.skip_msrunsample_by_mzxml[mzxml_name],
                                 skip_files,
+                                self.skip_msrunsample_by_mzxml[mzxml_name],
                                 file=self.friendly_file,
                                 sheet=self.DataSheetName,
                                 column=self.DataHeaders.MZXMLNAME,
+                                suggestion=(
+                                    "The mzXML files listed above will not be loaded.  If all mzXML files named "
+                                    f"'{mzxml_name}' must be skipped, please ensure that the number of rows in the "
+                                    f"'{self.DataSheetName}' sheet equals the number of files above "
+                                    f"({len(skip_files)}), or if not all should be skipped, the directory paths should "
+                                    "be included for each mzXML file in the mzXML file name column so that we can tell "
+                                    "which ones to load and which to skip)."
+                                ),
                             )
                         )
                         continue

--- a/DataRepo/utils/exceptions.py
+++ b/DataRepo/utils/exceptions.py
@@ -3312,7 +3312,11 @@ class NoMZXMLFiles(Exception):
 
 class MzXMLSkipRowError(InfileError):
     def __init__(
-        self, mzxml_name, existing_paths, skip_paths_dict, skip_files, **kwargs
+        self,
+        mzxml_name: str,
+        existing_files: List[str],
+        skip_paths_dict: Dict[str, int],
+        **kwargs,
     ):
         """The situation here is that we may not be able to identify which files to skip and which to
         load.  dirs could contain files we should skip because the user didn't provide directory paths on the skipped
@@ -3321,40 +3325,30 @@ class MzXMLSkipRowError(InfileError):
 
         Args:
             mzxml_name (str): The mzXML filename without the extension
-            existing_paths (List[str]): Directories that hold a file named {mzxml_name} (i.e. same-named files)
+            existing_files (List[str]): mzXML files all named mzxml_name
             skip_paths_dict (Dict[str, int]): Directories extracted from a Peak Annotation Details sheet that do not
                 match existing_paths.  If a key is an empty string, it means no path was provided (or the path is the
                 root directory).
-            skip_files (List[str]): List of mzXML files (with paths) whose load will be skipped.
         """
         dirs_from_infile = [d for d in skip_paths_dict.keys() if d != ""]
         nlt = "\n\t"
         # In this instance, we don't have any paths from the infile
         if len(dirs_from_infile) == 0:
             message = (
-                f"The number of mzXML files with the name '{mzxml_name}' found in directory(/ies):\n"
-                f"\t{nlt.join(existing_paths)}\n"
-                "matches a different number of skipped sample headers (without directory paths included in the mzXML "
-                f"file name column): {skip_paths_dict['']}.  If all mzXML files named '{mzxml_name}' must be skipped, "
-                "the number of skipped rows with that sample header in %s must equal the number of files above "
-                f"({len(existing_paths)}), or if not all should be skipped, the directory paths must be included for "
-                f"these mzXML files in the mzXML file name column so that we can tell which to ones skip)."
+                f"The number of supplied mzXML files with the name '{mzxml_name}':\n"
+                f"\t{nlt.join(existing_files)}\n"
+                f"matches a different number of skipped sample headers ({skip_paths_dict['']}) in %s."
             )
         else:
             message = (
-                f"The paths of the following mzXML files with the same sample name '{mzxml_name}':"
-                f"\n\t{nlt.join(existing_paths)}\n"
-                f"do not match the paths supplied in %s:\n"
-                f"{nlt.join(dirs_from_infile)}\n"
-                "If all must be skipped, you don't need to specify the paths - you just need the same number of rows "
-                "in %s with that sample header.  If not all should be skipped, the directory paths must be included in "
-                "the existing rows so that we can tell which mzXML files to load/skip).  Search for rows in the "
-                f"file and update/add the mzXML file names with their paths."
+                f"The paths of the following mzXML files with the same sample name ({mzxml_name}):"
+                f"\n\t{nlt.join(existing_files)}\n"
+                "do not match the paths supplied in %s:\n"
+                f"{nlt.join(dirs_from_infile)}"
             )
-        message += f"\n\nThe following mzXML files will not be loaded:\n\t{nlt.join(skip_files)}"
         super().__init__(message, **kwargs)
         self.mzxml_name = mzxml_name
-        self.existing_paths = existing_paths
+        self.existing_files = existing_files
         self.skip_paths_dict = skip_paths_dict
 
 


### PR DESCRIPTION
## Summary Change Description

Addressed exceptions I ran into while trying to load Michael's water study mzxml files.

Details:

- Prevented any error when the file contains no scans.
- Fixed issues related to skipping mzXML file loads.
  We do not anticipate the user to fill out the mzXML file name column in the Peak Annotation Details sheet (though it's there in case the name doesn't match the sample header or when disambiguation is necessary in the face of same-named files.  This means that the skipping of files for skipped sample headers needs to account for the fact that the files can have the same name and are thus stored in a dict that includes the directories.  The way it was written, it would only skip files whose paths were provided in the Peak Annotation Details sheet, thus this PR adds code that makes an assumption that if the sample header matches the mzXML file name, and the number of files matches the number of skipped rows in the Peak Annotation Details sheet, then the load of those files should be skipped.

  This code also accounts for the possibility that paths might be provided for not all matching sample headers, or when not all sample headers are skipped.

  - Added exception class: `MzXMLSkipRowError`
  - Changed the value at the end of the `skip_msrunsample_by_mzxml` dict to indicate the number of matching files (instead of bool) so that we could compare the non-matching actual files with the number of rows that are skipped for that sample header.
  - When the number of files after the skip filter is zero, we no longer try to look up a matching sample.  This fixes a bug where we were getting `DoesNotExist` errors.
  - Made a small unrelated change having to do with how study doc version differences are reported (because referring to headers as "unknown" is confusing and inaccurate).

## Affected Issues/Pull Requests

- Resolves #1248
- Merges into PR #1245

## Review Notes
<!--
For added context for reviewers, add comments to relevant lines of code.  Use
this space to describe any general areas of concern not linked to a specific
line of code that reviewers should pay particular attention to, e.g. please
make sure I have accounted for all possible inputs.
-->
See comments in-line.

## Checklist
<!--
If any of the checkbox requirements are not met, uncheck them and add an
explanation. E.g. Linting errors pre-date this PR.
-->
This pull request will be merged once the following requirements are met.  The
author and/or reviewers should uncheck any unmet requirements:

- Review requirements
  - Minimum approvals: 1 <!-- Edit as desired (e.g. based on complexity) -->
  - No changes requested
  - All blocking issues resolved by reviewers
  - Specific reviewers: @__add_username_here__
    <!--
    Require reviewers with specific expertise to be included among the minimum
    number of reviewers by tagging them.  Also please send them a message.
    -->
  - Review period: 2 days <!-- Edit as desired (e.g. based on complexity) -->
- Associated issue/pull request requirements:
  <!--
  Assert that all requirements in issues marked "resolved" are done and that
  all required pull requests are merged.  If any are not done, either edit or
  split the issue or explain the unmerged affected pull requests.
  -->
  - [x] All requirements in affected issues marked "resolved" are satisfied
  - [x] All required pull requests are merged *(or none)*
- Basic requirements
  <!--
  Uncheck items to acknowledge failures/conflicts you intend to address.
  Add an explanation if any won't be addressed before merge.
  -->
  - [x] [All linters pass](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#linting)
  - [x] [All tests pass](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#quality-control)
  - [x] All conflicts resolved
- Overhead requirements
  <!--
  These are additional requirements that are not directly associated with
  resolving the affected issue(s).
  -->
  - [x] [New/changed method tests implemented/updated *(or no change)*](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#test-implementation)
  - [ ] [Updated *Unreleased* section of `changelog.md` *(or no change)*](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/changelog.md)
  - [x] [Migrations created & committed *(or no change)*](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#migration-process)
