### PR TITLE
Fixed blocking `ProgrammingError` exception edge case stemming from a recent change

### DIFF
--- a/DataRepo/loaders/base/table_loader.py
+++ b/DataRepo/loaders/base/table_loader.py
@@ -2772,7 +2772,7 @@ class TableLoader(ABC):
         ):
             is_fatal = exception.is_fatal
         elif is_fatal is None:
-            is_fatal = True
+            is_fatal = is_error
 
         if hasattr(exception, "file") and exception.file is not None:
             file = exception.file

--- a/DataRepo/loaders/msruns_loader.py
+++ b/DataRepo/loaders/msruns_loader.py
@@ -835,7 +835,7 @@ class MSRunsLoader(TableLoader):
                 sh = os.path.splitext(fn)[0]
 
             modded_sh = sh
-            if not self.exact_mode:
+            if mzxml_name_with_opt_path is not None and not self.exact_mode:
                 modded_sh = sh.replace("-", "_")
 
             # If we haven't seen an mzXML by this name before or we haven't see its directory before
@@ -844,7 +844,7 @@ class MSRunsLoader(TableLoader):
                 or dr not in expected_mzxmls[sh].keys()
             ):
                 expected_mzxmls[modded_sh][dr] = {
-                    "sample_header": sh,
+                    "sample_header": sample_header if sample_header is not None else sh,
                     "sample_name": sample_name,
                     "skip": skip,
                 }
@@ -1383,23 +1383,40 @@ class MSRunsLoader(TableLoader):
             sample = self.get_sample_by_name(sample_name)
             msrun_sequence = self.get_msrun_sequence(name=sequence_name)
 
-            if mzxml_path is not None and sample_header is not None:
+            if mzxml_path is not None:
                 mzxml_name = self.get_sample_header_from_mzxml_name(
                     os.path.basename(mzxml_path)
                 )
