### PR TITLE
Fixed precision issue in the `AnimalsLoader`

### DIFF
--- a/DataRepo/loaders/animals_loader.py
+++ b/DataRepo/loaders/animals_loader.py
@@ -25,7 +25,7 @@ from DataRepo.utils.exceptions import (
     RollbackException,
 )
 from DataRepo.utils.infusate_name_parser import parse_infusate_name_with_concs
-from DataRepo.utils.text_utils import sigfig, sigfigrange
+from DataRepo.utils.text_utils import sigfigfilter
 
 AnimalStudy = Animal.studies.through
 
@@ -342,11 +342,13 @@ class AnimalsLoader(TableLoader):
         if infusion_rate is not None:
             try:
                 # TODO: Make it possible to parse and use units for infusion_rate
-                rec_dict["infusion_rate"] = sigfig(
-                    float(infusion_rate), Animal.INFUSION_RATE_SIGNIFICANT_FIGURES
-                )
-                qry_dict["infusion_rate__range"] = sigfigrange(
-                    float(infusion_rate), Animal.INFUSION_RATE_SIGNIFICANT_FIGURES
+                rec_dict["infusion_rate"] = float(infusion_rate)
+                qry_dict.update(
+                    sigfigfilter(
+                        infusion_rate,
+                        "infusion_rate",
+                        figures=Animal.INFUSION_RATE_SIGNIFICANT_FIGURES,
+                    )
                 )
             except Exception as e:
                 self.buffer_infile_exception(e, column=self.headers.INFUSIONRATE)
@@ -358,11 +360,13 @@ class AnimalsLoader(TableLoader):
         if weight is not None:
             try:
                 # TODO: Make it possible to parse and use units for weight
-                rec_dict["body_weight"] = sigfig(
-                    float(weight), Animal.BODY_WEIGHT_SIGNIFICANT_FIGURES
-                )
-                qry_dict["body_weight__range"] = sigfigrange(
-                    float(weight), Animal.BODY_WEIGHT_SIGNIFICANT_FIGURES
+                rec_dict["body_weight"] = float(weight)
+                qry_dict.update(
+                    sigfigfilter(
+                        weight,
+                        "body_weight",
+                        figures=Animal.BODY_WEIGHT_SIGNIFICANT_FIGURES,
+                    )
                 )
             except Exception as e:
                 self.buffer_infile_exception(e, column=self.headers.WEIGHT)

--- a/DataRepo/loaders/animals_loader.py
+++ b/DataRepo/loaders/animals_loader.py
@@ -355,7 +355,7 @@ class AnimalsLoader(TableLoader):
             rec_dict["body_weight"] = sigfig(
                 weight, Animal.BODY_WEIGHT_SIGNIFICANT_FIGURES
             )
-            qry_dict["body_weight"] = sigfigrange(
+            qry_dict["body_weight__range"] = sigfigrange(
                 weight, Animal.BODY_WEIGHT_SIGNIFICANT_FIGURES
             )
         if age is not None:

--- a/DataRepo/loaders/animals_loader.py
+++ b/DataRepo/loaders/animals_loader.py
@@ -340,24 +340,34 @@ class AnimalsLoader(TableLoader):
 
         # Optional fields
         if infusion_rate is not None:
-            # TODO: Make it possible to parse and use units for infusion_rate
-            rec_dict["infusion_rate"] = sigfig(
-                infusion_rate, Animal.INFUSION_RATE_SIGNIFICANT_FIGURES
-            )
-            qry_dict["infusion_rate__range"] = sigfigrange(
-                infusion_rate, Animal.INFUSION_RATE_SIGNIFICANT_FIGURES
-            )
+            try:
+                # TODO: Make it possible to parse and use units for infusion_rate
+                rec_dict["infusion_rate"] = sigfig(
+                    float(infusion_rate), Animal.INFUSION_RATE_SIGNIFICANT_FIGURES
+                )
+                qry_dict["infusion_rate__range"] = sigfigrange(
+                    float(infusion_rate), Animal.INFUSION_RATE_SIGNIFICANT_FIGURES
+                )
+            except Exception as e:
+                self.buffer_infile_exception(e, column=self.headers.INFUSIONRATE)
+                errored = True
+                # Press on to find more errors...
         if genotype is not None:
             rec_dict["genotype"] = genotype
             qry_dict["genotype"] = genotype
         if weight is not None:
-            # TODO: Make it possible to parse and use units for weight
-            rec_dict["body_weight"] = sigfig(
-                weight, Animal.BODY_WEIGHT_SIGNIFICANT_FIGURES
-            )
-            qry_dict["body_weight__range"] = sigfigrange(
-                weight, Animal.BODY_WEIGHT_SIGNIFICANT_FIGURES
-            )
+            try:
+                # TODO: Make it possible to parse and use units for weight
+                rec_dict["body_weight"] = sigfig(
+                    float(weight), Animal.BODY_WEIGHT_SIGNIFICANT_FIGURES
+                )
+                qry_dict["body_weight__range"] = sigfigrange(
+                    float(weight), Animal.BODY_WEIGHT_SIGNIFICANT_FIGURES
+                )
+            except Exception as e:
+                self.buffer_infile_exception(e, column=self.headers.WEIGHT)
+                errored = True
+                # Press on to find more errors...
         if age is not None:
             try:
                 # TODO: Make it possible to parse and use units for age(/duration)

--- a/DataRepo/models/animal.py
+++ b/DataRepo/models/animal.py
@@ -21,6 +21,8 @@ class Animal(MaintainedModel, HierCachedModel, ElementLabel):
     FEMALE = "F"
     MALE = "M"
     SEX_CHOICES = [(FEMALE, "female"), (MALE, "male")]
+    INFUSION_RATE_SIGNIFICANT_FIGURES = 3
+    BODY_WEIGHT_SIGNIFICANT_FIGURES = 3
 
     # Instance / model fields
     id = models.AutoField(primary_key=True)

--- a/DataRepo/tests/loaders/test_animals_loader.py
+++ b/DataRepo/tests/loaders/test_animals_loader.py
@@ -7,7 +7,6 @@ from DataRepo.models import Animal, Compound, Infusate, Protocol, Study
 from DataRepo.tests.tracebase_test_case import TracebaseTestCase
 from DataRepo.utils.exceptions import (
     AggregatedErrors,
-    InfileDatabaseError,
     InfileError,
     MissingRecords,
     MissingTreatments,
@@ -155,17 +154,19 @@ class AnimalsLoaderTests(TracebaseTestCase):
         with self.assertRaises(AggregatedErrors) as ar:
             al.load_data()
         aes = ar.exception
-        self.assertEqual(4, len(aes.exceptions))
+        self.assertEqual(5, len(aes.exceptions))
         self.assertIsInstance(aes.exceptions[0], InfileError)
-        self.assertIn("timedelta", str(aes.exceptions[0]))
+        self.assertIn("could not convert string to float", str(aes.exceptions[0]))
         self.assertIsInstance(aes.exceptions[1], InfileError)
+        self.assertIn("could not convert string to float", str(aes.exceptions[1]))
+        self.assertIsInstance(aes.exceptions[2], InfileError)
+        self.assertIn("timedelta", str(aes.exceptions[2]))
+        self.assertIsInstance(aes.exceptions[3], InfileError)
         self.assertIn(
-            "must be one of [('F', 'female'), ('M', 'male')]", str(aes.exceptions[1])
+            "must be one of [('F', 'female'), ('M', 'male')]", str(aes.exceptions[3])
         )
-        self.assertIsInstance(aes.exceptions[2], InfileDatabaseError)
-        self.assertIn("Field 'body_weight' expected a number", str(aes.exceptions[2]))
-        self.assertIsInstance(aes.exceptions[3], MissingRecords)
-        self.assertIn("Study", str(aes.exceptions[3]))
+        self.assertIsInstance(aes.exceptions[4], MissingRecords)
+        self.assertIn("Study", str(aes.exceptions[4]))
         self.assertEqual(0, Animal.objects.count())
         self.assertDictEqual(
             {

--- a/DataRepo/tests/utils/test_text_utils.py
+++ b/DataRepo/tests/utils/test_text_utils.py
@@ -1,5 +1,12 @@
 from DataRepo.tests.tracebase_test_case import TracebaseTestCase
-from DataRepo.utils.text_utils import autowrap, sigfig
+from DataRepo.utils.text_utils import (
+    autowrap,
+    get_num_parts,
+    sigfig,
+    sigfigceil,
+    sigfigfloor,
+    sigfigrange,
+)
 
 
 class TextUtilsTests(TracebaseTestCase):
@@ -41,3 +48,97 @@ class TextUtilsTests(TracebaseTestCase):
 
     def test_sigfig(self):
         self.assertEqual("1.23e+05", sigfig(123456.789))
+
+    def test_get_num_parts(self):
+        self.assertEqual(("+", ".122", "33"), get_num_parts("+.122e33"))
+        self.assertEqual(("", "0.122", None), get_num_parts("0.122"))
+        self.assertEqual(("-", "000.122", "+33"), get_num_parts("-000.122e+33"))
+        self.assertEqual(("", "0", None), get_num_parts("0"))
+        self.assertEqual(("", "66", None), get_num_parts("66"))
+        self.assertEqual(("", "99", "33"), get_num_parts("99E33"))
+
+        # * python applies its own rules to scientific notation
+        self.assertEqual(("", "1.22", "+32"), get_num_parts(0.122e33))  # *
+        self.assertEqual(("", "0.122", None), get_num_parts(0.122))
+        self.assertEqual(("-", "1.22", "+32"), get_num_parts(-000.122e33))  # *
+        self.assertEqual(("", "0", None), get_num_parts(0))
+        self.assertEqual(("", "66", None), get_num_parts(66))
+        self.assertEqual(("", "9.9", "+34"), get_num_parts(99e33))  # *
+
+    def test_sigfigfloor(self):
+        self.assertEqual(0.001234, sigfigfloor("0.0012345", 4))
+        self.assertEqual(0.01234, sigfigfloor("0.012345", 4))
+        self.assertEqual(0.1234, sigfigfloor("0.12345", 4))
+        self.assertEqual(1.234, sigfigfloor("1.2345", 4))
+        self.assertEqual(12.34, sigfigfloor("12.345", 4))
+        self.assertEqual(123.4, sigfigfloor("123.45", 4))
+        self.assertEqual(1234, sigfigfloor("1234.5", 4))
+        self.assertEqual(12340, sigfigfloor("12345", 4))
+        self.assertEqual(123400, sigfigfloor("123450", 4))
+        self.assertEqual(1234000, sigfigfloor("1234500", 4))
+        self.assertEqual(12340000, sigfigfloor("12345000", 4))
+        self.assertEqual(123400000, sigfigfloor("123450000", 4))
+        self.assertEqual(0, sigfigfloor("0", 4))
+        self.assertEqual(1, sigfigfloor("1", 4))
+        self.assertEqual(0, sigfigfloor("0.0", 4))
+        self.assertEqual(1, sigfigfloor("1.0", 4))
+        self.assertEqual(0.0012, sigfigfloor("0.0012", 4))
+        self.assertEqual(0.012, sigfigfloor("0.012", 4))
+        self.assertEqual(0.12, sigfigfloor("0.12", 4))
+        self.assertEqual(1.2, sigfigfloor("1.2", 4))
+        self.assertEqual(12, sigfigfloor("12", 4))
+        self.assertEqual(120, sigfigfloor("120", 4))
+        self.assertEqual(1200, sigfigfloor("1200", 4))
+        # * python applies its own rules to scientific notation
+        self.assertEqual(-1.234e-13, sigfigfloor("-0.0012345E-10", 4))
+
+    def test_sigfigceil(self):
+        self.assertEqual(0.001235, sigfigceil("0.0012345", 4))
+        self.assertEqual(0.01235, sigfigceil("0.012345", 4))
+        self.assertEqual(0.1235, sigfigceil("0.12345", 4))
+        self.assertEqual(1.235, sigfigceil("1.2345", 4))
+        self.assertEqual(12.35, sigfigceil("12.345", 4))
+        self.assertEqual(123.5, sigfigceil("123.45", 4))
+        self.assertEqual(1235, sigfigceil("1234.5", 4))
+        self.assertEqual(12350, sigfigceil("12345", 4))
+        self.assertEqual(123500, sigfigceil("123450", 4))
+        self.assertEqual(1235000, sigfigceil("1234500", 4))
+        self.assertEqual(12350000, sigfigceil("12345000", 4))
+        self.assertEqual(123500000, sigfigceil("123450000", 4))
+        self.assertEqual(0.001, sigfigceil("0", 4))
+        self.assertEqual(1.001, sigfigceil("1", 4))
+        self.assertEqual(0.001, sigfigceil("0.0", 4))
+        self.assertEqual(1.001, sigfigceil("1.0", 4))
+        self.assertEqual(0.001201, sigfigceil("0.0012", 4))
+        self.assertEqual(0.01201, sigfigceil("0.012", 4))
+        self.assertEqual(0.1201, sigfigceil("0.12", 4))
+        self.assertEqual(1.201, sigfigceil("1.2", 4))
+        self.assertEqual(12.01, sigfigceil("12", 4))
+        self.assertEqual(120.1, sigfigceil("120", 4))
+        self.assertEqual(1201, sigfigceil("1200", 4))
+        self.assertEqual(-0.001235e-10, sigfigceil("-0.0012345E-10", 4))
+
+        # Increments carry over
+        self.assertEqual(0.01, sigfigceil("0.0099999", 4))
+        self.assertEqual(0.1, sigfigceil("0.099999", 4))
+        self.assertEqual(1, sigfigceil("0.99999", 4))
+        self.assertEqual(10, sigfigceil("9.9999", 4))
+        self.assertEqual(100, sigfigceil("99.999", 4))
+        self.assertEqual(1000, sigfigceil("999.99", 4))
+        self.assertEqual(10000, sigfigceil("9999.9", 4))
+        self.assertEqual(100000, sigfigceil("99999.0", 4))
+        self.assertEqual(1000000, sigfigceil("999990.0", 4))
+        self.assertEqual(10000000, sigfigceil("9999900.0", 4))
+        self.assertEqual(100000000, sigfigceil("99999000.0", 4))
+        self.assertEqual(1000000000, sigfigceil("999990000.0", 4))
+
+        # Special cases
+        self.assertEqual(1, sigfigceil("0", 1))
+        self.assertEqual(0.1, sigfigceil("0.099999", 4))
+
+        # Invalid figures
+        with self.assertRaises(ValueError):
+            sigfigceil(1, 0)
+
+    def test_sigfigrange(self):
+        self.assertEqual((0.001, 0.00101), sigfigrange(0.001))

--- a/DataRepo/utils/text_utils.py
+++ b/DataRepo/utils/text_utils.py
@@ -365,14 +365,16 @@ def iswhole(num):
         elif len(whl) < abs(int(exp)):
             dec = ("0" * (abs(int(exp)) - len(whl))) + whl + dec
         else:
-            dec = whl[len(whl) - abs(int(exp)):] + dec
+            start = len(whl) - abs(int(exp))
+            dec = whl[start:] + dec
     else:
         if len(dec) == abs(int(exp)):
             dec = ""
         elif len(dec) < abs(int(exp)):
             dec = ""
         else:
-            dec = dec[int(exp):]
+            start = int(exp)
+            dec = dec[start:]
     return dec == "" or int(dec) == 0
 
 

--- a/DataRepo/utils/text_utils.py
+++ b/DataRepo/utils/text_utils.py
@@ -59,8 +59,24 @@ def is_number(val):
     return True
 
 
-def sigfig(num, figures=3) -> str:
-    """Return the supplied num with the significant number of figures/digits."""
+def sigfig(num: Union[int, float], figures=3) -> str:
+    """Return the supplied num with the significant number of figures/digits.
+
+    Examples:
+        sigfig(123.45678, 4)  # 123.5
+        sigfig(12345678, 4)  # 12350000
+        sigfig(1234312, 4)  # 12340000
+        sigfig(12, 4)  # 12
+    Args:
+        num (Union[int, float]): A number with any number of digits/figures.  May have a sign and optionally be in
+            scientific notation.
+        figures (int): A number of significant digits in num
+    Exceptions:
+        None
+    Returns:
+        (str): Formatted number containing only significant figures/digits
+    """
+    # TODO: Add support for trailing significant zeroes (with the python g format specifier removes)
     return f"{num:.{figures}g}"
 
 
@@ -108,7 +124,7 @@ def sigfigfloor(num, figures: int = 3) -> Union[float, int]:
         sigfigfloor(12345678, 4)  # 12340000
         sigfigfloor(12, 4)  # 12.01  # The last of 4 significant digits is incremented
     Args:
-        num (Any): a number with any number of digits/figures.  May be str, int, float with sign and optionally in
+        num (Union[str, float, int]): A number with any number of digits/figures.  May have a sign and optionally be in
             scientific notation.
         figures (int): A number of significant digits in num
     Exceptions:
@@ -186,12 +202,13 @@ def sigfigceil(num, figures: int = 3) -> Union[float, int]:
         sigfigceil(120, 4)  # 120.1
         sigfigceil(12000000, 4)  # 12010000
         TODO: sigfigceil("0.0000000", 4)  # planned: 0.0000001 current: 1.
+            A description of support for significant zeros (which python's format specifier (g) removes...
             Sig digs should count from left-most non-zero, rightward.  If all are 0, count is from right-most, leftward.
             There should also be a type consideration.  If the type is a string, leading zeroes in a decimal could be
             considered significant if there are trailing zeroes and fewer non-zero digits than the number of significant
             digits, because scientists write as many trailing zeroes as are significant.
     Args:
-        num (Any): a number with any number of digits/figures.  May be str, int, float with sign and optionally in
+        num (Union[str, float, int]): A number with any number of digits/figures.  May have a sign and optionally be in
             scientific notation.
         figures (int): A number of significant digits in num
     Exceptions:

--- a/DataRepo/utils/text_utils.py
+++ b/DataRepo/utils/text_utils.py
@@ -1,4 +1,5 @@
 import textwrap
+from typing import Union
 
 
 def autowrap(text: str, default_width: int = 80, **kwargs):
@@ -61,3 +62,224 @@ def is_number(val):
 def sigfig(num, figures=3) -> str:
     """Return the supplied num with the significant number of figures/digits."""
     return f"{num:.{figures}g}"
+
+
+def get_num_parts(num):
+    """Breaks up a number into sign, number, and exponent.  sign and exponent are optional.
+
+    Args:
+        num (Any): a number with any number of digits/figures.  May be str, int, float with sign and optionally in
+            scientific notation.
+    Exceptions:
+        None
+    Returns:
+        sign (str): "", "+", or "-"
+        num_str (str)
+        exp (Optional[str]): Does not include the "e".  None, if no exponent.
+    """
+    e_str = str(num).lower()
+    if "e" in e_str:
+        num_str, exp = e_str.split("e")
+    else:
+        num_str = e_str
+        exp = None
+
+    sign = ""
+    if "+" in num_str:
+        sign = "+"
+        num_str = num_str.lstrip("+")
+    elif "-" in num_str:
+        sign = "-"
+        num_str = num_str.lstrip("-")
+
+    return sign, num_str, exp
+
+
+def sigfigfloor(num, figures: int = 3) -> Union[float, int]:
+    """Truncate a number to the number of significant digits (i.e. do not round)
+
+    Examples:
+        sigfigfloor(123.45678, 4)
+        # 123.4
+        sigfigfloor(12345678, 4)
+        # 12340000
+    Args:
+        num (Any): a number with any number of digits/figures.  May be str, int, float with sign and optionally in
+            scientific notation.
+        figures (int): A number of significant digits in num
+    Exceptions:
+        Raises:
+            ValueError
+        Buffers:
+            None
+    Returns:
+        floored (Union[float, int])
+    """
+    if figures < 1:
+        raise ValueError(f"'figures' must be grater than 0.  '{figures}' supplied.")
+
+    sign, num_str, exp = get_num_parts(num)
+
+    if "." in num_str:
+        whl_part, dec_part = num_str.split(".")
+        if whl_part == "" or int(whl_part) == 0:
+            # The number is less than 1
+            if int(dec_part) == 0:
+                floored_str = "0"
+            else:
+                # The number is greater than 0
+                dec_sd_part = dec_part.lstrip("0")
+                leader_len = len(dec_part) - len(dec_sd_part)
+                dec_sd_part = dec_sd_part[:figures]
+                floored_str = whl_part + "." + ("0" * leader_len) + dec_sd_part
+        else:
+            whl_part = whl_part.lstrip("0")
+            if len(whl_part) == figures:
+                floored_str = whl_part
+            elif len(whl_part) > figures:
+                trailer_len = len(whl_part) - figures
+                floored_str = whl_part[:figures] + ("0" * trailer_len)
+            else:
+                dec_figures = figures - len(whl_part)
+                floored_str = whl_part + "." + dec_part[:dec_figures]
+    else:
+        whl_part = num_str.lstrip("0")
+        if len(whl_part) == figures:
+            floored_str = whl_part
+        elif len(whl_part) > figures:
+            trailer_len = len(whl_part) - figures
+            floored_str = whl_part[:figures] + ("0" * trailer_len)
+        else:
+            floored_str = whl_part
+
+    if floored_str == "":
+        floored_str = "0"
+
+    if exp is None:
+        if "." in floored_str:
+            return float(sign + floored_str)
+        else:
+            return int(sign + floored_str)
+    else:
+        cased_e = "e"
+        if "E" in str(num):
+            cased_e = "E"
+        if "." in floored_str:
+            return float(sign + floored_str + cased_e + exp)
+        else:
+            return int(sign + floored_str + cased_e + exp)
+
+
+def sigfigceil(num, figures: int = 3) -> Union[float, int]:
+    """Truncate a number to the number of significant digits (i.e. do not round), then add a 1 in the last place of the
+    significant digits in the supplied num.
+
+    Examples:
+        sigfigceil(123.45678, 4)
+        # 123.5
+        sigfigceil(12345678, 4)
+        # 12350000
+    Args:
+        num (Any): a number with any number of digits/figures.  May be str, int, float with sign and optionally in
+            scientific notation.
+        figures (int): A number of significant digits in num
+    Exceptions:
+        Raises:
+            ValueError
+        Buffers:
+            None
+    Returns:
+        ceiled (Union[float, int])
+    """
+    if figures < 1:
+        raise ValueError(f"'figures' must be grater than 0.  '{figures}' supplied.")
+
+    floored = sigfigfloor(num, figures)
+
+    sign, num_str, exp = get_num_parts(floored)
+
+    if "." in num_str:
+        whl_part, dec_part = num_str.split(".")
+    else:
+        whl_part = num_str
+        dec_part = ""
+
+    whl_part = whl_part.lstrip("0")
+    dec_part = dec_part.rstrip("0")
+
+    if len(whl_part) >= figures:
+        add_one = int("1" + ("0" * (len(whl_part) - figures)))
+        ceiled_str = str(int(whl_part) + add_one)
+    elif len(whl_part) > 0:
+        dec_figures = figures - len(whl_part)
+        dec_sd_part = dec_part
+        if len(dec_sd_part) <= dec_figures:
+            dec_sd_part += "0" * (dec_figures - len(dec_sd_part))
+
+        if int(dec_sd_part) == 0:
+            dec_sd_part = ("0" * (dec_figures - 1)) + "1"
+        else:
+            dec_sd_part = str(int(dec_sd_part) + 1)
+
+        if len(dec_sd_part) > dec_figures:
+            dec_sd_part = dec_sd_part[1:]
+            whl_part = str(int(whl_part) + 1)
+
+        ceiled_str = whl_part + "." + dec_sd_part
+    else:
+        dec_sd_part = dec_part.lstrip("0")
+        dec_leader_len = len(dec_part) - len(dec_sd_part)
+        if len(dec_sd_part) <= figures:
+            dec_sd_part += "0" * (figures - len(dec_sd_part))
+
+        # Add 1 (treated as int)
+        if int(dec_sd_part) == 0:
+            dec_sd_part = ("0" * (figures - 1)) + "1"
+        else:
+            dec_sd_part = str(int(dec_sd_part) + 1)
+
+        if len(dec_sd_part) > figures:
+            dec_sd_part = dec_sd_part[1:]
+            if whl_part == "":
+                whl_part = "1"
+            else:
+                whl_part = str(int(whl_part) + 1)
+
+        ceiled_str = whl_part + "." + ("0" * dec_leader_len) + dec_sd_part
+
+    if exp is None:
+        if "." in ceiled_str:
+            return float(sign + ceiled_str)
+        else:
+            return int(sign + ceiled_str)
+    else:
+        cased_e = "e"
+        if "E" in str(floored):
+            cased_e = "E"
+        if "." in ceiled_str:
+            return float(sign + ceiled_str + cased_e + exp)
+        else:
+            return int(sign + ceiled_str + cased_e + exp)
+
+
+def sigfigrange(num, figures: int = 3) -> tuple:
+    """Takes a number and a number of significant figures and returns a tuple, representing a range, that can be used
+    in a greater than or equal to and less than query for numbers matching num.
+
+    Example:
+        start, stop = sigfigrange(123.45678, 4)
+        # start = 123.4
+        # stop = 123.5
+        testnum = 123.456
+        if testnum >= start and testnum < stop:
+            # Match! - The numbers are assumed to be the same and only differ by precision
+    Args:
+        num (Any): a number with any number of digits/figures.  May be str, int, float with sign and optionally in
+            scientific notation.
+        figures (int): A number of significant digits in num
+    Exceptions:
+        None
+    Returns:
+        range (Tuple[float, float])
+    """
+    return sigfigfloor(num, figures), sigfigceil(num, figures)


### PR DESCRIPTION
## Summary Change Description

The problem was caused by the researcher using an excel formula to calculate the infusion rate.  The precision supported by excel had 2 more digits than the database could store, so whenever the record already existed, `get_or_create` would raise a `ConflictingValueError`.

To solve this, instead of calling `get_or_create` with the raw value, I applied `sigfig()` to the value and set the significant figures to 3.  And in order to support previously loaded values (and changes in significant figures in the future, I implemented a query that searches for values that are within the given precision.

Details:

- Added `text_util` methods:
  - `sigfigfloor`
  - `sigfigceil`
  - `sigfigrange`
- Added class attributes to Animal:
  - `INFUSION_RATE_SIGNIFICANT_FIGURES`
  - `BODY_WEIGHT_SIGNIFICANT_FIGURES`
- `AnimalsLoader`
  - `infusion_rate` gets precision applied
  - `boy_weight` gets precision applied
  - Both are set to `3` significant figures
  - There is now a query preceding the `get_or_create` that searches for values within the precision indicated.

## Affected Issues/Pull Requests

- Resolves #1142
- Merges into PR #1350

## Review Notes
<!--
For added context for reviewers, add comments to relevant lines of code.  Use
this space to describe any general areas of concern not linked to a specific
line of code that reviewers should pay particular attention to, e.g. please
make sure I have accounted for all possible inputs.
-->
See comments in-line.

## Checklist
<!--
If any of the checkbox requirements are not met, uncheck them and add an
explanation. E.g. Linting errors pre-date this PR.
-->
This pull request will be merged once the following requirements are met.  The
author and/or reviewers should uncheck any unmet requirements:

- Review requirements
  - Minimum approvals: 1 <!-- Edit as desired (e.g. based on complexity) -->
  - No changes requested
  - All blocking issues resolved by reviewers
  - Specific reviewers: @__add_username_here__
    <!--
    Require reviewers with specific expertise to be included among the minimum
    number of reviewers by tagging them.  Also please send them a message.
    -->
  - Review period: 2 days <!-- Edit as desired (e.g. based on complexity) -->
- Associated issue/pull request requirements:
  <!--
  Assert that all requirements in issues marked "resolved" are done and that
  all required pull requests are merged.  If any are not done, either edit or
  split the issue or explain the unmerged affected pull requests.
  -->
  - [x] All requirements in affected issues marked "resolved" are satisfied
  - [x] All required pull requests are merged *(or none)*
- Basic requirements
  <!--
  Uncheck items to acknowledge failures/conflicts you intend to address.
  Add an explanation if any won't be addressed before merge.
  -->
  - [x] [All linters pass](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#linting)
  - [x] [All tests pass](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#quality-control)
  - [x] All conflicts resolved
- Overhead requirements
  <!--
  These are additional requirements that are not directly associated with
  resolving the affected issue(s).
  -->
  - [x] [New/changed method tests implemented/updated *(or no change)*](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#test-implementation)
  - [ ] [Updated *Unreleased* section of `changelog.md` *(or no change)*](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/changelog.md)
  - [x] [Migrations created & committed *(or no change)*](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#migration-process)
