### PR TITLE
Misc small fixes

### DIFF
--- a/DataRepo/loaders/msruns_loader.py
+++ b/DataRepo/loaders/msruns_loader.py
@@ -523,10 +523,15 @@ class MSRunsLoader(TableLoader):
     )
     def load_data(self):
         """Loads the MSRunSample table from the dataframe.
+
         Args:
             None
         Exceptions:
-            None
+            Buffers:
+                ConditionallyRequiredArgs
+                MzXMLSkipRowError
+            Raises:
+                None
         Returns:
             None
         """
@@ -723,7 +728,7 @@ class MSRunsLoader(TableLoader):
 
         self.report_discrepant_headers()
 
-        # If there were any exceptions (i.e. a rollback of everything will be triggered)
+        # If there were any exceptions (i.e. a rollback of everything will be triggered from the wrapper)
         if self.aggregated_errors_object.should_raise():
             self.clean_up_created_mzxmls_in_archive()
 

--- a/DataRepo/loaders/peak_annotations_loader.py
+++ b/DataRepo/loaders/peak_annotations_loader.py
@@ -1458,7 +1458,16 @@ class PeakAnnotationsLoader(ConvertedTableLoader, ABC):
                 isotope_label, possible_isotope_observations
             )
         except UnexpectedLabels as olnp:
-            olnp.set_formatted_message(**infile_err_args)
+            suggestion = None
+            if pgrec is not None:
+                suggestion = (
+                    f"Check to make sure animal '{pgrec.msrun_sample.sample.animal.name}' has the correct "
+                    "tracer(s)."
+                )
+            olnp.set_formatted_message(
+                **infile_err_args,
+                suggestion=suggestion,
+            )
             # There might be contamination.  Set is_fatal to true in validate mode to alert the researcher via a raised
             # warning (as opposed to just printing a warning for a curator running the load script on the command line -
             # who shouldn't have to worry about it)

--- a/DataRepo/models/maintained_model.py
+++ b/DataRepo/models/maintained_model.py
@@ -720,7 +720,9 @@ class MaintainedModel(Model):
                 f"Triggering lazy auto-update of fields: {cls.__name__}.{{{cs.join(lazy_update_fields)}}}"
             )
             # Trigger an auto-update
-            rec.save(fields_to_autoupdate=lazy_update_fields, via_query=True)
+            rec.save(  # pylint: disable=unexpected-keyword-arg
+                fields_to_autoupdate=lazy_update_fields, via_query=True
+            )
 
         return rec
 

--- a/DataRepo/tests/utils/test_exceptions.py
+++ b/DataRepo/tests/utils/test_exceptions.py
@@ -1259,7 +1259,8 @@ class ExceptionTests(TracebaseTestCase):
     def test_UnexpectedLabels(self):
         exc = UnexpectedLabels(["D"], ["C", "N"])
         self.assertIn(
-            "label(s) ['D'] were not among the expected labels ['C', 'N']", str(exc)
+            "label(s) ['D'] were not among the labels in the tracer(s): ['C', 'N']",
+            str(exc),
         )
 
     def test_MzxmlSampleHeaderMismatch(self):

--- a/DataRepo/utils/exceptions.py
+++ b/DataRepo/utils/exceptions.py
@@ -204,7 +204,12 @@ class InfileError(Exception):
             insertions = [vdict[k] for k in order]
             message = message % tuple(insertions)
         else:
-            message = message % self.loc
+            try:
+                message = message % self.loc
+            except TypeError:
+                if not message.endswith("\n"):
+                    message += "  "
+                message += "Location: %s."
 
         if suggestion is not None:
             if message.endswith("\n"):
@@ -3296,8 +3301,8 @@ class TracerLabeledElementNotFound(Exception):
 class UnexpectedLabels(InfileError):
     def __init__(self, unexpected, possible, **kwargs):
         message = (
-            f"Observed peak label(s) {unexpected} were not among the expected labels {possible}.  There may be "
-            "contamination."
+            f"Observed peak label(s) {unexpected} were not among the labels in the tracer(s): {possible}.  There may "
+            "be contamination."
         )
         super().__init__(message, **kwargs)
         self.possible = possible
