### PR TITLE
Move missing parent catch to derived class

### DIFF
--- a/DataRepo/loaders/peak_annotations_loader.py
+++ b/DataRepo/loaders/peak_annotations_loader.py
@@ -2178,11 +2178,11 @@ class AccucorLoader(PeakAnnotationsLoader):
         "D_Label",
     ]
 
-    def check_c12_parents(self, orig_df):
+    def check_c12_parents(self, df):
         """This method ensures that every compound in the original peak annotations file had a row for the C12 PARENT.
 
         Args:
-            orig_df (Optional[pandas dataframe]): Data, e.g. as parsed from a table-like file.
+            df (Optional[pandas dataframe]): Data, e.g. as parsed from a table-like file.
         Exceptions:
             Raised:
                 None
@@ -2191,11 +2191,11 @@ class AccucorLoader(PeakAnnotationsLoader):
         Returns:
             None
         """
-        if orig_df is None:
+        if df is None:
             return
 
-        if isinstance(orig_df, dict) and "Original" in orig_df.keys():
-            self.check_c12_parents_original(orig_df["Original"])
+        if isinstance(df, dict) and "Original" in df.keys():
+            self.check_c12_parents_original(df["Original"])
 
         return
 

--- a/DataRepo/loaders/peak_annotations_loader.py
+++ b/DataRepo/loaders/peak_annotations_loader.py
@@ -2262,12 +2262,13 @@ class AccucorLoader(PeakAnnotationsLoader):
                 is_fatal=self.validate,
             )
 
-        missing_parent_compounds.apply(
-            lambda row: buffer_missing_parents(
-                row[self.OrigDataHeaders.COMPOUNDID], row["index"]
-            ),
-            axis=1,
-        )
+        if not missing_parent_compounds.empty:
+            missing_parent_compounds.apply(
+                lambda row: buffer_missing_parents(
+                    row[self.OrigDataHeaders.COMPOUNDID], row["index"]
+                ),
+                axis=1,
+            )
 
 
 class IsoautocorrLoader(PeakAnnotationsLoader):

--- a/DataRepo/models/peak_group.py
+++ b/DataRepo/models/peak_group.py
@@ -223,6 +223,7 @@ class PeakGroup(HierCachedModel, MaintainedModel):
         Returns:
             None
         """
+        from DataRepo.models.utilities import exists_in_db
         from DataRepo.utils.exceptions import MultiplePeakGroupRepresentation
 
         if (
@@ -238,6 +239,10 @@ class PeakGroup(HierCachedModel, MaintainedModel):
             name=self.name,
             msrun_sample__sample__pk=self.msrun_sample.sample.pk,
         ).exclude(peak_annotation_file=self.peak_annotation_file)
+
+        # If the record already exists (e.g. doing an update), exclude self.  (self.pk is None otherwise.)
+        if exists_in_db(self):
+            conflicts = conflicts.exclude(pk=self.pk)
 
         if conflicts.count() > 0:
             raise MultiplePeakGroupRepresentation(self, conflicts)

--- a/DataRepo/models/peak_group.py
+++ b/DataRepo/models/peak_group.py
@@ -223,7 +223,6 @@ class PeakGroup(HierCachedModel, MaintainedModel):
         Returns:
             None
         """
-        from DataRepo.models.utilities import exists_in_db
         from DataRepo.utils.exceptions import MultiplePeakGroupRepresentation
 
         if (
@@ -233,15 +232,12 @@ class PeakGroup(HierCachedModel, MaintainedModel):
             # This cannot be a multiple representation issue if no peak annotation file is provided
             return None
 
-        # Look for peak groups with the same name (i.e. compound) for the same sample
+        # Look for peak groups with the same name (i.e. compound) for the same sample, coming from a different peak
+        # annotation file
         conflicts = PeakGroup.objects.filter(
             name=self.name,
             msrun_sample__sample__pk=self.msrun_sample.sample.pk,
-        )
-
-        # If the record already exists (e.g. doing an update), exclude self.  (self.pk is None otherwise.)
-        if exists_in_db(self):
-            conflicts = conflicts.exclude(pk=self.pk)
+        ).exclude(peak_annotation_file=self.peak_annotation_file)
 
         if conflicts.count() > 0:
             raise MultiplePeakGroupRepresentation(self, conflicts)