-                sample_header_name = self.get_sample_header_from_mzxml_name(
-                    sample_header
-                )
-                if sample_header_name != mzxml_name:
-                    self.aggregated_errors_object.buffer_exception(
-                        MzxmlSampleHeaderMismatch(sample_header, mzxml_path),
-                        is_error=False,  # This is always a warning.
-                        # This exception will be fatal/raised in validate mode (but only printed in curator mode).
-                        # I.e. This can be ignored by a curator, but it should be brought to the attention of an
-                        # unprivileged user.
-                        is_fatal=self.validate,
+
+                if mzxml_name[0].isdigit() and sample_header != mzxml_name:
+                    # The leftover mzXMLs code uses self.header_to_sample_name to lookup the DB sample name.  The peak
+                    # correction software does not allow sample names to start with a number, and we don't want that
+                    # lookup to fail and raise an error, so we're going to throw it in there.  It doesn't matter that
+                    # the sample header version was already set.  It differs from the mzxml name.
+                    self.header_to_sample_name[mzxml_name][sample_name].append(
+                        self.rownum
                     )
-                    self.warned(MSRunSample.__name__)
+
+                if sample_header is not None:
+                    # We're going to check to see if the sample_header and mzxml_name differ and issue a warning for
+                    # users to double-check things in case they accidentally mismatches an mzXML and a sample header in
+                    # the peak annotation details sheet.
+                    sample_header_name = self.get_sample_header_from_mzxml_name(
+                        sample_header
+                    )
+                    if sample_header_name != mzxml_name and (
+                        # mzxmls that start with a digit must be changed due to peak correction software requirements
+                        not mzxml_name[0].isdigit()
+                        or mzxml_name not in sample_header_name
+                    ):
+                        self.aggregated_errors_object.buffer_warning(
+                            MzxmlSampleHeaderMismatch(sample_header, mzxml_path),
+                            # This exception will be fatal/raised in validate mode (but only printed in curator mode).
+                            # I.e. This can be ignored by a curator, but it should be brought to the attention of an
+                            # unprivileged user.
+                            is_fatal=self.validate,
+                        )
+                        self.warned(MSRunSample.__name__)
 
             if sample is None or msrun_sequence is None:
                 print(
@@ -1601,6 +1618,7 @@ class MSRunsLoader(TableLoader):
             rec = Sample.objects.get(name=sample_name)
         except Sample.DoesNotExist as dne:
             if from_mzxml is not None:
+
                 # Let's see if this is a "dash" issue
                 sample_name_nodash = self.get_sample_header_from_mzxml_name(sample_name)
                 if sample_name_nodash != sample_name:
@@ -1609,15 +1627,57 @@ class MSRunsLoader(TableLoader):
                     except Sample.DoesNotExist:
                         # Ignore this attempt and press on with processing the original exception
                         pass
+
+                if sample_name[0].isdigit():
+                    try:
+                        # Some peak correction tools disallow sample names that start with a number, so let's
+                        # see if the user potentially prepended the sample name and the rest of it happens to be
+                        # unique
+                        rec = Sample.objects.get(name__endswith=sample_name)
+
+                        # Buffer an error that says that we're going to proceed assuming the found sample is a
+                        # match
+                        self.aggregated_errors_object.buffer_error(
+                            RecordDoesNotExist(
+                                Sample,
+                                {"name": sample_name},
+                                file=self.friendly_file,
+                                sheet=self.sheet,
+                                column=self.headers.MZXMLNAME,
+                                rownum="no row - sample name was derived from an mzXML filename",
+                                message=(
+                                    f"{Sample.__name__} record matching the mzXML file's basename [{sample_name}] does "
+                                    "not exist, but the filename starts with a number and happens to otherwise "
+                                    f"uniquely match sample '{rec.name}'.  Please identify the associated sample(s) "
+                                    f"and add a the file '{from_mzxml}' to %s.  If no such row exists and this is an "
+                                    f"unanalyzed mzXML file, add a row and fill in the '{self.headers.SKIP}' column."
+                                ),
+                                suggestion=(
+                                    "Proceeding with the assumption that the mzXML-derived sample name "
+                                    f"'{sample_name}' is intended to match sample '{rec.name}'."
+                                ),
+                            ),
+                            orig_exception=dne,
+                        )
+
+                        return rec
+                    except Sample.DoesNotExist or Sample.MultipleObjectsReturned:
+                        # Ignore this attempt and press on with processing the original exception
+                        pass
+
                 self.aggregated_errors_object.buffer_error(
                     RecordDoesNotExist(
                         Sample,
                         {"name": sample_name},
-                        file=from_mzxml,
+                        file=self.friendly_file,
+                        sheet=self.sheet,
+                        column=self.headers.MZXMLNAME,
+                        rownum="no row - sample name was derived from an mzXML filename",
                         message=(
                             f"{Sample.__name__} record matching the mzXML file's{' exact' if self.exact_mode else ''} "
-                            f"basename [{sample_name}] does not exist.  Please identify the associated sample and add "
-                            f"a row with it, the matching mzXML file name(s), and the {self.headers.SEQNAME} to %s."
+                            f"basename [{sample_name}] does not exist.  Please identify the associated sample(s) and "
+                            f"add a the file '{from_mzxml}' to %s.  If no such row exists and this is an unanalyzed "
+                            f"mzXML file, add a row and fill in the '{self.headers.SKIP}' column."
                         ),
                     ),
                     orig_exception=dne,

--- a/DataRepo/utils/exceptions.py
+++ b/DataRepo/utils/exceptions.py
@@ -1054,8 +1054,8 @@ class RecordDoesNotExist(InfileError, ObjectDoesNotExist, SummarizableError):
                 model = inst.model
             elif inst.model != model:
                 raise ProgrammingError(
-                    "instances must be a list of RecordDoesNotExist exceptions generated from queries of the same "
-                    f"model.  {inst.model} != {model}"
+                    "The instances argument must be a list of RecordDoesNotExist exceptions generated from queries of "
+                    f"the same model.  {inst.model} != {model}"
                 )
 
             if _one_source:
@@ -1068,8 +1068,8 @@ class RecordDoesNotExist(InfileError, ObjectDoesNotExist, SummarizableError):
                     loc_args = cur_loc_args
                 elif cur_loc_args != loc_args:
                     raise ProgrammingError(
-                        "instances must be a list of RecordDoesNotExist exceptions generated from queries of the same "
-                        f"file/column.  {cur_loc_args} != {loc_args}"
+                        "The instances argument must be a list of RecordDoesNotExist exceptions generated from queries "
+                        f"of the same file/column.  {cur_loc_args} != {loc_args}"
                     )
 
             query_fields_str = inst._get_query_stub()
@@ -1078,8 +1078,8 @@ class RecordDoesNotExist(InfileError, ObjectDoesNotExist, SummarizableError):
                 fields_str = query_fields_str
             elif fields_str != query_fields_str:
                 raise ProgrammingError(
-                    "instances must be a list of RecordDoesNotExist exceptions generated from queries using the same "
-                    f"search fields (and comparators).  {fields_str} != {query_fields_str}"
+                    "The instances argument must be a list of RecordDoesNotExist exceptions generated from queries "
+                    f"using the same search fields (and comparators).  {fields_str} != {query_fields_str}"
                 )
 
             query_values_str = inst._get_query_values_str()

--- a/DataRepo/utils/exceptions.py
+++ b/DataRepo/utils/exceptions.py
@@ -1409,6 +1409,7 @@ class UnexpectedSamples(InfileError):
         rel_sheet,
         rel_column,
         suggestion=None,
+        possible_blanks=False,
         **kwargs,
     ):
         if missing_samples is None or len(missing_samples) == 0:
@@ -1422,11 +1423,13 @@ class UnexpectedSamples(InfileError):
             rel_loc = generate_file_location_string(
                 file=rel_file, sheet=rel_sheet, column=rel_column
             )
+            blnkmsg = ", that appear to possibly be blanks," if possible_blanks else ""
             message = (
-                f"According to the values in {rel_loc} the following sample data headers should be in %s, but they "
-                f"were not there: {missing_samples}.  This can likely be fixed by changing the file associated with "
-                f"the headers in {rel_loc}."
+                f"According to the values in {rel_loc}, the following sample data headers{blnkmsg} should be in %s, "
+                f"but they were not there: {missing_samples}."
             )
+            if not possible_blanks:
+                message += "  This can likely be fixed by changing the file associated with the headers."
         if suggestion is not None:
             message += f"  {suggestion}"
         super().__init__(message, **kwargs)
@@ -3648,7 +3651,7 @@ class AllMzxmlSequenceUnknown(Exception):
 
     def __init__(self, exceptions, message=None):
         if not message:
-            loc_msg_default = ", obtained from the indicated file locations"
+            loc_msg_default = ""
             loc_msg = ""
             err_dict = defaultdict(lambda: defaultdict(lambda: defaultdict(list)))
             exc: MzxmlSequenceUnknown
@@ -3703,9 +3706,9 @@ class AllMzxmlSequenceUnknown(Exception):
                 )
 
             message = (
-                f"Multiple mzXML files with the same basename{loc_msg}.  Cannot determine the MSRunSequence, so one "
-                "will be attempted to be deduced.  If unsuccessful, an error requiring defaults to be supplied will "
-                f"occur below:\n{mzxml_str}"
+                f"Multiple mzXML files with the same basename{loc_msg}.  Cannot determine the MSRunSequence without a "
+                "row for each, so one will be attempted to be deduced.  If unsuccessful, an error requiring defaults "
+                f"to be supplied will occur below:\n{mzxml_str}"
             )
 
         super().__init__(message)
@@ -3859,7 +3862,8 @@ class AllMzXMLSkipRowErrors(Exception):
                                 if len(v["rows"]) > 0
                                 else ""
                             )
