### PR TITLE
Fixed minor bug where `AggregatedErrorsSet` exceptions were being buffered in `AggregatedErrors` exceptions

### DIFF
--- a/DataRepo/loaders/base/converted_table_loader.py
+++ b/DataRepo/loaders/base/converted_table_loader.py
@@ -319,7 +319,7 @@ class ConvertedTableLoader(TableLoader, ABC):
             if hdr not in outdf.columns:
                 missing.append(hdr)
         if len(missing) > 0:
-            raise AggregatedErrors().buffer_error(
+            raise AggregatedErrors(debug=self.debug).buffer_error(
                 RequiredHeadersError(self.revert_headers(missing))
             )
 
@@ -459,7 +459,7 @@ class ConvertedTableLoader(TableLoader, ABC):
                         id_vars=existing_static_columns,
                     )
                 except Exception as e:
-                    raise AggregatedErrors().buffer_error(e)
+                    raise AggregatedErrors(debug=self.debug).buffer_error(e)
             # Else, we will assume the user did the conversion themselves
         elif isinstance(in_df, dict):
             check_sheets_consistent = True
@@ -480,7 +480,7 @@ class ConvertedTableLoader(TableLoader, ABC):
                         id_vars=existing_static_columns,
                     )
                 except Exception as e:
-                    raise AggregatedErrors().buffer_error(e)
+                    raise AggregatedErrors(debug=self.debug).buffer_error(e)
         else:
             raise TypeError("df must be either a pandas.DataFrame or a dict.")
 

--- a/DataRepo/loaders/msruns_loader.py
+++ b/DataRepo/loaders/msruns_loader.py
@@ -2667,14 +2667,20 @@ class MSRunsLoader(TableLoader):
                 )
                 delstats["failures"].append(rec.file_location.path)
 
-        print(
-            (
-                f"mzXML file rollback disk archive clean up stats: {len(delstats['deleted'])} deleted, "
-                f"{len(delstats['failures'])} failed to be deleted, and {len(delstats['skipped'])} expected files did "
-                "not exist."
-            ),
-            flush=True,
-        )
+        if len(self.created_mzxml_archive_file_recs) == 0:
+            print(
+                "No archived mzXML files to clean up from the disk archive.",
+                flush=True,
+            )
+        else:
+            print(
+                (
+                    f"mzXML file rollback disk archive clean up stats: {len(delstats['deleted'])} deleted, "
+                    f"{len(delstats['failures'])} failed to be deleted, and {len(delstats['skipped'])} expected files "
+                    "did not exist."
+                ),
+                flush=True,
+            )
 
         return delstats
 

--- a/DataRepo/loaders/peak_annotations_loader.py
+++ b/DataRepo/loaders/peak_annotations_loader.py
@@ -333,7 +333,8 @@ class PeakAnnotationsLoader(ConvertedTableLoader, ABC):
             or self.peak_annotation_details_df is not None
             or self.peak_group_conflicts_df is not None
         ):
