### PR TITLE
Added a time limit to the computation of results stats

### DIFF
--- a/DataRepo/formats/dataformat.py
+++ b/DataRepo/formats/dataformat.py
@@ -1056,9 +1056,11 @@ class Format:
         .distinct() requires them to be present.  Otherwise, you will encounter an exception when the queryset is made
         distinct on the returned fields.  Only a single order_by field is supported.
 
-        assume_distinct - This assumes (when split_rows is False) that all records are distinct/not-identical.  In that
-        case, this method returns an empty list (as the parameters to .distinct()).  This is the default behavior.  If
-        that assumption is false, supply assume_distinct=False.
+        assume_distinct - When True (and split_rows is False) all records are assumed to be distinct/not-identical (even
+        though they appear to be identical because there are multiple unsplit records).  This method will return an
+        empty list (to be supplied to .distinct()).  This is the default behavior.  If false, and no fields are
+        determined to need to be "distinct", "pk" is added to the list of distinct fields returned to force records to
+        be distinct.
         """
         distinct_fields = []
         for mdl_inst_nm in self.model_instances:

--- a/DataRepo/templates/DataRepo/search/results/stats.html
+++ b/DataRepo/templates/DataRepo/search/results/stats.html
@@ -1,6 +1,9 @@
 {% load customtags %}
 <div id="resultstats" style="font-size: 12px !important; width: 30% !important; margin-left: 16px; float: right;" class="collapse{% if stats.show %} show{% endif %}">
     {% if stats.populated %}
+        {% if stats.based_on %}
+            {{ stats.based_on }}
+        {% endif %}
         <table class="table table-condensed table-striped text-xsmall" style="padding: 2px;">
             <tr>
                 <th class="col-sm-1 text-end" style="padding: 1px 5px !important;">#</th>

--- a/DataRepo/tests/test_formats.py
+++ b/DataRepo/tests/test_formats.py
@@ -1100,7 +1100,11 @@ class FormatsTests(TracebaseTestCase):
         qry = self.get_advanced_qry()
         res, _, _ = basv.performQuery(qry, "pgtemplate", generate_stats=True)
         got, based_on = basv.getQueryStats(
-            res, qry["selectedtemplate"], time_limit_secs=0
+            res,
+            qry["selectedtemplate"],
+            # A time limit of 0 seconds will produce 1 result because the elapsed time if checked at the bottom of the
+            # for loop that iterates over the queryset
+            time_limit_secs=0,
         )
         full_stats = self.getExpectedStats()
         expected = full_stats["data"]

--- a/TraceBase/.env.example
+++ b/TraceBase/.env.example
@@ -7,6 +7,7 @@ DATABASE_USER=db_user
 DEBUG=False
 SECRET_KEY=CHANGETHISKEY
 SQL_LOGGING=False
+GATEWAY_TIMEOUT=60
 
 # Set READONLY to True if users are not allowed to submit data.
 READONLY=False

--- a/TraceBase/settings.py
+++ b/TraceBase/settings.py
@@ -46,6 +46,9 @@ DEBUG = env.bool("DEBUG", default=False)
 # You can achive this by having 2 sites: a public one and a private one.
 READONLY = env.bool("READONLY", default=False)
 
+# Web Server timout in seconds
+GATEWAY_TIMEOUT = env.int("GATEWAY_TIMEOUT", default=60)
+
 ALLOWED_HOSTS = env.list("ALLOWED_HOSTS", default=["localhost", "127.0.0.1"])
 
 # Application definition


### PR DESCRIPTION
## Summary Change Description

This is a simple truncation of the loop that counts all the stats.  I'd tried downsampling, but doing that took way longer than just stopping the loop based on the elapsed time.  This is not a perfect solution, but a stop-gap to prevent 500 gateway timeout errors.

The result is that if the calculation of the stats takes over 55 seconds, the loop is stopped and this message appears above the stats presented:

![truncated_stats](https://github.com/user-attachments/assets/e4b19ddf-6e6a-4537-92a2-c25a85808d47)

## Affected Issues/Pull Requests

- Resolves #1281
- Merges into main

## Review Notes
<!--
For added context for reviewers, add comments to relevant lines of code.  Use
this space to describe any general areas of concern not linked to a specific
line of code that reviewers should pay particular attention to, e.g. please
make sure I have accounted for all possible inputs.
-->
See comments in-line.

## Checklist
<!--
If any of the checkbox requirements are not met, uncheck them and add an
explanation. E.g. Linting errors pre-date this PR.
-->
This pull request will be merged once the following requirements are met.  The
author and/or reviewers should uncheck any unmet requirements:

- Review requirements
  - Minimum approvals: 1 <!-- Edit as desired (e.g. based on complexity) -->
  - No changes requested
  - All blocking issues resolved by reviewers
  - Specific reviewers: @__add_username_here__
    <!--
    Require reviewers with specific expertise to be included among the minimum
    number of reviewers by tagging them.  Also please send them a message.
    -->
  - Review period: 2 days <!-- Edit as desired (e.g. based on complexity) -->
- Associated issue/pull request requirements:
  <!--
  Assert that all requirements in issues marked "resolved" are done and that
  all required pull requests are merged.  If any are not done, either edit or
  split the issue or explain the unmerged affected pull requests.
  -->
  - [x] All requirements in affected issues marked "resolved" are satisfied
  - [x] All required pull requests are merged *(or none)*
- Basic requirements
  <!--
  Uncheck items to acknowledge failures/conflicts you intend to address.
  Add an explanation if any won't be addressed before merge.
  -->
  - [x] [All linters pass](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#linting)
  - [x] [All tests pass](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#quality-control)
  - [x] All conflicts resolved
- Overhead requirements
  <!--
  These are additional requirements that are not directly associated with
  resolving the affected issue(s).
  -->
  - [x] [New/changed method tests implemented/updated *(or no change)*](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#test-implementation)
  - [ ] [Updated *Unreleased* section of `changelog.md` *(or no change)*](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/changelog.md)
  - [x] [Migrations created & committed *(or no change)*](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#migration-process)