-                            + f" ({len(v['num_header_rows'][0])} skipped sample headers from the infile)"
+                            + f" ({len(v['num_header_rows'][0])} sample header(s) from the infile [that is/are "
+                            + f"skipped] and {len(v['existing_files'])} mzXML files)"
                             + nlttt
                             + (
                                 nlttt.join(v["existing_files"])


### PR DESCRIPTION
## Summary Change Description

These changes relate to errors I encountered upon attempting to load Edmundo's cystine study **with** his `mzXML` files.  The load was failing and it was due to recent changes that had not been tested against a load that included `mzXML` files.

The main change that prevented the load was the change to make the `RecordDoesNotExist` exceptions to be reported as being from the `mzXML` file instead of from the study doc's `Peak Annotation Details` sheet.  The intention was to disambiguate the source of the exception.  The problem with that was that the `MissingSamples` class that summarizes these exceptions has a documented limitation that all exceptions must be from a single file.  If they aren't, it raises a `ProgrammingError` exception, and that was stopping the load.  And all this was being prompted by trying to associate `mzXML` files with samples (and rows in the `Peak Annotation Details` sheet).  And it may even be the case that those initial changes were only tested using a single `mzXML` file, which is why the test never raised the programming error.  The change I made still shows the `mzXML` file source of the issue, but uses the study doc file reference to say where the fix needs to be added.

Fixing that then revealed another edge case: when these as-yet unassociated `mzXML` files encountered the `NoScans` warnings (about `mzXML` files not containing any peak data) those warnings were unintentionally being marked as fatal.  I located the cause and changed the default `is_fatal` value in `TableLoader.buffer_infile_exception` to match the `is_error` value.  I swear I'd fixed this fatal `NoScans` warning before, but I probably didn't fix it in the correct place.  I believe this fixes the fundamental issue there.

Related changes:

- `MSRunsLoader`
  - When a missing sample is from a search based on an mzXML filename and and the filename starts with a number, a fallback search is made to look for samples that end with the mzXML filename.
  - When an `mzXML` filename doesn't match a sample header, `self.header_to_sample_name` is updated to mark the sample its linked to as seen.
  - I prevented `MzxmlSampleHeaderMismatch` warnings from being buffered when the mzXML filename starts with a number.
- Minor exception changes
  - Improved the `AllMzxmlSequenceUnknown` exception message.
  - Added argument `possible_blanks` to the `UnexpectedSamples` constructor.
  - Improved the `AllMzXMLSkipRowErrors` exception message.
  - Split the `UnexpectedSamples` exception in the `PeakAnnotationsLoader` into a set with and without possible blanks (the blanks one being a warning).

Fixed tests that the above changes broke by modifying `MSRunsLoader.get_sample_by_name` to have a fallback that checks to see if the sample name has dashes.
    
There are multiple places from which the method is called and how the sample name is massaged is different for different purposes, but mainly when dealing with accounting for differences between the mzXML file names and the sample names.  This branch has a fix that accounts for the edge case where a skipped mzXML was not included in a peak annotation file, and that change revealed an edge case inside get_sample_by_name that was not covered.  This change also accounted for sample name differences involving mzXML files whose names started with a number.  All of these case combinations are now accounted for in the method.
    
This change is not ideal, and a holistic refactor should be applied to make the code simpler, but given the current time constraints, this patch is pragmatic.

## Affected Issues/Pull Requests

- Resolves no documented issue
- Merges into main

## Review Notes
<!--
For added context for reviewers, add comments to relevant lines of code.  Use
this space to describe any general areas of concern not linked to a specific
line of code that reviewers should pay particular attention to, e.g. please
make sure I have accounted for all possible inputs.
-->
See comments in-line.

## Checklist
<!--
If any of the checkbox requirements are not met, uncheck them and add an
explanation. E.g. Linting errors pre-date this PR.
-->
This pull request will be merged once the following requirements are met.  The
author and/or reviewers should uncheck any unmet requirements:

- Review requirements
  - Minimum approvals: 1 <!-- Edit as desired (e.g. based on complexity) -->
  - No changes requested
  - All blocking issues resolved by reviewers
  - Specific reviewers: @__add_username_here__
    <!--
    Require reviewers with specific expertise to be included among the minimum
    number of reviewers by tagging them.  Also please send them a message.
    -->
  - Review period: 2 days <!-- Edit as desired (e.g. based on complexity) -->
- Associated issue/pull request requirements:
  <!--
  Assert that all requirements in issues marked "resolved" are done and that
  all required pull requests are merged.  If any are not done, either edit or
  split the issue or explain the unmerged affected pull requests.
  -->
  - [x] All requirements in affected issues marked "resolved" are satisfied
  - [x] All required pull requests are merged *(or none)*
- Basic requirements
  <!--
  Uncheck items to acknowledge failures/conflicts you intend to address.
  Add an explanation if any won't be addressed before merge.
  -->
  - [x] [All linters pass](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#linting)
  - [x] [All tests pass](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#quality-control)
  - [x] All conflicts resolved
- Overhead requirements
  <!--
  These are additional requirements that are not directly associated with
  resolving the affected issue(s).
  -->
  - [x] [New/changed method tests implemented/updated *(or no change)*](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#test-implementation)
  - [ ] [Updated *Unreleased* section of `changelog.md` *(or no change)*](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/changelog.md)
  - [x] [Migrations created & committed *(or no change)*](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#migration-process)