-            raise AggregatedErrors().buffer_error(
+            debug = kwargs.get("debug") or False
+            raise AggregatedErrors(debug=debug).buffer_error(
                 ConditionallyRequiredArgs(
                     "The [file] argument is required if either the [df], [peak_annotation_details_df], or "
                     "[peak_group_conflicts_df] argument is supplied."

--- a/DataRepo/loaders/study_loader.py
+++ b/DataRepo/loaders/study_loader.py
@@ -453,13 +453,13 @@ class StudyLoader(ConvertedTableLoader, ABC):
         # use something like "study doc" in place of the actual name.  This facilitates testing where the name doesn't
         # matter.
         if self.file is None:
-            raise AggregatedErrors().buffer_error(
+            raise self.aggregated_errors_object.buffer_error(
                 ValueError(
                     f"The [file] argument to {type(self).__name__}() is required to load data."
                 )
             )
         elif not is_excel(self.file):
-            raise AggregatedErrors().buffer_error(
+            raise self.aggregated_errors_object.buffer_error(
                 ValueError(
                     f"'{self.file}' is not an excel file.  {type(self).__name__}'s file argument requires excel."
                 )
@@ -930,7 +930,10 @@ class StudyLoader(ConvertedTableLoader, ABC):
         Args:
             df_dict (Dict[str,pd.DataFrame]|pd.DataFrame)
         Exceptions:
-            None
+            Raises:
+                ProgrammingError
+            Buffers:
+                None
         Returns:
             matching_version_numbers (List[str]): Version numbers of the matching study doc versions.
             version_match_data (dict): Details of the sheets and headers that do and don't match every study doc version

--- a/DataRepo/management/commands/load_compounds.py
+++ b/DataRepo/management/commands/load_compounds.py
@@ -39,12 +39,10 @@ class Command(LoadTableCommand):
 
         Args:
             options (dict of strings): String values provided on the command line by option name.
-
-        Raises:
-            Nothing (See LoadTableCommand._handler for exceptions in the wrapper)
-
+        Exceptions:
+            None
         Returns:
-            Nothing
+            None
         """
         # The CompoundsLoader class constructor has 1 custom argument
         # The TableLoader superclass arguments are controlled by the LoadTableCommand superclass

--- a/DataRepo/management/commands/load_infusates.py
+++ b/DataRepo/management/commands/load_infusates.py
@@ -31,7 +31,7 @@ class Command(LoadTableCommand):
 
         Args:
             options (dict of strings): String values provided on the command line by option name.
-        Raises:
+        Exceptions:
             None
         Returns:
             None

--- a/DataRepo/management/commands/load_lcprotocols.py
+++ b/DataRepo/management/commands/load_lcprotocols.py
@@ -26,11 +26,9 @@ class Command(LoadTableCommand):
 
         Args:
             options (dict of strings): String values provided on the command line by option name.
-
-        Raises:
-            Nothing (See LoadTableCommand._handler for exceptions in the wrapper)
-
+        Exceptions:
+            None
         Returns:
-            Nothing
+            None
         """
         self.load_data()

--- a/DataRepo/management/commands/load_msruns.py
+++ b/DataRepo/management/commands/load_msruns.py
@@ -119,10 +119,8 @@ class Command(LoadTableCommand):
 
         Args:
             options (dict of strings): String values provided on the command line by option name.
-
         Exceptions:
-            None (See LoadTableCommand._handler for exceptions in the wrapper)
-
+            None
         Returns:
             None
         """

--- a/DataRepo/management/commands/load_protocols.py
+++ b/DataRepo/management/commands/load_protocols.py
@@ -27,11 +27,9 @@ class Command(LoadTableCommand):
 
         Args:
             options (dict of strings): String values provided on the command line by option name.
-
-        Raises:
-            Nothing (See LoadTableCommand._handler for exceptions in the wrapper)
-
+        Exceptions:
+            None
         Returns:
-            Nothing
+            None
         """
         self.load_data()

--- a/DataRepo/management/commands/load_samples.py
+++ b/DataRepo/management/commands/load_samples.py
@@ -51,7 +51,10 @@ class Command(LoadTableCommand):
         Args:
             options (dict): Values provided on the command line.
         Exceptions:
-            CommandError
+            Raises:
+                CommandError
+            Buffers:
+                None
         Returns:
             None
         """

--- a/DataRepo/management/commands/load_sequences.py
+++ b/DataRepo/management/commands/load_sequences.py
@@ -26,11 +26,9 @@ class Command(LoadTableCommand):
 
         Args:
             options (dict of strings): String values provided on the command line by option name.
-
-        Raises:
-            Nothing (See LoadTableCommand._handler for exceptions in the wrapper)
-
+        Exceptions:
+            None
         Returns:
-            Nothing
+            None
         """
         self.load_data()

--- a/DataRepo/management/commands/load_study_set.py
+++ b/DataRepo/management/commands/load_study_set.py
@@ -27,7 +27,7 @@ class Command(BaseCommand):
         studies_loaded = list()
         studies_skipped = list()
         studies_failed = list()
-        study_set_dir = os.path.dirname(os.path.realpath(set_file_handle.name))
+        study_set_dir = os.path.dirname(os.path.realpath(set_file))
         with set_file_handle as study_set:
             study_doc_str: str
             for study_doc_str in study_set:

--- a/DataRepo/management/commands/load_study_set.py
+++ b/DataRepo/management/commands/load_study_set.py
@@ -4,11 +4,6 @@ import sys
 
 from django.core.management import BaseCommand, call_command
 
-from DataRepo.models.hier_cached_model import (
-    disable_caching_updates,
-    enable_caching_updates,
-)
-from DataRepo.models.maintained_model import MaintainedModel
 from DataRepo.utils.exceptions import AggregatedErrorsSet
 
 
@@ -26,30 +21,49 @@ class Command(BaseCommand):
             help=("File of study doc filenames, one per line."),
         )
 
-    @MaintainedModel.defer_autoupdates(
-        # There is no dry-run or validate mode in this script, so mass autoupdate and buffering will never be disabled
-        # here.
-        pre_mass_update_func=disable_caching_updates,
-        post_mass_update_func=enable_caching_updates,
-    )
     def handle(self, *args, **options):
-        set_file = str(options["study_set_list"])
+        set_file_handle = options["study_set_list"]
+        set_file = set_file_handle.name
         studies_loaded = list()
+        studies_skipped = list()
         studies_failed = list()
-        study_set_dir = os.path.dirname(
-            os.path.realpath(options["study_set_list"].name)
-        )
-        with options["study_set_list"] as study_set:
-            for study in study_set:
+        study_set_dir = os.path.dirname(os.path.realpath(set_file_handle.name))
+        with set_file_handle as study_set:
+            study_doc_str: str
+            for study_doc_str in study_set:
+
                 try:
-                    study_path = os.path.join(study_set_dir, study.strip())
-                    study_dir_name = os.path.dirname(study)
+                    study_doc_str = study_doc_str.strip()
+                    study_path = os.path.join(study_set_dir, study_doc_str)
+                    study_dir_name = os.path.dirname(study_doc_str)
+
+                    if study_doc_str.startswith("#"):
+                        skipped_dir_name = study_dir_name.lstrip("# ")
+                        self.stdout.write(
+                            self.style.MIGRATE_HEADING(
+                                f"Skipping commented study '{skipped_dir_name}'"
+                            )
+                        )
+                        studies_skipped.append(skipped_dir_name)
+                        continue
+
+                    if not os.path.isfile(study_path):
+                        self.stdout.write(
+                            self.style.ERROR(
+                                f"FileNotFound: No such file or directory: '{study_path}'"
+                            )
+                        )
+                        studies_failed.append(study_dir_name)
+                        continue
 
                     self.stdout.write(
-                        self.style.MIGRATE_HEADING(f"Loading study using {study_path}")
+                        self.style.MIGRATE_HEADING(f"Loading study '{study_dir_name}'")
                     )
 
-                    call_command("load_study", infile=study_path)
+                    call_command(
+                        "load_study",
+                        infile=study_path,
+                    )
 
                     studies_loaded.append(study_dir_name)
 
@@ -59,25 +73,29 @@ class Command(BaseCommand):
                 except AggregatedErrorsSet as aes:
                     self.stdout.write(
                         self.style.ERROR(
-                            f"Study {study_path} failed with {aes.num_errors} errors and {aes.num_warnings} warnings."
+                            f"Study '{study_dir_name}' failed with {aes.num_errors} errors and {aes.num_warnings} "
+                            "warnings."
                         )
                     )
                     studies_failed.append(study_dir_name)
                     continue
 
-        msg = f"'{set_file}' Done.\n"
+        msg = f"\n'{set_file}' Done.\n"
 
         if len(studies_loaded) == 0 and len(studies_failed) == 0:
             msg += "Study set file empty.\n"
             self.stdout.write(self.style.WARNING(msg))
         else:
-            msg += f"Studies loaded: [{len(studies_loaded)}], failed: [{len(studies_failed)}].\n"
+            msg += (
+                f"Studies loaded: [{len(studies_loaded)}], failed: [{len(studies_failed)}], "
+                f"skipped: [{len(studies_skipped)}].\n"
+            )
 
             # Overall stats
             if len(studies_failed) > 0:
-                self.stdout.write(self.style.SUCCESS(msg))
-            else:
                 self.stdout.write(self.style.ERROR(msg))
+            else:
+                self.stdout.write(self.style.SUCCESS(msg))
 
             # Details
             nlindent = "\n\t"
@@ -85,6 +103,12 @@ class Command(BaseCommand):
                 self.stdout.write(
                     self.style.SUCCESS(
                         f"Loaded studies:\n\t{nlindent.join(studies_loaded)}"
+                    )
+                )
+            if len(studies_skipped) > 0:
+                self.stdout.write(
+                    self.style.WARNING(
+                        f"Skipped studies:\n\t{nlindent.join(studies_skipped)}"
                     )
                 )
             if len(studies_failed) > 0:

--- a/DataRepo/management/commands/load_tissues.py
+++ b/DataRepo/management/commands/load_tissues.py
@@ -26,11 +26,9 @@ class Command(LoadTableCommand):
 
         Args:
             options (dict of strings): String values provided on the command line by option name.
-
         Raises:
-            Nothing (See LoadTableCommand._handler for exceptions in the wrapper)
-
+            None
         Returns:
-            Nothing
+            None
         """
         self.load_data()

--- a/DataRepo/management/commands/load_tracers.py
+++ b/DataRepo/management/commands/load_tracers.py
@@ -39,11 +39,9 @@ class Command(LoadTableCommand):
 
         Args:
             options (dict of strings): String values provided on the command line by option name.
-
         Raises:
-            Nothing (See LoadTableCommand._handler for exceptions in the wrapper)
-
+            None
         Returns:
-            Nothing
+            None
         """
         self.load_data()

--- a/DataRepo/tests/management/commands/test_load_table.py
+++ b/DataRepo/tests/management/commands/test_load_table.py
@@ -18,6 +18,7 @@ from DataRepo.utils.exceptions import (
     OptionsNotAvailable,
     RequiredOptions,
 )
+from TraceBase import settings
 
 
 # Class (Model) used for testing
@@ -70,6 +71,7 @@ class LoadTableCommandTests(TracebaseTestCase):
         "data_sheet": "test sheet",
         "verbosity": 0,
         "defaults_file": None,
+        "debug": settings.DEBUG,
     }
 
     def test_init_required_optnames_default_infile(self):
@@ -84,6 +86,7 @@ class LoadTableCommandTests(TracebaseTestCase):
                 data_sheet=None,
                 verbosity=0,
                 defaults_file=None,
+                debug=settings.DEBUG,
             )
         exc = ar.exception
         self.assertEqual("Missing required options: ['infile'].", str(exc))
@@ -99,6 +102,7 @@ class LoadTableCommandTests(TracebaseTestCase):
             data_sheet=None,
             verbosity=0,
             defaults_file=None,
+            debug=settings.DEBUG,
         )
         # No exception = successful test
 
@@ -113,6 +117,7 @@ class LoadTableCommandTests(TracebaseTestCase):
             data_sheet=None,
             verbosity=0,
             defaults_file="DataRepo/data/tests/load_table/defaults.tsv",
+            debug=settings.DEBUG,
         )
 
     def test_init_required_optname_groups_error(self):
@@ -127,6 +132,7 @@ class LoadTableCommandTests(TracebaseTestCase):
                 data_sheet=None,
                 verbosity=0,
                 defaults_file=None,
+                debug=settings.DEBUG,
             )
         aes = ar.exception
         self.assertEqual(1, len(aes.exceptions))