--- a/DataRepo/tests/loaders/test_msruns_loader.py
+++ b/DataRepo/tests/loaders/test_msruns_loader.py
@@ -1100,10 +1100,24 @@ class MSRunsLoaderTests(TracebaseTestCase):
         Result: Concrete record created, placeholder deleted, and peak groups moved to concrete record
         """
 
+        path = Path(
+            "DataRepo/data/tests/small_obob/small_obob_maven_6eaas_inf_glucose.xlsx"
+        )
+        with path.open(mode="rb") as f:
+            myfile = File(f, name=path.name)
+            tmp_accucor_file = ArchiveFile.objects.create(
+                filename="small_obob_maven_6eaas_inf_lactate.xlsx",
+                file_location=myfile,
+                checksum="558ea654d7f2914ca4527580edf4fac11bd151c9",
+                data_type=DataType.objects.get(code="ms_peak_annotation"),
+                data_format=DataFormat.objects.get(code="accucor"),
+            )
+            tmp_accucor_file.save()
+
         # Change the accucor file in the second peak group to be the same as the first so that all peak groups in the
         # existing placeholder record (created in setUpTestData) will **NOT** match the added mzXML file / concrete
         # msrun_sample record
-        self.pg2.peak_annotation_file = self.accucor_file1
+        self.pg2.peak_annotation_file = tmp_accucor_file
         self.pg2.save()
 
         # Set up the loader object

--- a/DataRepo/tests/management/commands/test_load_peak_annotations.py
+++ b/DataRepo/tests/management/commands/test_load_peak_annotations.py
@@ -25,6 +25,7 @@ from DataRepo.models.archive_file import ArchiveFile
 from DataRepo.tests.tracebase_test_case import TracebaseTestCase
 from DataRepo.utils.exceptions import (
     AggregatedErrors,
+    ConflictingValueError,
     DuplicateFileHeaders,
     MultiplePeakGroupRepresentation,
     MultiplePeakGroupRepresentations,
@@ -412,12 +413,12 @@ class LoadAccucorSmallObobCommandTests(TracebaseTestCase):
 
         aes = adl.aggregated_errors_object
         self.assertEqual(1, len(aes.exceptions))
-        self.assertIsInstance(aes.exceptions[0], MultiplePeakGroupRepresentation)
+        self.assertIsInstance(aes.exceptions[0], ConflictingValueError)
 
     def test_multiple_accucor_labels(self):
         """
         The infusate has tracers that cumulatively contain multiple Tracers/labels.  This tests that it loads without
-        error
+        error.
         """
         call_command(
             "load_study",

--- a/DataRepo/tests/utils/test_exceptions.py
+++ b/DataRepo/tests/utils/test_exceptions.py
@@ -21,7 +21,7 @@ from DataRepo.utils.exceptions import (
     InvalidHeaderCrossReferenceError,
     IsotopeStringDupe,
     MissingC12ParentPeak,
-    MissingC12ParentPeakErrors,
+    MissingC12ParentPeaks,
     MissingColumnGroup,
     MissingCompounds,
     MissingDataAdded,
@@ -1459,7 +1459,7 @@ class ExceptionTests(TracebaseTestCase):
 
     def test_MissingC12ParentPeakErrors(self):
         mcpp = MissingC12ParentPeak("lysine")
-        mcppe = MissingC12ParentPeakErrors([mcpp])
+        mcppe = MissingC12ParentPeaks([mcpp])
         # Check problem described
         self.assertIn("C12 PARENT peak row is missing", str(mcppe))
         # Check data included

--- a/DataRepo/tests/utils/test_exceptions.py
+++ b/DataRepo/tests/utils/test_exceptions.py
@@ -1464,8 +1464,11 @@ class ExceptionTests(TracebaseTestCase):
         self.assertIn("C12 PARENT peak row is missing", str(mcppe))
         # Check data included
         self.assertIn("lysine", str(mcppe))
-        # Check suggestion exists
-        self.assertIn("Please re-pick peaks", str(mcppe))
+        # Check suggestions exists
+        self.assertIn("neglect to include the C12 PARENT peak", str(mcppe))
+        self.assertIn(
+            "ignore this error if the peak is below the detection threshold", str(mcppe)
+        )
 
     def test_MissingC12ParentPeak(self):
         mcpp = MissingC12ParentPeak("lysine", file="accucor.xlsx")
@@ -1474,8 +1477,12 @@ class ExceptionTests(TracebaseTestCase):
             "C12 PARENT peak row missing for compound 'lysine' in 'accucor.xlsx'.",
             str(mcpp),
         )
-        # Check suggestion exists
-        self.assertIn("Please re-pick the peaks", str(mcpp))
+        # Check suggestions exists
+        self.assertIn(
+            "ignore this error if the peak is below the detection threshold",
+            str(mcpp),
+        )
+        self.assertIn("neglect to include the C12 PARENT peak", str(mcpp))
 
     def test_PossibleDuplicateSamplesError(self):
         pds = PossibleDuplicateSamples("s1", ["s1_pos", "s1_neg"])

--- a/DataRepo/utils/exceptions.py
+++ b/DataRepo/utils/exceptions.py
@@ -3117,7 +3117,7 @@ class IsotopeStringDupe(InfileError):
         self.parent = parent
 
 
-class MissingC12ParentPeakErrors(SummarizedInfileError, Exception):
+class MissingC12ParentPeaks(SummarizedInfileError, Exception):
     """Summary of all MissingC12ParentPeak errors
 
     Attributes:
@@ -3144,18 +3144,20 @@ class MissingC12ParentPeakErrors(SummarizedInfileError, Exception):
             loc = " in " + list(self.file_dict.keys())[0]
         message = (
             f"The C12 PARENT peak row is missing for the following compounds{loc}:\n{compounds_str}"
-            "Please re-pick peaks to include the C12 PARENT peaks for these compounds."
+            "Please make sure you didn't neglect to include the C12 PARENT peak for these compounds.  You may safely "
+            "ignore this error if the peak is below the detection threshold."
         )
         Exception.__init__(self, message)
 
 
 class MissingC12ParentPeak(InfileError, SummarizableError):
