### PR TITLE
Mitigated a cascade of errors stemming from a mismatched infusate

### DIFF
--- a/DataRepo/models/infusate.py
+++ b/DataRepo/models/infusate.py
@@ -28,28 +28,37 @@ class InfusateQuerySet(models.QuerySet):
 
         # Matching record not found, create new record
         if infusate is None:
-            # create infusate
-            infusate = self.create(tracer_group_name=infusate_data["infusate_name"])
-
-            # create tracers
-            Tracer = get_model_by_name("Tracer")
-            InfusateTracer = get_model_by_name("InfusateTracer")
-            for infusate_tracer in infusate_data["tracers"]:
-                tracer = Tracer.objects.get_tracer(infusate_tracer["tracer"])
-                if tracer is None:
-                    (tracer, _) = Tracer.objects.get_or_create_tracer(
-                        infusate_tracer["tracer"],
-                    )
-                # associate tracers with specific conectrations
-                InfusateTracer.objects.create(
-                    infusate=infusate,
-                    tracer=tracer,
-                    concentration=infusate_tracer["concentration"],
-                )
-            infusate.full_clean()
-            infusate.save()
+            infusate = self.create_infusate(infusate_data)
             created = True
-        return (infusate, created)
+
+        return infusate, created
+
+    def create_infusate(
+        self,
+        infusate_data: InfusateData,
+    ) -> Infusate:
+        """Create a new infusate"""
+        infusate = self.create(tracer_group_name=infusate_data["infusate_name"])
+
+        # create tracers
+        Tracer = get_model_by_name("Tracer")
+        InfusateTracer = get_model_by_name("InfusateTracer")
+        for infusate_tracer in infusate_data["tracers"]:
+            tracer = Tracer.objects.get_tracer(infusate_tracer["tracer"])
+            if tracer is None:
+                (tracer, _) = Tracer.objects.get_or_create_tracer(
+                    infusate_tracer["tracer"],
+                )
+            # associate tracers with specific conectrations
+            InfusateTracer.objects.create(
+                infusate=infusate,
+                tracer=tracer,
+                concentration=infusate_tracer["concentration"],
+            )
+        infusate.full_clean()
+        infusate.save()
+
+        return infusate
 
     def get_infusate(self, infusate_data: InfusateData) -> Optional[Infusate]:
         """Get Infusate matching the infusate_data"""

--- a/DataRepo/tests/loaders/test_animals_loader.py
+++ b/DataRepo/tests/loaders/test_animals_loader.py
@@ -37,12 +37,12 @@ class AnimalsLoaderTests(TracebaseTestCase):
         )
 
         # Test create
-        rec, cre = al.get_or_create_animal(row, self.infusate)
+        rec, cre = al.get_or_create_animal(row, infusate=self.infusate)
         self.assertTrue(cre)
         self.assertEqual("anml1", rec.name)
 
         # Test get
-        rec2, cre2 = al.get_or_create_animal(row, self.infusate)
+        rec2, cre2 = al.get_or_create_animal(row, infusate=self.infusate)
         self.assertFalse(cre2)
         self.assertEqual("anml1", rec2.name)
 
@@ -63,7 +63,9 @@ class AnimalsLoaderTests(TracebaseTestCase):
         treatment = Protocol.objects.create(
             name="test", category=Protocol.ANIMAL_TREATMENT
         )
-        rec, cre = al.get_or_create_animal(row, self.infusate, treatment)
+        rec, cre = al.get_or_create_animal(
+            row, infusate=self.infusate, treatment=treatment
+        )
         self.assertTrue(cre)
         self.assertEqual("anml1", rec.name)
         self.assertEqual("WT", rec.genotype)
@@ -75,7 +77,9 @@ class AnimalsLoaderTests(TracebaseTestCase):
         self.assertEqual("test", rec.treatment.name)
 
         # Test get
-        rec2, cre2 = al.get_or_create_animal(row, self.infusate, treatment)
+        rec2, cre2 = al.get_or_create_animal(
+            row, infusate=self.infusate, treatment=treatment
+        )
         self.assertFalse(cre2)
         self.assertEqual("anml1", rec2.name)
 

--- a/DataRepo/tests/loaders/test_animals_loader.py
+++ b/DataRepo/tests/loaders/test_animals_loader.py
@@ -218,8 +218,7 @@ class AnimalsLoaderTests(TracebaseTestCase):
 
     def test_animals_loader_get_infusate_int(self):
         al = AnimalsLoader()
