### PR TITLE
Fixed a couple of advanced search template typos

### DIFF
--- a/DataRepo/templates/DataRepo/search/results/peakdata.html
+++ b/DataRepo/templates/DataRepo/search/results/peakdata.html
@@ -339,10 +339,10 @@
                     <td>
                         <!-- Put displayed link text first for sorting -->
                         <div style="display:none;">{{ pd.peak_group.peak_annotation_file.filename }}</div>
-                        {% if pg.peak_group.peak_annotation_file %}
-                        <a href="{% url 'archive_file_detail' pd.peak_group.peak_annotation_file.id %}">
-                            {{ pd.peak_group.peak_annotation_file.filename }}
-                        </a>
+                        {% if pd.peak_group.peak_annotation_file %}
+                            <a href="{% url 'archive_file_detail' pd.peak_group.peak_annotation_file.id %}">
+                                {{ pd.peak_group.peak_annotation_file.filename }}
+                            </a>
                         {% endif %}
                     </td>
 

--- a/DataRepo/templates/DataRepo/search/results/peakgroups.html
+++ b/DataRepo/templates/DataRepo/search/results/peakgroups.html
@@ -117,7 +117,7 @@
                 <th data-valign="top" data-sortable="{% if mode == 'view' %}true{% else %}false{% endif %}" data-sorter="alphanum" data-visible="{% get_template_cookie selfmt 'Labeled_Element-data-visible' 'true' %}" data-field="Labeled_Element" class="idgrp">
                     {% with "Labeled<br>Element" as colhead %}
                         {% if mode == "view" %}{{ colhead }}{% else %}
-                            <div onclick="sortColumn(this)" class="sortable" id="peak_data_labels_element">{{ colhead }}</div>
+                            <div onclick="sortColumn(this)" class="sortable" id="peak_data__labels__element">{{ colhead }}</div>
                         {% endif %}
                     {% endwith %}
                 </th>


### PR DESCRIPTION
## Summary Change Description

- The peak data format now has visible peak annotation filenames.
- The Labeled Element column in the PeakGroups format no longer causes an exception.

## Affected Issues/Pull Requests

- Resolves #1252
- Resolves #1253
- Merges into PR #1251

## Review Notes
<!--
For added context for reviewers, add comments to relevant lines of code.  Use
this space to describe any general areas of concern not linked to a specific
line of code that reviewers should pay particular attention to, e.g. please
make sure I have accounted for all possible inputs.
-->
See comments in-line.

## Checklist
<!--
If any of the checkbox requirements are not met, uncheck them and add an
explanation. E.g. Linting errors pre-date this PR.
-->
This pull request will be merged once the following requirements are met.  The
author and/or reviewers should uncheck any unmet requirements:

- Review requirements
  - Minimum approvals: 1 <!-- Edit as desired (e.g. based on complexity) -->
  - No changes requested
  - All blocking issues resolved by reviewers
  - Specific reviewers: @__add_username_here__
    <!--
    Require reviewers with specific expertise to be included among the minimum
    number of reviewers by tagging them.  Also please send them a message.
    -->
  - Review period: 2 days <!-- Edit as desired (e.g. based on complexity) -->
- Associated issue/pull request requirements:
  <!--
  Assert that all requirements in issues marked "resolved" are done and that
  all required pull requests are merged.  If any are not done, either edit or
  split the issue or explain the unmerged affected pull requests.
  -->
  - [x] All requirements in affected issues marked "resolved" are satisfied
  - [x] All required pull requests are merged *(or none)*
- Basic requirements
  <!--
  Uncheck items to acknowledge failures/conflicts you intend to address.
  Add an explanation if any won't be addressed before merge.
  -->
  - [x] [All linters pass](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#linting)
  - [x] [All tests pass](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#quality-control)
  - [x] All conflicts resolved
- Overhead requirements
  <!--
  These are additional requirements that are not directly associated with
  resolving the affected issue(s).
  -->
  - [x] [New/changed method tests implemented/updated *(or no change)*](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#test-implementation)
  - [ ] [Updated *Unreleased* section of `changelog.md` *(or no change)*](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/changelog.md)
  - [x] [Migrations created & committed *(or no change)*](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#migration-process)
