### PR TITLE
Added graceful handling of errors related to peak annotation file conversion

### DIFF
--- a/DataRepo/loaders/base/converted_table_loader.py
+++ b/DataRepo/loaders/base/converted_table_loader.py
@@ -998,7 +998,7 @@ class ConvertedTableLoader(TableLoader, ABC):
             Raises:
                 AggregatedErrors
             Buffers:
-                ConditionallyRequiredArgs
+                Any unhandled exception raised by convert_df
         Returns:
             None
         """

--- a/DataRepo/loaders/peak_annotations_loader.py
+++ b/DataRepo/loaders/peak_annotations_loader.py
@@ -356,9 +356,18 @@ class PeakAnnotationsLoader(ConvertedTableLoader, ABC):
             self.peakgroupconflicts.get_selected_representations()
         )
 
-        # Convert the supplied df using the derived class.
-        # Cannot call super().__init__() because ABC.__init__() takes a custom argument
-        ConvertedTableLoader.__init__(self, *args, **kwargs)
+        try:
+            # Convert the supplied df using the derived class.
+            # Cannot call super().__init__() because ABC.__init__() takes a custom argument
+            ConvertedTableLoader.__init__(self, *args, **kwargs)
+        except AggregatedErrors:
+            # Whenever ConvertedTableLoader raises an AggregatedErrors object, it is raising
+            # self.aggregated_errors_object, so there is no need to merge
+            # The conversion failed, so we cannot proceed
+            raise self.aggregated_errors_object
+        except Exception as e:
+            # The conversion failed, so we cannot proceed
+            raise self.aggregated_errors_object.buffer_error(e)
 
         # Check that every compound has a valid C12 PARENT row.
         self.check_c12_parents()


### PR DESCRIPTION
## Summary Change Description

After this PR, when you submit the carnosine study's accucor files to the submission start page, instead of a 500 error, you get:

<img width="387" alt="image" src="https://github.com/user-attachments/assets/fed072b3-51ce-429b-b689-be87c99b4cd5">

## Affected Issues/Pull Requests

- Partially addresses #1320
- Merges into main

## Review Notes
<!--
For added context for reviewers, add comments to relevant lines of code.  Use
this space to describe any general areas of concern not linked to a specific
line of code that reviewers should pay particular attention to, e.g. please
make sure I have accounted for all possible inputs.
-->
See comments in-line.

## Checklist
<!--
If any of the checkbox requirements are not met, uncheck them and add an
explanation. E.g. Linting errors pre-date this PR.
-->
This pull request will be merged once the following requirements are met.  The
author and/or reviewers should uncheck any unmet requirements:

- Review requirements
  - Minimum approvals: 1 <!-- Edit as desired (e.g. based on complexity) -->
  - No changes requested
  - All blocking issues resolved by reviewers
  - Specific reviewers: @__add_username_here__
    <!--
    Require reviewers with specific expertise to be included among the minimum
    number of reviewers by tagging them.  Also please send them a message.
    -->
  - Review period: 2 days <!-- Edit as desired (e.g. based on complexity) -->
- Associated issue/pull request requirements:
  <!--
  Assert that all requirements in issues marked "resolved" are done and that
  all required pull requests are merged.  If any are not done, either edit or
  split the issue or explain the unmerged affected pull requests.
  -->
  - [x] All requirements in affected issues marked "resolved" are satisfied
  - [x] All required pull requests are merged *(or none)*
- Basic requirements
  <!--
  Uncheck items to acknowledge failures/conflicts you intend to address.
  Add an explanation if any won't be addressed before merge.
  -->
  - [x] [All linters pass](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#linting)
  - [x] [All tests pass](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#quality-control)
  - [x] All conflicts resolved
- Overhead requirements
  <!--
  These are additional requirements that are not directly associated with
  resolving the affected issue(s).
  -->
  - [x] [New/changed method tests implemented/updated *(or no change)*](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#test-implementation)
  - [ ] [Updated *Unreleased* section of `changelog.md` *(or no change)*](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/changelog.md)
  - [x] [Migrations created & committed *(or no change)*](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#migration-process)