@@ -262,6 +268,7 @@ class LoadTableCommandTests(TracebaseTestCase):
             defaults_sheet=None,
             defaults_file=None,
             user_headers=None,
+            debug=settings.DEBUG,
         )
         self.assertTrue(hasattr(tc, "loader"))
 
@@ -303,6 +310,7 @@ class LoadTableCommandTests(TracebaseTestCase):
                 "dry_run": False,
                 "defer_rollback": False,
                 "verbosity": 1,
+                "debug": settings.DEBUG,
             }
 
             tc.init_loader()
@@ -352,6 +360,7 @@ class LoadTableCommandTests(TracebaseTestCase):
                 "dry_run": True,
                 "defer_rollback": False,
                 "verbosity": 1,
+                "debug": settings.DEBUG,
             }
 
             tc.init_loader()
@@ -406,6 +415,7 @@ class LoadTableCommandTests(TracebaseTestCase):
             "dry_run": False,
             "defer_rollback": False,
             "verbosity": 0,
+            "debug": settings.DEBUG,
         }
         tc.handle(**opts)
         self.assertEqual("MyDefaults", tc.get_defaults_sheet())
@@ -421,6 +431,7 @@ class LoadTableCommandTests(TracebaseTestCase):
             "dry_run": False,
             "defer_rollback": False,
             "verbosity": 0,
