### PR TITLE
Fixed sample blanking bug

### DIFF
--- a/DataRepo/views/upload/submission.py
+++ b/DataRepo/views/upload/submission.py
@@ -2352,13 +2352,8 @@ class BuildSubmissionView(FormView):
                 for exc in self.load_status_data.get_exception_type(
                     load_key, exc_class
                 ):
-                    # If this is an error (as opposed to a warning)
-                    if not hasattr(exc, "is_error") or exc.is_error:
-                        if retain_as_warnings:
-                            self.extracted_exceptions[exc_class.__name__][
-                                "errors"
-                            ].append(exc)
-                    elif retain_as_warnings:
+                    # Every matched exception will be made into a warning
+                    if retain_as_warnings:
                         self.extracted_exceptions[exc_class.__name__][
                             "warnings"
                         ].append(exc)


### PR DESCRIPTION
## Summary Change Description

Sample data in the Samples sheet of the study doc was getting overwritten with empty values when the sample record creation had encountered an exception.  Later steps in the MSRunsLoader subsequently raised missing sample exceptions, which was handled by trying to stup out the missing samples in the samples sheet.  That was overwriting the manually entered sample data.  This PR adds a check for the existence of sample data in the sheet before trying to autofill it.

This was apparently an edge case bug that might be related to fixes/changes in the `MSRunsLoader` related to the handling of the missing sample exceptions.  Or it could have existed all along and we just didn't see it due to the fact that other exceptions that would prevent animal or sample record creation had placeholder fallbacks that caused the samples to still be created even though errors had occurred.  The original exception that was causing this error cascade and the data overwrite was a mismatch in the infusate names in the infusates versus animals sheets.  The researcher indicated that they had retroactively changes the tracer concentration, which resulted in the mismatch.  That issue will be handled in a separate PR.

## Affected Issues/Pull Requests

- Resolves #1405
- Merges into main

## Review Notes
<!--
For added context for reviewers, add comments to relevant lines of code.  Use
this space to describe any general areas of concern not linked to a specific
line of code that reviewers should pay particular attention to, e.g. please
make sure I have accounted for all possible inputs.
-->
See comments in-line.

## Checklist
<!--
If any of the checkbox requirements are not met, uncheck them and add an
explanation. E.g. Linting errors pre-date this PR.
-->
This pull request will be merged once the following requirements are met.  The
author and/or reviewers should uncheck any unmet requirements:

- Review requirements
  - Minimum approvals: 1 <!-- Edit as desired (e.g. based on complexity) -->
  - No changes requested
  - All blocking issues resolved by reviewers
  - Specific reviewers: @__add_username_here__
    <!--
    Require reviewers with specific expertise to be included among the minimum
    number of reviewers by tagging them.  Also please send them a message.
    -->
  - Review period: 2 days <!-- Edit as desired (e.g. based on complexity) -->
- Associated issue/pull request requirements:
  <!--
  Assert that all requirements in issues marked "resolved" are done and that
  all required pull requests are merged.  If any are not done, either edit or
  split the issue or explain the unmerged affected pull requests.
  -->
  - [x] All requirements in affected issues marked "resolved" are satisfied
  - [x] All required pull requests are merged *(or none)*
- Basic requirements
  <!--
  Uncheck items to acknowledge failures/conflicts you intend to address.
  Add an explanation if any won't be addressed before merge.
  -->
  - [x] [All linters pass](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#linting)
  - [x] [All tests pass](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#quality-control)
  - [x] All conflicts resolved
- Overhead requirements
  <!--
  These are additional requirements that are not directly associated with
  resolving the affected issue(s).
  -->
  - [x] [New/changed method tests implemented/updated *(or no change)*](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#test-implementation)
  - [ ] [Updated *Unreleased* section of `changelog.md` *(or no change)*](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/changelog.md)
  - [x] [Migrations created & committed *(or no change)*](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#migration-process)
