### PR TITLE
A fix for running the `AnimalsLoader` from the command line by itself when the animal's `age` is empty

### DIFF
--- a/DataRepo/loaders/base/converted_table_loader.py
+++ b/DataRepo/loaders/base/converted_table_loader.py
@@ -825,7 +825,12 @@ class ConvertedTableLoader(TableLoader, ABC):
         # numeric, fill them with zeros.
         num_type_fill_dict = {}
         for col, typ in self.get_column_types().items():
-            if col in _outdf.columns and typ in [int, float]:
+            if col in _outdf.columns and typ in [
+                int,
+                float,
+                pd.Int64Dtype(),
+                pd.Float64Dtype(),
+            ]:
                 num_type_fill_dict[col] = 0
         if len(num_type_fill_dict.keys()) > 0:
             _outdf.fillna(num_type_fill_dict, inplace=True)

--- a/DataRepo/loaders/base/converted_table_loader.py
+++ b/DataRepo/loaders/base/converted_table_loader.py
@@ -844,7 +844,7 @@ class ConvertedTableLoader(TableLoader, ABC):
             _merge_dict=_merge_dict["next_merge_dict"].copy(),
         )
 
-    def get_column_types(self):
+    def get_column_types(self, **kwargs):
         """Override of TableLoader.get_column_types, to add the original header types to the converted header types.
         Returns a dict of column types by header name (not header key).
 
@@ -859,7 +859,7 @@ class ConvertedTableLoader(TableLoader, ABC):
             dtypes (dict): Types by header name (instead of by header key)
         """
         # Get the converted header types
-        dtypes = super().get_column_types()
+        dtypes = super().get_column_types(**kwargs)
         if dtypes is None:
             dtypes = {}
 

--- a/DataRepo/loaders/base/table_loader.py
+++ b/DataRepo/loaders/base/table_loader.py
@@ -1079,6 +1079,7 @@ class TableLoader(ABC):
         try:
             self.set_headers()
         except TypeError as te:
+            self.aggregated_errors_object.buffer_warning(te)
             typeerrs.append(str(te))
             # TODO: Buffering at the caught exception would be better, because it provides a better trace.  Refactor
             # spots where I do this.
@@ -1087,6 +1088,7 @@ class TableLoader(ABC):
         try:
             self.set_defaults()
         except TypeError as te:
+            self.aggregated_errors_object.buffer_warning(te)
             typeerrs.append(str(te))
             # self.aggregated_errors_object.buffer_error(te)
 

--- a/DataRepo/loaders/base/table_loader.py
+++ b/DataRepo/loaders/base/table_loader.py
@@ -5,6 +5,7 @@ from collections import defaultdict, namedtuple
 from collections.abc import Iterable
 from typing import Dict, List, Optional, Type
 