+            "debug": settings.DEBUG,
         }
         tc.handle(**opts)
         self.assertIsNone(tc.get_defaults_sheet())
@@ -436,6 +447,7 @@ class LoadTableCommandTests(TracebaseTestCase):
             "dry_run": False,
             "defer_rollback": False,
             "verbosity": 0,
+            "debug": settings.DEBUG,
         }
         tc.handle(**opts)
         self.assertEqual({"TEST": "Test2"}, tc.get_user_headers())
@@ -463,6 +475,7 @@ class LoadTableCommandTests(TracebaseTestCase):
             "headers": None,
             "dry_run": False,
             "defer_rollback": False,
+            "debug": settings.DEBUG,
             "verbosity": 0,
         }
         tc.handle(**opts)
@@ -487,6 +500,7 @@ class LoadTableCommandTests(TracebaseTestCase):
             "dry_run": False,
             "defer_rollback": False,
             "verbosity": 0,
+            "debug": settings.DEBUG,
         }
         tc.handle(**opts)
         ud_df_as_dict = tc.get_user_defaults().to_dict("records")
@@ -510,6 +524,7 @@ class LoadTableCommandTests(TracebaseTestCase):
             "defer_rollback": False,
             "verbosity": 1,
             "defaults_file": None,
+            "debug": settings.DEBUG,
         }
         tc.init_loader()
 

