### PR TITLE
Created zip archive of mzXML files advanced search download view

### DIFF
--- a/DataRepo/tests/models/test_msrun_sample.py
+++ b/DataRepo/tests/models/test_msrun_sample.py
@@ -85,7 +85,7 @@ class MSRunSampleTests(TracebaseTestCase):
         msrs.full_clean()
         msrs.save()
 
-    def test_msrun_sample_all(self):
+    def create_rec(self):
         mstype = DataType.objects.get(code="ms_data")
         rawfmt = DataFormat.objects.get(code="ms_raw")
         mzxfmt = DataFormat.objects.get(code="mzxml")
@@ -107,11 +107,17 @@ class MSRunSampleTests(TracebaseTestCase):
             msrun_sequence=self.seq,
             sample=self.smpl,
             polarity=MSRunSample.POSITIVE_POLARITY,
+            mz_min=1,
+            mz_max=1234,
             ms_raw_file=rawrec,
             ms_data_file=mzxrec,
         )
         msrs.full_clean()
         msrs.save()
+        return msrs
+
+    def test_msrun_sample_all(self):
+        self.create_rec()
 
     def test_msdata_format_unknown(self):
         mstype = DataType.objects.get(code="ms_data")
@@ -200,3 +206,10 @@ class MSRunSampleTests(TracebaseTestCase):
         exc = self.assert_archive_file_exception("test.mzxml", mstype, mzxfmt, False)
         self.assertIn("ms_data_file", str(exc))
         self.assertIn("data format", str(exc))
+
+    def test_mzxml_export_path(self):
+        msrs = self.create_rec()
+        self.assertEqual(
+            "1972-11-24/Jerry Seinfeld/QE/unknown/positive/1-1.23e+03/test.mzxml",
+            msrs.mzxml_export_path,
+        )

--- a/DataRepo/tests/tracebase_test_case.py
+++ b/DataRepo/tests/tracebase_test_case.py
@@ -14,6 +14,12 @@ LONG_TEST_THRESH_SECS = 20
 LONG_TEST_ALERT_STR = f" [ALERT > {LONG_TEST_THRESH_SECS}]"
 
 
+# See: https://stackoverflow.com/a/61345284/2057516
+if "unittest.util" in __import__("sys").modules:
+    # Show full diff in self.assertEqual.
+    __import__("sys").modules["unittest.util"]._MAX_LENGTH = 999999999
+
+
 def test_case_class_factory(base_class) -> Type[TestCase]:
     """
     Class creation factory where the base class is an argument.  Note, it must receive a TestCase-compatible class.

--- a/DataRepo/views/search/download.py
+++ b/DataRepo/views/search/download.py
@@ -1,13 +1,14 @@
 import csv
+import io
 import json
-import os
+import zipfile
 from abc import ABC, abstractmethod
 from datetime import datetime
-from typing import List, Union
+from io import BytesIO
+from typing import Any, List, Optional, Tuple
 
 import _csv
 from django.conf import settings
-from django.db.models import Model
 from django.http import Http404, StreamingHttpResponse
 from django.template import loader
 from django.views.generic.edit import FormView
@@ -22,7 +23,6 @@ from DataRepo.models.msrun_sample import MSRunSample
 from DataRepo.models.peak_data import PeakData
 from DataRepo.models.peak_group import PeakGroup
 from DataRepo.utils.file_utils import date_to_string
-from DataRepo.utils.text_utils import sigfig
 
 
 # See https://docs.djangoproject.com/en/5.1/howto/outputting-csv/#streaming-large-csv-files
@@ -116,8 +116,8 @@ class RecordToMzxmlTSV(ABC):
     """This class defines a download format and type.  In this instance, it is a tsv file format that defines a file of
     mzXML metadata.  It is an abstract base class.  Derived classes define how to convert a queryset from one or more
     search Format classes belonging to the SearchGroup class.  Derived classes must set a format_id class attribute that
-    matches one of the SearchGroup Format classes, and a rec_to_rows method that does the conversion of a queryset
-    record to a list of lists.
+    matches one of the SearchGroup Format classes, and a queryset_to_rows_iterator method that does the conversion of a
+    queryset record to a list of lists.
 
     This class and its derived classes are used by AdvancedSearchDownloadMzxmlTSVView to generate mzXML tsv download
     data.
@@ -131,7 +131,7 @@ class RecordToMzxmlTSV(ABC):
         pass
 
     @abstractmethod
-    def rec_to_rows(self, rec: Model) -> Union[List[list], List[str]]:
+    def queryset_to_rows_iterator(self, qs):
         """Derived classes must implement this as a class attribute."""
         pass
 