-    SummarizerExceptionClass = MissingC12ParentPeakErrors
+    SummarizerExceptionClass = MissingC12ParentPeaks
 
     def __init__(self, compound: str, **kwargs):
         message = (
             f"C12 PARENT peak row missing for compound '{compound}' in '%s'.\n"
-            "Please re-pick the peaks to include the C12 PARENT."
+            "Please make sure you didn't neglect to include the C12 PARENT peak for these compounds.  You may safely "
+            "ignore this error if the peak is below the detection threshold."
         )
         super().__init__(message, **kwargs)
         self.compound = compound

--- a/DataRepo/utils/exceptions.py
+++ b/DataRepo/utils/exceptions.py
@@ -3156,7 +3156,7 @@ class MissingC12ParentPeak(InfileError, SummarizableError):
     def __init__(self, compound: str, **kwargs):
         message = (
             f"C12 PARENT peak row missing for compound '{compound}' in '%s'.\n"
-            "Please make sure you didn't neglect to include the C12 PARENT peak for these compounds.  You may safely "
+            "Please make sure you didn't neglect to include the C12 PARENT peak for this compound.  You may safely "
             "ignore this error if the peak is below the detection threshold."
         )
         super().__init__(message, **kwargs)


### PR DESCRIPTION
## Summary Change Description

Fixed PeakAnnotationsLoader.check_c12_parents to warn and fix instead of error and skip.

Michael had pointed out in a comment on an issue in the data repo:

http://github.com/PrincetonUniversity/tracebase-rabinowitz-data#138

that the parent row can be legit missing if the compound is below the detection threshold, or it could be that the researcher just neglected to pick the peak.  He would like the code to warn and inpute the counts.

Count imputation was already happening, but the formula was wrong due to the fill down strategy.  I figured out a clever solution to the fill down by filling empty formulas won parent rows with a placeholder value and then replacing that in the fill down method with a Nan before back filling.

Details:

- Renamed MissingC12ParentPeakErrors to MissingC12ParentPeaks
- Added a more precise suggestion for the related warnings.
- Fixed an issue in PeakGroup.check_for_multiple_representations where the same file, added twice, as the reason for a peak group conflict by including the archive file in an exclude filter.
- Made PeakAnnotationsLoader.check_c12_parents into an abstract method.
- Made PeakAnnotationsLoader.check_c12_parents take a dataframe as input.  I could have made it just reference self.orig_df, but whatever.
- Added a setting to AccucorLoader.nan_defaults_dict to fill in missing formulas on rows for C12 PARENTs specifically with the "BACKFILL" placeholder.
- Added AccucorLoader.check_c12_parents_original
- Eliminated a pandas warning by changing the way I created the index column.

## Affected Issues/Pull Requests

- Resolves #1317
- Resolves #1318
- Merges into PR #1424

## Review Notes
<!--
For added context for reviewers, add comments to relevant lines of code.  Use
this space to describe any general areas of concern not linked to a specific
line of code that reviewers should pay particular attention to, e.g. please
make sure I have accounted for all possible inputs.
-->
See comments in-line.

## Checklist
<!--
If any of the checkbox requirements are not met, uncheck them and add an
explanation. E.g. Linting errors pre-date this PR.
-->
This pull request will be merged once the following requirements are met.  The
author and/or reviewers should uncheck any unmet requirements:

- Review requirements
  - Minimum approvals: 1 <!-- Edit as desired (e.g. based on complexity) -->
  - No changes requested
  - All blocking issues resolved by reviewers
  - Specific reviewers: @__add_username_here__
    <!--
    Require reviewers with specific expertise to be included among the minimum
    number of reviewers by tagging them.  Also please send them a message.
    -->
  - Review period: 2 days <!-- Edit as desired (e.g. based on complexity) -->
- Associated issue/pull request requirements:
  <!--
  Assert that all requirements in issues marked "resolved" are done and that
  all required pull requests are merged.  If any are not done, either edit or
  split the issue or explain the unmerged affected pull requests.
  -->
  - [x] All requirements in affected issues marked "resolved" are satisfied
  - [x] All required pull requests are merged *(or none)*
- Basic requirements
  <!--
  Uncheck items to acknowledge failures/conflicts you intend to address.
  Add an explanation if any won't be addressed before merge.
  -->
  - [x] [All linters pass](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#linting)
  - [x] [All tests pass](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#quality-control)
  - [x] All conflicts resolved
- Overhead requirements
  <!--
  These are additional requirements that are not directly associated with
  resolving the affected issue(s).
  -->
  - [x] [New/changed method tests implemented/updated *(or no change)*](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#test-implementation)
  - [ ] [Updated *Unreleased* section of `changelog.md` *(or no change)*](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/changelog.md)
  - [x] [Migrations created & committed *(or no change)*](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#migration-process)
