### PR TITLE
Set the database "isolation_level" to `REPEATABLE_READ` to prevent gateway timeouts

### DIFF
--- a/TraceBase/settings.py
+++ b/TraceBase/settings.py
@@ -15,6 +15,7 @@ from pathlib import Path
 from typing import Dict
 
 import environ
+from django.db.backends.postgresql.psycopg_any import IsolationLevel
 
 env = environ.Env()
 # reading .env file
@@ -101,6 +102,20 @@ DATABASES = {
         "PASSWORD": env("DATABASE_PASSWORD"),
         "HOST": env("DATABASE_HOST"),
         "PORT": env("DATABASE_PORT"),
+        # Remove the isolation_level option if your DB does not support IsolationLevel.REPEATABLE_READ.
+        "OPTIONS": {
+            # Django's default isolation_level is READ_COMMITTED.  REPEATABLE_READ is a stricter isolation level.  It
+            # causes concurrent database writes to not block, and if there is a conflict, the winner is the first one to
+            # write.  The loser encounters a SerializationError upon commit.  The point of making this change is to
+            # allow validation processes to not get blocked by concurrent validations or load processes.  The validation
+            # page never commits any changes, so users will never encounter a SerializationError.  And the only time
+            # admins would encounter the error is if for example, a conflicting edit is made on the admin edit interface
+            # during a load (or during manual concurrent DB manipulations in for examplem the shell).
+            # NOTE: The only database architectures that support REPEATABLE_READ are postgres and MySQL.  The site will
+            # still work in for example, SQLite, but concurrent validations could encounter timeout errors due to
+            # record/row blocking, because the validations can only happen serially.
+            "isolation_level": IsolationLevel.REPEATABLE_READ,
+        },
     }
 }
 

--- a/TraceBase/settings.py
+++ b/TraceBase/settings.py
@@ -104,9 +104,10 @@ DATABASES = {
         "PORT": env("DATABASE_PORT"),
         # Remove the isolation_level option if your DB does not support IsolationLevel.REPEATABLE_READ.
         "OPTIONS": {
-            # Django's default isolation_level is READ_COMMITTED.  REPEATABLE_READ is a stricter isolation level.  It
-            # causes concurrent database writes to not block, and if there is a conflict, the winner is the first one to
-            # write.  The loser encounters a SerializationError upon commit.  The point of making this change is to
+            # See: https://www.postgresql.org/docs/13/transaction-iso.html#XACT-REPEATABLE-READ
+            # NOTE: Django's default isolation_level is READ_COMMITTED.  REPEATABLE_READ is a stricter isolation level.
+            # It causes concurrent database writes to not block, and if there is a conflict, the winner is the first one
+            # to write.  The loser encounters a SerializationError upon commit.  The point of making this change is to
             # allow validation processes to not get blocked by concurrent validations or load processes.  The validation
             # page never commits any changes, so users will never encounter a SerializationError.  And the only time
             # admins would encounter the error is if for example, a conflicting edit is made on the admin edit interface


### PR DESCRIPTION
## Summary Change Description

I have been unsuccessful in figuring out how to reproduce the blocking/timeout behavior.  Nothing I try seems to be able to make it happen - even redoing exactly what I did before when I had encountered it.  There must be some other factor involved that I'm unaware of.  As described in comments in the issue, I will rarely (sometimes) run into a gateway timeout, though when it starts happening, it seems to be reproducible.

During one documented occurrence of the blocking behavior, I proved (during one validation of the cold exposure study doc) that the reason it was taking 7 minutes was due to a blocked query relating to a cache table delete.  I have a separate branch on which I'm working to prevent the cache deletion during a validation or dry-run, which should mitigate the issue.

Since I cannot figure out how to reliably reproduce this issue, the django documentation seems clear that this "`REPEATABLE_READ`" isolation level should fix the blocking behavior that I have proven is happening, and the only downside is that 2 concurrent/conflicting loads would fail upon commit instead of hang, I say we merge it, close the issue, and re-open if we encounter the validation page timeout again.

Note, I created a [ticket](https://nplc-helpdesk.princeton.edu/Ticket/Display.html?id=107052) to monitor for these timeouts, so we will know if this should be reopened.  I will try to push that ticket along.

## Affected Issues/Pull Requests

- Resolves #1069
- Merges into main

## Review Notes
<!--
For added context for reviewers, add comments to relevant lines of code.  Use
this space to describe any general areas of concern not linked to a specific
line of code that reviewers should pay particular attention to, e.g. please
make sure I have accounted for all possible inputs.
-->
See comments in-line.

## Checklist
<!--
If any of the checkbox requirements are not met, uncheck them and add an
explanation. E.g. Linting errors pre-date this PR.
-->
This pull request will be merged once the following requirements are met.  The
author and/or reviewers should uncheck any unmet requirements:

- Review requirements
  - Minimum approvals: 1 <!-- Edit as desired (e.g. based on complexity) -->
  - No changes requested
  - All blocking issues resolved by reviewers
  - Specific reviewers: @__add_username_here__
    <!--
    Require reviewers with specific expertise to be included among the minimum
    number of reviewers by tagging them.  Also please send them a message.
    -->
  - Review period: 2 days <!-- Edit as desired (e.g. based on complexity) -->
- Associated issue/pull request requirements:
  <!--
  Assert that all requirements in issues marked "resolved" are done and that
  all required pull requests are merged.  If any are not done, either edit or
  split the issue or explain the unmerged affected pull requests.
  -->
  - [x] All requirements in affected issues marked "resolved" are satisfied
  - [x] All required pull requests are merged *(or none)*
- Basic requirements
  <!--
  Uncheck items to acknowledge failures/conflicts you intend to address.
  Add an explanation if any won't be addressed before merge.
  -->
  - [x] [All linters pass](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#linting)
  - [x] [All tests pass](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#quality-control)
  - [x] All conflicts resolved
- Overhead requirements
  <!--
  These are additional requirements that are not directly associated with
  resolving the affected issue(s).
  -->
  - [x] [New/changed method tests implemented/updated *(or no change)*](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#test-implementation)
  - [ ] [Updated *Unreleased* section of `changelog.md` *(or no change)*](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/changelog.md)
  - [x] [Migrations created & committed *(or no change)*](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#migration-process)