@@ -3935,7 +3940,7 @@ class InfileDatabaseError(InfileError):
     def __init__(self, exception, rec_dict, **kwargs):
         if rec_dict is not None:
             nltab = "\n\t"
-            deets = [f"{k}: {v}" for k, v in rec_dict.items()]
+            deets = [f"{k}: {str(v).replace('%', '%%')}" for k, v in rec_dict.items()]
         message = f"{type(exception).__name__} in %s"
         if rec_dict is not None:
             message += f", creating record:\n\t{nltab.join(deets)}"

--- a/DataRepo/views/upload/submission.py
+++ b/DataRepo/views/upload/submission.py
@@ -171,7 +171,6 @@ class BuildSubmissionView(FormView):
             CompoundsLoader.DataSheetName: [
                 CompoundsLoader.DataHeaders.NAME,  # Consumes
                 CompoundsLoader.DataHeaders.FORMULA,  # Consumes
-                CompoundsLoader.DataHeaders.NAME,  # Consumes
             ],
             TracersLoader.DataSheetName: [
                 TracersLoader.DataHeaders.ID,  # Consumes


### PR DESCRIPTION
## Summary Change Description

Miscellaneous small fixes to issues encountered while making changes to accommodate the data in the example studies, so their loads succeed.

Details:

- Removed a duplicate instance of `CompoundsLoader.DataHeaders.NAME` I encountered when simultaneously looking for an issue Michael reported while I was wouking on the contrib doc.  Incidentally, that issue turned out to be user error (me), but also inspired a new feature issue about preserving the Peak Group Conflicts dropdowns when they go through validation.
- Discovered that an exception can arise under the InfileError code when there is a percent sign in the error string.  Fixed one case.  There are likely potentially more, but the problematic feature is planned to be refactored.
- Added a pylint disable that arises in MaintainedModel when using newer linter versions, while I was working on the linter section of the contrib doc.
- Added a suggestion to the `UnexpectedLabels` error in the `PeakAnnotationsLoader` to make it clearer what the problem is.
- Updated/improved some comments in the `MSRunsLoader`.

## Affected Issues/Pull Requests

- Resolves no documented issue
- Merges into PR #1359

## Review Notes
<!--
For added context for reviewers, add comments to relevant lines of code.  Use
this space to describe any general areas of concern not linked to a specific
line of code that reviewers should pay particular attention to, e.g. please
make sure I have accounted for all possible inputs.
-->
See comments in-line.

## Checklist
<!--
If any of the checkbox requirements are not met, uncheck them and add an
explanation. E.g. Linting errors pre-date this PR.
-->
This pull request will be merged once the following requirements are met.  The
author and/or reviewers should uncheck any unmet requirements:

- Review requirements
  - Minimum approvals: 1 <!-- Edit as desired (e.g. based on complexity) -->
  - No changes requested
  - All blocking issues resolved by reviewers
  - Specific reviewers: @__add_username_here__
    <!--
    Require reviewers with specific expertise to be included among the minimum
    number of reviewers by tagging them.  Also please send them a message.
    -->
  - Review period: 2 days <!-- Edit as desired (e.g. based on complexity) -->
- Associated issue/pull request requirements:
  <!--
  Assert that all requirements in issues marked "resolved" are done and that
  all required pull requests are merged.  If any are not done, either edit or
  split the issue or explain the unmerged affected pull requests.
  -->
  - [x] All requirements in affected issues marked "resolved" are satisfied
  - [x] All required pull requests are merged *(or none)*
- Basic requirements
  <!--
  Uncheck items to acknowledge failures/conflicts you intend to address.
  Add an explanation if any won't be addressed before merge.
  -->
  - [x] [All linters pass](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#linting)
  - [x] [All tests pass](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#quality-control)
  - [x] All conflicts resolved
- Overhead requirements
  <!--
  These are additional requirements that are not directly associated with
  resolving the affected issue(s).
  -->
  - [x] [New/changed method tests implemented/updated *(or no change)*](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#test-implementation)
  - [ ] [Updated *Unreleased* section of `changelog.md` *(or no change)*](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/changelog.md)
  - [x] [Migrations created & committed *(or no change)*](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#migration-process)
