### PR TITLE
Batch 8 of legacy loader test updates (tests for `PeakAnnotationsLoader.is_selected_peak_group`)

### DIFF
--- a/DataRepo/data/tests/small_obob2/sample_table_headers_v3.yaml
+++ b/DataRepo/data/tests/small_obob2/sample_table_headers_v3.yaml
@@ -1,0 +1,7 @@
+---
+SAMPLE: "Sample Name"
+DATE: "Date Collected"
+HANDLER: "Researcher Name"
+TISSUE: "Tissue"
+DAYS_INFUSED: "Time Collected"
+ANIMAL: "Animal ID"

--- a/DataRepo/data/tests/small_obob2/serum_lactate_sample_table_han_solo_v3.tsv
+++ b/DataRepo/data/tests/small_obob2/serum_lactate_sample_table_han_solo_v3.tsv
@@ -1,0 +1,6 @@
+Sample Name	Date Collected	Researcher Name	Tissue	Time Collected	Animal ID
+exp024f_M2_0	210421	Han Solo	serum_plasma_unspecified_location	0	exp024f_M2
+exp024f_M2_1dot5	210421	Han Solo	serum_plasma_unspecified_location	1.5	exp024f_M2
+exp024f_M2_3	210421	Han Solo	serum_plasma_unspecified_location	3	exp024f_M2
+exp024f_M2_10	210421	Han Solo	serum_plasma_unspecified_location	10	exp024f_M2
+exp024f_M2_30	210421	Han Solo	serum_plasma_unspecified_location	30	exp024f_M2

--- a/DataRepo/loaders/msruns_loader.py
+++ b/DataRepo/loaders/msruns_loader.py
@@ -505,7 +505,7 @@ class MSRunsLoader(TableLoader):
         self.exact_mode = exact_mode
 
         # This will contain metadata parsed from the mzXML files (and the created ArchiveFile records to be added to
-        # MSRunSample records
+        # MSRunSample records)
         self.mzxml_dict = defaultdict(lambda: defaultdict(list))
 
         # This will contain the sample header mapped to the sample name in the database.  It will be used to map

--- a/DataRepo/loaders/peak_annotations_loader.py
+++ b/DataRepo/loaders/peak_annotations_loader.py
@@ -357,7 +357,7 @@ class PeakAnnotationsLoader(ConvertedTableLoader, ABC):
             instrument=kwargs.pop("instrument", None),
         )
 
-        # Example: self.peak_group_selections[sample][pgname.lower()] = selected_peak_annotation_filename
+        # Example: self.peak_group_selections[sample][pgname.lower()]["filename"] = selected_peak_annotation_filename
         self.peakgroupconflicts = PeakGroupConflicts(
             file=self.peak_group_conflicts_file,
             data_sheet=self.peak_group_conflicts_sheet,
@@ -971,12 +971,13 @@ class PeakAnnotationsLoader(ConvertedTableLoader, ABC):
         __init__ method.
 
         Args:
-            pgname (str): The name of the peak group to be loaded.  peak_annot_file (ArchiveFile): The peak annotation
-            file that the peak group to be loaded came from.  msrun_sample (MSRunSample): The MSRunSample of the peak
-            group to be loaded.
+            pgname (str): The name of the peak group to be loaded.
+            peak_annot_file (ArchiveFile): The peak annotation file that the peak group to be loaded came from.
+            msrun_sample (MSRunSample): The MSRunSample of the peak group to be loaded.
         Exceptions:
             Buffers:
-                ProgrammingError ReplacingPeakGroupRepresentation
+                ProgrammingError
+                ReplacingPeakGroupRepresentation
             Raises:
                 None
         Returns:
@@ -998,13 +999,10 @@ class PeakAnnotationsLoader(ConvertedTableLoader, ABC):
                 ]
                 is None
             ):
