### PR TITLE
Skip empty mzxmls

### DIFF
--- a/DataRepo/loaders/base/table_loader.py
+++ b/DataRepo/loaders/base/table_loader.py
@@ -2623,22 +2623,55 @@ class TableLoader(ABC):
         Returns:
             None
         """
-        if hasattr(exception, "is_error") and isinstance(exception.is_error, bool):
+        if (
+            hasattr(exception, "is_error")
+            and isinstance(exception.is_error, bool)
+            and is_error is None
+        ):
             is_error = exception.is_error
-        else:
+        elif is_error is None:
             is_error = True
 
-        if hasattr(exception, "is_fatal") and isinstance(exception.is_fatal, bool):
+        if (
+            hasattr(exception, "is_fatal")
+            and isinstance(exception.is_fatal, bool)
+            and is_fatal is None
+        ):
             is_fatal = exception.is_fatal
-        else:
+        elif is_fatal is None:
             is_fatal = True
+
+        if hasattr(exception, "file") and exception.file is not None:
+            file = exception.file
+        else:
+            file = self.friendly_file
+        if hasattr(exception, "sheet") and exception.sheet is not None:
+            sheet = exception.sheet
+        else:
+            sheet = self.sheet
+        if (
+            hasattr(exception, "column")
+            and exception.column is not None
+            and column is None
+        ):
+            column = exception.column
+        if hasattr(exception, "rownum") and exception.rownum is not None:
+            rownum = exception.rownum
+        else:
+            rownum = self.rownum
+        if (
+            hasattr(exception, "suggestion")
+            and exception.suggestion is not None
+            and suggestion is None
+        ):
+            suggestion = exception.suggestion
 
         if isinstance(exception, InfileError):
             exception.set_formatted_message(
-                file=self.friendly_file,
-                sheet=self.sheet,
+                file=file,
+                sheet=sheet,
                 column=column,
-                rownum=self.rownum,
+                rownum=rownum,
                 suggestion=suggestion,
             )
             self.aggregated_errors_object.buffer_exception(
@@ -2650,10 +2683,10 @@ class TableLoader(ABC):
             self.aggregated_errors_object.buffer_exception(
                 InfileError(
                     str(exception),
-                    file=self.friendly_file,
-                    sheet=self.sheet,
+                    file=file,
+                    sheet=sheet,
                     column=column,
-                    rownum=self.rownum,
+                    rownum=rownum,
                     suggestion=suggestion,
                 ),
                 is_error=is_error,

--- a/DataRepo/loaders/base/table_loader.py
+++ b/DataRepo/loaders/base/table_loader.py
@@ -2603,7 +2603,7 @@ class TableLoader(ABC):
         return found_errors
 
     def buffer_infile_exception(
-        self, exception, is_error=True, is_fatal=True, column=None, suggestion=None
+        self, exception, is_error=None, is_fatal=None, column=None, suggestion=None
     ):
         """Convenience method to keep the loading code succinct.  Buffers an exception (default: as fatal error) as an
         InfileError.  Use this to provide file context to any non-database related exception.  The file name, sheet, and
@@ -2611,8 +2611,8 @@ class TableLoader(ABC):
 
         Args:
             exception (Exception)
-            is_error (bool) [True]
-            is_fatal (bool) [True]
+            is_error (Optional[bool]) [True]
+            is_fatal (Optional[bool]) [True]
             column (str|int) [None]: Name of the column or columns that is the source of the erroneous data.
             suggestion (Optional[str])
         Exceptions:
