### PR TITLE
Catch missing C12 PARENT row issues

### DIFF
--- a/DataRepo/loaders/peak_annotations_loader.py
+++ b/DataRepo/loaders/peak_annotations_loader.py
@@ -509,7 +509,7 @@ class PeakAnnotationsLoader(ConvertedTableLoader, ABC):
             compound = row[self.headers.COMPOUND]
             formula = row[self.headers.FORMULA]
             row_indexes = list(row["INDEX"])
-            print(f"DOING ROW: {compound} {formula} {row_indexes}")
+
             if previous_compound is not None:
                 # If the compound has changed
                 if compound != previous_compound:

--- a/DataRepo/loaders/peak_annotations_loader.py
+++ b/DataRepo/loaders/peak_annotations_loader.py
@@ -36,6 +36,7 @@ from DataRepo.utils.exceptions import (
     DuplicateValues,
     InfileError,
     IsotopeStringDupe,
+    MissingC12ParentPeak,
     MissingCompounds,
     MissingSamples,
     MultiplePeakGroupRepresentation,
@@ -359,6 +360,9 @@ class PeakAnnotationsLoader(ConvertedTableLoader, ABC):
         # Cannot call super().__init__() because ABC.__init__() takes a custom argument
         ConvertedTableLoader.__init__(self, *args, **kwargs)
 
+        # Check that every compound has a valid C12 PARENT row.
+        self.check_c12_parents()
+
         # Initialize the MSRun Sample and Sequence data (obtained from self.msrunsloader)
         self.operator_default = None
         self.date_default = None
@@ -410,6 +414,141 @@ class PeakAnnotationsLoader(ConvertedTableLoader, ABC):
         self.aggregated_errors_object.merge_aggregated_errors_object(
             self.peakgroupconflicts.aggregated_errors_object
         )
+
+    def check_c12_parents(self):
+        """This method ensures that every compound in the original peak annotations file had a row for the C12 PARENT.
+        It does this by looking through the sorted compounds and formulas in the unicorr converted dataframe and
+        inferring that if the compound changes, but the formula stays the same, then the formula was filled down from
+        the preceding compound.
+
+        Note that it is technically possible that the formulas of 2 adjacent compounds could be the same, so when it
+        finds that the formula did not change, it keeps track and only buffers an error if the formula for that compound
+        later changes.  At that point, we can infer that the parent row was actually missing, because the only reason
+        the formula would change is because the assumption had been made that all C12 PARENT records were present and
+        the fill down strategy only fills empty formulas with the one above it.
+
+        This check is performed on all peak annotation files, but currently the only possible errors it catches come
+        from the AccucorLoader.
+
+        Example:
+            Originals sheet missing a C12 PARENT row for 3-hydroxyisobutyrate:
+                C12 PARENT	2-keto-isovalerate	C5H8O3
+                C13-label-2	2-keto-isovalerate	C5H8O3
+                C13-label-3	3-hydroxyisobutyrate	C4H8O3
+            Data after the merge (before the fill-down):
+                C12 PARENT	2-keto-isovalerate	C5H8O3
+                C13-label-1	2-keto-isovalerate	None
+                C13-label-2	2-keto-isovalerate	C5H8O3
+                C12 PARENT	3-hydroxyisobutyrate	None
+                C13-label-1	3-hydroxyisobutyrate	None
+                C13-label-2	3-hydroxyisobutyrate	None
+                C13-label-3	3-hydroxyisobutyrate	C4H8O3
+            Data after the fill-down is applied for the formula:
+                C12 PARENT	2-keto-isovalerate	C5H8O3
+                C13-label-1	2-keto-isovalerate	C5H8O3
+                C13-label-2	2-keto-isovalerate	C5H8O3
+                C12 PARENT	3-hydroxyisobutyrate	C5H8O3  # <-- WRONG
+                C13-label-1	3-hydroxyisobutyrate	C5H8O3  # <-- WRONG
+                C13-label-2	3-hydroxyisobutyrate	C5H8O3  # <-- WRONG
+                C13-label-3	3-hydroxyisobutyrate	C4H8O3
+        Args:
+            None
+        Exceptions:
+            Raised:
+                None
+            Buffered:
+                MissingC12ParentPeak
+        Returns:
+            None
+        """
+        if self.df is None:
+            return
+
+        # Create a dataframe with just the relevant data needed to identify missing C12 PARENT rows in the original data
+        # We infer this from the fact that a formula from an above compound filled down into the next compound (because
+        # its parent was missing)
+        compounds_and_formulas = self.df[[self.headers.COMPOUND, self.headers.FORMULA]]
+
+        # Create a column containing the original indexes - we will use this to mark skip rows
+        compounds_and_formulas["INDEX"] = compounds_and_formulas.index
+
+        # Get the unique compound and formula combos, and make the INDEX column be a list of original indexes
+        compounds_and_formulas = (
+            compounds_and_formulas.groupby(
+                [self.headers.COMPOUND, self.headers.FORMULA]
+            )["INDEX"]
+            .apply(list)
+            .reset_index()
+        )
+
+        # In order to sort by compound and then the first row index, we must create another column to contain the first
+        # row index.
+        compounds_and_formulas["FIRSTINDEX"] = compounds_and_formulas["INDEX"].apply(
+            lambda lst: lst[0]
+        )
+
+        # The above groupby does not preserve the row order that existed before the fill down (which was sorted by
+        # compound and isotope), so this re-sorts by the compound and original first row index (to represent the first
+        # isotope).
+        # Note also that these compound/formula combos repeat for every sample, so the indexes will be chunks or
+        # contiguous rows.
+        compounds_and_formulas.sort_values(
+            by=[self.headers.COMPOUND, "FIRSTINDEX"],
+            inplace=True,
+        )
+
+        # Keep track of the previous row values
+        previous_formula = None
+        previous_compound = None
+        previous_row_indexes = None
+        possible_stale_formula = None
+
+        # Cycle through the unique compound and formula combos
+        for _, row in compounds_and_formulas.iterrows():
+            # Get the values from this row
+            compound = row[self.headers.COMPOUND]
+            formula = row[self.headers.FORMULA]
+            row_indexes = list(row["INDEX"])
+            print(f"DOING ROW: {compound} {formula} {row_indexes}")
+            if previous_compound is not None:
+                # If the compound has changed
+                if compound != previous_compound:
+                    # And the formula has NOT changed
+                    if formula == previous_formula:
+                        # Note that 2 different (distinguishable) compounds can have the same formula, so this is a
+                        # candidate, not a definite missing parent instance
+                        possible_stale_formula = formula
+                    else:
+                        possible_stale_formula = None
+
+                elif (
+                    compound == previous_compound and possible_stale_formula is not None
+                ):
+                    # The compound is the same and it is a candidate for a missing C12 PARENT row
+                    if formula != possible_stale_formula:
+                        # The formula for this compound changed mid-isotope. This confirms that the formula that didn't
+                        # change when the compound changed is the result of a missing C12 PARENT row from the original
+                        # data.  Buffer an error.
+                        self.aggregated_errors_object.buffer_error(
+                            MissingC12ParentPeak(
+                                compound,
+                                file=self.friendly_file,
+                                # The sheet, column, and row numbers are irrelevant in the converted format
+                            )
+                        )
+
+                        # Mark the rows of the previous chunk as skip rows
+                        self.add_skip_row_index(index_list=previous_row_indexes)
+                        # Mark the rows of the current chunk as skip rows
+                        self.add_skip_row_index(index_list=row_indexes)
+
+                        # No longer need to track for a stale formula
+                        possible_stale_formula = None
+
+            # Update the previous row vars
+            previous_formula = formula
+            previous_compound = compound
+            previous_row_indexes = row_indexes
 
     def initialize_msrun_data(self):
         """Initializes the msrun_sample_dict (a dict of MSRunSample records keyed on sample header), if a PeakAnnotation

--- a/DataRepo/utils/exceptions.py
+++ b/DataRepo/utils/exceptions.py
@@ -2946,6 +2946,53 @@ class IsotopeStringDupe(InfileError):
         self.parent = parent
 
 
+class MissingC12ParentPeakErrors(SummarizedInfileError, Exception):
+    """Summary of all MissingC12ParentPeak errors
+
+    Attributes:
+        exceptions: A list of MissingC12ParentPeak exceptions
+    """
+
+    def __init__(
+        self,
+        exceptions: list[MissingC12ParentPeak],
+        suggestion=None,
+    ):
+        SummarizedInfileError.__init__(self, exceptions)
+        compounds_str = ""
+        include_loc = len(self.file_dict.keys()) > 1
+        exc: MissingC12ParentPeak
+        for loc, exc_list in self.file_dict.items():
+            if include_loc:
+                compounds_str += f"\t{loc}\n"
+            for exc in exc_list:
+                if include_loc:
+                    compounds_str += "\t"
+                compounds_str += f"\t{exc.compound}\n"
+        loc = ""
+        if not include_loc:
+            loc = " in " + list(self.file_dict.keys())[0]
+        message = (
+            f"The C12 PARENT peak row is missing for the following compounds{loc}:\n{compounds_str}\n"
+            "Please re-pick peaks to include the C12 PARENT peaks for these compounds."
+        )
+        if suggestion is not None:
+            message += f"\n{suggestion}"
+        Exception.__init__(self, message)
+
+
+class MissingC12ParentPeak(InfileError, SummarizableError):
+    SummarizerExceptionClass = MissingC12ParentPeakErrors
+
+    def __init__(self, compound: str, **kwargs):
+        message = (
+            f"C12 PARENT peak row missing for compound '{compound}' in '%s'.\n"
+            "Please re-pick the peaks to include the C12 PARENT."
+        )
+        super().__init__(message, **kwargs)
+        self.compound = compound
+
+
 class UnexpectedIsotopes(Exception):
     def __init__(self, detected_isotopes, labeled_isotopes, compounds):
         message = (

--- a/DataRepo/views/upload/submission.py
+++ b/DataRepo/views/upload/submission.py
@@ -534,6 +534,7 @@ class BuildSubmissionView(FormView):
                             # These are the essential arguments
                             df=df,
                             file=peak_annot_file,
+                            filename=peak_annot_filename,
                             # We don't need the default sequence info - we only want to read the file
                         )
                     )
@@ -545,7 +546,7 @@ class BuildSubmissionView(FormView):
                     # For the purposes of autofill, "isocorr" and "isoautocorr" versions are similar enough to be able
                     # to extract data using one or the other version
                     peak_annot_loader_class = IsocorrLoader
-                    self.files_with_format_errors.append(peak_annot_filenames[index])
+                    self.files_with_format_errors.append(peak_annot_filename)
                     print("Creating peak annotations loader")
                     # Create an instance of the loader, appended onto the loaders
                     self.peak_annotations_loaders.append(
@@ -553,6 +554,7 @@ class BuildSubmissionView(FormView):
                             # These are the essential arguments
                             df=df,
                             file=peak_annot_file,
+                            filename=peak_annot_filename,
                             # We don't need the default sequence info - we only want to read the file
                         )
                     )
@@ -567,13 +569,13 @@ class BuildSubmissionView(FormView):
 
                     exc = MultiplePeakAnnotationFileFormats(
                         matching_formats,
-                        file=peak_annot_filenames[index],
+                        file=peak_annot_filename,
                         suggestion=suggestion,
                     )
 
                     self.load_status_data.set_load_exception(
                         exc,
-                        peak_annot_filenames[index],
+                        peak_annot_filename,
                         top=False,
                         default_is_error=False,
                         default_is_fatal=True,
@@ -589,22 +591,31 @@ class BuildSubmissionView(FormView):
                         self.peak_annotations_loaders.append(None)
                         exc = UnknownPeakAnnotationFileFormat(
                             PeakAnnotationsLoader.get_supported_formats(),
-                            file=peak_annot_filenames[index],
+                            file=peak_annot_filename,
                             suggestion=suggestion,
                         )
                     else:
                         self.peak_annotations_loaders.append(None)
                         exc = MultiplePeakAnnotationFileFormats(
                             matching_formats,
-                            file=peak_annot_filenames[index],
+                            file=peak_annot_filename,
                             suggestion=suggestion,
                         )
 
                     self.load_status_data.set_load_exception(
                         exc,
-                        peak_annot_filenames[index],
+                        peak_annot_filename,
                         top=False,
                     )
+
+                # Go through the loaders and log any exceptions that occurred
+                pal: PeakAnnotationsLoader = self.peak_annotations_loaders[-1]
+                if pal is not None:
+                    for pal_exc in pal.aggregated_errors_object.exceptions:
+                        self.load_status_data.set_load_exception(
+                            pal_exc,
+                            peak_annot_filename,
+                        )
 
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)


### PR DESCRIPTION
## Summary Change Description

Added identification of an edge case where the user omitted adding a peak for the C12 PARENT when picking peaks.  Michael said that if this is encountered, the researcher must re-pick the peaks to include the C12 PARENT peak.

Details:

- Incorporated exceptions from the PeakAnnotationsLoader into the status of the submission start page.
- Created exception classes: MissingC12ParentPeak and MissingC12ParentPeakErrors (to summarize the exceptions).
- Created PeakAnnotationsLoader.check_c12_parents() and called it from the constructor, to buffer errors about missing C12 PARENT rows and to mark affected rows as skip rows, so that there will not be related multiple representations errors that follow.

## Affected Issues/Pull Requests

- Resolves #1300
- Merges into PR #1314

## Review Notes
<!--
For added context for reviewers, add comments to relevant lines of code.  Use
this space to describe any general areas of concern not linked to a specific
line of code that reviewers should pay particular attention to, e.g. please
make sure I have accounted for all possible inputs.
-->
See comments in-line.

## Checklist
<!--
If any of the checkbox requirements are not met, uncheck them and add an
explanation. E.g. Linting errors pre-date this PR.
-->
This pull request will be merged once the following requirements are met.  The
author and/or reviewers should uncheck any unmet requirements:

- Review requirements
  - Minimum approvals: 1 <!-- Edit as desired (e.g. based on complexity) -->
  - No changes requested
  - All blocking issues resolved by reviewers
  - Specific reviewers: @__add_username_here__
    <!--
    Require reviewers with specific expertise to be included among the minimum
    number of reviewers by tagging them.  Also please send them a message.
    -->
  - Review period: 2 days <!-- Edit as desired (e.g. based on complexity) -->
- Associated issue/pull request requirements:
  <!--
  Assert that all requirements in issues marked "resolved" are done and that
  all required pull requests are merged.  If any are not done, either edit or
  split the issue or explain the unmerged affected pull requests.
  -->
  - [x] All requirements in affected issues marked "resolved" are satisfied
  - [x] All required pull requests are merged *(or none)*
- Basic requirements
  <!--
  Uncheck items to acknowledge failures/conflicts you intend to address.
  Add an explanation if any won't be addressed before merge.
  -->
  - [x] [All linters pass](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#linting)
  - [x] [All tests pass](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#quality-control)
  - [x] All conflicts resolved
- Overhead requirements
  <!--
  These are additional requirements that are not directly associated with
  resolving the affected issue(s).
  -->
  - [x] [New/changed method tests implemented/updated *(or no change)*](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#test-implementation)
  - [ ] [Updated *Unreleased* section of `changelog.md` *(or no change)*](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/changelog.md)
  - [x] [Migrations created & committed *(or no change)*](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#migration-process)
