### PR TITLE
Raise `PermissionError` if the site is `READONLY`

### DIFF
--- a/DataRepo/tests/views/upload/test_submission.py
+++ b/DataRepo/tests/views/upload/test_submission.py
@@ -4,6 +4,7 @@ from copy import deepcopy
 from io import BytesIO
 
 from django.core.management import call_command
+from django.test import override_settings
 from django.urls import reverse
 
 from DataRepo.loaders import ProtocolsLoader, TissuesLoader
@@ -1019,6 +1020,11 @@ class DataValidationViewTests1(TracebaseTransactionTestCase):
         # Invalid sheet name
         with self.assertRaises(ValueError):
             result2 = dvv.header_to_cell("Invalid", "Age")
+
+    @override_settings(READONLY=True)
+    def test_readonly_exception(self):
+        with self.assertRaises(PermissionError):
+            BuildSubmissionView()
 
     def test_get_existing_dfs_index(self):
         # TODO: Implement test

--- a/DataRepo/views/upload/submission.py
+++ b/DataRepo/views/upload/submission.py
@@ -110,6 +110,11 @@ class BuildSubmissionView(FormView):
     ]
 
     def __init__(self):
+        if settings.READONLY:
+            raise PermissionError(
+                "The ability to upload data is restricted on this site."
+            )
+
         super().__init__()
 
         self.autofill_dict = defaultdict(lambda: defaultdict(dict))


### PR DESCRIPTION
## Summary Change Description
<!-- Briefly describe the changes in this pull request (put details in the
developer section of the linked issue(s)). -->
See affected issue(s).

## Affected Issues/Pull Requests

- Resolves #1367
- Merges into main

## Review Notes
<!--
For added context for reviewers, add comments to relevant lines of code.  Use
this space to describe any general areas of concern not linked to a specific
line of code that reviewers should pay particular attention to, e.g. please
make sure I have accounted for all possible inputs.
-->
See comments in-line.

## Checklist
<!--
If any of the checkbox requirements are not met, uncheck them and add an
explanation. E.g. Linting errors pre-date this PR.
-->
This pull request will be merged once the following requirements are met.  The
author and/or reviewers should uncheck any unmet requirements:

- Review requirements
  - Minimum approvals: 1 <!-- Edit as desired (e.g. based on complexity) -->
  - No changes requested
  - All blocking issues resolved by reviewers
  - Specific reviewers: @__add_username_here__
    <!--
    Require reviewers with specific expertise to be included among the minimum
    number of reviewers by tagging them.  Also please send them a message.
    -->
  - Review period: 2 days <!-- Edit as desired (e.g. based on complexity) -->
- Associated issue/pull request requirements:
  <!--
  Assert that all requirements in issues marked "resolved" are done and that
  all required pull requests are merged.  If any are not done, either edit or
  split the issue or explain the unmerged affected pull requests.
  -->
  - [x] All requirements in affected issues marked "resolved" are satisfied
  - [x] All required pull requests are merged *(or none)*
- Basic requirements
  <!--
  Uncheck items to acknowledge failures/conflicts you intend to address.
  Add an explanation if any won't be addressed before merge.
  -->
  - [x] [All linters pass](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#linting)
  - [x] [All tests pass](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#quality-control)
  - [x] All conflicts resolved
- Overhead requirements
  <!--
  These are additional requirements that are not directly associated with
  resolving the affected issue(s).
  -->
  - [x] [New/changed method tests implemented/updated *(or no change)*](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#test-implementation)
  - [ ] [Updated *Unreleased* section of `changelog.md` *(or no change)*](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/changelog.md)
  - [x] [Migrations created & committed *(or no change)*](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#migration-process)