@@ -161,26 +161,26 @@ class RecordToMzxmlTSV(ABC):
     ]
 
     @classmethod
-    def get_rec_to_rows_method(cls, format_id: str):
-        """Takes a format_id and returns a rec_to_rows method that comes from the subclass whose format_id matches the
-        supplied format_id.
+    def get_converter_object(cls, format_id: str):
+        """Takes a format_id and returns the derived class object that comes from the subclass whose format_id matches
+        the supplied format_id.
 
         Args:
             format_id (str)
         Exceptions:
             Http404
-        Returns
-            rec_to_rows (funtion)
+        Returns:
+            (RecordToMzxmlTSV)
         """
         for derived_class in cls.__subclasses__():
             if format_id == derived_class.format_id:
-                return derived_class().rec_to_rows
+                return derived_class()
         raise Http404(
             f"Invalid format ID: {format_id}.  Must be one of "
-            f"{[c.format_id for c in RecordToMzxmlTSV.__subclasses__()]}"
+            f"{[c.format_id for c in cls.__subclasses__()]}"
         )
 
-    def msrun_sample_rec_to_row(self, msrsrec: MSRunSample) -> List[str]:
+    def msrun_sample_rec_to_row(self, msrsrec: MSRunSample) -> List[Optional[str]]:
         """Takes an MSRunSample record and returns a list of values for the download of mzXML metadata.
 
         It is intended to accompany a series of mzXML files organized into subdirectories.
@@ -190,19 +190,10 @@ class RecordToMzxmlTSV(ABC):
         Exceptions:
             None
         Returns:
-            (List[str])
+            (List[Optional[str]])
         """
-        filepath = os.path.join(
-            date_to_string(msrsrec.msrun_sequence.date),
-            msrsrec.msrun_sequence.researcher,
-            msrsrec.msrun_sequence.instrument,
-            msrsrec.msrun_sequence.lc_method.name,
-            msrsrec.polarity,
-            f"{sigfig(msrsrec.mz_min)}-{sigfig(msrsrec.mz_max)}",
-            msrsrec.ms_data_file.filename,
-        )
         return [
-            filepath,
+            msrsrec.mzxml_export_path,
             msrsrec.polarity,
             msrsrec.mz_min,
             msrsrec.mz_max,
@@ -234,24 +225,24 @@ class PeakGroupsToMzxmlTSV(RecordToMzxmlTSV):
     # This format ID matches PeakGroupsFormat.id
     format_id = "pgtemplate"
 
-    def rec_to_rows(self, rec: PeakGroup) -> Union[List[list], List[str]]:
-        """Takes a PeakGroup record (from a queryset) and returns a list of lists of column data.
-
-        Each record can link to many mzXML files, hence it returns multiple rows.
+    def queryset_to_rows_iterator(self, qs):
+        """Takes a queryset of PeakGroup records and returns a list of lists of column data.
 
         Args:
-            rec (PeakGroup)
+            qs (QuerySet[PeakGroup])
         Exceptions:
             None
         Returns:
-            rows (List[List[str]])
+            (List[str])
         """
-        rows = []
-        msrsrec: MSRunSample
-        for msrsrec in rec.msrun_sample.sample.msrun_samples.all():
-            if msrsrec.ms_data_file:
-                rows.append(self.msrun_sample_rec_to_row(msrsrec))
-        return rows
+        seen = {}
+        pgrec: PeakGroup
+        for pgrec in qs.all():
+            msrsrec: MSRunSample
+            for msrsrec in pgrec.msrun_sample.sample.msrun_samples.all():
+                if msrsrec.id not in seen.keys() and msrsrec.ms_data_file is not None:
+                    yield self.msrun_sample_rec_to_row(msrsrec)
+                    seen[msrsrec.id] = True
 
 
 class PeakDataToMzxmlTSV(RecordToMzxmlTSV):
@@ -261,61 +252,85 @@ class PeakDataToMzxmlTSV(RecordToMzxmlTSV):
     # This format ID matches PeakDataFormat.id
     format_id = "pdtemplate"
 
-    def rec_to_rows(self, rec: PeakData) -> Union[List[list], List[str]]:
-        """Takes a PeakData record (from a queryset) and returns a list of lists of column data.
-
-        Each record can link to many mzXML files, hence it returns multiple rows.
+    def queryset_to_rows_iterator(self, qs):
+        """Takes a queryset of PeakData records and returns a list of lists of column data.
 
         Args:
-            rec (PeakData)
+            qs (QuerySet[PeakData])
         Exceptions:
             None
         Returns:
             rows (List[List[str]])
         """
-        rows = []
-        msrsrec: MSRunSample
-        for msrsrec in rec.peak_group.msrun_sample.sample.msrun_samples.all():
-            if msrsrec.ms_data_file:
-                rows.append(self.msrun_sample_rec_to_row(msrsrec))
-        return rows
+        seen = {}
+        pdrec: PeakData
+        for pdrec in qs.all():
+            msrsrec: MSRunSample
+            for msrsrec in pdrec.peak_group.msrun_sample.sample.msrun_samples.all():
+                if msrsrec.ms_data_file is not None and msrsrec.id not in seen.keys():
+                    yield self.msrun_sample_rec_to_row(msrsrec)
+                    seen[msrsrec.id] = True
 
 
 class AdvancedSearchDownloadMzxmlTSVView(AdvancedSearchDownloadView):
     """This is a secondary download view for the advanced search page.
 
     This view is for a subset of SearchGroup formats (those that include mz data files in their results:
-    PeakGroupsFormat and PeakDataFormat).
+    PeakGroupsFormat and PeakDataFormat).  It is for streaming a download of the mzXML metadata in a TSV format.
     """
 
     header_template = "DataRepo/search/downloads/search_metadata.txt"
     content_type = "application/text"
 
-    # See https://docs.djangoproject.com/en/5.1/howto/outputting-csv/#streaming-large-csv-files
-    def form_valid(self, form):
-        # Get the query object (for the commented metadata header)
-        self.qry = self.get_qry(form.cleaned_data)
+    def __init__(self, qry=None, res=None):
+        self.qry = qry
+
         # Get the date (for the commented metadata header)
         now = datetime.now()
         self.date_str = now.strftime(self.date_format)
+        self.datestamp_str = now.strftime(self.datestamp_format)
+
         # Set the metadata header template object
         self.headtmplt = loader.get_template(self.header_template)
 
         # Get the column headers list
         self.headers = RecordToMzxmlTSV.headers
 
-        # Get the search format ID and name
-        format_id = self.qry["selectedtemplate"]
-        self.format_name = self.qry["searches"][format_id]["name"]
+        self.format_id = None
+        self.format_name = None
+        self.converter = None
+        self.res = None
+        self.filename = None
 
-        # Get the method that converts a record from the results queryset to a list of lists
-        self.rec_to_rows = RecordToMzxmlTSV.get_rec_to_rows_method(format_id)
+        if qry is not None:
+            self.prepare_download(qry=qry, res=res)
+
+    def prepare_download(self, qry=None, res=None):
+        if qry is None and self.qry is None:
+            raise ValueError("Argument 'qry' cannot be None.")
+
+        if self.qry is None:
+            self.qry = qry
+
+        # Get the search format ID and name
+        self.format_id = self.qry["selectedtemplate"]
+        self.format_name = self.qry["searches"][self.format_id]["name"]
+
+        # Get the converter object that converts a record from the results queryset to a list we can supply to csv
+        self.converter = RecordToMzxmlTSV.get_converter_object(self.format_id)
 
         # Perform the query and save the queryset
-        self.res = self.get_query_results(self.qry)
+        self.res = res if res is not None else self.get_query_results(self.qry)
 
         # Set the output file name
-        self.filename = f"{self.format_name}_{now.strftime(self.datestamp_format)}.tsv"
+        self.filename = f"{self.format_name}_{self.datestamp_str}.tsv"
+
+    # See https://docs.djangoproject.com/en/5.1/howto/outputting-csv/#streaming-large-csv-files
+    def form_valid(self, form):
+        # Get the query object (for the commented metadata header)
+        self.qry = self.get_qry(form.cleaned_data)
+
+        self.prepare_download()
 
         # Create a fake buffer object (needed to be able to use the csv package for streaming the tsv)
         pseudo_buffer = Echo()
@@ -333,8 +348,171 @@ class AdvancedSearchDownloadMzxmlTSVView(AdvancedSearchDownloadView):
         yield self.headtmplt.render({"qry": self.qry, "dt": self.date_str})
         # Column headers
         yield writer.writerow(self.headers)
-        for rec in self.res:
-            rows = self.rec_to_rows(rec)
-            if len(rows) > 0:
-                for row in rows:
-                    yield writer.writerow(row)
+        for row in self.converter.queryset_to_rows_iterator(self.res):
+            yield writer.writerow(row)
+
+
+class RecordToMzxmlZIP(ABC):
+    """This class defines a download format and type.  In this instance, it is a tsv file format that defines a file of
+    mzXML metadata.  It is an abstract base class.  Derived classes define how to convert a queryset from one or more
+    search Format classes belonging to the SearchGroup class.  Derived classes must set a format_id class attribute that
+    matches one of the SearchGroup Format classes, and a queryset_to_files_iterator method that does the conversion of a
+    queryset record to a list of tuples (where each tuple is an export path and file object).
+
+    This class and its derived classes are used by AdvancedSearchDownloadMzxmlZIPView to generate an mzXML zip archive
+    download file.
+    """
+
+    @property
+    @abstractmethod
+    def format_id(self) -> str:
+        """Derived classes must implement this as a class attribute.  The format_id must match one of the ids in the
+        Format classes in the SearchGroup class."""
+        pass
+
+    @abstractmethod
+    def queryset_to_files_iterator(self, qs):
+        """Derived classes must implement this as a class attribute."""
+        pass
+
+    def msrun_sample_rec_to_file(
+        self, msrsrec: MSRunSample
+    ) -> Tuple[Optional[str], Any]:
+        """Takes an MSRunSample record and returns an export path string and a File object.  The path is generated as:
+        date/researcher/instrument/protocol/polarity/mz_min-mz_max/filename.
+
+        Args:
+            msrsrec (MSRunSample)
+        Exceptions:
+            None
+        Returns:
+            export_path, file_location (str, File)
+        """
+        return msrsrec.mzxml_export_path, msrsrec.ms_data_file.file_location
+
+    @classmethod
+    def get_converter_object(cls, format_id: str):
+        """Takes a format_id and returns the derived class object that comes from the subclass whose format_id matches
+        the supplied format_id.
+
+        Args:
+            format_id (str)
+        Exceptions:
+            Http404
+        Returns:
+            (RecordToMzxmlZIP)
+        """
+        for derived_class in cls.__subclasses__():
+            if format_id == derived_class.format_id:
+                return derived_class()
+        raise Http404(
+            f"Invalid format ID: {format_id}.  Must be one of "
+            f"{[c.format_id for c in cls.__subclasses__()]}"
+        )
+
+
+class PeakGroupsToMzxmlZIP(RecordToMzxmlZIP):
+    """This class defines how to convert a PeakGroupsFormat class's queryset record to a list of lists (1 PeakGroup
+    record can link to 0 or more mzXML files)."""
+
+    # This format ID matches PeakGroupsFormat.id
+    format_id = "pgtemplate"
+
+    def queryset_to_files_iterator(self, qs):
+        """Takes a queryset of PeakGroup records and returns a list of tuples of file data.
+
+        Args:
+            qs (QuerySet[PeakGroup])
+        Exceptions:
+            None
+        Returns:
+            rows (Tuple[str, File])
+        """
+        seen = {}
+        pgrec: PeakGroup
+        for pgrec in qs.all():
+            msrsrec: MSRunSample
+            for msrsrec in pgrec.msrun_sample.sample.msrun_samples.all():
+                if msrsrec.ms_data_file is not None and msrsrec.id not in seen.keys():
+                    yield self.msrun_sample_rec_to_file(msrsrec)
+                    seen[msrsrec.id] = True
+
+
+class PeakDataToMzxmlZIP(RecordToMzxmlZIP):
+    """This class defines how to convert a PeakDataFormat class's queryset record to a list of lists (1 PeakData record
+    can link to 0 or more mzXML files)."""
+
+    # This format ID matches PeakDataFormat.id
+    format_id = "pdtemplate"
+
+    def queryset_to_files_iterator(self, qs):
+        """Takes a queryset of PeakData records and returns a list of tuples of file data.
+
+        Args:
+            qs (QuerySet[PeakData])
+        Exceptions:
+            None
+        Returns:
+            rows (Tuple[str, File])
+        """
+        seen = {}
+        pgrec: PeakData
+        for pgrec in qs.all():
+            msrsrec: MSRunSample
+            for msrsrec in pgrec.peak_group.msrun_sample.sample.msrun_samples.all():
+                if msrsrec.ms_data_file is not None and msrsrec.id not in seen.keys():
+                    yield self.msrun_sample_rec_to_file(msrsrec)
+                    seen[msrsrec.id] = True
+
+
+class AdvancedSearchDownloadMzxmlZIPView(AdvancedSearchDownloadView):
+    """This is a secondary download view for the advanced search page.
+
+    This view is for a subset of SearchGroup formats (those that include mz data files in their results:
+    PeakGroupsFormat and PeakDataFormat).  It is for streaming a download of the mzXML files in a zip archive.
+    """
+
+    content_type = "application/zip"
+
+    def form_valid(self, form):
+        # Get the query object (for the commented metadata header)
+        self.qry = self.get_qry(form.cleaned_data)
+        # Get the date (for the commented metadata header)
+        now = datetime.now()
+        self.date_str = now.strftime(self.date_format)
+        self.datestamp_str = now.strftime(self.datestamp_format)
+
+        # Get the search format ID and name
+        self.format_id = self.qry["selectedtemplate"]
+        self.format_name = self.qry["searches"][self.format_id]["name"]
+
+        # Perform the query and save the queryset
+        self.res = self.get_query_results(self.qry)
+
+        # Set the output file name
+        self.filename = f"{self.format_name}_mzxmls_{self.datestamp_str}.zip"
+        # Get the object that converts a record from the results queryset to a list of file tuples (containing the
+        # export path and a file_location field value from an ArchiveFile record)
+        self.converter = RecordToMzxmlZIP.get_converter_object(self.format_id)
+
+        self.asdtv = AdvancedSearchDownloadMzxmlTSVView(qry=self.qry, res=self.res)
+        with io.StringIO() as metadata_io:
+            metadata_tsv_writer = csv.writer(metadata_io, delimiter="\t")
+            metadata_content = self.asdtv.tsv_iterator(metadata_tsv_writer)
+
+        zipio = BytesIO()
+        with zipfile.ZipFile(zipio, "w") as zipf:
+            return StreamingHttpResponse(
+                self.mzxml_zip_iterator(zipf, metadata_content),
+                content_type=self.content_type,
+                headers={
+                    "Content-Disposition": f"attachment; filename={self.filename}"
+                },
+            )
+
+    def mzxml_zip_iterator(self, zipf, metadata_content):
+        yield zipf.writestr(self.asdtv.filename, metadata_content)
+        for file_tuple in self.converter.queryset_to_files_iterator(self.res):
+            export_path, file_obj = file_tuple
+            with open(file_obj, "r") as fl:
+                yield zipf.writestr(export_path, fl.read())


### PR DESCRIPTION
## Summary Change Description

This PR streamlines the mzXML metadata download view (from the previous PR) and creates a new view for the bulk download of mzXML files from the advanced search results.  The zip archive includes the metadata file.

This does not actually add a widget yet to the advanced search template.  It is just the view that builds and streams the zip archive.

## Affected Issues/Pull Requests

- Partially addresses #1261
- Merges into PR #1284 (`mzxml_tsv_download`)

## Review Notes
<!--
For added context for reviewers, add comments to relevant lines of code.  Use
this space to describe any general areas of concern not linked to a specific
line of code that reviewers should pay particular attention to, e.g. please
make sure I have accounted for all possible inputs.
-->
See comments in-line.

## Checklist
<!--
If any of the checkbox requirements are not met, uncheck them and add an
explanation. E.g. Linting errors pre-date this PR.
-->
This pull request will be merged once the following requirements are met.  The
author and/or reviewers should uncheck any unmet requirements:

- Review requirements
  - Minimum approvals: 1 <!-- Edit as desired (e.g. based on complexity) -->
  - No changes requested
  - All blocking issues resolved by reviewers
  - Specific reviewers: @__add_username_here__
    <!--
    Require reviewers with specific expertise to be included among the minimum
    number of reviewers by tagging them.  Also please send them a message.
    -->
  - Review period: 2 days <!-- Edit as desired (e.g. based on complexity) -->
- Associated issue/pull request requirements:
  <!--
  Assert that all requirements in issues marked "resolved" are done and that
  all required pull requests are merged.  If any are not done, either edit or
  split the issue or explain the unmerged affected pull requests.
  -->
  - [x] All requirements in affected issues marked "resolved" are satisfied
  - [x] All required pull requests are merged *(or none)*
- Basic requirements
  <!--
  Uncheck items to acknowledge failures/conflicts you intend to address.
  Add an explanation if any won't be addressed before merge.
  -->
  - [x] [All linters pass](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#linting)
  - [x] [All tests pass](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#quality-control)
  - [x] All conflicts resolved
- Overhead requirements
  <!--
  These are additional requirements that are not directly associated with
  resolving the affected issue(s).
  -->
  - [x] [New/changed method tests implemented/updated *(or no change)*](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#test-implementation)
  - [ ] [Updated *Unreleased* section of `changelog.md` *(or no change)*](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/changelog.md)
  - [x] [Migrations created & committed *(or no change)*](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#migration-process)