+import pandas as pd
 from django.core.exceptions import (
     MultipleObjectsReturned,
     ObjectDoesNotExist,
@@ -200,7 +201,7 @@ class TableLoader(ABC):
     DefaultsRequiredValues = ["SHEET_NAME", "COLUMN_NAME"]
 
     # For handling empty "cells".  Any value to be converted to None, when evaluated as a string.
-    none_vals = ["", "nan", "None", "dummy", "NaT"]
+    none_vals = ["", "nan", "None", "dummy", "NaT", "<NA>"]
 
     def __init__(
         self,
@@ -1150,13 +1151,14 @@ class TableLoader(ABC):
             and hasattr(obj, "_fields")
         )
 
-    def get_column_types(self, optional_mode=False):
+    def get_column_types(self, optional_mode=False, pandas_mode=True):
         """Returns a dict of column types by header name (not header key).
 
         Args:
             optional_mode (bool): Only include types that do not raise pandas exceptions when empty (because they are
                 optional).  Currently, this means it will only include string types, e.g. so that animal names that are
                 only numbers stay as strings.
+            pandas_mode (bool) [True]: Whether to return pandas types or not.
         Exceptions:
             None
         Returns:
@@ -1166,12 +1168,20 @@ class TableLoader(ABC):
             return None
 
         if hasattr(self, "headers") and self.headers is not None:
-            return self._get_column_types(self.headers, optional_mode=optional_mode)
+            types, aes = self._get_column_types(
+                self.headers, optional_mode=optional_mode, pandas_mode=pandas_mode
+            )
+        else:
+            types, aes = self._get_column_types(
+                optional_mode=optional_mode, pandas_mode=pandas_mode
+            )
 
-        return self._get_column_types(optional_mode=optional_mode)
+        self.aggregated_errors_object.merge_aggregated_errors_object(aes)
+
+        return types
 
     @classmethod
-    def _get_column_types(self, headers=None, optional_mode=False):
+    def _get_column_types(cls, headers=None, optional_mode=False, pandas_mode=True):
         """Returns a dict of column types by header name (not header key).
 
         Args:
@@ -1179,31 +1189,52 @@ class TableLoader(ABC):
             optional_mode (bool): Only include types that do not raise pandas exceptions when empty (because they are
                 optional).  Currently, this means it will only include string types, e.g. so that animal names that are
                 only numbers stay as strings.
+            pandas_mode (bool) [True]: Whether to return pandas types or not.
         Exceptions:
             None
         Returns:
             dtypes (dict): Types by header name (instead of by header key)
+            aes (AggregatedErrors)
         """
+        aes = AggregatedErrors()
+
         # TODO: Make optional mode have the ability to consider the required state for the column
-        if self.DataColumnTypes is None:
-            return None
+        if cls.DataColumnTypes is None:
+            return None, aes
 
         if headers is None:
-            headers = self.DataHeaders
+            headers = cls.DataHeaders
 
         dtypes = {}
-        for key in self.DataColumnTypes.keys():
-            if optional_mode and self.DataColumnTypes[key] != str:
+        for key in cls.DataColumnTypes.keys():
+            if optional_mode and cls.DataColumnTypes[key] != str:
                 continue
             hdr = getattr(headers, key)
             if hdr is None:
                 # This is in case the custom-supplied headers are incomplete (they should not be if they came from the
                 # instance - only if this is called externally)
-                dtypes[getattr(self.DataHeaders, key)] = self.DataColumnTypes[key]
+                dtypes[getattr(cls.DataHeaders, key)] = cls.DataColumnTypes[key]
             else:
-                dtypes[hdr] = self.DataColumnTypes[key]
+                if not pandas_mode or hdr in cls.DataRequiredValues:
+                    dtypes[hdr] = cls.DataColumnTypes[key]
+                elif cls.DataColumnTypes[key] == int:
+                    # Pandas' Nullable integer
+                    dtypes[hdr] = pd.Int64Dtype()
+                elif cls.DataColumnTypes[key] == float:
+                    # Pandas' Nullable float
+                    dtypes[hdr] = pd.Float64Dtype()
+                else:
+                    if cls.DataColumnTypes[key] != str:
+                        aes.buffer_warning(
+                            ProgrammingError(
+                                f"A Pandas Type for '{cls.DataColumnTypes[key].__name__}' is not yet "
+                                "implemented."
+                            )
+                        )
+                    # Add types as needed
+                    dtypes[hdr] = cls.DataColumnTypes[key]
 
-        return dtypes
+        return dtypes, aes
 
     def get_hidden_columns(self):
         """Returns a list of hidden columns by header name (not header key).
@@ -2002,7 +2033,7 @@ class TableLoader(ABC):
             apply_types = False
 
         # Get the column types by header name
-        coltypes = self.get_column_types()
+        coltypes = self.get_column_types(pandas_mode=False)
 
         # Error tracking
         unknown_sheets = defaultdict(list)

--- a/DataRepo/loaders/study_loader.py
+++ b/DataRepo/loaders/study_loader.py
@@ -605,15 +605,21 @@ class StudyLoader(ConvertedTableLoader, ABC):
             dtypes (dict): Types keyed on header names (not keys)
         """
         if headers is not None:
-            return loader_class._get_column_types(headers, optional_mode=True)
+            dtypes, aes = loader_class._get_column_types(headers, optional_mode=True)
+            self.aggregated_errors_object.merge_aggregated_errors_object(aes)
+            return dtypes
 
         # TODO Get rid of (/refactor) the ProtocolsLoader to not use this "DataHeadersExcel" class attribute
         if hasattr(loader_class, "DataHeadersExcel"):
-            return loader_class._get_column_types(
+            dtypes, aes = loader_class._get_column_types(
                 loader_class.DataHeadersExcel, optional_mode=True
             )
+            self.aggregated_errors_object.merge_aggregated_errors_object(aes)
+            return dtypes
 
-        return loader_class._get_column_types(optional_mode=True)
+        dtypes, aes = loader_class._get_column_types(optional_mode=True)
+        self.aggregated_errors_object.merge_aggregated_errors_object(aes)
+        return dtypes
 
     def get_sheet_names_tuple(self):
         """Retrieve a tuple containing all of the loaders' sheet names.

--- a/DataRepo/management/commands/load_table.py
+++ b/DataRepo/management/commands/load_table.py
@@ -557,7 +557,7 @@ class LoadTableCommand(ABC, BaseCommand):
             df = read_from_file(file, sheet=sheet)
         else:
             keep_default_na = False
-            if len([val for val in dtypes.values() if not isinstance(val, str)]) > 0:
+            if len([val for val in dtypes.values() if val != str]) > 0:
                 # pandas will throw an error on empty cells if it cannot convert an empty string into a specified type,
                 # so setting keep_default_na to True will allow them to just be null.
                 keep_default_na = True

--- a/DataRepo/views/upload/submission.py
+++ b/DataRepo/views/upload/submission.py
@@ -432,17 +432,21 @@ class BuildSubmissionView(FormView):
                 # code that says that supplying keep_default_na=True fixes it, but that didn't work.  I have to think
                 # about it.  But not setting types works for now.  Setting optional_mode=True explicitly sets str types
                 # in order to avoid accidental int(/etc) types...
+                # 11/1/2024 - I figured out a good part of this to solve a different problem, but I still need to make
+                # sure this solution is comprehensive before I refactor this code (more)
+                dtypes, aes = PeakAnnotationFilesLoader._get_column_types(
+                    optional_mode=True
+                )
                 pafl = PeakAnnotationFilesLoader(
                     df=read_from_file(
                         self.study_file,
                         sheet=PeakAnnotationFilesLoader.DataSheetName,
-                        dtype=PeakAnnotationFilesLoader._get_column_types(
-                            optional_mode=True
-                        ),
+                        dtype=dtypes,
                     ),
                     file=self.study_file,
                     filename=self.study_filename,
                 )
+                pafl.aggregated_errors_object.merge_aggregated_errors_object(aes)
                 for _, row in pafl.df.iterrows():
                     if pafl.is_row_empty(row):
                         continue
@@ -1324,15 +1328,19 @@ class BuildSubmissionView(FormView):
         # code that says that supplying keep_default_na=True fixes it, but that didn't work.  I have to think
         # about it.  But not setting types works for now.  Setting optional_mode=True explicitly sets str types
         # in order to avoid accidental int(/etc) types...
+        # 11/1/2024 - I figured out a good part of this to solve a different problem, but I still need to make sure this
+        # solution is comprehensive before I refactor this code (more)
+        dtypes, aes = AnimalsLoader._get_column_types(optional_mode=True)
         loader = AnimalsLoader(
             df=read_from_file(
                 self.study_file,
                 sheet=AnimalsLoader.DataSheetName,
-                dtype=AnimalsLoader._get_column_types(optional_mode=True),
+                dtype=dtypes,
             ),
             file=self.study_file,
             filename=self.study_filename,
         )
+        loader.aggregated_errors_object.merge_aggregated_errors_object(aes)
         seen = {
             "infusates": defaultdict(dict),
             "tracers": defaultdict(dict),
@@ -1508,15 +1516,19 @@ class BuildSubmissionView(FormView):
         # code that says that supplying keep_default_na=True fixes it, but that didn't work.  I have to think
         # about it.  But not setting types works for now.  Setting optional_mode=True explicitly sets str types
         # in order to avoid accidental int(/etc) types...
+        # 11/1/2024 - I figured out a good part of this to solve a different problem, but I still need to make sure this
+        # solution is comprehensive before I refactor this code (more)
+        dtypes, aes = SamplesLoader._get_column_types(optional_mode=True)
         loader = SamplesLoader(
             df=read_from_file(
                 self.study_file,
                 sheet=SamplesLoader.DataSheetName,
-                dtype=SamplesLoader._get_column_types(optional_mode=True),
+                dtype=dtypes,
             ),
             file=self.study_file,
             filename=self.study_filename,
         )
+        loader.aggregated_errors_object.merge_aggregated_errors_object(aes)
         seen = {
             "tissues": defaultdict(dict),
             "animals": defaultdict(dict),
@@ -1548,15 +1560,19 @@ class BuildSubmissionView(FormView):
         # code that says that supplying keep_default_na=True fixes it, but that didn't work.  I have to think
         # about it.  But not setting types works for now.  Setting optional_mode=True explicitly sets str types
         # in order to avoid accidental int(/etc) types...
+        # 11/1/2024 - I figured out a good part of this to solve a different problem, but I still need to make sure this
+        # solution is comprehensive before I refactor this code (more)
+        dtypes, aes = PeakAnnotationFilesLoader._get_column_types(optional_mode=True)
         loader = PeakAnnotationFilesLoader(
             df=read_from_file(
                 self.study_file,
                 sheet=PeakAnnotationFilesLoader.DataSheetName,
-                dtype=PeakAnnotationFilesLoader._get_column_types(optional_mode=True),
+                dtype=dtypes,
             ),
             file=self.study_file,
             filename=self.study_filename,
         )
+        loader.aggregated_errors_object.merge_aggregated_errors_object(aes)
         seen = {
             "sequences": defaultdict(dict),
             "lcprotocols": defaultdict(dict),
@@ -1621,15 +1637,19 @@ class BuildSubmissionView(FormView):
         # code that says that supplying keep_default_na=True fixes it, but that didn't work.  I have to think
         # about it.  But not setting types works for now.  Setting optional_mode=True explicitly sets str types
         # in order to avoid accidental int(/etc) types...
+        # 11/1/2024 - I figured out a good part of this to solve a different problem, but I still need to make sure this
+        # solution is comprehensive before I refactor this code (more)
+        dtypes, aes = MSRunsLoader._get_column_types(optional_mode=True)
         loader = MSRunsLoader(
             df=read_from_file(
                 self.study_file,
                 sheet=MSRunsLoader.DataSheetName,
-                dtype=MSRunsLoader._get_column_types(optional_mode=True),
+                dtype=dtypes,
             ),
             file=self.study_file,
             filename=self.study_filename,
         )
+        loader.aggregated_errors_object.merge_aggregated_errors_object(aes)
         # We're going to ignore the sample column.  It's way more likely it will have been auto-filled itself, and the
         # samples sheet is populated at the same time, so doing that here is just wasted cycles.  Instead, we're looking
         # for manually filled-in data to autofill elsewhere.
@@ -1728,15 +1748,19 @@ class BuildSubmissionView(FormView):
         # code that says that supplying keep_default_na=True fixes it, but that didn't work.  I have to think
         # about it.  But not setting types works for now.  Setting optional_mode=True explicitly sets str types
         # in order to avoid accidental int(/etc) types...
+        # 11/1/2024 - I figured out a good part of this to solve a different problem, but I still need to make sure this
+        # solution is comprehensive before I refactor this code (more)
+        dtypes, aes = InfusatesLoader._get_column_types(optional_mode=True)
         loader = InfusatesLoader(
             df=read_from_file(
                 self.study_file,
                 sheet=InfusatesLoader.DataSheetName,
-                dtype=InfusatesLoader._get_column_types(optional_mode=True),
+                dtype=dtypes,
             ),
             file=self.study_file,
             filename=self.study_filename,
         )
+        loader.aggregated_errors_object.merge_aggregated_errors_object(aes)
 
         # Convenience shortcut
         trcr_sheet_cols = self.dfs_dict[TracersLoader.DataSheetName]
@@ -1769,15 +1793,19 @@ class BuildSubmissionView(FormView):
         # code that says that supplying keep_default_na=True fixes it, but that didn't work.  I have to think
         # about it.  But not setting types works for now.  Setting optional_mode=True explicitly sets str types
         # in order to avoid accidental int(/etc) types...
+        # 11/1/2024 - I figured out a good part of this to solve a different problem, but I still need to make sure this
+        # solution is comprehensive before I refactor this code (more)
+        dtypes, aes = TracersLoader._get_column_types(optional_mode=True)
         loader = TracersLoader(
             df=read_from_file(
                 self.study_file,
                 sheet=TracersLoader.DataSheetName,
-                dtype=TracersLoader._get_column_types(optional_mode=True),
+                dtype=dtypes,
             ),
             file=self.study_file,
             filename=self.study_filename,
         )
+        loader.aggregated_errors_object.merge_aggregated_errors_object(aes)
         seen = {"compounds": defaultdict(dict)}
         for _, row in loader.df.iterrows():
             if loader.is_row_empty(row):
@@ -1795,15 +1823,19 @@ class BuildSubmissionView(FormView):
         # code that says that supplying keep_default_na=True fixes it, but that didn't work.  I have to think
         # about it.  But not setting types works for now.  Setting optional_mode=True explicitly sets str types
         # in order to avoid accidental int(/etc) types...
+        # 11/1/2024 - I figured out a good part of this to solve a different problem, but I still need to make sure this
+        # solution is comprehensive before I refactor this code (more)
+        dtypes, aes = SequencesLoader._get_column_types(optional_mode=True)
         loader = SequencesLoader(
             df=read_from_file(
                 self.study_file,
                 sheet=SequencesLoader.DataSheetName,
-                dtype=SequencesLoader._get_column_types(optional_mode=True),
+                dtype=dtypes,
             ),
             file=self.study_file,
             filename=self.study_filename,
         )
+        loader.aggregated_errors_object.merge_aggregated_errors_object(aes)
         seen = {"lcprotocols": defaultdict(dict)}
         for _, row in loader.df.iterrows():
             if loader.is_row_empty(row):

--- a/DataRepo/views/upload/submission.py
+++ b/DataRepo/views/upload/submission.py
@@ -88,6 +88,7 @@ class BuildSubmissionView(FormView):
         "None",  # none_vals is(/should be) evaluated with the value inside str() to handle weird types
         "dummy",  # Some studies used this on rows for blank samples
         "NaT",  # This happens when a dfs_dict entry is changed to None (e.g. when replacing a "dummy" value)
+        "<NA>",  # This happens when the type is a pandas nullable type and the cell was empty
     ]
 
     # TODO: Until all sheets are supported, this variable will be used to filter the sheets obtained from StudyLoader


### PR DESCRIPTION
## Summary Change Description
<!-- Briefly describe the changes in this pull request (put details in the
developer section of the linked issue(s)). -->
See affected issue(s).

## Affected Issues/Pull Requests

- Resolves #1299
- Merges into PR #1302

## Review Notes
<!--
For added context for reviewers, add comments to relevant lines of code.  Use
this space to describe any general areas of concern not linked to a specific
line of code that reviewers should pay particular attention to, e.g. please
make sure I have accounted for all possible inputs.
-->
See comments in-line.

## Checklist
<!--
If any of the checkbox requirements are not met, uncheck them and add an
explanation. E.g. Linting errors pre-date this PR.
-->
This pull request will be merged once the following requirements are met.  The
author and/or reviewers should uncheck any unmet requirements:

- Review requirements
  - Minimum approvals: 1 <!-- Edit as desired (e.g. based on complexity) -->
  - No changes requested
  - All blocking issues resolved by reviewers
  - Specific reviewers: @__add_username_here__
    <!--
    Require reviewers with specific expertise to be included among the minimum
    number of reviewers by tagging them.  Also please send them a message.
    -->
  - Review period: 2 days <!-- Edit as desired (e.g. based on complexity) -->
- Associated issue/pull request requirements:
  <!--
  Assert that all requirements in issues marked "resolved" are done and that
  all required pull requests are merged.  If any are not done, either edit or
  split the issue or explain the unmerged affected pull requests.
  -->
  - [x] All requirements in affected issues marked "resolved" are satisfied
  - [x] All required pull requests are merged *(or none)*
- Basic requirements
  <!--
  Uncheck items to acknowledge failures/conflicts you intend to address.
  Add an explanation if any won't be addressed before merge.
  -->
  - [x] [All linters pass](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#linting)
  - [x] [All tests pass](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#quality-control)
  - [x] All conflicts resolved
- Overhead requirements
  <!--
  These are additional requirements that are not directly associated with
  resolving the affected issue(s).
  -->
  - [x] [New/changed method tests implemented/updated *(or no change)*](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#test-implementation)
  - [ ] [Updated *Unreleased* section of `changelog.md` *(or no change)*](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/changelog.md)
  - [x] [Migrations created & committed *(or no change)*](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#migration-process)
