### PR TITLE
Better single sheet handling for csv and tsv format conversions

### DIFF
--- a/DataRepo/tests/loaders/base/test_converted_table_loader.py
+++ b/DataRepo/tests/loaders/base/test_converted_table_loader.py
@@ -607,8 +607,8 @@ class TestConvertedLoaderTests(TracebaseTestCase):
         self.assertIsInstance(aes.exceptions[0], RequiredHeadersError)
         self.assertIn(
             (
-                "missing: {'Unnamed sheet': ['medMz', 'medRt', 'isotopeLabel', 'formula', 'mzXML Name', "
-                "'Corrected Abundance']}"
+                "missing: {'Corrected': ['medMz', 'medRt', 'isotopeLabel', 'formula', 'mzXML Name', 'Corrected "
+                "Abundance']}"
             ),
             str(aes.exceptions[0]),
         )
@@ -798,19 +798,20 @@ class TestConvertedLoaderTests(TracebaseTestCase):
             # dataframe, thus it seems like it's saying (for example) that "medMz" is missing (when it's not), because
             # to do the test, we skipped conversion and passed it a bogus original dataframe as if it was converted.
             # So, this result is the expected result given the manipulation.
-            # It also names the sheet as "Unnamed sheet" for the same reason.  The class is compatible with either a
-            # dict of dataframes or a dataframe.  When it's given a dataframe (as in this case), it doesn't know the
-            # name of the sheet, which is gets from the keys of the dict of dataframes that we did not provide.
+            # It also names the sheet as "absolte" because it assumes that when it's given a single sheet, it is the one
+            # required sheet.  The class is compatible with either a dict of dataframes or a dataframe.  When it's given
+            # a dataframe (as in this case), it doesn't really know the name of the sheet, which it gets from the keys
+            # of the dict of dataframes that we did not provide.  It just assumes it's the one it needs.
             (
-                "{'Unnamed sheet': ['medMz', 'medRt', 'isotopeLabel', 'formula', 'compound', 'mzXML Name', 'Corrected "
+                "{'absolte': ['medMz', 'medRt', 'isotopeLabel', 'formula', 'compound', 'mzXML Name', 'Corrected "
                 "Abundance']}"
             ),
             str(aes.exceptions[0]),
         )
 
-    def test_get_single_sheet(self):
+    def test_get_single_required_sheet(self):
         il = self.TestConvertedLoader2()  # pylint: disable=not-callable
-        sheet = il.get_single_sheet()
+        sheet = il.get_single_required_sheet()
         self.assertEqual("absolte", sheet)
 
     def test_get_existing_static_columns_success(self):

--- a/DataRepo/tests/loaders/base/test_converted_table_loader.py
+++ b/DataRepo/tests/loaders/base/test_converted_table_loader.py
@@ -606,10 +606,7 @@ class TestConvertedLoaderTests(TracebaseTestCase):
         self.assertEqual(1, len(aes.exceptions))
         self.assertIsInstance(aes.exceptions[0], RequiredHeadersError)
         self.assertIn(
-            (
-                "missing: {'Corrected': ['medMz', 'medRt', 'isotopeLabel', 'formula', 'mzXML Name', 'Corrected "
-                "Abundance']}"
-            ),
+            "missing: {'Corrected': ['medMz', 'medRt', 'isotopeLabel', 'formula']}",
             str(aes.exceptions[0]),
         )
 


### PR DESCRIPTION
## Summary Change Description

Conversion of single accucor corrected sheets in csv or tsv format were failing due in part to the ambiguity of the context when dealing with one required sheet or one supplied sheet.  These code changes make a distinction for that context, allowing columns in the one supplied sheet to be condensed ("melted" in pandas' terminology).

## Affected Issues/Pull Requests

- Resolves no documented issue
- Merges into PR #1308

## Review Notes
<!--
For added context for reviewers, add comments to relevant lines of code.  Use
this space to describe any general areas of concern not linked to a specific
line of code that reviewers should pay particular attention to, e.g. please
make sure I have accounted for all possible inputs.
-->
See comments in-line.

## Checklist
<!--
If any of the checkbox requirements are not met, uncheck them and add an
explanation. E.g. Linting errors pre-date this PR.
-->
This pull request will be merged once the following requirements are met.  The
author and/or reviewers should uncheck any unmet requirements:

- Review requirements
  - Minimum approvals: 1 <!-- Edit as desired (e.g. based on complexity) -->
  - No changes requested
  - All blocking issues resolved by reviewers
  - Specific reviewers: @__add_username_here__
    <!--
    Require reviewers with specific expertise to be included among the minimum
    number of reviewers by tagging them.  Also please send them a message.
    -->
  - Review period: 2 days <!-- Edit as desired (e.g. based on complexity) -->
- Associated issue/pull request requirements:
  <!--
  Assert that all requirements in issues marked "resolved" are done and that
  all required pull requests are merged.  If any are not done, either edit or
  split the issue or explain the unmerged affected pull requests.
  -->
  - [x] All requirements in affected issues marked "resolved" are satisfied
  - [x] All required pull requests are merged *(or none)*
- Basic requirements
  <!--
  Uncheck items to acknowledge failures/conflicts you intend to address.
  Add an explanation if any won't be addressed before merge.
  -->
  - [x] [All linters pass](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#linting)
  - [x] [All tests pass](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#quality-control)
  - [x] All conflicts resolved
- Overhead requirements
  <!--
  These are additional requirements that are not directly associated with
  resolving the affected issue(s).
  -->
  - [x] [New/changed method tests implemented/updated *(or no change)*](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#test-implementation)
  - [ ] [Updated *Unreleased* section of `changelog.md` *(or no change)*](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/changelog.md)
  - [x] [Migrations created & committed *(or no change)*](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#migration-process)