@@ -2623,6 +2623,16 @@ class TableLoader(ABC):
         Returns:
             None
         """
+        if hasattr(exception, "is_error") and isinstance(exception.is_error, bool):
+            is_error = exception.is_error
+        else:
+            is_error = True
+
+        if hasattr(exception, "is_fatal") and isinstance(exception.is_fatal, bool):
+            is_fatal = exception.is_fatal
+        else:
+            is_fatal = True
+
         if isinstance(exception, InfileError):
             exception.set_formatted_message(
                 file=self.friendly_file,

--- a/DataRepo/loaders/msruns_loader.py
+++ b/DataRepo/loaders/msruns_loader.py
@@ -1503,7 +1503,7 @@ class MSRunsLoader(TableLoader):
                         "The default MSRunSequence will be used if provided.  If this is followed by an error "
                         "requiring defaults to be supplied, add one of the paths of the above files to the "
                         f"{self.defaults.MZXMLNAME} column in %s.  All PeakGroups will be linked to a placeholder "
-                        "MSRunSample record."
+                        f"MSRunSample record.  DEBUG: {multiple_mzxml_dict}"
                     ),
                     file=self.friendly_file,
                     sheet=self.sheet,

--- a/DataRepo/loaders/msruns_loader.py
+++ b/DataRepo/loaders/msruns_loader.py
@@ -484,6 +484,7 @@ class MSRunsLoader(TableLoader):
 
                 if mzxml_name in self.skip_msrunsample_by_mzxml.keys():
                     if len(dirs) == 0:
+                        print(f"EXACT SKIP {mzxml_name} {list(self.mzxml_dict[mzxml_name].keys())}")
                         # The sample (header) / mzXML file has been explicitly skipped by having added the directory
                         # path to the mzXML file name column of the infile
                         continue
@@ -498,10 +499,12 @@ class MSRunsLoader(TableLoader):
                         # files with this name (inferred by the number of directory paths)
                         and len(dirs) == self.skip_msrunsample_by_mzxml[mzxml_name][""]
                     ):
+                        print(f"SAME NUM SKIP {mzxml_name} {list(self.mzxml_dict[mzxml_name].keys())}")
                         # We will skip the files that matches the number of infile rows where the sample header was
                         # marked as a skip row even though we haven't confirmed any explicit directory matches.
                         continue
                     elif "" in self.skip_msrunsample_by_mzxml[mzxml_name].keys():
+                        print(f"DIFF NUM SKIP {mzxml_name} {list(self.mzxml_dict[mzxml_name].keys())}")
                         skip_files = []
                         for dr in self.mzxml_dict[mzxml_name].keys():
                             for dct in self.mzxml_dict[mzxml_name][dr]:
@@ -553,9 +556,11 @@ class MSRunsLoader(TableLoader):
                                 sample, msrun_sequence, mzxml_metadata
                             )
                         except RollbackException:
+                            print(f"ERROR SKIP {mzxml_dir}/{mzxml_name} {self.aggregated_errors_object.exceptions[-1]}")
                             # Exception handling was handled
                             # Continue processing rows to find more errors
                             pass
+                        print(f"CREATED/GOT {mzxml_dir}/{mzxml_name}")
 
         # If there were any exceptions (i.e. a rollback of everything will be triggered)
         if self.aggregated_errors_object.should_raise():
@@ -1156,6 +1161,7 @@ class MSRunsLoader(TableLoader):
             rec (MSRunSample)
             created (boolean)
         """
+        # This doesn't return a "gotten" record (which is "wrong"), but returning here keeps the stats accurate.
         if mzxml_metadata["added"] is True or msrun_sequence is None or sample is None:
             return None, False
 
@@ -1503,6 +1509,7 @@ class MSRunsLoader(TableLoader):
                         "The default MSRunSequence will be used if provided.  If this is followed by an error "
                         "requiring defaults to be supplied, add one of the paths of the above files to the "
                         f"{self.defaults.MZXMLNAME} column in %s.  All PeakGroups will be linked to a placeholder "
+                        # TODO: Remove debug content
                         f"MSRunSample record.  DEBUG: {multiple_mzxml_dict}"
                     ),
                     file=self.friendly_file,

--- a/DataRepo/management/commands/load_msruns.py
+++ b/DataRepo/management/commands/load_msruns.py
@@ -145,6 +145,12 @@ class Command(LoadTableCommand):
             files=options.get("mzxml_files"), dir=options.get("mzxml_dir")
         )
 
