### PR TITLE
Tracer concentration precision issue fix

### DIFF
--- a/DataRepo/loaders/infusates_loader.py
+++ b/DataRepo/loaders/infusates_loader.py
@@ -735,6 +735,8 @@ class InfusatesLoader(TableLoader):
                                         Infusate.CONCENTRATION_SIGNIFICANT_FIGURES,
                                     )
                                 ),
+                                rel_tol=1
+                                * 10**-Infusate.CONCENTRATION_SIGNIFICANT_FIGURES,
                             ) and (
                                 # Ignoring whitespace and case differences
                                 parsed_tracer_name.replace(" ", "").lower()
@@ -1403,7 +1405,11 @@ class InfusatesLoader(TableLoader):
 
             if file_conc is None:
                 bad_tracer_names.append(db_tracer_name)
-            elif not math.isclose(file_conc, db_conc):
+            elif not math.isclose(
+                file_conc,
+                db_conc,
+                rel_tol=1 * 10**-Infusate.CONCENTRATION_SIGNIFICANT_FIGURES,
+            ):
                 bad_concentrations.append(f"{db_tracer_name}: {db_conc}")
 
         if len(bad_tracer_names) > 0:


### PR DESCRIPTION
## Summary Change Description

This is another issue encountered during conversion of the example data.

And it is another edge case of matching tracer concentrations in the sheet vs in the infusate name (which has significant digits applied).  It prevents this error in the infusates loader, as seen on the validation interface:

<img width="1131" alt="image" src="https://github.com/user-attachments/assets/b5e305fa-d0e1-465a-9f12-df5b37f33e9f">

This fix is different from the recent `sigfig` strategy.  You can't use `math.isclose` in the DB search.  But it is also another case of making this name match in the past (and a better one).  There's probably a consolidated strategy that could be applied.  I haven't settled on one yet.

## Affected Issues/Pull Requests

- Resolves no documented issue.
- Merges into PR #1357

## Review Notes
<!--
For added context for reviewers, add comments to relevant lines of code.  Use
this space to describe any general areas of concern not linked to a specific
line of code that reviewers should pay particular attention to, e.g. please
make sure I have accounted for all possible inputs.
-->
See comments in-line.

## Checklist
<!--
If any of the checkbox requirements are not met, uncheck them and add an
explanation. E.g. Linting errors pre-date this PR.
-->
This pull request will be merged once the following requirements are met.  The
author and/or reviewers should uncheck any unmet requirements:

- Review requirements
  - Minimum approvals: 1 <!-- Edit as desired (e.g. based on complexity) -->
  - No changes requested
  - All blocking issues resolved by reviewers
  - Specific reviewers: @__add_username_here__
    <!--
    Require reviewers with specific expertise to be included among the minimum
    number of reviewers by tagging them.  Also please send them a message.
    -->
  - Review period: 2 days <!-- Edit as desired (e.g. based on complexity) -->
- Associated issue/pull request requirements:
  <!--
  Assert that all requirements in issues marked "resolved" are done and that
  all required pull requests are merged.  If any are not done, either edit or
  split the issue or explain the unmerged affected pull requests.
  -->
  - [x] All requirements in affected issues marked "resolved" are satisfied
  - [x] All required pull requests are merged *(or none)*
- Basic requirements
  <!--
  Uncheck items to acknowledge failures/conflicts you intend to address.
  Add an explanation if any won't be addressed before merge.
  -->
  - [x] [All linters pass](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#linting)
  - [x] [All tests pass](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#quality-control)
  - [x] All conflicts resolved
- Overhead requirements
  <!--
  These are additional requirements that are not directly associated with
  resolving the affected issue(s).
  -->
  - [x] [New/changed method tests implemented/updated *(or no change)*](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#test-implementation)
  - [ ] [Updated *Unreleased* section of `changelog.md` *(or no change)*](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/changelog.md)
  - [x] [Migrations created & committed *(or no change)*](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#migration-process)
