### PR TITLE
A fix to the `Accucor` to `Unicorr` format conversion that caused compounds to get the wrong formula when a `C12 PARENT` row is missing

### DIFF
--- a/DataRepo/loaders/peak_annotations_loader.py
+++ b/DataRepo/loaders/peak_annotations_loader.py
@@ -1924,28 +1924,11 @@ class AccucorLoader(PeakAnnotationsLoader):
         "medMz": 0,
         "medRt": 0,
         "isotopeLabel": lambda df: "C13-label-" + df["C_Label"].astype(str),
-        # This is a much less efficient way of filling in missing formulas than the previous strategy of using
-        # nan_filldown_columns, but in some edge cases, there can exist no C12 parent row in the accucor file, which
-        # resulted in invalid formulas is a very infrequent manner.  This builds a dict from the entire dataframe each
-        # time in order to be able to perform the formula lookup.
-        "formula": (
-            lambda df: df["formula"].fillna(
-                df["Compound"].apply(
-                    lambda x:
-                    # This gets all compounds and formulas where the formula is populated
-                    df.loc[df["formula"].notna(), ["Compound", "formula"]]
-                    # Then we create a dict where the compound is the key and the formula is the value
-                    .set_index("Compound")["formula"].to_dict()
-                    # Then we lookup the formula for the compound on this row
-                    .get(x)
-                )
-            )
-        ),
     }
 
     sort_columns = ["Sample Header", "Compound", "C_Label"]
 
-    nan_filldown_columns = None
+    nan_filldown_columns = ["formula"]
 
     merged_column_rename_dict = {
         "formula": "Formula",


### PR DESCRIPTION
## Summary Change Description
<!-- Briefly describe the changes in this pull request (put details in the
developer section of the linked issue(s)). -->
See affected issue(s).

## Affected Issues/Pull Requests

- Resolves #1300
- Merges into PR #1301

## Review Notes
<!--
For added context for reviewers, add comments to relevant lines of code.  Use
this space to describe any general areas of concern not linked to a specific
line of code that reviewers should pay particular attention to, e.g. please
make sure I have accounted for all possible inputs.
-->
See comments in-line.

## Checklist
<!--
If any of the checkbox requirements are not met, uncheck them and add an
explanation. E.g. Linting errors pre-date this PR.
-->
This pull request will be merged once the following requirements are met.  The
author and/or reviewers should uncheck any unmet requirements:

- Review requirements
  - Minimum approvals: 1 <!-- Edit as desired (e.g. based on complexity) -->
  - No changes requested
  - All blocking issues resolved by reviewers
  - Specific reviewers: @__add_username_here__
    <!--
    Require reviewers with specific expertise to be included among the minimum
    number of reviewers by tagging them.  Also please send them a message.
    -->
  - Review period: 2 days <!-- Edit as desired (e.g. based on complexity) -->
- Associated issue/pull request requirements:
  <!--
  Assert that all requirements in issues marked "resolved" are done and that
  all required pull requests are merged.  If any are not done, either edit or
  split the issue or explain the unmerged affected pull requests.
  -->
  - [x] All requirements in affected issues marked "resolved" are satisfied
  - [x] All required pull requests are merged *(or none)*
- Basic requirements
  <!--
  Uncheck items to acknowledge failures/conflicts you intend to address.
  Add an explanation if any won't be addressed before merge.
  -->
  - [x] [All linters pass](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#linting)
  - [x] [All tests pass](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#quality-control)
  - [x] All conflicts resolved
- Overhead requirements
  <!--
  These are additional requirements that are not directly associated with
  resolving the affected issue(s).
  -->
  - [x] [New/changed method tests implemented/updated *(or no change)*](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#test-implementation)
  - [ ] [Updated *Unreleased* section of `changelog.md` *(or no change)*](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/changelog.md)
  - [x] [Migrations created & committed *(or no change)*](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#migration-process)