+        if len(mzxml_files) == 0 and options.get("infile") is None:
+            raise ConditionallyRequiredOptions(
+                "Either --mzxml-dir (with a directory containing mzxml files), --mzxml-files, or --infile is "
+                "required."
+            )
+
         # Check conditionally required options
         if (
             len(mzxml_files) > 0
@@ -166,9 +172,9 @@ class Command(LoadTableCommand):
             if len(missing) > 0:
                 missing_str = f" or {missing}"
             raise ConditionallyRequiredOptions(
-                "When --mzxml-files are supplied without an --infile, either a --defaults-file must be provided or "
-                "each of these default options must all be supplied: --operator, --date, --lc-protocol-name, and "
-                f"--instrument.  Missing: infile or defaults_file{missing_str}."
+                "When mzxml files are supplied (using --mzxml-dir or --mzxml-files) without an --infile, either a "
+                "--defaults-file must be provided or each of these default options must all be supplied: --operator, "
+                f"--date, --lc-protocol-name, and --instrument.  Missing: infile or defaults_file{missing_str}."
             )
 
         # The MSRunsLoader class constructor has custom arguments, so we must call init_loader to supply them

--- a/DataRepo/management/commands/load_msruns.py
+++ b/DataRepo/management/commands/load_msruns.py
@@ -1,3 +1,5 @@
+import os
+import sys
 from typing import Type
 
 from DataRepo.loaders.base.table_loader import TableLoader
@@ -20,7 +22,7 @@ class Command(LoadTableCommand):
         # Don't require any options (i.e. don't require the --infile option)
         super().__init__(
             *args,
-            required_optname_groups=[["mzxml_files", "infile"]],
+            required_optnames=[],
             **kwargs,
         )
 
@@ -124,6 +126,13 @@ class Command(LoadTableCommand):
         Returns:
             None
         """
+        if len(sys.argv) == 2:  # ['manage.py', 'load_msruns']
+            self.print_help(
+                "manage.py", list(os.path.splitext(os.path.basename(__file__)))[1]
+            )
+            self.options["help"] = True
+            return
+
         if (
             options.get("mzxml_files") is not None
             and options.get("mzxml_dir") is not None

--- a/DataRepo/management/commands/load_msruns.py
+++ b/DataRepo/management/commands/load_msruns.py
@@ -164,7 +164,7 @@ class Command(LoadTableCommand):
 
         # The MSRunsLoader class constructor has custom arguments, so we must call init_loader to supply them
         self.init_loader(
-            mzxml_files=options.get("mzxml_files"),
+            mzxml_files=mzxml_files,
             operator=options.get("operator"),
             date=options.get("date"),
             lc_protocol_name=options.get("lc_protocol_name"),

--- a/DataRepo/management/commands/load_msruns.py
+++ b/DataRepo/management/commands/load_msruns.py
@@ -126,7 +126,9 @@ class Command(LoadTableCommand):
         Returns:
             None
         """
-        if len(sys.argv) == 2:  # ['manage.py', 'load_msruns']
+        if (
+            len(sys.argv) == 2 and sys.argv[1] == "load_msruns"
+        ):  # ['manage.py', 'load_msruns']
             self.print_help(
                 "manage.py", list(os.path.splitext(os.path.basename(__file__)))[1]
             )

--- a/DataRepo/management/commands/load_table.py
+++ b/DataRepo/management/commands/load_table.py
@@ -418,7 +418,8 @@ class LoadTableCommand(ABC, BaseCommand):
                 self.saved_aes = AggregatedErrors()
                 self.saved_aes.buffer_error(e)
 
-            self.report_status()
+            if not self.options.get("help"):
+                self.report_status()
 
             if self.saved_aes is not None and self.saved_aes.should_raise():
                 self.saved_aes.print_summary()

--- a/DataRepo/tests/management/commands/test_load_msruns.py
+++ b/DataRepo/tests/management/commands/test_load_msruns.py
@@ -109,4 +109,7 @@ class LoadMSRunsCommandTests(TracebaseTestCase):
         aes = ar.exception
         self.assertEqual(1, len(aes.exceptions))
         self.assertEqual(ConditionallyRequiredOptions, type(aes.exceptions[0]))
-        self.assertIn("['mzxml_files', 'infile']", str(aes.exceptions[0]))
+        self.assertIn(
+            "--mzxml-dir (with a directory containing mzxml files), --mzxml-files, or --infile",
+            str(aes.exceptions[0]),
+        )

--- a/DataRepo/utils/exceptions.py
+++ b/DataRepo/utils/exceptions.py
@@ -3310,6 +3310,12 @@ class NoMZXMLFiles(Exception):
         super().__init__(message)
 
 
+class NoScans(InfileError):
+    def __init__(self, **kwargs):
+        message = "mzXML File '%s' contains no scans."
+        super().__init__(message, **kwargs)
+
+
 class MzXMLSkipRowError(InfileError):
     def __init__(
         self,


### PR DESCRIPTION
## Summary Change Description

I didn't know what was causing `mzXML` files to not get added to newly created `MSRunSample` records, so my first hunch was that it had to do with the fact that the `mzXML`s couldn't be linked to a row in the file due to the fact that there were more mzXMLs than there were rows.  That issues was caused by the fact that there exist empty `mzXML` files that are byproducts of the process that generates them.  I figured if I could skip these empty `mzXML`s, then the method that links rows (containing the necessary sequence info needed to create `MSRunSample` records) to files would work and would then create the records.  Ultimately, as a product of this effort, I figured out the real cause of the problem (which was not this issue), but this effort does dramatically reduce the warning output and it will be necessary when we need to associate sequences with the files (if a peak annotation file ever uses mzXMLs from multiple sequences).

- Skip mzXML files that have no scan tags.
  - Added a NoScans exception class
  - Fixed tuple returns from `MSRunsLoader.parse_mzxml`
  - Always merge the exceptions returned by `parse_mzxml`
  - Continue parsing the return of `parse_mzxml` if the returned errors object only has warnings
- Account for the `--mzxml-dir` option when checking required options
- Output usage if no arguments supplied to load_msruns
  - Made the handle wrapper not print stats if `--help` was provided (or there were no command line arguments)
- Preserve `is_error` and `is_warning` added by `AggregatedErrors` in `buffer_infile_exception`.

## Affected Issues/Pull Requests

- Resolves #1258
- Merges into main

## Review Notes
<!--
For added context for reviewers, add comments to relevant lines of code.  Use
this space to describe any general areas of concern not linked to a specific
line of code that reviewers should pay particular attention to, e.g. please
make sure I have accounted for all possible inputs.
-->
See comments in-line.

## Checklist
<!--
If any of the checkbox requirements are not met, uncheck them and add an
explanation. E.g. Linting errors pre-date this PR.
-->
This pull request will be merged once the following requirements are met.  The
author and/or reviewers should uncheck any unmet requirements:

- Review requirements
  - Minimum approvals: 1 <!-- Edit as desired (e.g. based on complexity) -->
  - No changes requested
  - All blocking issues resolved by reviewers
  - Specific reviewers: @__add_username_here__
    <!--
    Require reviewers with specific expertise to be included among the minimum
    number of reviewers by tagging them.  Also please send them a message.
    -->
  - Review period: 2 days <!-- Edit as desired (e.g. based on complexity) -->
- Associated issue/pull request requirements:
  <!--
  Assert that all requirements in issues marked "resolved" are done and that
  all required pull requests are merged.  If any are not done, either edit or
  split the issue or explain the unmerged affected pull requests.
  -->
  - [x] All requirements in affected issues marked "resolved" are satisfied
  - [x] All required pull requests are merged *(or none)*
- Basic requirements
  <!--
  Uncheck items to acknowledge failures/conflicts you intend to address.
  Add an explanation if any won't be addressed before merge.
  -->
  - [x] [All linters pass](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#linting)
  - [x] [All tests pass](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#quality-control)
  - [x] All conflicts resolved
- Overhead requirements
  <!--
  These are additional requirements that are not directly associated with
  resolving the affected issue(s).
  -->
  - [x] [New/changed method tests implemented/updated *(or no change)*](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#test-implementation)
  - [x] [Updated *Unreleased* section of `changelog.md` *(or no change)*](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/changelog.md)
  - [x] [Migrations created & committed *(or no change)*](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#migration-process)