-                if (
-                    self.peakgroupconflicts.aggregated_errors_object.exception_exists(
-                        DuplicatePeakGroupResolutions,
-                        attr_name="conflicting",
-                        attr_val=True,
-                    )
-                    == 0
+                if not self.peakgroupconflicts.aggregated_errors_object.exception_exists(
+                    DuplicatePeakGroupResolutions,
+                    attr_name="conflicting",
+                    attr_val=True,
                 ):
                     self.aggregated_errors_object.buffer_error(
                         ProgrammingError(

--- a/DataRepo/loaders/peak_group_conflicts.py
+++ b/DataRepo/loaders/peak_group_conflicts.py
@@ -175,7 +175,7 @@ class PeakGroupConflicts(TableLoader):
                         "rownum": rownum,
                     }
         """
-        selected_representations = defaultdict(lambda: defaultdict(str))
+        selected_representations = defaultdict(lambda: defaultdict(dict))
 
         if self.df is None:
             return selected_representations

--- a/DataRepo/management/commands/load_samples.py
+++ b/DataRepo/management/commands/load_samples.py
@@ -55,12 +55,10 @@ class Command(LoadTableCommand):
         Returns:
             None
         """
-        # TODO: Remove this after all dependent code has been updated for the new version of this script
         if options["sample_table_filename"] is not None:
             raise CommandError(
                 "By supplying --sample-table-filename, it looks like you're trying to call the old version of this "
-                "script.  This script has been renamed.  Use `pythong manage.py legacy_load_samples ...` instead."
-                f"{options}"
+                "script.  The interface has changed.  Please use --help to see the new options."
             )
 
         self.load_data()

--- a/DataRepo/management/commands/load_samples.py
+++ b/DataRepo/management/commands/load_samples.py
@@ -51,7 +51,7 @@ class Command(LoadTableCommand):
         Args:
             options (dict): Values provided on the command line.
         Exceptions:
-            None
+            CommandError
         Returns:
             None
         """
@@ -59,6 +59,11 @@ class Command(LoadTableCommand):
             raise CommandError(
                 "By supplying --sample-table-filename, it looks like you're trying to call the old version of this "
                 "script.  The interface has changed.  Please use --help to see the new options."
+            )
+        elif options["animal_and_sample_table_filename"] is not None:
+            raise CommandError(
+                "By supplying --animal-and-sample-table-filename, it looks like you're trying to call the old version "
+                "of this script.  The interface has changed.  Please use --help to see the new options."
             )
 
         self.load_data()

--- a/DataRepo/management/commands/load_study.py
+++ b/DataRepo/management/commands/load_study.py
@@ -123,12 +123,10 @@ class Command(LoadTableCommand):
         Returns:
             None
         """
-        # TODO: Remove this after all dependent code has been updated for the new version of this script
         if options["study_params"] is not None:
             raise CommandError(
                 "By supplying a positional argument, it looks like you're trying to call the old version of this "
-                "script.  This script has been renamed.  Use `python manage.py legacy_load_study ...` to use the old "
-                f"version.  {options}"
+                "script.  The interface has changed.  Please use --help to see the new options."
             )
 
         try:

--- a/DataRepo/utils/file_utils.py
+++ b/DataRepo/utils/file_utils.py
@@ -48,7 +48,7 @@ def read_from_file(
     Exceptions:
         None
     Returns:
-        DateParserError (Union[DataFrame, object]): Pandas dataframe of parsed and processed infile data or, if the
+        retval (Union[DataFrame, object]): Pandas dataframe of parsed and processed infile data or, if the
             filetype is yaml, returns a python object (dict, list, etc).
     """
     filetype = _get_file_type(filepath, filetype=filetype)


### PR DESCRIPTION
## Summary Change Description

The tests for `PeakAnnotationsLoader.is_selected_peak_group` deserved their own PR.  They are an important relatively new feature that I never tested in the tests (just manually with real data).  They turned up a couple minor issues that I was surprised hadn't already been encountered.  I made a couple trivial unrelated changes as well.

- Removed reference to the legacy scripts from load_study and load_samples.
- Removed the TODO comment to remove the associated error code about attempting to use the old interface.  I.e. I decided to keep it.
- Added tests to test every code block of the method: `PeakAnnotationsLoader.is_selected_peak_group` and fixed minor issues the tests uncovered.
  - The cases covered by the tests are:
    - No Peak Group Conflict exists to check
    - A conflict exists but no selection was made in the Peak Group Conflicts sheet
    - A conflict exists, no selection was made, and no conflict exception was buffered.
    - A conflict exists, a selection was made, and it differs.
    - A conflict exists, a selection was made, it differs, AND a previous conflict pre-exists.
    - A conflict exists, a selection was made, and it matches.
  - Found a type mismatch in PeakGroupConflicts.selected_representations.  It was 1 dict deeper than was declared, so I fixed the declaration.  I'm a little surprised mypy didn't complain about this before.
  - In the PeakAnnotationsLoader, the value checked on the return of PeakAnnotationsLoader.peakgroupconflicts.aggregated_errors_object.exception_exists() was an integer, but it should have been a boolean.  Also not sure why this wasn't an issue before.
  - Fixed some comments/docstrings in PeakAnnotationsLoader.
  - Trivial comment fix in the MSRunsLoader.

## Affected Issues/Pull Requests

- Partially addresses #1148
- Merges into main

## Review Notes
<!--
For added context for reviewers, add comments to relevant lines of code.  Use
this space to describe any general areas of concern not linked to a specific
line of code that reviewers should pay particular attention to, e.g. please
make sure I have accounted for all possible inputs.
-->
See comments in-line.

## Checklist
<!--
If any of the checkbox requirements are not met, uncheck them and add an
explanation. E.g. Linting errors pre-date this PR.
-->
This pull request will be merged once the following requirements are met.  The
author and/or reviewers should uncheck any unmet requirements:

- Review requirements
  - Minimum approvals: 1 <!-- Edit as desired (e.g. based on complexity) -->
  - No changes requested
  - All blocking issues resolved by reviewers
  - Specific reviewers: @__add_username_here__
    <!--
    Require reviewers with specific expertise to be included among the minimum
    number of reviewers by tagging them.  Also please send them a message.
    -->
  - Review period: 2 days <!-- Edit as desired (e.g. based on complexity) -->
- Associated issue/pull request requirements:
  <!--
  Assert that all requirements in issues marked "resolved" are done and that
  all required pull requests are merged.  If any are not done, either edit or
  split the issue or explain the unmerged affected pull requests.
  -->
  - [x] All requirements in affected issues marked "resolved" are satisfied
  - [x] All required pull requests are merged *(or none)*
- Basic requirements
  <!--
  Uncheck items to acknowledge failures/conflicts you intend to address.
  Add an explanation if any won't be addressed before merge.
  -->
  - [x] [All linters pass](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#linting)
  - [x] [All tests pass](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#quality-control)
  - [x] All conflicts resolved
- Overhead requirements
  <!--
  These are additional requirements that are not directly associated with
  resolving the affected issue(s).
  -->
  - [x] [New/changed method tests implemented/updated *(or no change)*](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#test-implementation)
  - [ ] [Updated *Unreleased* section of `changelog.md` *(or no change)*](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/changelog.md)
  - [x] [Migrations created & committed *(or no change)*](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#migration-process)