--- a/DataRepo/utils/exceptions.py
+++ b/DataRepo/utils/exceptions.py
@@ -2031,6 +2031,15 @@ class AggregatedErrorsSet(Exception):
     def should_raise(self):
         return self.is_fatal
 
+    def get_num_errors(self):
+        return self.num_errors
+
+    def get_num_warnings(self):
+        return self.num_warnings
+
+    def print_summary(self):
+        print(self.get_summary_string())
+
     def get_summary_string(self):
         smry_str = ""
         for aes_key in self.aggregated_errors_dict.keys():


### PR DESCRIPTION
## Summary Change Description

### Explanation

`AggregatedErrorsSet` is an exception class meant to contain a series of `AggregatedErrors` exception classes that are organized by both load file and overall checks, e.g. an accucor file, and a check like for missing samples (that can be repeated across multiple files)

`AggregatedErrors` is an exception class that contains all exceptions that arise from running an individual loader.

The problem was that some loaders run other loaders and thus raise `AggregatedErrorsSet` exceptions.  Mostly, this was correctly handled by either merging or appending the different types of errors into the appropriate object, but there was one place where I wasn't checking for `AggregatedErrorsSet` exceptions, which resulted in appending those exceptions to `AggregatedErrors` exceptions inappropriately.  That was in the wrapper that wraps the `handle` methods (called `_handler`) in all of the `Command` scripts.  That's located in `load_table.py`, which defines a superclass for all of the `Command` scripts.

This PR does a few unrelated things as well.  It adds a `--debug` option, updates a bunch of docstrings, and makes a number of improvements to `load_study_set`.

Details:

- Added these methods to `AggregatedErrorsSet`, to make the interfaces similar enough to be able to process the 2 classes in a similar manner.
  - `get_num_errors`
  - `get_num_warnings`
  - `print_summary`
- Made a bunch of docstring updates.
- Made `load_table.py` catch `AggregatedErrorsSet` and raise it.
- Added `--debug` to `load_table.py`
- `load_study_set` changes
  - Removed context manager: `MaintainedModel.defer_autoupdates` so that autoupdates will happen at the end of each study load.
  - Added the ability to skip commented studies.
- Added a validity check of excluded sheets in `load_study.py` to make the error easier to understand.
- Modified archive cleanup message when nothing was there to clean up in the `msruns_loader.py`
- Added a `debug` argument to `TableLoader` and modified all creations of `AggregatedErrors` objects to take a `debug` argument in this and all derived classes.

## Affected Issues/Pull Requests

- Resolves #1428
- Resolves #1305 (a previous PR resolved this, but there were issues, so this actually resolves it)
- Resolves #1389
- Merges into main

## Review Notes

I know this is a big PR. I can split it up if you want, but I'm pushing for the fast approaching publication deadline.

## Checklist
<!--
If any of the checkbox requirements are not met, uncheck them and add an
explanation. E.g. Linting errors pre-date this PR.
-->
This pull request will be merged once the following requirements are met.  The
author and/or reviewers should uncheck any unmet requirements:

- Review requirements
  - Minimum approvals: 1 <!-- Edit as desired (e.g. based on complexity) -->
  - No changes requested
  - All blocking issues resolved by reviewers
  - Specific reviewers: @__add_username_here__
    <!--
    Require reviewers with specific expertise to be included among the minimum
    number of reviewers by tagging them.  Also please send them a message.
    -->
  - Review period: 2 days <!-- Edit as desired (e.g. based on complexity) -->
- Associated issue/pull request requirements:
  <!--
  Assert that all requirements in issues marked "resolved" are done and that
  all required pull requests are merged.  If any are not done, either edit or
  split the issue or explain the unmerged affected pull requests.
  -->
  - [x] All requirements in affected issues marked "resolved" are satisfied
  - [x] All required pull requests are merged *(or none)*
- Basic requirements
  <!--
  Uncheck items to acknowledge failures/conflicts you intend to address.
  Add an explanation if any won't be addressed before merge.
  -->
  - [x] [All linters pass](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#linting)
  - [x] [All tests pass](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#quality-control)
  - [x] All conflicts resolved
- Overhead requirements
  <!--
  These are additional requirements that are not directly associated with
  resolving the affected issue(s).
  -->
  - [x] [New/changed method tests implemented/updated *(or no change)*](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#test-implementation)
  - [ ] [Updated *Unreleased* section of `changelog.md` *(or no change)*](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/changelog.md)
  - [x] [Migrations created & committed *(or no change)*](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#migration-process)