-        row = pd.Series({AnimalsLoader.DataHeaders.INFUSATE: "Leucine-[1,2-13C2][1]"})
-        rec = al.get_infusate(row)
+        rec = al.get_infusate("Leucine-[1,2-13C2][1]")
         self.assertIsNotNone(rec)
         self.assertEqual(0, len(al.aggregated_errors_object.exceptions))
 
@@ -246,13 +245,11 @@ class AnimalsLoaderTests(TracebaseTestCase):
         self.assertEqual(0, len(al.aggregated_errors_object.exceptions))
 
         # Now get the infusate using the Infusate.CONCENTRATION_SIGNIFICANT_FIGURES (3), i.e. 149
-        row = pd.Series({AnimalsLoader.DataHeaders.INFUSATE: "Leucine-[13C6][149]"})
-        rec = al.get_infusate(row)
+        rec = al.get_infusate("Leucine-[13C6][149]")
         self.assertEqual(inf, rec)
 
         # Now get the infusate using the number supplied by the user, i.e. 148.88
-        row = pd.Series({AnimalsLoader.DataHeaders.INFUSATE: "Leucine-[13C6][148.88]"})
-        rec2 = al.get_infusate(row)
+        rec2 = al.get_infusate("Leucine-[13C6][148.88]")
         self.assertEqual(inf, rec2)
 
     def test_animals_loader_get_treatment(self):


### PR DESCRIPTION
## Summary Change Description

This change reduces the number of pages of errors from Edmundo's originally submitted file from 6.5 down to 1 (counting by the number of times you have to hit the page down key):

![cascadesuppressed](https://github.com/user-attachments/assets/b44ac69d-b380-492d-8fcc-3d58b4f5ce23)

- Removed the marking of the row as a skip row on the animals sheet when the infusate is not found (since infusate is no longer a required column anyway).  I did not attempt to create a placeholder infusate (e.g. from the name entered into the animals sheet) because there are no other errors it being missing causes (unless performing and actual load of the peak annotation data, which won't occur until this issue is fixed on the website anyway).
- Skipped the buffering of an UnexpectedInput exception about an infusion rate being supplied without an infusate being present (if an infusate name was supplied on that row).
- Split up get_or_create_infusate to create a separate InfusateQuerySet.create_infusate method.  I actually didn't end up ultimately using it because it inadvertently suppressed error reporting for subsequent rows with the same missing infusate.

## Affected Issues/Pull Requests

- Resolves #1409
- Merges into main

## Review Notes
<!--
For added context for reviewers, add comments to relevant lines of code.  Use
this space to describe any general areas of concern not linked to a specific
line of code that reviewers should pay particular attention to, e.g. please
make sure I have accounted for all possible inputs.
-->
See comments in-line.

## Checklist
<!--
If any of the checkbox requirements are not met, uncheck them and add an
explanation. E.g. Linting errors pre-date this PR.
-->
This pull request will be merged once the following requirements are met.  The
author and/or reviewers should uncheck any unmet requirements:

- Review requirements
  - Minimum approvals: 1 <!-- Edit as desired (e.g. based on complexity) -->
  - No changes requested
  - All blocking issues resolved by reviewers
  - Specific reviewers: @__add_username_here__
    <!--
    Require reviewers with specific expertise to be included among the minimum
    number of reviewers by tagging them.  Also please send them a message.
    -->
  - Review period: 2 days <!-- Edit as desired (e.g. based on complexity) -->
- Associated issue/pull request requirements:
  <!--
  Assert that all requirements in issues marked "resolved" are done and that
  all required pull requests are merged.  If any are not done, either edit or
  split the issue or explain the unmerged affected pull requests.
  -->
  - [x] All requirements in affected issues marked "resolved" are satisfied
  - [x] All required pull requests are merged *(or none)*
- Basic requirements
  <!--
  Uncheck items to acknowledge failures/conflicts you intend to address.
  Add an explanation if any won't be addressed before merge.
  -->
  - [x] [All linters pass](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#linting)
  - [x] [All tests pass](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#quality-control)
  - [x] All conflicts resolved
- Overhead requirements
  <!--
  These are additional requirements that are not directly associated with
  resolving the affected issue(s).
  -->
  - [x] [New/changed method tests implemented/updated *(or no change)*](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#test-implementation)
  - [ ] [Updated *Unreleased* section of `changelog.md` *(or no change)*](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/changelog.md)
  - [x] [Migrations created & committed *(or no change)*](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#migration-process)
