### PR TITLE
Study dir empty fix

### DIFF
--- a/DataRepo/loaders/msruns_loader.py
+++ b/DataRepo/loaders/msruns_loader.py
@@ -2337,6 +2337,8 @@ class MSRunsLoader(TableLoader):
             return files
         if dir is None:
             return []
+        if dir == "":
+            dir = "."
         return [
             os.path.join(p, fl)
             for p, _, fs in os.walk(dir)

--- a/DataRepo/loaders/msruns_loader.py
+++ b/DataRepo/loaders/msruns_loader.py
@@ -2338,7 +2338,7 @@ class MSRunsLoader(TableLoader):
         if dir is None:
             return []
         if dir == "":
-            dir = "."
+            dir = os.getcwd()
         return [
             os.path.join(p, fl)
             for p, _, fs in os.walk(dir)

--- a/DataRepo/loaders/study_loader.py
+++ b/DataRepo/loaders/study_loader.py
@@ -328,11 +328,14 @@ class StudyLoader(ConvertedTableLoader, ABC):
 
         # Before the superclass constructor is called, we want to use the file path to get its enclosing directory as a
         # default for the (custom derived class argument:) mzxml_dir
-        study_file = kwargs.get("file")
-        study_dir = None if study_file is None else os.path.dirname(study_file)
-        mzxml_dir = kwargs.pop("mzxml_dir", study_dir)
+        mzxml_dir = kwargs.pop("mzxml_dir", None)
+        if mzxml_dir is None:
+            study_file = kwargs.get("file")
+            study_dir = None if study_file is None else os.path.dirname(study_file)
+            mzxml_dir = study_dir
 
         self.mzxml_files = MSRunsLoader.get_mzxml_files(dir=mzxml_dir)
+        print(f"study_dir: '{study_dir}' study_file: '{study_file}'  mzxml dir: '{mzxml_dir}' files: {self.mzxml_files} kwargs: {kwargs}")
         self.exclude_sheets = kwargs.pop("exclude_sheets", []) or []
 
         clkwa = self.CustomLoaderKwargs._asdict()

--- a/DataRepo/loaders/study_loader.py
+++ b/DataRepo/loaders/study_loader.py
@@ -335,7 +335,6 @@ class StudyLoader(ConvertedTableLoader, ABC):
             mzxml_dir = study_dir
 
         self.mzxml_files = MSRunsLoader.get_mzxml_files(dir=mzxml_dir)
-        print(f"study_dir: '{study_dir}' study_file: '{study_file}'  mzxml dir: '{mzxml_dir}' files: {self.mzxml_files} kwargs: {kwargs}")
         self.exclude_sheets = kwargs.pop("exclude_sheets", []) or []
 
         clkwa = self.CustomLoaderKwargs._asdict()

--- a/DataRepo/management/commands/export_studies.py
+++ b/DataRepo/management/commands/export_studies.py
@@ -1,3 +1,5 @@
+import os
+
 from django.core.management import BaseCommand
 
 from DataRepo.utils.studies_exporter import StudiesExporter
@@ -11,7 +13,7 @@ class Command(BaseCommand):
         parser.add_argument(
             "--outdir",
             required=True,
-            default=".",
+            default=os.getcwd(),
             help="Directory to create and save exported files.",
         )
         parser.add_argument(


### PR DESCRIPTION
## Summary Change Description

The mzXMLs were not being found when the study doc is supplied without a path (i.e. the path was relative to the current directory.  This fixes that.  I discovered this issue when trying to load the mzXML files for the perturbative infusions study.  The changes that introduced the bug were the recent ones that use the directory that the study doc is in.

## Affected Issues/Pull Requests

- Resolves no documented issue
- Merges into main

## Review Notes
<!--
For added context for reviewers, add comments to relevant lines of code.  Use
this space to describe any general areas of concern not linked to a specific
line of code that reviewers should pay particular attention to, e.g. please
make sure I have accounted for all possible inputs.
-->
See comments in-line.

## Checklist
<!--
If any of the checkbox requirements are not met, uncheck them and add an
explanation. E.g. Linting errors pre-date this PR.
-->
This pull request will be merged once the following requirements are met.  The
author and/or reviewers should uncheck any unmet requirements:

- Review requirements
  - Minimum approvals: 1 <!-- Edit as desired (e.g. based on complexity) -->
  - No changes requested
  - All blocking issues resolved by reviewers
  - Specific reviewers: @__add_username_here__
    <!--
    Require reviewers with specific expertise to be included among the minimum
    number of reviewers by tagging them.  Also please send them a message.
    -->
  - Review period: 2 days <!-- Edit as desired (e.g. based on complexity) -->
- Associated issue/pull request requirements:
  <!--
  Assert that all requirements in issues marked "resolved" are done and that
  all required pull requests are merged.  If any are not done, either edit or
  split the issue or explain the unmerged affected pull requests.
  -->
  - [x] All requirements in affected issues marked "resolved" are satisfied
  - [x] All required pull requests are merged *(or none)*
- Basic requirements
  <!--
  Uncheck items to acknowledge failures/conflicts you intend to address.
  Add an explanation if any won't be addressed before merge.
  -->
  - [x] [All linters pass](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#linting)
  - [x] [All tests pass](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#quality-control)
  - [x] All conflicts resolved
- Overhead requirements
  <!--
  These are additional requirements that are not directly associated with
  resolving the affected issue(s).
  -->
  - [x] [New/changed method tests implemented/updated *(or no change)*](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#test-implementation)
  - [ ] [Updated *Unreleased* section of `changelog.md` *(or no change)*](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/changelog.md)
  - [x] [Migrations created & committed *(or no change)*](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#migration-process)
