### PR TITLE
Addressed uncaught `InvalidDtypeDict` exceptions on the submission interface

### DIFF
--- a/DataRepo/views/upload/submission.py
+++ b/DataRepo/views/upload/submission.py
@@ -59,6 +59,7 @@ from DataRepo.utils.exceptions import (
     AllMissingTreatments,
     DuplicatePeakAnnotationFileName,
     FileFromInputNotFound,
+    InvalidDtypeDict,
     InvalidPeakAnnotationFileFormat,
     InvalidStudyDocVersion,
     MissingDataAdded,
@@ -438,12 +439,31 @@ class BuildSubmissionView(FormView):
                 dtypes, aes = PeakAnnotationFilesLoader._get_column_types(
                     optional_mode=True
                 )
-                pafl = PeakAnnotationFilesLoader(
-                    df=read_from_file(
+
+                try:
+                    df = read_from_file(
                         self.study_file,
                         sheet=PeakAnnotationFilesLoader.DataSheetName,
                         dtype=dtypes,
-                    ),
+                    )
+                except InvalidDtypeDict as idd:
+                    if (
+                        StudyLoader.ConversionHeading
+                        not in self.load_status_data.statuses.keys()
+                    ):
+                        self.load_status_data.set_load_exception(
+                            idd,
+                            StudyLoader.ConversionHeading,
+                            top=True,
+                            default_is_error=False,
+                        )
+                    # Avoid exception by not supplying dtypes & let pandas decide types (which can cause date problems)
+                    df = read_from_file(
+                        self.study_file, sheet=PeakAnnotationFilesLoader.DataSheetName
+                    )
+
+                pafl = PeakAnnotationFilesLoader(
+                    df=df,
                     file=self.study_file,
                     filename=self.study_filename,
                 )
@@ -1356,12 +1376,29 @@ class BuildSubmissionView(FormView):
         # 11/1/2024 - I figured out a good part of this to solve a different problem, but I still need to make sure this
         # solution is comprehensive before I refactor this code (more)
         dtypes, aes = AnimalsLoader._get_column_types(optional_mode=True)
-        loader = AnimalsLoader(
-            df=read_from_file(
+
+        try:
+            df = read_from_file(
                 self.study_file,
                 sheet=AnimalsLoader.DataSheetName,
                 dtype=dtypes,
-            ),
+            )
+        except InvalidDtypeDict as idd:
+            if (
+                StudyLoader.ConversionHeading
+                not in self.load_status_data.statuses.keys()
+            ):
+                self.load_status_data.set_load_exception(
+                    idd,
+                    StudyLoader.ConversionHeading,
+                    top=True,
+                    default_is_error=False,
+                )
+            # Avoid exception by not supplying dtypes & let pandas decide types (which can cause date problems)
+            df = read_from_file(self.study_file, sheet=AnimalsLoader.DataSheetName)
+
+        loader = AnimalsLoader(
+            df=df,
             file=self.study_file,
             filename=self.study_filename,
         )
@@ -1544,12 +1581,29 @@ class BuildSubmissionView(FormView):
         # 11/1/2024 - I figured out a good part of this to solve a different problem, but I still need to make sure this
         # solution is comprehensive before I refactor this code (more)
         dtypes, aes = SamplesLoader._get_column_types(optional_mode=True)
-        loader = SamplesLoader(
-            df=read_from_file(
+
+        try:
+            df = read_from_file(
                 self.study_file,
                 sheet=SamplesLoader.DataSheetName,
                 dtype=dtypes,
-            ),
+            )
+        except InvalidDtypeDict as idd:
+            if (
+                StudyLoader.ConversionHeading
+                not in self.load_status_data.statuses.keys()
+            ):
+                self.load_status_data.set_load_exception(
+                    idd,
+                    StudyLoader.ConversionHeading,
+                    top=True,
+                    default_is_error=False,
+                )
+            # Avoid exception by not supplying dtypes & let pandas decide types (which can cause date problems)
+            df = read_from_file(self.study_file, sheet=SamplesLoader.DataSheetName)
+
+        loader = SamplesLoader(
+            df=df,
             file=self.study_file,
             filename=self.study_filename,
         )
@@ -1588,12 +1642,31 @@ class BuildSubmissionView(FormView):
         # 11/1/2024 - I figured out a good part of this to solve a different problem, but I still need to make sure this
         # solution is comprehensive before I refactor this code (more)
         dtypes, aes = PeakAnnotationFilesLoader._get_column_types(optional_mode=True)
-        loader = PeakAnnotationFilesLoader(
-            df=read_from_file(
+
+        try:
+            df = read_from_file(
                 self.study_file,
                 sheet=PeakAnnotationFilesLoader.DataSheetName,
                 dtype=dtypes,
-            ),
+            )
+        except InvalidDtypeDict as idd:
+            if (
+                StudyLoader.ConversionHeading
+                not in self.load_status_data.statuses.keys()
+            ):
+                self.load_status_data.set_load_exception(
+                    idd,
+                    StudyLoader.ConversionHeading,
+                    top=True,
+                    default_is_error=False,
+                )
+            # Avoid exception by not supplying dtypes & let pandas decide types (which can cause date problems)
+            df = read_from_file(
+                self.study_file, sheet=PeakAnnotationFilesLoader.DataSheetName
+            )
+
+        loader = PeakAnnotationFilesLoader(
+            df=df,
             file=self.study_file,
             filename=self.study_filename,
         )
@@ -1665,12 +1738,29 @@ class BuildSubmissionView(FormView):
         # 11/1/2024 - I figured out a good part of this to solve a different problem, but I still need to make sure this
         # solution is comprehensive before I refactor this code (more)
         dtypes, aes = MSRunsLoader._get_column_types(optional_mode=True)
-        loader = MSRunsLoader(
-            df=read_from_file(
+
+        try:
+            df = read_from_file(
                 self.study_file,
                 sheet=MSRunsLoader.DataSheetName,
                 dtype=dtypes,
-            ),
+            )
+        except InvalidDtypeDict as idd:
+            if (
+                StudyLoader.ConversionHeading
+                not in self.load_status_data.statuses.keys()
+            ):
+                self.load_status_data.set_load_exception(
+                    idd,
+                    StudyLoader.ConversionHeading,
+                    top=True,
+                    default_is_error=False,
+                )
+            # Avoid exception by not supplying dtypes & let pandas decide types (which can cause date problems)
+            df = read_from_file(self.study_file, sheet=MSRunsLoader.DataSheetName)
+
+        loader = MSRunsLoader(
+            df=df,
             file=self.study_file,
             filename=self.study_filename,
         )
@@ -1776,12 +1866,29 @@ class BuildSubmissionView(FormView):
         # 11/1/2024 - I figured out a good part of this to solve a different problem, but I still need to make sure this
         # solution is comprehensive before I refactor this code (more)
         dtypes, aes = InfusatesLoader._get_column_types(optional_mode=True)
-        loader = InfusatesLoader(
-            df=read_from_file(
+
+        try:
+            df = read_from_file(
                 self.study_file,
                 sheet=InfusatesLoader.DataSheetName,
                 dtype=dtypes,
-            ),
+            )
+        except InvalidDtypeDict as idd:
+            if (
+                StudyLoader.ConversionHeading
+                not in self.load_status_data.statuses.keys()
+            ):
+                self.load_status_data.set_load_exception(
+                    idd,
+                    StudyLoader.ConversionHeading,
+                    top=True,
+                    default_is_error=False,
+                )
+            # Avoid exception by not supplying dtypes & let pandas decide types (which can cause date problems)
+            df = read_from_file(self.study_file, sheet=InfusatesLoader.DataSheetName)
+
+        loader = InfusatesLoader(
+            df=df,
             file=self.study_file,
             filename=self.study_filename,
         )
@@ -1821,12 +1928,29 @@ class BuildSubmissionView(FormView):
         # 11/1/2024 - I figured out a good part of this to solve a different problem, but I still need to make sure this
         # solution is comprehensive before I refactor this code (more)
         dtypes, aes = TracersLoader._get_column_types(optional_mode=True)
-        loader = TracersLoader(
-            df=read_from_file(
+
+        try:
+            df = read_from_file(
                 self.study_file,
                 sheet=TracersLoader.DataSheetName,
                 dtype=dtypes,
-            ),
+            )
+        except InvalidDtypeDict as idd:
+            if (
+                StudyLoader.ConversionHeading
+                not in self.load_status_data.statuses.keys()
+            ):
+                self.load_status_data.set_load_exception(
+                    idd,
+                    StudyLoader.ConversionHeading,
+                    top=True,
+                    default_is_error=False,
+                )
+            # Avoid exception by not supplying dtypes & let pandas decide types (which can cause date problems)
+            df = read_from_file(self.study_file, sheet=TracersLoader.DataSheetName)
+
+        loader = TracersLoader(
+            df=df,
             file=self.study_file,
             filename=self.study_filename,
         )
@@ -1851,12 +1975,29 @@ class BuildSubmissionView(FormView):
         # 11/1/2024 - I figured out a good part of this to solve a different problem, but I still need to make sure this
         # solution is comprehensive before I refactor this code (more)
         dtypes, aes = SequencesLoader._get_column_types(optional_mode=True)
-        loader = SequencesLoader(
-            df=read_from_file(
+
+        try:
+            df = read_from_file(
                 self.study_file,
                 sheet=SequencesLoader.DataSheetName,
                 dtype=dtypes,
-            ),
+            )
+        except InvalidDtypeDict as idd:
+            if (
+                StudyLoader.ConversionHeading
+                not in self.load_status_data.statuses.keys()
+            ):
+                self.load_status_data.set_load_exception(
+                    idd,
+                    StudyLoader.ConversionHeading,
+                    top=True,
+                    default_is_error=False,
+                )
+            # Avoid exception by not supplying dtypes & let pandas decide types (which can cause date problems)
+            df = read_from_file(self.study_file, sheet=SequencesLoader.DataSheetName)
+
+        loader = SequencesLoader(
+            df=df,
             file=self.study_file,
             filename=self.study_filename,
         )
@@ -3122,20 +3263,34 @@ class BuildSubmissionView(FormView):
         Returns:
             dfs_dict (dict of dicts): pandas-style dicts dict keyed on sheet name
         """
-        # TODO: I would like to provide dtypes to manage the types we get back, but I have not figured out yet how
-        # to address a type error from pandas when it encounters empty cells.  I have a comment in other code that
-        # says that supplying keep_default_na=True fixes it, but that didn't work.  I have to think about it.  But
-        # not setting types works for now.  I might need to explicitly set str in some places to avoid accidental
-        # int types...
-        dfd = read_from_file(
-            self.study_file,
-            sheet=None,
-            dtype=self.get_study_dtypes_dict(),
-        )
+        load_status_data = MultiLoadStatus(load_keys=self.all_infile_names)
+
+        try:
+            # TODO: I would like to provide dtypes to manage the types we get back, but I have not figured out yet how
+            # to address a type error from pandas when it encounters empty cells.  I have a comment in other code that
+            # says that supplying keep_default_na=True fixes it, but that didn't work.  I have to think about it.  But
+            # not setting types works for now.  I might need to explicitly set str in some places to avoid accidental
+            # int types...
+            dfd = read_from_file(
+                self.study_file,
+                sheet=None,
+                dtype=self.get_study_dtypes_dict(),
+            )
+        except InvalidDtypeDict as idd:
+            if (
+                StudyLoader.ConversionHeading
+                not in self.load_status_data.statuses.keys()
+            ):
+                load_status_data.set_load_exception(
+                    idd,
+                    StudyLoader.ConversionHeading,
+                    top=True,
+                    default_is_error=False,
+                )
+            # Avoid the exception by not supplying dtypes & let pandas decide the types (which can cause date problems)
+            dfd = read_from_file(self.study_file, sheet=None)
 
         dfs_dict = None
-
-        load_status_data = MultiLoadStatus(load_keys=self.all_infile_names)
 
         try:
             # This creates the current version StudyLoader.

--- a/DataRepo/views/upload/submission.py
+++ b/DataRepo/views/upload/submission.py
@@ -440,27 +440,11 @@ class BuildSubmissionView(FormView):
                     optional_mode=True
                 )
 
-                try:
-                    df = read_from_file(
-                        self.study_file,
-                        sheet=PeakAnnotationFilesLoader.DataSheetName,
-                        dtype=dtypes,
-                    )
-                except InvalidDtypeDict as idd:
-                    if (
-                        StudyLoader.ConversionHeading
-                        not in self.load_status_data.statuses.keys()
-                    ):
-                        self.load_status_data.set_load_exception(
-                            idd,
-                            StudyLoader.ConversionHeading,
-                            top=True,
-                            default_is_error=False,
-                        )
-                    # Avoid exception by not supplying dtypes & let pandas decide types (which can cause date problems)
-                    df = read_from_file(
-                        self.study_file, sheet=PeakAnnotationFilesLoader.DataSheetName
-                    )
+                df = self.read_from_file(
+                    self.study_file,
+                    sheet=PeakAnnotationFilesLoader.DataSheetName,
+                    dtype=dtypes,
+                )
 
                 pafl = PeakAnnotationFilesLoader(
                     df=df,
@@ -468,6 +452,7 @@ class BuildSubmissionView(FormView):
                     filename=self.study_filename,
                 )
                 pafl.aggregated_errors_object.merge_aggregated_errors_object(aes)
+
                 for _, row in pafl.df.iterrows():
                     if pafl.is_row_empty(row):
                         continue
@@ -649,6 +634,43 @@ class BuildSubmissionView(FormView):
                         pal.aggregated_errors_object,
                         peak_annot_filename,
                     )
+
+    def read_from_file(
+        self, file, sheet=None, dtype=None, top=True, default_is_error=False
+    ):
+        """Wraps read_from_file in a try block.
+
+        Args:
+            file (str)
+            sheet (str)
+            dtype (dict): Types keyed by header.  At least 1 header must be present in the file.
+            top (bool) [True]
+            default_is_error (bool) [False]
+        Exceptions:
+            Buffered:
+                InvalidDtypeDict
+            Raises:
+                None
+        Returns:
+            df [Union[DataFrame, Dict[str, DataFrame]]
+        """
+        try:
+            df = read_from_file(file, sheet=sheet, dtype=dtype)
+        except InvalidDtypeDict as idd:
+            if (
+                StudyLoader.ConversionHeading
+                not in self.load_status_data.statuses.keys()
+            ):
+                self.load_status_data.set_load_exception(
+                    idd,
+                    StudyLoader.ConversionHeading,
+                    top=top,
+                    default_is_error=default_is_error,
+                )
+            # Avoid exception by not supplying dtypes & let pandas decide types (which can cause date problems)
+            df = read_from_file(file, sheet=sheet)
+
+        return df
 
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
@@ -1377,25 +1399,11 @@ class BuildSubmissionView(FormView):
         # solution is comprehensive before I refactor this code (more)
         dtypes, aes = AnimalsLoader._get_column_types(optional_mode=True)
 
-        try:
-            df = read_from_file(
-                self.study_file,
-                sheet=AnimalsLoader.DataSheetName,
-                dtype=dtypes,
-            )
-        except InvalidDtypeDict as idd:
-            if (
-                StudyLoader.ConversionHeading
-                not in self.load_status_data.statuses.keys()
-            ):
-                self.load_status_data.set_load_exception(
-                    idd,
-                    StudyLoader.ConversionHeading,
-                    top=True,
-                    default_is_error=False,
-                )
-            # Avoid exception by not supplying dtypes & let pandas decide types (which can cause date problems)
-            df = read_from_file(self.study_file, sheet=AnimalsLoader.DataSheetName)
+        df = self.read_from_file(
+            self.study_file,
+            sheet=AnimalsLoader.DataSheetName,
+            dtype=dtypes,
+        )
 
         loader = AnimalsLoader(
             df=df,
@@ -1582,25 +1590,11 @@ class BuildSubmissionView(FormView):
         # solution is comprehensive before I refactor this code (more)
         dtypes, aes = SamplesLoader._get_column_types(optional_mode=True)
 
-        try:
-            df = read_from_file(
-                self.study_file,
-                sheet=SamplesLoader.DataSheetName,
-                dtype=dtypes,
-            )
-        except InvalidDtypeDict as idd:
-            if (
-                StudyLoader.ConversionHeading
-                not in self.load_status_data.statuses.keys()
-            ):
-                self.load_status_data.set_load_exception(
-                    idd,
-                    StudyLoader.ConversionHeading,
-                    top=True,
-                    default_is_error=False,
-                )
-            # Avoid exception by not supplying dtypes & let pandas decide types (which can cause date problems)
-            df = read_from_file(self.study_file, sheet=SamplesLoader.DataSheetName)
+        df = self.read_from_file(
+            self.study_file,
+            sheet=SamplesLoader.DataSheetName,
+            dtype=dtypes,
+        )
 
         loader = SamplesLoader(
             df=df,
@@ -1612,6 +1606,7 @@ class BuildSubmissionView(FormView):
             "tissues": defaultdict(dict),
             "animals": defaultdict(dict),
         }
+
         for _, row in loader.df.iterrows():
             if loader.is_row_empty(row):
                 continue
@@ -1643,27 +1638,11 @@ class BuildSubmissionView(FormView):
         # solution is comprehensive before I refactor this code (more)
         dtypes, aes = PeakAnnotationFilesLoader._get_column_types(optional_mode=True)
 
-        try:
-            df = read_from_file(
-                self.study_file,
-                sheet=PeakAnnotationFilesLoader.DataSheetName,
-                dtype=dtypes,
-            )
-        except InvalidDtypeDict as idd:
-            if (
-                StudyLoader.ConversionHeading
-                not in self.load_status_data.statuses.keys()
-            ):
-                self.load_status_data.set_load_exception(
-                    idd,
-                    StudyLoader.ConversionHeading,
-                    top=True,
-                    default_is_error=False,
-                )
-            # Avoid exception by not supplying dtypes & let pandas decide types (which can cause date problems)
-            df = read_from_file(
-                self.study_file, sheet=PeakAnnotationFilesLoader.DataSheetName
-            )
+        df = self.read_from_file(
+            self.study_file,
+            sheet=PeakAnnotationFilesLoader.DataSheetName,
+            dtype=dtypes,
+        )
 
         loader = PeakAnnotationFilesLoader(
             df=df,
@@ -1675,6 +1654,7 @@ class BuildSubmissionView(FormView):
             "sequences": defaultdict(dict),
             "lcprotocols": defaultdict(dict),
         }
+
         for _, row in loader.df.iterrows():
             if loader.is_row_empty(row):
                 continue
@@ -1739,25 +1719,11 @@ class BuildSubmissionView(FormView):
         # solution is comprehensive before I refactor this code (more)
         dtypes, aes = MSRunsLoader._get_column_types(optional_mode=True)
 
-        try:
-            df = read_from_file(
-                self.study_file,
-                sheet=MSRunsLoader.DataSheetName,
-                dtype=dtypes,
-            )
-        except InvalidDtypeDict as idd:
-            if (
-                StudyLoader.ConversionHeading
-                not in self.load_status_data.statuses.keys()
-            ):
-                self.load_status_data.set_load_exception(
-                    idd,
-                    StudyLoader.ConversionHeading,
-                    top=True,
-                    default_is_error=False,
-                )
-            # Avoid exception by not supplying dtypes & let pandas decide types (which can cause date problems)
-            df = read_from_file(self.study_file, sheet=MSRunsLoader.DataSheetName)
+        df = self.read_from_file(
+            self.study_file,
+            sheet=MSRunsLoader.DataSheetName,
+            dtype=dtypes,
+        )
 
         loader = MSRunsLoader(
             df=df,
@@ -1765,6 +1731,7 @@ class BuildSubmissionView(FormView):
             filename=self.study_filename,
         )
         loader.aggregated_errors_object.merge_aggregated_errors_object(aes)
+
         # We're going to ignore the sample column.  It's way more likely it will have been auto-filled itself, and the
         # samples sheet is populated at the same time, so doing that here is just wasted cycles.  Instead, we're looking
         # for manually filled-in data to autofill elsewhere.
@@ -1772,6 +1739,7 @@ class BuildSubmissionView(FormView):
             "sequences": defaultdict(dict),
             "lcprotocols": defaultdict(dict),
         }
+
         for _, row in loader.df.iterrows():
             if loader.is_row_empty(row):
                 continue
@@ -1867,25 +1835,11 @@ class BuildSubmissionView(FormView):
         # solution is comprehensive before I refactor this code (more)
         dtypes, aes = InfusatesLoader._get_column_types(optional_mode=True)
 
-        try:
-            df = read_from_file(
-                self.study_file,
-                sheet=InfusatesLoader.DataSheetName,
-                dtype=dtypes,
-            )
-        except InvalidDtypeDict as idd:
-            if (
-                StudyLoader.ConversionHeading
-                not in self.load_status_data.statuses.keys()
-            ):
-                self.load_status_data.set_load_exception(
-                    idd,
-                    StudyLoader.ConversionHeading,
-                    top=True,
-                    default_is_error=False,
-                )
-            # Avoid exception by not supplying dtypes & let pandas decide types (which can cause date problems)
-            df = read_from_file(self.study_file, sheet=InfusatesLoader.DataSheetName)
+        df = self.read_from_file(
+            self.study_file,
+            sheet=InfusatesLoader.DataSheetName,
+            dtype=dtypes,
+        )
 
         loader = InfusatesLoader(
             df=df,
@@ -1901,6 +1855,7 @@ class BuildSubmissionView(FormView):
             "tracers": defaultdict(dict),
             "compounds": defaultdict(dict),
         }
+
         for _, row in loader.df.iterrows():
             if loader.is_row_empty(row):
                 continue
@@ -1929,25 +1884,11 @@ class BuildSubmissionView(FormView):
         # solution is comprehensive before I refactor this code (more)
         dtypes, aes = TracersLoader._get_column_types(optional_mode=True)
 
-        try:
-            df = read_from_file(
-                self.study_file,
-                sheet=TracersLoader.DataSheetName,
-                dtype=dtypes,
-            )
-        except InvalidDtypeDict as idd:
-            if (
-                StudyLoader.ConversionHeading
-                not in self.load_status_data.statuses.keys()
-            ):
-                self.load_status_data.set_load_exception(
-                    idd,
-                    StudyLoader.ConversionHeading,
-                    top=True,
-                    default_is_error=False,
-                )
-            # Avoid exception by not supplying dtypes & let pandas decide types (which can cause date problems)
-            df = read_from_file(self.study_file, sheet=TracersLoader.DataSheetName)
+        df = self.read_from_file(
+            self.study_file,
+            sheet=TracersLoader.DataSheetName,
+            dtype=dtypes,
+        )
 
         loader = TracersLoader(
             df=df,
@@ -1955,7 +1896,9 @@ class BuildSubmissionView(FormView):
             filename=self.study_filename,
         )
         loader.aggregated_errors_object.merge_aggregated_errors_object(aes)
+
         seen = {"compounds": defaultdict(dict)}
+
         for _, row in loader.df.iterrows():
             if loader.is_row_empty(row):
                 continue
@@ -1976,25 +1919,11 @@ class BuildSubmissionView(FormView):
         # solution is comprehensive before I refactor this code (more)
         dtypes, aes = SequencesLoader._get_column_types(optional_mode=True)
 
-        try:
-            df = read_from_file(
-                self.study_file,
-                sheet=SequencesLoader.DataSheetName,
-                dtype=dtypes,
-            )
-        except InvalidDtypeDict as idd:
-            if (
-                StudyLoader.ConversionHeading
-                not in self.load_status_data.statuses.keys()
-            ):
-                self.load_status_data.set_load_exception(
-                    idd,
-                    StudyLoader.ConversionHeading,
-                    top=True,
-                    default_is_error=False,
-                )
-            # Avoid exception by not supplying dtypes & let pandas decide types (which can cause date problems)
-            df = read_from_file(self.study_file, sheet=SequencesLoader.DataSheetName)
+        df = self.read_from_file(
+            self.study_file,
+            sheet=SequencesLoader.DataSheetName,
+            dtype=dtypes,
+        )
 
         loader = SequencesLoader(
             df=df,
@@ -2002,7 +1931,9 @@ class BuildSubmissionView(FormView):
             filename=self.study_filename,
         )
         loader.aggregated_errors_object.merge_aggregated_errors_object(aes)
+
         seen = {"lcprotocols": defaultdict(dict)}
+
         for _, row in loader.df.iterrows():
             if loader.is_row_empty(row):
                 continue
@@ -3265,30 +3196,16 @@ class BuildSubmissionView(FormView):
         """
         load_status_data = MultiLoadStatus(load_keys=self.all_infile_names)
 
-        try:
-            # TODO: I would like to provide dtypes to manage the types we get back, but I have not figured out yet how
-            # to address a type error from pandas when it encounters empty cells.  I have a comment in other code that
-            # says that supplying keep_default_na=True fixes it, but that didn't work.  I have to think about it.  But
-            # not setting types works for now.  I might need to explicitly set str in some places to avoid accidental
-            # int types...
-            dfd = read_from_file(
-                self.study_file,
-                sheet=None,
-                dtype=self.get_study_dtypes_dict(),
-            )
-        except InvalidDtypeDict as idd:
-            if (
-                StudyLoader.ConversionHeading
-                not in self.load_status_data.statuses.keys()
-            ):
-                load_status_data.set_load_exception(
-                    idd,
-                    StudyLoader.ConversionHeading,
-                    top=True,
-                    default_is_error=False,
-                )
-            # Avoid the exception by not supplying dtypes & let pandas decide the types (which can cause date problems)
-            dfd = read_from_file(self.study_file, sheet=None)
+        # TODO: I would like to provide dtypes to manage the types we get back, but I have not figured out yet how
+        # to address a type error from pandas when it encounters empty cells.  I have a comment in other code that
+        # says that supplying keep_default_na=True fixes it, but that didn't work.  I have to think about it.  But
+        # not setting types works for now.  I might need to explicitly set str in some places to avoid accidental
+        # int types...
+        dfd = self.read_from_file(
+            self.study_file,
+            sheet=None,
+            dtype=self.get_study_dtypes_dict(),
+        )
 
         dfs_dict = None
 


### PR DESCRIPTION
## Summary Change Description

While converting the example data, I encountered server 500 errors caused by custom header usage.  The submission interface currently only supports default headers and explains them in conversion errors, but the dtype exceptions are separate and only occur if all headers in the dtype dict do not match (which was the case for the Study sheet in one example study).  I added try/catch blocks around each one.

I would eventually like to move the file reading into `TableLoader`, which will eliminate a lot of repeated code here, but this is a quick fix - bigger fish to fry.

## Affected Issues/Pull Requests

- Resolves no documented issue
- Merges into main

## Review Notes
<!--
For added context for reviewers, add comments to relevant lines of code.  Use
this space to describe any general areas of concern not linked to a specific
line of code that reviewers should pay particular attention to, e.g. please
make sure I have accounted for all possible inputs.
-->
See comments in-line.

## Checklist
<!--
If any of the checkbox requirements are not met, uncheck them and add an
explanation. E.g. Linting errors pre-date this PR.
-->
This pull request will be merged once the following requirements are met.  The
author and/or reviewers should uncheck any unmet requirements:

- Review requirements
  - Minimum approvals: 1 <!-- Edit as desired (e.g. based on complexity) -->
  - No changes requested
  - All blocking issues resolved by reviewers
  - Specific reviewers: @__add_username_here__
    <!--
    Require reviewers with specific expertise to be included among the minimum
    number of reviewers by tagging them.  Also please send them a message.
    -->
  - Review period: 2 days <!-- Edit as desired (e.g. based on complexity) -->
- Associated issue/pull request requirements:
  <!--
  Assert that all requirements in issues marked "resolved" are done and that
  all required pull requests are merged.  If any are not done, either edit or
  split the issue or explain the unmerged affected pull requests.
  -->
  - [x] All requirements in affected issues marked "resolved" are satisfied
  - [x] All required pull requests are merged *(or none)*
- Basic requirements
  <!--
  Uncheck items to acknowledge failures/conflicts you intend to address.
  Add an explanation if any won't be addressed before merge.
  -->
  - [x] [All linters pass](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#linting)
  - [x] [All tests pass](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#quality-control)
  - [x] All conflicts resolved
- Overhead requirements
  <!--
  These are additional requirements that are not directly associated with
  resolving the affected issue(s).
  -->
  - [x] [New/changed method tests implemented/updated *(or no change)*](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#test-implementation)
  - [ ] [Updated *Unreleased* section of `changelog.md` *(or no change)*](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/changelog.md)
  - [x] [Migrations created & committed *(or no change)*](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#migration-process)
