### PR TITLE
Polarity removal

### DIFF
--- a/DataRepo/formats/peakdata_dataformat.py
+++ b/DataRepo/formats/peakdata_dataformat.py
@@ -595,27 +595,6 @@ class PeakDataFormat(Format):
                 },
             },
         },
-        "MSRunSample": {
-            "model": "MSRunSample",
-            "path": "peak_group__msrun_sample",
-            "reverse_path": "peak_groups__peak_data",
-            "manyrelated": {
-                "is": False,
-                "through": False,
-                "manytomany": False,
-                "split_rows": False,
-            },
-            "fields": {
-                # There is no single identifying field, so no ID field.  No handoff.  This means that a link from the
-                # basic_search to MSRunSample cannot be serviced.
-                "polarity": {
-                    "displayname": "Polarity",
-                    "searchable": True,
-                    "displayed": True,
-                    "type": "string",
-                },
-            },
-        },
         "MZFile": {
             "model": "ArchiveFile",
             "path": "peak_group__msrun_sample__sample__msrun_samples__ms_data_file",

--- a/DataRepo/formats/peakgroups_dataformat.py
+++ b/DataRepo/formats/peakgroups_dataformat.py
@@ -557,27 +557,6 @@ class PeakGroupsFormat(Format):
                 },
             },
         },
-        "MSRunSample": {
-            "model": "MSRunSample",
-            "path": "msrun_sample",
-            "reverse_path": "peak_groups",
-            "manyrelated": {
-                "is": False,
-                "through": False,
-                "manytomany": False,
-                "split_rows": False,
-            },
-            "fields": {
-                # There is no single identifying field, so no ID field.  No handoff.  This means that a link from the
-                # basic_search to MSRunSample cannot be serviced.
-                "polarity": {
-                    "displayname": "Polarity",
-                    "searchable": True,
-                    "displayed": True,
-                    "type": "string",
-                },
-            },
-        },
         "MZFile": {
             "model": "ArchiveFile",
             "path": "msrun_sample__sample__msrun_samples__ms_data_file",

--- a/DataRepo/tests/test_formats.py
+++ b/DataRepo/tests/test_formats.py
@@ -182,7 +182,6 @@ class FormatsTests(TracebaseTestCase):
             ("med_rt", "Median RT"),
             ("peak_group__peak_annotation_file__filename", "Peak Annotation Filename"),
             ("peak_group__name", "Peak Group"),
-            ("peak_group__msrun_sample__polarity", "Polarity"),
             (
                 "peak_group__msrun_sample__sample__msrun_samples__ms_raw_file__filename",
                 "RAW Data Filename",
@@ -237,7 +236,6 @@ class FormatsTests(TracebaseTestCase):
             ("msrun_sample__msrun_sequence__instrument", "Mass Spectrometer Name"),
             ("peak_annotation_file__filename", "Peak Annotation Filename"),
             ("name", "Peak Group"),
-            ("msrun_sample__polarity", "Polarity"),
             (
                 "msrun_sample__sample__msrun_samples__ms_raw_file__filename",
                 "RAW Data Filename",
@@ -330,7 +328,7 @@ class FormatsTests(TracebaseTestCase):
 
     def assertIsAPgUnitsLookupDict(self, fld_units_lookup):
         # There should be 39 fields with units lookups
-        self.assertEqual(46, len(fld_units_lookup.keys()))
+        self.assertEqual(45, len(fld_units_lookup.keys()))
         # Path should be prepended to the field name
         self.assertIsNone(fld_units_lookup["msrun_sample__sample__animal__genotype"])
         # Each value should be a dict with the units, this one having 15 keys
@@ -1215,7 +1213,6 @@ class FormatsTests(TracebaseTestCase):
             ("msrun_sample__msrun_sequence__instrument", "Mass Spectrometer Name"),
             ("peak_annotation_file__filename", "Peak Annotation Filename"),
             ("name", "Peak Group"),
-            ("msrun_sample__polarity", "Polarity"),
             (
                 "msrun_sample__sample__msrun_samples__ms_raw_file__filename",
                 "RAW Data Filename",
@@ -1290,7 +1287,6 @@ class FormatsTests(TracebaseTestCase):
             "CompoundSynonym",
             "Study",
             "MSRunSequence",
-            "MSRunSample",
             "MZFile",
             "RAWFile",
         ]
@@ -1536,8 +1532,8 @@ class FormatsTests(TracebaseTestCase):
             expected_age_dict, fld_units_dict["fctemplate"]["serum_sample__animal__age"]
         )
         self.assertEqual(31, len(fld_units_dict["fctemplate"].keys()))
-        self.assertEqual(47, len(fld_units_dict["pgtemplate"].keys()))
-        self.assertEqual(51, len(fld_units_dict["pdtemplate"].keys()))
+        self.assertEqual(46, len(fld_units_dict["pgtemplate"].keys()))
+        self.assertEqual(50, len(fld_units_dict["pdtemplate"].keys()))
 
     def test_getAllFieldUnitsChoices(self):
         sg = SearchGroup()


### PR DESCRIPTION
## Summary Change Description

Searching for polarity makes no sense.  Every peakgroup and/or peakdata row links to multiple polarities, so it never narrows down the results.  Polarity was thus removed from the dataformats for both of those advanced search views.

## Affected Issues/Pull Requests

- Resolves #1283
- Merges into main

## Review Notes
<!--
For added context for reviewers, add comments to relevant lines of code.  Use
this space to describe any general areas of concern not linked to a specific
line of code that reviewers should pay particular attention to, e.g. please
make sure I have accounted for all possible inputs.
-->
See comments in-line.

## Checklist
<!--
If any of the checkbox requirements are not met, uncheck them and add an
explanation. E.g. Linting errors pre-date this PR.
-->
This pull request will be merged once the following requirements are met.  The
author and/or reviewers should uncheck any unmet requirements:

- Review requirements
  - Minimum approvals: 1 <!-- Edit as desired (e.g. based on complexity) -->
  - No changes requested
  - All blocking issues resolved by reviewers
  - Specific reviewers: @__add_username_here__
    <!--
    Require reviewers with specific expertise to be included among the minimum
    number of reviewers by tagging them.  Also please send them a message.
    -->
  - Review period: 2 days <!-- Edit as desired (e.g. based on complexity) -->
- Associated issue/pull request requirements:
  <!--
  Assert that all requirements in issues marked "resolved" are done and that
  all required pull requests are merged.  If any are not done, either edit or
  split the issue or explain the unmerged affected pull requests.
  -->
  - [x] All requirements in affected issues marked "resolved" are satisfied
  - [x] All required pull requests are merged *(or none)*
- Basic requirements
  <!--
  Uncheck items to acknowledge failures/conflicts you intend to address.
  Add an explanation if any won't be addressed before merge.
  -->
  - [x] [All linters pass](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#linting)
  - [x] [All tests pass](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#quality-control)
  - [x] All conflicts resolved
- Overhead requirements
  <!--
  These are additional requirements that are not directly associated with
  resolving the affected issue(s).
  -->
  - [x] [New/changed method tests implemented/updated *(or no change)*](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#test-implementation)
  - [ ] [Updated *Unreleased* section of `changelog.md` *(or no change)*](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/changelog.md)
  - [x] [Migrations created & committed *(or no change)*](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#migration-process)
