### PR TITLE
Handled uncaught date and duration exceptions

### DIFF
--- a/DataRepo/loaders/study_loader.py
+++ b/DataRepo/loaders/study_loader.py
@@ -1682,10 +1682,14 @@ class StudyV2Loader(StudyLoader):
             for idx, date_str in dfs_dict[sheet][date_header].items():
                 if idx in blank_row_idxs or date_str in self.none_vals:
                     continue
-                # Ensure what we get is a string, then convert it to a date (not a datetime)
-                dfs_dict[sheet][date_header][idx] = datetime_to_string(
-                    string_to_date(str(date_str))
-                )
+
+                try:
+                    # Convert the provided value (as a string) to a date (not a datetime)
+                    dfs_dict[sheet][date_header][idx] = datetime_to_string(
+                        string_to_date(str(date_str))
+                    )
+                except Exception as e:
+                    self.buffer_infile_exception(e)
 
             # Rename Animal ID -> Animal
             old_header = "Animal ID"

--- a/DataRepo/tests/loaders/test_samples_loader.py
+++ b/DataRepo/tests/loaders/test_samples_loader.py
@@ -181,12 +181,12 @@ class SamplesLoaderTests(TracebaseTestCase):
         )
         self.assertIsInstance(sl.aggregated_errors_object.exceptions[1], InfileError)
         self.assertIn(
-            "Unknown string format: invalid  Location: column [Date Collected]",
+            "date string 'invalid' found in column [Date Collected] in the load file data did not match the pattern",
             str(sl.aggregated_errors_object.exceptions[1]),
         )
         self.assertIsInstance(sl.aggregated_errors_object.exceptions[2], InfileError)
         self.assertIn(
-            "Must be numeric.",
+            "must be a number of minutes",
             str(sl.aggregated_errors_object.exceptions[2]),
         )
         self.assertIsInstance(

--- a/DataRepo/tests/utils/test_exceptions.py
+++ b/DataRepo/tests/utils/test_exceptions.py
@@ -990,11 +990,7 @@ class ExceptionTests(TracebaseTestCase):
         ve = ValueError("unconverted data remains:  00:00:00")
         dpe = DateParseError("a date", ve, "a format")
         self.assertEqual(
-            (
-                "The date string a date obtained from the file did not match the pattern supplied a format.  This is "
-                "likely the result of excel converting a string to a date.  Try editing the data type of the column in "
-                "the load file data.\nOriginal error: ValueError: unconverted data remains:  00:00:00"
-            ),
+            "The date string 'a date' found in the load file data did not match the pattern 'a format'.",
             str(dpe),
         )
 

--- a/DataRepo/utils/exceptions.py
+++ b/DataRepo/utils/exceptions.py
@@ -3723,7 +3723,7 @@ class DateParseError(InfileError):
             if any(char.isdigit() for char in str(string))
             else ""
         )
-        message = f"The date string '{string}' found in %s did not match the pattern '{format}'.{sugg}\n"
+        message = f"The date string '{string}' found in %s did not match the pattern '{format}'.{sugg}"
         super().__init__(message, **kwargs)
         self.string = string
         self.ve_exc = ve_exc

--- a/DataRepo/utils/exceptions.py
+++ b/DataRepo/utils/exceptions.py
@@ -3714,15 +3714,29 @@ class InvalidDtypeKeys(InfileError):
 class DateParseError(InfileError):
     def __init__(self, string, ve_exc, format, **kwargs):
         format = format.replace("%", "%%")
-        message = (
-            f"The date string {string} obtained from the file did not match the pattern supplied {format}.  This is "
-            "likely the result of excel converting a string to a date.  Try editing the data type of the column in "
-            f"%s.\nOriginal error: {type(ve_exc).__name__}: {ve_exc}"
+        # If the string has any number in it, suggest that the issue could be excel
+        sugg = (
+            (
+                "  This may be the result of excel converting a string to a date.  If so, try editing the data type of "
+                "the column in %s."
+            )
+            if any(char.isdigit() for char in str(string))
+            else ""
         )
+        message = f"The date string '{string}' found in %s did not match the pattern '{format}'.{sugg}\n"
         super().__init__(message, **kwargs)
         self.string = string
         self.ve_exc = ve_exc
         self.format = format
+
+
+class DurationError(InfileError):
+    def __init__(self, string, units, exc, **kwargs):
+        message = f"The duration '{string}' found in %s must be a number of {units}.\n"
+        super().__init__(message, **kwargs)
+        self.string = string
+        self.exc = exc
+        self.units = units
 
 
 class InvalidMSRunName(InfileError):


### PR DESCRIPTION
## Summary Change Description

Caught exceptions related to date and duration parsing errors.

Details:

- Cleaned up some docstrings.
- Added a catch of DateParserError in file_utils.py.
- Created exception class DurationError.
- Gated the builtin suggestion in DateParseError to only be present if the string has a number in it.
- Caught date parse errors in the StudyLoader's convert_df code.
- Caught date and duration related errors in the SamplesLoader and streamlined the error text and suggestions.

## Affected Issues/Pull Requests

- Resolves #1343
- Merges into main

## Review Notes
<!--
For added context for reviewers, add comments to relevant lines of code.  Use
this space to describe any general areas of concern not linked to a specific
line of code that reviewers should pay particular attention to, e.g. please
make sure I have accounted for all possible inputs.
-->
See comments in-line.

## Checklist
<!--
If any of the checkbox requirements are not met, uncheck them and add an
explanation. E.g. Linting errors pre-date this PR.
-->
This pull request will be merged once the following requirements are met.  The
author and/or reviewers should uncheck any unmet requirements:

- Review requirements
  - Minimum approvals: 1 <!-- Edit as desired (e.g. based on complexity) -->
  - No changes requested
  - All blocking issues resolved by reviewers
  - Specific reviewers: @__add_username_here__
    <!--
    Require reviewers with specific expertise to be included among the minimum
    number of reviewers by tagging them.  Also please send them a message.
    -->
  - Review period: 2 days <!-- Edit as desired (e.g. based on complexity) -->
- Associated issue/pull request requirements:
  <!--
  Assert that all requirements in issues marked "resolved" are done and that
  all required pull requests are merged.  If any are not done, either edit or
  split the issue or explain the unmerged affected pull requests.
  -->
  - [x] All requirements in affected issues marked "resolved" are satisfied
  - [x] All required pull requests are merged *(or none)*
- Basic requirements
  <!--
  Uncheck items to acknowledge failures/conflicts you intend to address.
  Add an explanation if any won't be addressed before merge.
  -->
  - [x] [All linters pass](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#linting)
  - [x] [All tests pass](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#quality-control)
  - [x] All conflicts resolved
- Overhead requirements
  <!--
  These are additional requirements that are not directly associated with
  resolving the affected issue(s).
  -->
  - [x] [New/changed method tests implemented/updated *(or no change)*](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#test-implementation)
  - [ ] [Updated *Unreleased* section of `changelog.md` *(or no change)*](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/changelog.md)
  - [x] [Migrations created & committed *(or no change)*](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#migration-process)
