### PR TITLE
Fixed an Infusate name check to do with significant figures

### DIFF
--- a/DataRepo/loaders/infusates_loader.py
+++ b/DataRepo/loaders/infusates_loader.py
@@ -24,6 +24,7 @@ from DataRepo.utils.infusate_name_parser import (
     parse_infusate_name_with_concs,
     parse_tracer_string,
 )
+from DataRepo.utils.text_utils import sigfig
 
 
 class InfusatesLoader(TableLoader):
@@ -719,12 +720,21 @@ class InfusatesLoader(TableLoader):
                             parsed_tracer_name = parsed_infusate_tracer["tracer"][
                                 "unparsed_string"
                             ]
-                            parsed_concentration = parsed_infusate_tracer[
-                                "concentration"
-                            ]
+                            parsed_concentration = float(
+                                sigfig(
+                                    parsed_infusate_tracer["concentration"],
+                                    Infusate.CONCENTRATION_SIGNIFICANT_FIGURES,
+                                )
+                            )
 
                             if math.isclose(
-                                parsed_concentration, float(table_tracer_conc)
+                                parsed_concentration,
+                                float(
+                                    sigfig(
+                                        table_tracer_conc,
+                                        Infusate.CONCENTRATION_SIGNIFICANT_FIGURES,
+                                    )
+                                ),
                             ) and (
                                 # Ignoring whitespace and case differences
                                 parsed_tracer_name.replace(" ", "").lower()


### PR DESCRIPTION
## Summary Change Description

Note, this fix does not have to be perfect.  The inclusion of the concentrations in the infusate name will no longer be necessary after the implementation of issue #1053, for which I have a [plan](https://stackoverflow.com/a/79122435/2057516).

## Affected Issues/Pull Requests

- Resolves #1336
- Merges into main

## Review Notes
<!--
For added context for reviewers, add comments to relevant lines of code.  Use
this space to describe any general areas of concern not linked to a specific
line of code that reviewers should pay particular attention to, e.g. please
make sure I have accounted for all possible inputs.
-->
See comments in-line.

## Checklist
<!--
If any of the checkbox requirements are not met, uncheck them and add an
explanation. E.g. Linting errors pre-date this PR.
-->
This pull request will be merged once the following requirements are met.  The
author and/or reviewers should uncheck any unmet requirements:

- Review requirements
  - Minimum approvals: 1 <!-- Edit as desired (e.g. based on complexity) -->
  - No changes requested
  - All blocking issues resolved by reviewers
  - Specific reviewers: @__add_username_here__
    <!--
    Require reviewers with specific expertise to be included among the minimum
    number of reviewers by tagging them.  Also please send them a message.
    -->
  - Review period: 2 days <!-- Edit as desired (e.g. based on complexity) -->
- Associated issue/pull request requirements:
  <!--
  Assert that all requirements in issues marked "resolved" are done and that
  all required pull requests are merged.  If any are not done, either edit or
  split the issue or explain the unmerged affected pull requests.
  -->
  - [x] All requirements in affected issues marked "resolved" are satisfied
  - [x] All required pull requests are merged *(or none)*
- Basic requirements
  <!--
  Uncheck items to acknowledge failures/conflicts you intend to address.
  Add an explanation if any won't be addressed before merge.
  -->
  - [x] [All linters pass](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#linting)
  - [x] [All tests pass](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#quality-control)
  - [x] All conflicts resolved
- Overhead requirements
  <!--
  These are additional requirements that are not directly associated with
  resolving the affected issue(s).
  -->
  - [x] [New/changed method tests implemented/updated *(or no change)*](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#test-implementation)
  - [ ] [Updated *Unreleased* section of `changelog.md` *(or no change)*](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/changelog.md)
  - [x] [Migrations created & committed *(or no change)*](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#migration-process)
