### PR TITLE
Read dropped folder poc

### DIFF
--- a/DataRepo/forms.py
+++ b/DataRepo/forms.py
@@ -455,7 +455,7 @@ def create_BuildSubmissionForm() -> Type[Form]:
         # run_date.
         sequence_dir = CharField(
             required=False,
-            widget=TextInput(attrs={"id": "sequence_dir_input_id"}),
+            widget=TextInput(attrs={"id": "sequence_dir_input_id", "size": 40}),
         )
 
         # This following fields are for a single file's form, but will be replicated using javascript.  The fields above
@@ -474,7 +474,8 @@ def create_BuildSubmissionForm() -> Type[Form]:
         #   {<peak_annotation_file name>: {"sequence dir": <sequence dir selected>, "scan dir": <scan dir selected>}}
         peak_annot_to_mzxml_metadata = JSONField(
             required=False,
-            widget=HiddenInput(attrs={"id": "peak_annot_to_mzxml_metadata_input_id"}),
+            # widget=HiddenInput(attrs={"id": "peak_annot_to_mzxml_metadata_input_id"}),
+            widget=Textarea(attrs={"id": "peak_annot_to_mzxml_metadata_input_id"}),
         )
 
         @property

--- a/DataRepo/forms.py
+++ b/DataRepo/forms.py
@@ -13,6 +13,7 @@ from django.forms import (
     JSONField,
     Select,
     TextInput,
+    Textarea,
     ValidationError,
     formset_factory,
 )
@@ -454,7 +455,7 @@ def create_BuildSubmissionForm() -> Type[Form]:
         # run_date.
         sequence_dir = CharField(
             required=False,
-            widget=TextInput(attrs={"placeholder": "search term", "id": "sequence_dir_input_id"}),
+            widget=TextInput(attrs={"id": "sequence_dir_input_id"}),
         )
 
         # This following fields are for a single file's form, but will be replicated using javascript.  The fields above
@@ -464,7 +465,8 @@ def create_BuildSubmissionForm() -> Type[Form]:
         mzxml_file_list = JSONField(
             decoder="array",
             required=False,
-            widget=HiddenInput(attrs={"id": "mzxml_file_list_input_id"}),
+            # widget=HiddenInput(attrs={"id": "mzxml_file_list_input_id"}),
+            widget=Textarea(attrs={"id": "mzxml_file_list_input_id"}),
         )
 
         # A mapping of peak annotation files to sequence and scan directories they were built from

--- a/DataRepo/forms.py
+++ b/DataRepo/forms.py
@@ -360,15 +360,12 @@ def create_BuildSubmissionForm() -> Type[Form]:
 
         # "Study doc" (hidden on the start tab)
         study_doc = FileField(
-            required=False, widget=ClearableFileInput(attrs={"multiple": False})
+            required=False, widget=ClearableFileInput(attrs={"multiple": False, "id": "study_doc_input_id"})
         )
 
-        # This following fields are for a single file's form, but will be replicated using javascript.  The fields above
-        # should only occur once, but all should be a part of the same form submission.
-
-        peak_annotation_file = FileField(
+        peak_annotation_files = MultipleFileField(
             required=False,
-            widget=ClearableFileInput(attrs={"multiple": False}),
+            widget=MultipleFileInput(attrs={"multiple": True, "id": "peak_annotation_files_input_id"}),
         )
 
         # The following fields are for specifying sequence details for each peak annotation file (and will also be
@@ -445,6 +442,37 @@ def create_BuildSubmissionForm() -> Type[Form]:
                     "autocomplete": "off",
                 },
             ),
+        )
+
+        # This will contain a directory path relative to the study directory that corresponds to a single MSRunSequence.
+        # The directory path should go no deeper than the first one directory containing mzXML files.  E.g. no "scan2"
+        # or "scan3" directories should be added to this field.  The purpose is to have only 1 form in a series of form
+        # rows that corresponds to a unique MSRunSequence.
+        # NOTE: THIS IS NOT THE sequence_dir FROM THE SELECT LIST NEXT TO EACH PEAK ANNOTATION FILE, NOR DOES THERE
+        # EXIST A scan_dir FIELD.  BOTH OF THOSE SELECT LISTS SERVE TO POPULATE THE JSON IN THE
+        # peak_annot_to_mzxml_metadata FIELD.  THIS FIELD APPEARS ON A FORM ROW WITH operator, protocol, instrument, and
+        # run_date.
+        sequence_dir = CharField(
+            required=False,
+            widget=TextInput(attrs={"placeholder": "search term", "id": "sequence_dir_input_id"}),
+        )
+
+        # This following fields are for a single file's form, but will be replicated using javascript.  The fields above
+        # should only occur once, but all should be a part of the same form submission.
+
+        # This will contain a master list of all mzXML file paths (relative to the study directory).
+        mzxml_file_list = JSONField(
+            decoder="array",
+            required=False,
+            widget=HiddenInput(attrs={"id": "mzxml_file_list_input_id"}),
+        )
+
+        # A mapping of peak annotation files to sequence and scan directories they were built from
+        # JSON example (constructed by javascript triggered by selecting from select lists built by javascript):
+        #   {<peak_annotation_file name>: {"sequence dir": <sequence dir selected>, "scan dir": <scan dir selected>}}
+        peak_annot_to_mzxml_metadata = JSONField(
+            required=False,
+            widget=HiddenInput(attrs={"id": "peak_annot_to_mzxml_metadata_input_id"}),
         )
 
         @property

--- a/DataRepo/forms.py
+++ b/DataRepo/forms.py
@@ -360,12 +360,12 @@ def create_BuildSubmissionForm() -> Type[Form]:
 
         # "Study doc" (hidden on the start tab)
         study_doc = FileField(
-            required=False, widget=ClearableFileInput(attrs={"multiple": False, "id": "study_doc_input_id"})
+            required=False, widget=ClearableFileInput(attrs={"multiple": False})
         )
 
         peak_annotation_files = MultipleFileField(
             required=False,
-            widget=MultipleFileInput(attrs={"multiple": True, "id": "peak_annotation_files_input_id"}),
+            widget=MultipleFileInput(attrs={"multiple": True}),
         )
 
         # The following fields are for specifying sequence details for each peak annotation file (and will also be

--- a/DataRepo/forms.py
+++ b/DataRepo/forms.py
@@ -361,7 +361,8 @@ def create_BuildSubmissionForm() -> Type[Form]:
 
         # "Study doc" (hidden on the start tab)
         study_doc = FileField(
-            required=False, widget=ClearableFileInput(attrs={"multiple": False})
+            required=False,
+            widget=ClearableFileInput(attrs={"multiple": False})
         )
 
         peak_annotation_files = MultipleFileField(

--- a/DataRepo/templates/submission/includes/1_start.html
+++ b/DataRepo/templates/submission/includes/1_start.html
@@ -17,7 +17,7 @@
                     <div id="raw-drop-area">
                         <!-- Hidden form that does not submit - just used as a target to drop files, from which, just their names are extracted to populate the other form's hidden character input -->
                         <label class="btn btn-secondary">
-                            <input type="file" multiple id="raw-drop-area-input" onchange="handleFiles(this.files, 'raw');"/>
+                            <input type="file" webkitdirectory multiple id="raw-drop-area-input" onchange="handleFiles(this.files, 'raw');"/>
                             Choose Folder
                         </label>  <span class="drop-area-message">(Drop raw data folder)</span>
                     </div>
@@ -26,7 +26,7 @@
                     <table>
                         <!-- 'form-set-row' identifies the duplicated row as one belonging to the final submitted formset.  The javascript code in submission_start.js has this value hard-coded inside the code that prepares the formset for submission.  All of the other IDs on this page are initialized using variables as arguments in calls to init methods in submission.html, with a few exceptions. -->
                         <tr style="vertical-align: middle;" name="form-set-row" id="drop-raw-metadata-row-template">
-                            <td style="display: none;" id="UnHideMe">
+                            <td style="display: none;" class="UnHideMe">
                                 <!-- id="sequence_dir_input_id" -->
                                 {{ form.sequence_dir }}
                             </td>
@@ -67,24 +67,28 @@
         <div id="single-form-elems"> <!--  style="display: none;"> -->
             <!-- These are intentionally hidden and controlled by javascript -->
 
+NORMALLY HIDDEN vvv
             <!-- On this page, this is always "autofill" -->
             {{ form.mode }}
 
+mzXML file list
             <!-- The JSON data that is a list of mzXML filepaths (relative to the dropped study folder) -->
             <!-- id="mzxml_file_list_input_id" -->
             {{ form.mzxml_file_list }}
 
-NORMALLY HIDDEN PEAK ANNOT FILES vvv
+annot files
             <!-- The peak annotation files and their metadata (the default sequence directory containing all of the mzXML files in the sequence and the default scan directory (containing all of the mzXML files that were used to produce the peak annotation file)) -->
             <!-- id="peak_annotation_files_input_id" -->
             {{ form.peak_annotation_files }}
-NORMALLY HIDDEN PEAK ANNOT FILES ^^^
+annot file metadata
             <!-- id="peak_annot_to_mzxml_metadata_input_id" -->
             {{ form.peak_annot_to_mzxml_metadata }}
 
+study doc
             <!-- The study doc, currently not supported on this page, but will eventually be an option for autofilling an existing study doc -->
             <!-- id="study_doc_input_id" -->
             {{ form.study_doc }}
+NORMALLY HIDDEN ^^^
         </div>
 
         <br>

--- a/DataRepo/templates/submission/includes/1_start.html
+++ b/DataRepo/templates/submission/includes/1_start.html
@@ -5,59 +5,30 @@
     <h3>Start a Submission</h3>
     <span class="small text-muted">Generate a Study Submission Template with auto-filled samples and compounds extracted from your peak annotation files (e.g. AccuCor) along with other supporting data from the database.</span><br><br>
     <label for="peak_annotation_file" class="tight-form-label">
-        Peak Annotation Files:
-        <span class="small"><span class="small text-muted">(e.g. AccuCor, IsoCorr, and/or IsoAutoCorr files)</span></span>
+        Raw Data Folder:
+        <span class="small"><span class="small text-muted">(containing mzXML files. Other files ignored.)</span></span>
     </label>
-    <!-- The 2 form strategy (the one below for adding (mzXML) file names by drag and drop of the actual files and the one above to just submit their names (because that's all we need, and these files can be numerous and large) is based on https://stackoverflow.com/questions/2175831/is-it-possible-to-use-input-type-file-just-to-post-the-filename-without-actu -->
+
+    <!-- This form section is just for show.  None of thois is actually submitted.  In totally controls/populates the hidden form elements in the form above, namely: form.peak_annotation_files and form.peak_annot_to_mzxml_metadata -->
     <form class="tbform-control">
         <table>
-            <tr>
-                <td>
-                    <div id="annot-drop-area">
-                        <!-- Hidden form that does not submit - just used as a target to drop files, from which, just their names are extracted to populate the other form's hidden character input -->
-                        <label class="btn btn-secondary">
-                            <input type="file" multiple id="annot-drop-area-input" onchange="handleFiles(this.files);"/>
-                            Choose Files
-                        </label>  <span class="drop-area-message">(Drop peak annotation files here)</span>
-                    </div>
-                </td>
-                <td style="vertical-align: middle;">
-                    <table>
-                        <tr style="vertical-align: middle;" name="drop-annot-metadata-row" id="drop-annot-metadata-row-template">
-                            <td style="display: none;" id="fileColumn">
-                                {{ form.peak_annotation_file }}
-                            </td>
-                            <td>
-                                {{ form.operator }}
-                            </td>
-                            <td>
-                                {{ form.instrument }}
-                            </td>
-                            <td>
-                                {{ form.protocol }}
-                            </td>
-                            <td>
-                                {{ form.run_date }}
-                            </td>
-                        </tr>
-                    </table>
-                </td>
-            </tr>
             <tr>
                 <td>
                     <div id="raw-drop-area">
                         <!-- Hidden form that does not submit - just used as a target to drop files, from which, just their names are extracted to populate the other form's hidden character input -->
                         <label class="btn btn-secondary">
                             <input type="file" multiple id="raw-drop-area-input" onchange="handleFiles(this.files);"/>
-                            Choose Files
-                        </label>  <span class="drop-area-message">(Drop MS data folder here)</span>
+                            Choose Folder
+                        </label>  <span class="drop-area-message">(Drop raw data folder)</span>
                     </div>
                 </td>
                 <td style="vertical-align: middle;">
                     <table>
-                        <tr style="vertical-align: middle;" name="drop-annot-metadata-row" id="drop-annot-metadata-row-template">
-                            <td style="display: none;" id="fileColumn">
-                                {{ form.peak_annotation_file }}
+                        <!-- 'form-set-row' identifies the duplicated row as one belonging to the final submitted formset.  The javascript code in submission_start.js has this value hard-coded inside the code that prepares the formset for submission.  All of the other IDs on this page are initialized using variables as arguments in calls to init methods in submission.html, with a few exceptions. -->
+                        <tr style="vertical-align: middle;" name="form-set-row" id="drop-raw-metadata-row-template">
+                            <td style="display: none;" id="UnHideMe">
+                                <!-- id="sequence_dir_input_id" -->
+                                {{ form.sequence_dir }}
                             </td>
                             <td>
                                 {{ form.operator }}
@@ -88,18 +59,29 @@
         {{ form.run_date_datalist }}
 
         <div class="level-indent">
-            <!-- Peak annotation file forms will be added to this table via javascript -->
-            <table id="peak-annot-forms-elem">
+            <!-- Sequence forms will be added to this table via javascript -->
+            <table id="sequence-forms-elem">
             </table>
         </div>
 
         <div id="single-form-elems" style="display: none;">
+            <!-- These are intentionally hidden and controlled by javascript -->
+
+            <!-- On this page, this is always "autofill" -->
             {{ form.mode }}
 
-            <label for="study_doc" class="tight-form-label">
-                Study doc:
-                <span class="small"><span class="small text-muted">(OPTIONAL <span class="fst-italic">excel</span>, if exists)</span></span>
-            </label>
+            <!-- The JSON data that is a list of mzXML filepaths (relative to the dropped study folder) -->
+            <!-- id="mzxml_file_list_input_id" -->
+            {{ form.mzxml_file_list }}
+
+            <!-- The peak annotation files and their metadata (the default sequence directory containing all of the mzXML files in the sequence and the default scan directory (containing all of the mzXML files that were used to produce the peak annotation file)) -->
+            <!-- id="peak_annotation_files_input_id" -->
+            {{ form.peak_annotation_files }}
+            <!-- id="peak_annot_to_mzxml_metadata_input_id" -->
+            {{ form.peak_annot_to_mzxml_metadata }}
+
+            <!-- The study doc, currently not supported on this page, but will eventually be an option for autofilling an existing study doc -->
+            <!-- id="study_doc_input_id" -->
             {{ form.study_doc }}
         </div>
 
@@ -114,13 +96,67 @@
                 </ul>
             {% endif %}
         </span>
-
-        <button type="submit" class="btn btn-primary" id="submit">Download Template</button>
-        <button type="reset" class="btn btn-secondary" id="clear" onclick="document.getElementById('annot-drop-area-input').value = null;document.getElementById('submission-validation').reset();clearPeakAnnotFiles();disablePeakAnnotForm();">Clear</button>
-        {% if results %}
-            <a class="btn {% if valid %}btn-success{% elif state == 'FAILED' %}btn-danger{% elif state == 'WARNING' %}btn-warning{% else %}btn-secondary{% endif %}" href="{% url 'submission' %}?page=Fill%20In" role="button" style="float: right;">Next</a>
-        {% endif %}
     </form>
+
+    <label for="peak_annotation_file" class="tight-form-label">
+        Peak Annotation Files:
+        <span class="small"><span class="small text-muted">(e.g. AccuCor, IsoCorr, and/or IsoAutoCorr files)</span></span>
+    </label>
+
+    <!-- This form section is just for show.  None of thois is actually submitted.  In totally controls/populates the hidden form elements in the form above, namely: form.peak_annotation_files and form.peak_annot_to_mzxml_metadata -->
+    <form class="tbform-control">
+        <table>
+            <tr>
+                <td>
+                    <div id="annot-drop-area">
+                        <!-- Hidden form that does not submit - just used as a target to drop files, from which, just their names are extracted to populate the other form's hidden character input -->
+                        <label class="btn btn-secondary">
+                            <input type="file" multiple id="annot-drop-area-input" onchange="handleFiles(this.files);"/>
+                            Add Files
+                        </label>  <span class="drop-area-message">(Drop peak annotation files)</span>
+                    </div>
+                </td>
+                <td style="vertical-align: middle;">
+                    <table>
+                        <tr style="vertical-align: middle;" name="drop-annot-metadata-row" id="drop-annot-metadata-row-template">
+                            <td style="display: none;" id="UnHideMe">
+                                <input type="text" name="peak_annotation_file" id="peak_annotation_file" />
+                            </td>
+                            <td style="display: none;" id="UnHideMe">
+                                <select name="default_sequence_dir" id="default_sequence_dir">
+                                    <!-- Populated and selection made by javascript when a study directory is dropped on the raw data folder input -->
+                                </select>
+                            </td>
+                            <td style="display: none;" id="UnHideMe">
+                                <select name="default_scan_dir" id="default_scan_dir">
+                                    <!-- Populated and selection made by javascript when a study directory is dropped on the raw data folder input -->
+                                </select>
+                            </td>
+                        </tr>
+                    </table>
+                </td>
+            </tr>
+        </table>
+    </form>
+
+    <!-- This form is just for javascript -->
+    <form class="tbform-control">
+        <div class="level-indent">
+            <!-- Peak annotation file forms will be added to this table via javascript to update the form.peak_annot_to_mzxml_metadata JSON for selections in default_sequence_dir and default_scan_dir.  Rows are added when peak annotation files are dropped onto the annot-drop-area-input. -->
+            <!-- TODO: A future feature would be to make default selections here based on matching peak annotation file names from the directory walk, but currently, that's not implemented. -->
+            <table id="peak-annot-forms-elem">
+            </table>
+        </div>
+    </form>
+
+    <br>
+
+    <button type="submit" class="btn btn-primary" onclick="document.getElementById('submission-validation').submit();">Download Template</button>
+    <button type="reset" class="btn btn-secondary" id="clear" onclick="document.getElementById('annot-drop-area-input').value = null;document.getElementById('submission-validation').reset();clearPeakAnnotFiles();disablePeakAnnotForm();">Clear</button>
+    {% if results %}
+        <a class="btn {% if valid %}btn-success{% elif state == 'FAILED' %}btn-danger{% elif state == 'WARNING' %}btn-warning{% else %}btn-secondary{% endif %}" href="{% url 'submission' %}?page=Fill%20In" role="button" style="float: right;">Next</a>
+    {% endif %}
+
 </div>
 
 

--- a/DataRepo/templates/submission/includes/1_start.html
+++ b/DataRepo/templates/submission/includes/1_start.html
@@ -17,7 +17,7 @@
                     <div id="raw-drop-area">
                         <!-- Hidden form that does not submit - just used as a target to drop files, from which, just their names are extracted to populate the other form's hidden character input -->
                         <label class="btn btn-secondary">
-                            <input type="file" webkitdirectory multiple id="raw-drop-area-input" onchange="handleFiles(this.files, 'raw');"/>
+                            <input type="file" webkitdirectory id="raw-drop-area-input" onchange="handleFiles(this.files, 'raw-drop-area');"/>
                             Choose Folder
                         </label>  <span class="drop-area-message">(Drop raw data folder)</span>
                     </div>
@@ -117,7 +117,7 @@ NORMALLY HIDDEN ^^^
                     <div id="annot-drop-area">
                         <!-- Hidden form that does not submit - just used as a target to drop files, from which, just their names are extracted to populate the other form's hidden character input -->
                         <label class="btn btn-secondary">
-                            <input type="file" multiple id="annot-drop-area-input" onchange="handleFiles(this.files, 'annot');"/>
+                            <input type="file" multiple id="annot-drop-area-input" onchange="handleFiles(this.files, 'annot-drop-area');"/>
                             Add Files
                         </label>  <span class="drop-area-message">(Drop peak annotation files)</span>
                     </div>
@@ -156,7 +156,7 @@ NORMALLY HIDDEN ^^^
     <br>
 
     <button type="submit" class="btn btn-primary" id="submit" onclick="document.getElementById('submission-validation').submit();">Download Template</button>
-    <button type="reset" class="btn btn-secondary" id="clear" onclick="document.getElementById('annot-drop-area-input').value = null;document.getElementById('submission-validation').reset();clearPeakAnnotFiles();disablePeakAnnotForm();">Clear</button>
+    <button type="reset" class="btn btn-secondary" id="clear" onclick="clearSubmissionForm();">Clear</button>
     {% if results %}
         <a class="btn {% if valid %}btn-success{% elif state == 'FAILED' %}btn-danger{% elif state == 'WARNING' %}btn-warning{% else %}btn-secondary{% endif %}" href="{% url 'submission' %}?page=Fill%20In" role="button" style="float: right;">Next</a>
     {% endif %}

--- a/DataRepo/templates/submission/includes/1_start.html
+++ b/DataRepo/templates/submission/includes/1_start.html
@@ -13,12 +13,44 @@
         <table>
             <tr>
                 <td>
-                    <div id="drop-area">
+                    <div id="annot-drop-area">
                         <!-- Hidden form that does not submit - just used as a target to drop files, from which, just their names are extracted to populate the other form's hidden character input -->
                         <label class="btn btn-secondary">
-                            <input type="file" multiple id="drop-area-input" onchange="handleFiles(this.files);"/>
+                            <input type="file" multiple id="annot-drop-area-input" onchange="handleFiles(this.files);"/>
                             Choose Files
-                        </label>  <span class="drop-area-message">(Drag and drop here)</span>
+                        </label>  <span class="drop-area-message">(Drop peak annotation files here)</span>
+                    </div>
+                </td>
+                <td style="vertical-align: middle;">
+                    <table>
+                        <tr style="vertical-align: middle;" name="drop-annot-metadata-row" id="drop-annot-metadata-row-template">
+                            <td style="display: none;" id="fileColumn">
+                                {{ form.peak_annotation_file }}
+                            </td>
+                            <td>
+                                {{ form.operator }}
+                            </td>
+                            <td>
+                                {{ form.instrument }}
+                            </td>
+                            <td>
+                                {{ form.protocol }}
+                            </td>
+                            <td>
+                                {{ form.run_date }}
+                            </td>
+                        </tr>
+                    </table>
+                </td>
+            </tr>
+            <tr>
+                <td>
+                    <div id="raw-drop-area">
+                        <!-- Hidden form that does not submit - just used as a target to drop files, from which, just their names are extracted to populate the other form's hidden character input -->
+                        <label class="btn btn-secondary">
+                            <input type="file" multiple id="raw-drop-area-input" onchange="handleFiles(this.files);"/>
+                            Choose Files
+                        </label>  <span class="drop-area-message">(Drop MS data folder here)</span>
                     </div>
                 </td>
                 <td style="vertical-align: middle;">
@@ -84,7 +116,7 @@
         </span>
 
         <button type="submit" class="btn btn-primary" id="submit">Download Template</button>
-        <button type="reset" class="btn btn-secondary" id="clear" onclick="document.getElementById('drop-area-input').value = null;document.getElementById('submission-validation').reset();clearPeakAnnotFiles();disablePeakAnnotForm();">Clear</button>
+        <button type="reset" class="btn btn-secondary" id="clear" onclick="document.getElementById('annot-drop-area-input').value = null;document.getElementById('submission-validation').reset();clearPeakAnnotFiles();disablePeakAnnotForm();">Clear</button>
         {% if results %}
             <a class="btn {% if valid %}btn-success{% elif state == 'FAILED' %}btn-danger{% elif state == 'WARNING' %}btn-warning{% else %}btn-secondary{% endif %}" href="{% url 'submission' %}?page=Fill%20In" role="button" style="float: right;">Next</a>
         {% endif %}

--- a/DataRepo/templates/submission/includes/1_start.html
+++ b/DataRepo/templates/submission/includes/1_start.html
@@ -17,7 +17,7 @@
                     <div id="raw-drop-area">
                         <!-- Hidden form that does not submit - just used as a target to drop files, from which, just their names are extracted to populate the other form's hidden character input -->
                         <label class="btn btn-secondary">
-                            <input type="file" multiple id="raw-drop-area-input" onchange="handleFiles(this.files);"/>
+                            <input type="file" multiple id="raw-drop-area-input" onchange="handleFiles(this.files, 'raw');"/>
                             Choose Folder
                         </label>  <span class="drop-area-message">(Drop raw data folder)</span>
                     </div>
@@ -64,7 +64,7 @@
             </table>
         </div>
 
-        <div id="single-form-elems" style="display: none;">
+        <div id="single-form-elems"> <!--  style="display: none;"> -->
             <!-- These are intentionally hidden and controlled by javascript -->
 
             <!-- On this page, this is always "autofill" -->
@@ -74,9 +74,11 @@
             <!-- id="mzxml_file_list_input_id" -->
             {{ form.mzxml_file_list }}
 
+NORMALLY HIDDEN PEAK ANNOT FILES vvv
             <!-- The peak annotation files and their metadata (the default sequence directory containing all of the mzXML files in the sequence and the default scan directory (containing all of the mzXML files that were used to produce the peak annotation file)) -->
             <!-- id="peak_annotation_files_input_id" -->
             {{ form.peak_annotation_files }}
+NORMALLY HIDDEN PEAK ANNOT FILES ^^^
             <!-- id="peak_annot_to_mzxml_metadata_input_id" -->
             {{ form.peak_annot_to_mzxml_metadata }}
 
@@ -103,7 +105,7 @@
         <span class="small"><span class="small text-muted">(e.g. AccuCor, IsoCorr, and/or IsoAutoCorr files)</span></span>
     </label>
 
-    <!-- This form section is just for show.  None of thois is actually submitted.  In totally controls/populates the hidden form elements in the form above, namely: form.peak_annotation_files and form.peak_annot_to_mzxml_metadata -->
+    <!-- This form section is just for show.  None of this is actually submitted.  In totally controls/populates the hidden form elements in the form above, namely: form.peak_annotation_files and form.peak_annot_to_mzxml_metadata -->
     <form class="tbform-control">
         <table>
             <tr>
@@ -111,7 +113,7 @@
                     <div id="annot-drop-area">
                         <!-- Hidden form that does not submit - just used as a target to drop files, from which, just their names are extracted to populate the other form's hidden character input -->
                         <label class="btn btn-secondary">
-                            <input type="file" multiple id="annot-drop-area-input" onchange="handleFiles(this.files);"/>
+                            <input type="file" multiple id="annot-drop-area-input" onchange="handleFiles(this.files, 'annot');"/>
                             Add Files
                         </label>  <span class="drop-area-message">(Drop peak annotation files)</span>
                     </div>
@@ -119,18 +121,16 @@
                 <td style="vertical-align: middle;">
                     <table>
                         <tr style="vertical-align: middle;" name="drop-annot-metadata-row" id="drop-annot-metadata-row-template">
-                            <td style="display: none;" id="UnHideMe">
-                                <input type="text" name="peak_annotation_file" id="peak_annotation_file" />
+                            <td style="display: none;" class="UnHideMe">
+                                <span name="peak_annotation_file" id="peak_annotation_file"></span>
                             </td>
-                            <td style="display: none;" id="UnHideMe">
-                                <select name="default_sequence_dir" id="default_sequence_dir">
-                                    <!-- Populated and selection made by javascript when a study directory is dropped on the raw data folder input -->
-                                </select>
+                            <td style="display: none;" class="UnHideMe">
+                                <!-- Populated and selection made by javascript when a study directory is dropped on the raw data folder input -->
+                                <select name="default_sequence_dir" id="default_sequence_dir"></select>
                             </td>
-                            <td style="display: none;" id="UnHideMe">
-                                <select name="default_scan_dir" id="default_scan_dir">
-                                    <!-- Populated and selection made by javascript when a study directory is dropped on the raw data folder input -->
-                                </select>
+                            <td style="display: none;" class="UnHideMe">
+                                <!-- Populated and selection made by javascript when a study directory is dropped on the raw data folder input -->
+                                <select name="default_scan_dir" id="default_scan_dir"></select>
                             </td>
                         </tr>
                     </table>
@@ -151,7 +151,7 @@
 
     <br>
 
-    <button type="submit" class="btn btn-primary" onclick="document.getElementById('submission-validation').submit();">Download Template</button>
+    <button type="submit" class="btn btn-primary" id="submit" onclick="document.getElementById('submission-validation').submit();">Download Template</button>
     <button type="reset" class="btn btn-secondary" id="clear" onclick="document.getElementById('annot-drop-area-input').value = null;document.getElementById('submission-validation').reset();clearPeakAnnotFiles();disablePeakAnnotForm();">Clear</button>
     {% if results %}
         <a class="btn {% if valid %}btn-success{% elif state == 'FAILED' %}btn-danger{% elif state == 'WARNING' %}btn-warning{% else %}btn-secondary{% endif %}" href="{% url 'submission' %}?page=Fill%20In" role="button" style="float: right;">Next</a>

--- a/DataRepo/templates/submission/includes/1_start.html
+++ b/DataRepo/templates/submission/includes/1_start.html
@@ -1,6 +1,8 @@
 {% load customtags %}
 {% load static %}
 
+<div id="overlay"></div>
+<div id="popup"></div>
 <div>
     <h3>Start a Submission</h3>
     <span class="small text-muted">Generate a Study Submission Template with auto-filled samples and compounds extracted from your peak annotation files (e.g. AccuCor) along with other supporting data from the database.</span><br><br>
@@ -64,31 +66,30 @@
             </table>
         </div>
 
-        <div id="single-form-elems"> <!--  style="display: none;"> -->
+        <div id="single-form-elems" style="display: none;">
             <!-- These are intentionally hidden and controlled by javascript -->
 
-NORMALLY HIDDEN vvv
             <!-- On this page, this is always "autofill" -->
             {{ form.mode }}
 
-mzXML file list
+            mzXML file list
             <!-- The JSON data that is a list of mzXML filepaths (relative to the dropped study folder) -->
             <!-- id="mzxml_file_list_input_id" -->
             {{ form.mzxml_file_list }}
 
-annot files
+            annot files
             <!-- The peak annotation files and their metadata (the default sequence directory containing all of the mzXML files in the sequence and the default scan directory (containing all of the mzXML files that were used to produce the peak annotation file)) -->
             <!-- id="peak_annotation_files_input_id" -->
             {{ form.peak_annotation_files }}
-annot file metadata
+
+            annot file metadata
             <!-- id="peak_annot_to_mzxml_metadata_input_id" -->
             {{ form.peak_annot_to_mzxml_metadata }}
 
-study doc
+            study doc
             <!-- The study doc, currently not supported on this page, but will eventually be an option for autofilling an existing study doc -->
             <!-- id="study_doc_input_id" -->
             {{ form.study_doc }}
-NORMALLY HIDDEN ^^^
         </div>
 
         <br>
@@ -154,6 +155,10 @@ NORMALLY HIDDEN ^^^
     </form>
 
     <br>
+
+    Debug:
+    <button type="button" onclick="document.getElementById('single-form-elems').style.display = 'block';">Show</button>
+    <button type="button" onclick="document.getElementById('single-form-elems').style.display = 'none';">Hide</button><br><br>
 
     <button type="submit" class="btn btn-primary" id="submit" onclick="document.getElementById('submission-validation').submit();">Download Template</button>
     <button type="reset" class="btn btn-secondary" id="clear" onclick="clearSubmissionForm();">Clear</button>

--- a/DataRepo/templates/submission/includes/3_validate.html
+++ b/DataRepo/templates/submission/includes/3_validate.html
@@ -93,7 +93,7 @@
 
         <a class="btn {% if valid %}btn-success{% elif state == 'FAILED' %}btn-danger{% elif state == 'WARNING' %}btn-warning{% else %}btn-secondary{% endif %}" href="{% url 'submission' %}?page=Submit" role="button" style="float: right;">{% if results %}Next{% else %}Skip{% endif %}</a>
         <button type="submit" class="btn btn-primary" id="submit">Validate &amp; Repair</button>
-        <button type="reset" class="btn btn-secondary" id="clear" onclick="document.getElementById('drop-area-input').value = null;document.getElementById('submission-validation').reset();clearPeakAnnotFiles();disablePeakAnnotForm();">Clear</button>
+        <button type="reset" class="btn btn-secondary" id="clear" onclick="clearSubmissionForm();">Clear</button>
     </form>
 </div>
 

--- a/DataRepo/templates/submission/submission.html
+++ b/DataRepo/templates/submission/submission.html
@@ -28,7 +28,20 @@
                 initDropArea(
                     document.getElementById('annot-drop-area'),
                     addPeakAnnotFileToUpload,
-                    afterAddingFiles
+                    afterAddingPeakAnnotFiles
+                );
+                initMzxmlMetadataUploads(
+                    document.getElementById('drop-raw-metadata-row-template'),
+                    document.getElementById('sequence-forms-elem'),
+                    document.getElementById('raw-drop-area-input'),
+                    document.getElementById("submission-validation"),
+                    document.getElementById("single-form-elems"),
+                    studyDocInput
+                );
+                initDropArea(
+                    document.getElementById('raw-drop-area'),
+                    null,
+                    refreshMzxmlMetadata
                 );
             })
         </script>

--- a/DataRepo/templates/submission/submission.html
+++ b/DataRepo/templates/submission/submission.html
@@ -20,13 +20,13 @@
                 initPeakAnnotUploads(
                     document.getElementById('drop-annot-metadata-row-template'),
                     document.getElementById('peak-annot-forms-elem'),
-                    document.getElementById('drop-area-input'),
+                    document.getElementById('annot-drop-area-input'),
                     document.getElementById("submission-validation"),
                     document.getElementById("single-form-elems"),
                     studyDocInput
                 );
                 initDropArea(
-                    document.getElementById('drop-area'),
+                    document.getElementById('annot-drop-area'),
                     addPeakAnnotFileToUpload,
                     afterAddingFiles
                 );

--- a/DataRepo/templates/submission/submission.html
+++ b/DataRepo/templates/submission/submission.html
@@ -29,12 +29,11 @@
                     annotFilesInput
                 );
                 initDropArea(
-                    'annot',  // Key used to store/access drop area data
                     document.getElementById('annot-drop-area'),
                     null,
                     afterAddingPeakAnnotFiles
                 );
-                initMzxmlMetadataUploads(
+                initStudyMetadataUploads(
                     document.getElementById('drop-raw-metadata-row-template'),
                     document.getElementById('sequence-forms-elem'),
                     document.getElementById('raw-drop-area-input'),
@@ -43,10 +42,9 @@
                     studyDocInput
                 );
                 initDropArea(
-                    'raw',  // Key used to store/access drop area data
                     document.getElementById('raw-drop-area'),
                     null,
-                    refreshMzxmlMetadata
+                    refreshStudyMetadata
                 );
             })
         </script>

--- a/DataRepo/templates/submission/submission.html
+++ b/DataRepo/templates/submission/submission.html
@@ -17,28 +17,33 @@
             document.addEventListener("DOMContentLoaded", function(){
                 let tmpElems = document.getElementsByName("study_doc");
                 let studyDocInput = tmpElems[0];
+                tmpElems = document.getElementsByName("peak_annotation_files");
+                let annotFilesInput = tmpElems[0];
                 initPeakAnnotUploads(
                     document.getElementById('drop-annot-metadata-row-template'),
                     document.getElementById('peak-annot-forms-elem'),
                     document.getElementById('annot-drop-area-input'),
-                    document.getElementById("submission-validation"),
-                    document.getElementById("single-form-elems"),
-                    studyDocInput
+                    document.getElementById('submission-validation'),
+                    document.getElementById('single-form-elems'),
+                    studyDocInput,
+                    annotFilesInput
                 );
                 initDropArea(
+                    'annot',  // Key used to store/access drop area data
                     document.getElementById('annot-drop-area'),
-                    addPeakAnnotFileToUpload,
+                    null,
                     afterAddingPeakAnnotFiles
                 );
                 initMzxmlMetadataUploads(
                     document.getElementById('drop-raw-metadata-row-template'),
                     document.getElementById('sequence-forms-elem'),
                     document.getElementById('raw-drop-area-input'),
-                    document.getElementById("submission-validation"),
-                    document.getElementById("single-form-elems"),
+                    document.getElementById('submission-validation'),
+                    document.getElementById('single-form-elems'),
                     studyDocInput
                 );
                 initDropArea(
+                    'raw',  // Key used to store/access drop area data
                     document.getElementById('raw-drop-area'),
                     null,
                     refreshMzxmlMetadata

--- a/DataRepo/templates/submission/submission.html
+++ b/DataRepo/templates/submission/submission.html
@@ -19,6 +19,8 @@
                 let studyDocInput = tmpElems[0];
                 tmpElems = document.getElementsByName("peak_annotation_files");
                 let annotFilesInput = tmpElems[0];
+                tmpElems = document.getElementsByName("peak_annot_to_mzxml_metadata");
+                let annotToMzxmlInput = tmpElems[0];
                 initPeakAnnotUploads(
                     document.getElementById('drop-annot-metadata-row-template'),
                     document.getElementById('peak-annot-forms-elem'),
@@ -26,7 +28,8 @@
                     document.getElementById('submission-validation'),
                     document.getElementById('single-form-elems'),
                     studyDocInput,
-                    annotFilesInput
+                    annotFilesInput,
+                    annotToMzxmlInput
                 );
                 initDropArea(
                     document.getElementById('annot-drop-area'),

--- a/DataRepo/utils/exceptions.py
+++ b/DataRepo/utils/exceptions.py
@@ -5345,6 +5345,37 @@ class MultipleStudyDocVersions(StudyDocVersionException):
         self.matching_version_numbers = matching_version_numbers
 
 
+class MzxmlsWithoutSequences(Exception):
+    def __init__(self, mzxml_filepaths: List[str], sequence_dirs: List[str], suggestion=None):
+        nlt = "\n\t"
+        message = (
+            "None of the supplied sequence directories:\n"
+            f"\t{nlt.join(sequence_dirs)}\n"
+            "matched the following mzXML files:\n"
+            f"\t{nlt.join(mzxml_filepaths)}"
+        )
+        if suggestion is not None:
+            message += f"\n{suggestion}"
+        super().__init__(message)
+        self.mzxml_filepaths = mzxml_filepaths
+        self.sequence_dirs = sequence_dirs
+        self.suggestion = suggestion
+
+
+class SequencesWithoutMzxmls(Exception):
+    def __init__(self, empty_sequence_dirs: List[str], suggestion=None):
+        nlt = "\n\t"
+        message = (
+            "The following sequence directories either didn't exist or contained no mzXML files:\n"
+            f"\t{nlt.join(empty_sequence_dirs)}"
+        )
+        if suggestion is not None:
+            message += f"\n{suggestion}"
+        super().__init__(message)
+        self.empty_sequence_dirs = empty_sequence_dirs
+        self.suggestion = suggestion
+
+
 def generate_file_location_string(column=None, rownum=None, sheet=None, file=None):
     loc_str = ""
     if column is not None:

--- a/DataRepo/views/upload/submission.py
+++ b/DataRepo/views/upload/submission.py
@@ -1,4 +1,5 @@
 import base64
+import json
 import os.path
 import posixpath
 import warnings
@@ -789,10 +790,10 @@ class BuildSubmissionView(FormView):
                     # record (containing a specific mzXML) to link PeakGroup records to using the sample name (derived
                     # from the mzXML filename and the peak annotation header) and the sequence (via the selected
                     # directory)
-                    self.peak_annot_to_mzxml_metadata = rowform.get("peak_annot_to_mzxml_metadata")
+                    self.peak_annot_to_mzxml_metadata = json.loads(rowform.get("peak_annot_to_mzxml_metadata"))
 
-                    # Masterlist of mzXML filepaths
-                    mzxml_file_list = rowform.get("mzxml_file_list")
+                    # Masterlist of mzXML filepaths containing relative paths from the study(/mzxml) folder
+                    mzxml_file_list = json.loads(rowform.get("mzxml_file_list"))
                     for mzxml_filepath in mzxml_file_list:
                         if mzxml_filepath in self.mzxml_file_to_seq_dir.keys():
                             raise ProgrammingError(

--- a/static/css/drop_area.css
+++ b/static/css/drop_area.css
@@ -37,3 +37,29 @@
     vertical-align: middle;
     height: 100%;
 }
+
+#raw-drop-area {
+  border: 2px dashed #ccc;
+  border-radius: 20px;
+  width: 510px;
+  height: 130px;
+  font-family: sans-serif;
+  margin: 10px;
+  padding: 20px;
+}
+
+#raw-drop-area.highlight {
+  border-color: purple;
+}
+
+#raw-drop-area-input {
+  display: none;
+}
+
+/* This vertically centers the file button and raw-drop-area text in the dash raw-drop-area */
+#raw-drop-area::before {
+  content: "";
+  display: inline-block;
+  vertical-align: middle;
+  height: 100%;
+}

--- a/static/css/drop_area.css
+++ b/static/css/drop_area.css
@@ -1,4 +1,4 @@
-#drop-area {
+#annot-drop-area {
   border: 2px dashed #ccc;
   border-radius: 20px;
   width: 510px;
@@ -8,11 +8,11 @@
   padding: 20px;
 }
 
-#drop-area.highlight {
+#annot-drop-area.highlight {
   border-color: purple;
 }
 
-#drop-area-input {
+#annot-drop-area-input {
   display: none;
 }
 
@@ -30,8 +30,8 @@
   margin-bottom: 0.25rem;
 }
 
-/* This vertically centers the file button and drop-area text in the dash drop-area */
-#drop-area::before {
+/* This vertically centers the file button and annot-drop-area text in the dash annot-drop-area */
+#annot-drop-area::before {
     content: "";
     display: inline-block;
     vertical-align: middle;

--- a/static/css/drop_area.css
+++ b/static/css/drop_area.css
@@ -48,6 +48,10 @@
   padding: 20px;
 }
 
+#sequence_dir_input_id {
+  width: 500px;
+}
+
 #raw-drop-area.highlight {
   border-color: purple;
 }

--- a/static/css/drop_area.css
+++ b/static/css/drop_area.css
@@ -67,3 +67,26 @@
   vertical-align: middle;
   height: 100%;
 }
+
+#overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background-color: rgba(0, 0, 0, 0.5);
+  display: none;
+  z-index: 1000; /* Ensure it's on top */
+}
+
+#popup {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  background-color: white;
+  padding: 20px;
+  border-radius: 5px;
+  display: none;
+  z-index: 1001; /* Ensure it's on top of the overlay */
+}

--- a/static/js/file_list_drop_area.js
+++ b/static/js/file_list_drop_area.js
@@ -31,7 +31,11 @@ function initDropArea (dropArea, fileFunc, postDropFunc) { // eslint-disable-lin
   dropArea.addEventListener('drop', handleDrop, false)
 
   globalThis.dropArea = dropArea
-  globalThis.fileFunc = fileFunc
+  if (typeof fileFunc !== 'undefined' && fileFunc) {
+    globalThis.fileFunc = fileFunc
+  } else {
+    globalThis.fileFunc = null
+  }
   if (typeof postDropFunc !== 'undefined' && postDropFunc) {
     globalThis.postDropFunc = postDropFunc
   } else {
@@ -76,36 +80,12 @@ function handleFiles (files) { // eslint-disable-line no-unused-vars
       // See: https://stackoverflow.com/questions/8006715/
       const dT = new DataTransfer() // eslint-disable-line no-undef
       dT.items.add(files.item(i))
-      fileFunc(dT)
+      if (typeof fileFunc !== 'undefined' && fileFunc) {
+        fileFunc(dT)
+      }
     }
     if (typeof postDropFunc !== 'undefined' && postDropFunc) {
-      postDropFunc()
+      postDropFunc(files)
     }
   }
-}
-
-/**
- * This takes a FileList object and creates a string of all the file names for display.
- * @param {*} files [FileList]
- * @param {*} curstring [string]
- * @returns fileNamesString [string]
- */
-function getFileNamesString (files, curstring) { // eslint-disable-line no-unused-vars
-  let fileNamesString = ''
-  let cumulativeFileList = []
-  // If the current string is populated and we're not clearing the file list
-  if (typeof curstring !== 'undefined' && curstring && files.length > 0) {
-    cumulativeFileList = curstring.split('\n')
-  }
-  for (let i = 0; i < files.length; ++i) {
-    cumulativeFileList.push(files.item(i).name)
-  }
-  fileNamesString = cumulativeFileList.sort((a, b) => {
-    const itemA = a.toUpperCase() // ignore case
-    const itemB = b.toUpperCase()
-    if (itemA < itemB) { return -1 }
-    if (itemA > itemB) { return 1 }
-    return 0
-  }).join('\n')
-  return fileNamesString
 }

--- a/static/js/file_list_drop_area.js
+++ b/static/js/file_list_drop_area.js
@@ -1,7 +1,8 @@
 // A dictionary of dropArea info, e.g. dropAreas["dropAreakKey"] = {
 //     "dropArea": dropArea,
 //     "fileFunc": fileFunc,
-//     "postDropFunc": postDropFunc
+//     "postDropFunc": postDropFunc,
+//     "filesList": filesList
 // }
 var dropAreas = {} // eslint-disable-line no-unused-vars
 
@@ -16,7 +17,7 @@ var dropAreas = {} // eslint-disable-line no-unused-vars
  * @param {*} postDropFunc is an optional function without arguments that is called after all the files have been
  *   processed.
  */
-function initDropArea (dropAreaKey, dropArea, fileFunc, postDropFunc) { // eslint-disable-line no-unused-vars
+function initDropArea (dropArea, fileFunc, postDropFunc) { // eslint-disable-line no-unused-vars
   ;['dragenter', 'dragover', 'dragleave', 'drop'].forEach(eventName => {
     dropArea.addEventListener(eventName, preventDefaults, false)
   })
@@ -29,12 +30,13 @@ function initDropArea (dropAreaKey, dropArea, fileFunc, postDropFunc) { // eslin
     dropArea.addEventListener(eventName, unhighlight, false)
   })
 
-  dropArea.addEventListener('drop', function (e) {handleDrop(e, dropAreaKey)}, false)
+  let dropAreaKey = dropArea.id;
 
   globalThis.dropAreas[dropAreaKey] = {
     "dropArea": dropArea,
     "fileFunc": null,
-    "postDropFunc": null
+    "postDropFunc": null,
+    "filesList": []
   }
 
   if (typeof fileFunc !== 'undefined' && fileFunc) {
@@ -44,6 +46,10 @@ function initDropArea (dropAreaKey, dropArea, fileFunc, postDropFunc) { // eslin
   if (typeof postDropFunc !== 'undefined' && postDropFunc) {
     globalThis.dropAreas[dropAreaKey]["postDropFunc"] = postDropFunc
   }
+
+  // dropArea.addEventListener('drop', function (e) {handleDrop(e, dropAreaKey)}, false)
+  console.log("Attaching drop area listener to:", dropArea)
+  dropArea.addEventListener('drop', onDropItems, false)
 }
 
 function preventDefaults (e) { // eslint-disable-line no-unused-vars
@@ -62,8 +68,6 @@ function unhighlight (e) {
 function handleDrop (event, dropAreaKey) {
   console.log("Trying this out")
   // See: https://web.dev/patterns/files/drag-and-drop-directories#js
-  const supportsFileSystemAccessAPI = "getAsFileSystemHandle" in DataTransferItem.prototype;
-  const supportsWebkitGetAsEntry = "webkitGetAsEntry" in DataTransferItem.prototype;
   const fileHandlesPromises = [...event.dataTransfer.items]
     .filter((item) => item.kind === "file")
     .map((item) =>
@@ -131,19 +135,122 @@ function scanFiles(item, container) {
   }
 }
 
+const supportsFileSystemAccessAPI = "getAsFileSystemHandle" in DataTransferItem.prototype;
+const supportsWebkitGetAsEntry = "webkitGetAsEntry" in DataTransferItem.prototype;
+
+// See: https://mikeyland.netlify.app/post/multi-file-upload-made-easy-how-to-drag-and-drop-directories-in-your-web-app
+// This is an experiment to see if I can handle both drag and drop directories and input file directory selection
+const onDropItems = async (e) => {
+  // Prevent navigation.
+  e.preventDefault();
+
+  // Check for file system access capabilities
+  if (!supportsFileSystemAccessAPI && !supportsWebkitGetAsEntry) {
+    // Cannot handle directories.
+    return;
+  }
+
+  const files = await getAllFileEntries(e.dataTransfer.items);
+  const flattenFiles = files.reduce((acc, val) => acc.concat(val), []);
+  console.log("Results here dude!!! : ", flattenFiles);
+  console.log("Here is 'e':", e)
+  // Added "this" to refer to the drop-area.  We use its id as a key to the dropAreas data structure.
+  setResults(flattenFiles, e.target.parentElement);
+};
+
+// See: https://mikeyland.netlify.app/post/multi-file-upload-made-easy-how-to-drag-and-drop-directories-in-your-web-app
+// Supports onDropItems
+const getAllFileEntries = async (dataTransferItemList) => {
+  let fileEntries = [];
+  // Use BFS to traverse entire directory/file structure
+  let queue = [];
+  // Unfortunately dataTransferItemList is not iterable i.e. no forEach
+  for (let i = 0; i < dataTransferItemList.length; i++) {
+    queue.push(dataTransferItemList[i].webkitGetAsEntry());
+  }
+  while (queue.length > 0) {
+    let entry = queue.shift();
+    if (entry.isFile) {
+      fileEntries.push(entry);
+    } else if (entry.isDirectory) {
+      let reader = entry.createReader();
+      queue.push(...(await readAllDirectoryEntries(reader)));
+    }
+  }
+  // return fileEntries;
+  return Promise.all(
+    fileEntries.map((entry) => readEntryContentAsync(entry))
+  );
+};
+
+// See: https://mikeyland.netlify.app/post/multi-file-upload-made-easy-how-to-drag-and-drop-directories-in-your-web-app
+// Supports onDropItems
+// Get all the entries (files or sub-directories) in a directory by calling readEntries until it returns empty array
+const readAllDirectoryEntries = async (directoryReader) => {
+  let entries = [];
+  let readEntries = await readEntriesPromise(directoryReader);
+  while (readEntries.length > 0) {
+    entries.push(...readEntries);
+    readEntries = await readEntriesPromise(directoryReader);
+  }
+  return entries;
+};
+
+// See: https://mikeyland.netlify.app/post/multi-file-upload-made-easy-how-to-drag-and-drop-directories-in-your-web-app
+// Supports onDropItems
+// Wrap readEntries in a promise to make working with readEntries easier
+const readEntriesPromise = async (directoryReader) => {
+  try {
+    return await new Promise((resolve, reject) => {
+      directoryReader.readEntries(resolve, reject);
+    });
+  } catch (err) {
+    console.error(err);
+  }
+};
+
+// See: https://mikeyland.netlify.app/post/multi-file-upload-made-easy-how-to-drag-and-drop-directories-in-your-web-app
+// Supports onDropItems
+const readEntryContentAsync = async (entry) => {
+  return new Promise((resolve, reject) => {
+    let reading = 0;
+    const contents = [];
+
+    reading++;
+    entry.file(async (file) => {
+      reading--;
+      const rawFile = file;
+      rawFile.path = entry.fullPath;
+      contents.push(rawFile);
+
+      if (reading === 0) {
+        resolve(contents);
+      }
+    });
+  });
+};
+
+// See: https://mikeyland.netlify.app/post/multi-file-upload-made-easy-how-to-drag-and-drop-directories-in-your-web-app
+// Supports onDropItems
+function setResults(files, dropArea) {
+  console.log("setResults dropArea:", dropArea)
+  handleFiles(files, dropArea.id);
+}
+
 /**
  * This method calls the fileFunc that was initialized by the initDropArea function on each file and then calls the
  * postDropFunc, passing all files.
  * @param {*} files - An optional array of file objects.
  */
 function handleFiles (files, dropAreaKey) { // eslint-disable-line no-unused-vars
+  console.log("key:", dropAreaKey, "files", files, "dropAreas[dropAreaKey]:", dropAreas[dropAreaKey]);
   fileFunc = dropAreas[dropAreaKey]["fileFunc"];
   postDropFunc = dropAreas[dropAreaKey]["postDropFunc"];
   if (typeof files !== 'undefined' && files) {
     for (let i = 0; i < files.length; ++i) {
       // See: https://stackoverflow.com/questions/8006715/
       const dT = new DataTransfer() // eslint-disable-line no-undef
-      dT.items.add(files.item(i))
+      dT.items.add(files[i])
       if (typeof fileFunc !== 'undefined' && fileFunc) {
         fileFunc(dT)
       }

--- a/static/js/file_list_drop_area.js
+++ b/static/js/file_list_drop_area.js
@@ -2,7 +2,6 @@
 //     "dropArea": dropArea,
 //     "fileFunc": fileFunc,
 //     "postDropFunc": postDropFunc,
-//     "filesList": filesList
 // }
 var dropAreas = {} // eslint-disable-line no-unused-vars
 
@@ -36,20 +35,19 @@ function initDropArea (dropArea, fileFunc, postDropFunc) { // eslint-disable-lin
     "dropArea": dropArea,
     "fileFunc": null,
     "postDropFunc": null,
-    "filesList": []
   }
 
   if (typeof fileFunc !== 'undefined' && fileFunc) {
     globalThis.dropAreas[dropAreaKey]["fileFunc"] = fileFunc
   }
-  
+
   if (typeof postDropFunc !== 'undefined' && postDropFunc) {
     globalThis.dropAreas[dropAreaKey]["postDropFunc"] = postDropFunc
   }
 
   // dropArea.addEventListener('drop', function (e) {handleDrop(e, dropAreaKey)}, false)
   console.log("Attaching drop area listener to:", dropArea)
-  dropArea.addEventListener('drop', onDropItems, false)
+  dropArea.addEventListener('drop', function(e) {onDropItems(e, dropArea)}, false)
 }
 
 function preventDefaults (e) { // eslint-disable-line no-unused-vars
@@ -84,7 +82,7 @@ function handleDrop (event, dropAreaKey) {
     if (handle.kind === "directory" || handle.isDirectory) {
       console.log(`Directory: ${handle.name}`);
       console.log("handle:", handle)
-      
+
       // See: https://udn.realityripple.com/docs/Web/API/FileSystemDirectoryReader/readEntries
       // let directoryReader = handle.createReader();
       // console.log("directoryReader:", directoryReader)
@@ -140,13 +138,14 @@ const supportsWebkitGetAsEntry = "webkitGetAsEntry" in DataTransferItem.prototyp
 
 // See: https://mikeyland.netlify.app/post/multi-file-upload-made-easy-how-to-drag-and-drop-directories-in-your-web-app
 // This is an experiment to see if I can handle both drag and drop directories and input file directory selection
-const onDropItems = async (e) => {
+const onDropItems = async (e, dropArea) => {
   // Prevent navigation.
   e.preventDefault();
 
   // Check for file system access capabilities
   if (!supportsFileSystemAccessAPI && !supportsWebkitGetAsEntry) {
     // Cannot handle directories.
+    alert("Your browser does not support folder relative path access.")
     return;
   }
 
@@ -155,7 +154,7 @@ const onDropItems = async (e) => {
   console.log("Results here dude!!! : ", flattenFiles);
   console.log("Here is 'e':", e)
   // Added "this" to refer to the drop-area.  We use its id as a key to the dropAreas data structure.
-  setResults(flattenFiles, e.target.parentElement);
+  setResults(flattenFiles, dropArea);
 };
 
 // See: https://mikeyland.netlify.app/post/multi-file-upload-made-easy-how-to-drag-and-drop-directories-in-your-web-app
@@ -241,22 +240,34 @@ function setResults(files, dropArea) {
  * This method calls the fileFunc that was initialized by the initDropArea function on each file and then calls the
  * postDropFunc, passing all files.
  * @param {*} files - An optional array of file objects.
+ * @param {*} dropAreaKey - A string identifying the specific drop area
  */
 function handleFiles (files, dropAreaKey) { // eslint-disable-line no-unused-vars
+
   console.log("key:", dropAreaKey, "files", files, "dropAreas[dropAreaKey]:", dropAreas[dropAreaKey]);
-  fileFunc = dropAreas[dropAreaKey]["fileFunc"];
-  postDropFunc = dropAreas[dropAreaKey]["postDropFunc"];
+
+  try {
+    fileFunc = dropAreas[dropAreaKey]["fileFunc"];
+    postDropFunc = dropAreas[dropAreaKey]["postDropFunc"];
+  } catch (error) {
+    console.error(error);
+    console.log("dropAreaKey", dropAreaKey, "dropAreas", dropAreas);
+    alert("Your browser appears to be busy and is not ready to handle new files.  Please try again.");
+    return;
+  }
+
   if (typeof files !== 'undefined' && files) {
-    for (let i = 0; i < files.length; ++i) {
+    if (typeof fileFunc !== 'undefined' && fileFunc) {
+      for (let i = 0; i < files.length; ++i) {
       // See: https://stackoverflow.com/questions/8006715/
       const dT = new DataTransfer() // eslint-disable-line no-undef
       dT.items.add(files[i])
-      if (typeof fileFunc !== 'undefined' && fileFunc) {
         fileFunc(dT)
       }
     }
     if (typeof postDropFunc !== 'undefined' && postDropFunc) {
-      postDropFunc(files)
+      // This small delay should allow the processing message to update the page
+      setTimeout(function() { postDropFunc(files) }, 1);
     }
   }
 }

--- a/static/js/submission_start.js
+++ b/static/js/submission_start.js
@@ -189,8 +189,8 @@ function disablePeakAnnotForm () {
 
 /**
  * This function clears the file picker input element inside the drop area after having created form rows.  It is called
- * from the drop-area code after all dropped/picked files have been processed.  It intentionally leaves the entries in
- * the sequence metadata inputs for re-use upon additional drops/picks.
+ * from the annot-drop-area code after all dropped/picked files have been processed.  It intentionally leaves the
+ * entries in the sequence metadata inputs for re-use upon additional drops/picks.
  */
 function afterAddingFiles () { // eslint-disable-line no-unused-vars
   dropAreaInput.value = null

--- a/static/js/submission_start.js
+++ b/static/js/submission_start.js
@@ -5,12 +5,15 @@ var dataSubmissionForm = null // eslint-disable-line no-var
 var singleFormDiv = null // eslint-disable-line no-var
 var studyDocInput = null // eslint-disable-line no-var
 var annotFilesInput = null // eslint-disable-line no-var
+var peakAnnotHash = {} // eslint-disable-line no-var
 
 var mzxmlFormTemplateContainer = null // eslint-disable-line no-var
 var mzxmlFormsTable = null // eslint-disable-line no-var
 var mzxmlDirDropAreaInput = null // eslint-disable-line no-var
 var mzxmlSubmissionForm = null // eslint-disable-line no-var
 var mzxmlFileListDisplayElem = null // eslint-disable-line no-var
+var sequenceDirsHash = {} // eslint-disable-line no-var
+var possibleAnnotPaths = {} // eslint-disable-line no-var
 
 /**
  * A method to initialize the peak annotation file form interface.  Dropped files will call addPeakAnnotFileToUpload,
@@ -31,23 +34,24 @@ function initPeakAnnotUploads (peakAnnotFormTemplateContainer, peakAnnotFormsTab
 
   // Add an event listener to the study doc input to enable the submit button
   studyDocInput.addEventListener('change', function () {
-    enablePeakAnnotForm()
+    enableSubmissionForm()
   })
 
   // Disable the form submission button to start (because there are no peak annotation form rows yet).
-  disablePeakAnnotForm()
+  disableSubmissionForm()
 }
 
-function initMzxmlMetadataUploads (mzxmlFormTemplateContainer, mzxmlFormsTable, mzxmlDirDropAreaInput, mzxmlSubmissionForm, singleFormDiv, studyDocInput) { // eslint-disable-line no-unused-vars
+function initStudyMetadataUploads (mzxmlFormTemplateContainer, mzxmlFormsTable, mzxmlDirDropAreaInput, mzxmlSubmissionForm, singleFormDiv, studyDocInput) { // eslint-disable-line no-unused-vars
   globalThis.mzxmlFormTemplateContainer = mzxmlFormTemplateContainer
   globalThis.mzxmlFormsTable = mzxmlFormsTable
   globalThis.mzxmlDirDropAreaInput = mzxmlDirDropAreaInput
   globalThis.mzxmlSubmissionForm = mzxmlSubmissionForm
-  // TODO: Add support for supplying a study doc to "update". These study doc elements are placeholders that came from
-  // TODO: copying the start page but in this context (mzxml autofill), they are vestigial.
   globalThis.singleFormDiv = singleFormDiv
   globalThis.studyDocInput = studyDocInput
-  // TODO: Add ability to disable/enable the submit button
+
+  // TODO: Add ability to disable/enable the submit button, meaning, the ability to submit JUST the sequence metadata
+  // for autofill of the sequences tab, though that would mean that the feature to select an existing study doc would be
+  // required.
 }
 
 /**
@@ -57,11 +61,16 @@ function initMzxmlMetadataUploads (mzxmlFormTemplateContainer, mzxmlFormsTable, 
  */
 function addPeakAnnotFileToUpload (file) { // eslint-disable-line no-unused-vars
   // Create a row for the metadata inputs associated with each file
-  const newRow = createPeakAnnotFormRow()
-  makeAnnotFormModifications(file, newRow)
-  peakAnnotFormsTable.appendChild(newRow)
+  const newRow = createPeakAnnotFormRow();
+  // Clone the form row template, unhide, and set the file name
+  makeAnnotFormModifications(file, newRow);
+
+  // Append the row to the peak annotations form table
+  peakAnnotFormsTable.appendChild(newRow);
+
+  return newRow;
 }
-// TODO: There needs to exist a way to add mzxml form rows, but it cannot be per file.  The directory picker does not result in a selected directory for upload, it selects all files under the directory for upload, so what is needed is a way to compute each first directory that contains mzXML files and a form row for each directory must be created.  So we need a "addMzxmlDirsToUpload" that determines the directories, calls createPeakAnnotFormRow for each one, and calls refreshMzxmlMetadata for each one
+// TODO: Add the ability to populate the peak annotation files from the dropped study dir.
 
 /**
  * This function clones a tr row containing the form elements for a peak annotation file.
@@ -74,7 +83,6 @@ function createPeakAnnotFormRow (template) {
   }
   return template.cloneNode(true)
 }
-// TODO: Create a createMzxmlFormRow function
 
 /**
  * Un-hide the file input column and set the files of the file input.
@@ -207,13 +215,13 @@ function insertFormsetManagementInputs (numForms) {
  * @returns all tr elements containing an individual (cloned) form.
  */
 function getFormRows () {
-  return peakAnnotFormsTable.querySelectorAll('tr[name="form-set-row"]')
+  return mzxmlFormsTable.querySelectorAll('tr[name="form-set-row"]')
 }
 
 /**
  * This function enables the form submission button.
  */
-function enablePeakAnnotForm () {
+function enableSubmissionForm () {
   const submitInput = document.querySelector('#submit')
   submitInput.removeAttribute('disabled')
 }
@@ -221,7 +229,7 @@ function enablePeakAnnotForm () {
 /**
  * This function disables the form submission button.
  */
-function disablePeakAnnotForm () {
+function disableSubmissionForm () {
   const submitInput = document.querySelector('#submit')
   submitInput.disabled = true
 }
@@ -238,62 +246,251 @@ function afterAddingPeakAnnotFiles (newFiles) { // eslint-disable-line no-unused
   // See: https://stackoverflow.com/questions/8006715/
   // Create a new DataTransfer object to contain the merged list of files
   const newDT = new DataTransfer();
-  let filenames = []
+  let filenames = {}
   let dupes = []
   // Add the existing files
   for (i=0;i < globalThis.annotFilesInput.files.length;i++) {
-    if (filenames.includes(globalThis.annotFilesInput.files[i].name)) {
+    if (Object.keys(filenames).includes(globalThis.annotFilesInput.files[i].name)) {
       dupes.push(globalThis.annotFilesInput.files[i].name)
     } else {
-      newDT.items.add(globalThis.annotFilesInput.files[i]);
-      filenames.push(globalThis.annotFilesInput.files[i].name)
+      annotFile = annotFilesInput.files[i];
+      annotName = annotFile.name;
+      newDT.items.add(annotFile);
+      // TODO: Obtain the annot file path from the sequenceDirsHash, if it exists.
+      [studyDir, annotDirPath, annotFilePath] = getFilePath(annotFile);
+
+      // If there wasn't (somehow) a path (annotDirPath) supplied with the file and the annot file name matches one from
+      // the study directory, set the annot file path so that we can auto-select the correct sequence and scan dirs.
+      if (annotDirPath === '' && Object.keys(possibleAnnotPaths).length > 0 && Object.keys(possibleAnnotPaths).includes(annotName)) {
+        filenames[annotName] = possibleAnnotPaths[annotName];
+      } else {
+        filenames[annotName] = annotDirPath;
+      }
     }
   }
+  
   // Add the incoming files
   for (i=0;i < newFiles.length;i++) {
     if (filenames.includes(newFiles[i].name)) {
       dupes.push(newFiles[i].name)
     } else {
       newDT.items.add(newFiles[i]);
+
+      // Update filenames in case the dragged and dropped files include 2 files with the same name
       filenames.push(newFiles[i].name)
-      addPeakAnnotFileToUpload(newFiles[i])
+
+      let annotFormRow = addPeakAnnotFileToUpload(newFiles[i])
+      
+      globalThis.peakAnnotHash[annotName] = {
+        "annotFilePath": annotFilePath,
+        "defaultSequenceDirSelectElem": annotFormRow.querySelector('select[name=default_sequence_dir]'),
+        "defaultScanDirSelectElem": annotFormRow.querySelector('select[name=default_scan_dir]'),
+        "defaultSequenceDirs": [],
+        "defaultScanDirs": [],
+        "defaultSequenceSelectOptions": [],
+        "defaultScanSelectOptions": []
+      };
     }
   }
-  // Now replace the input element's old files with the merged new files
   globalThis.annotFilesInput.files = newDT.files;
   
   // Clear the drop area to accept new files
   peakAnnotDropAreaInput.value = null
-
+  
   if (dupes.length > 0) {
     alert("Peak annotation filenames must be unique.  Skipped these files with duplicate names:" + dupes)
   }
+  
+  // Now that the peak annot form rows have been added, we can populate the select lists and try to make default
+  // selections
+  updateAnnotSelectLists();
 
+  // Now replace the input element's old files with the merged new files
   // Enable form submission
-  enablePeakAnnotForm()
+  enableSubmissionForm();
 }
 
-function refreshMzxmlMetadata (files) { // eslint-disable-line no-unused-vars
-  filepaths = getAllMzxmlFilePaths(files)
+function getFilePath(fileObject) {
+  let tmpPath;
+
+  // Extract the relative path of the file (not including the file name)
+  if ((Object.hasOwn(fileObject, 'webkitRelativePath') || 'webkitRelativePath' in fileObject) && typeof fileObject.webkitRelativePath !== 'undefined' && fileObject.webkitRelativePath && fileObject.webkitRelativePath !== '') {
+    console.log("Getting webkitRelativePath for file", fileObject)
+    tmpPath = fileObject.webkitRelativePath;
+  } else if ((Object.hasOwn(fileObject, 'path') || 'path' in fileObject) && typeof fileObject.path !== 'undefined' && fileObject.path && fileObject.path !== '') {
+    console.log("Getting path for file", fileObject)
+    // Paths should be relative to the dropped directory, but the code that assigns the apth attribute includes the
+    // dropped directory in the path, so here, we trim it off:
+    tmpPath = fileObject.path
+  } else if ((Object.hasOwn(fileObject, 'fullpath') || 'fullpath' in fileObject) && typeof fileObject.fullpath !== 'undefined' && fileObject.fullpath && fileObject.fullpath !== '') {
+    console.log("Getting fullpath for file", fileObject)
+    tmpPath = fileObject.fullpath;
+  } else {
+    console.log("Getting name for file", fileObject)
+    tmpPath = fileObject.name
+  }
+  // Assumes always a relative path.  The dir walk done in the drop area code yields relative paths that start with
+  // a slash, as if it was an absolute path, but the webkitRelativePath never prepends that slash.
+  if (tmpPath.startsWith("/")) {
+    tmpPath = tmpPath.replace(/^\//, '');
+  }
+  // Both methods include the selected/dropped directory in the path, but we want paths that are relative to that
+  // directory, so we chop off the study directory.
+  let [root, ...filePathList] = tmpPath.split('/');
+
+  // Determine the relative directory path
+  let tmpDirPathList = filePathList.slice();
+  if (tmpDirPathList.length > 1) {
+    tmpDirPathList.pop();
+    dirPath = tmpDirPathList.join('/');
+  } else {
+    dirPath = '';
+  }
+
+  return [root, dirPath, filePathList.join('/')];
+}
+
+function updateAnnotSelectLists() {
+  // Return if either the sequenceDirsHash or peakAnnotHash are empty
+  if (Object.keys(sequenceDirsHash).length == 0 || Object.keys(peakAnnotHash).length == 0) {
+    return;
+  }
+
+  // For annotFileName in Object.keys(peakAnnotHash)
+  for (annotFileName in Object.keys(peakAnnotHash)) {
+    // Get the input defaultSequenceDir select list input element
+    annotSeqDirSelectElem = peakAnnotHash[annotFileName]["defaultSequenceDirSelectElem"];
+    annotScanDirSelectElem = peakAnnotHash[annotFileName]["defaultScanDirSelectElem"];
+    annotFilePath = peakAnnotHash[annotFileName]["annotFilePath"];
+
+    // If peakAnnotHash[annotFileName]["defaultSequenceDirs"] is empty
+    if (peakAnnotHash[annotFileName]["defaultSequenceDirs"].length == 0) {
+      // Populate html options from the sequenceDirsHash
+      annotSeqDirSelectElem.innerHTML = sequenceDirsHash["sequenceSelectOptions"];
+      // Populate peakAnnotHash[annotFileName]["defaultSequenceDirs"] from the sequenceDirsHash
+      globalThis.peakAnnotHash[annotFileName]["defaultSequenceDirs"] = sequenceDirsHash["allSequenceDirs"].slice();
+    }
+    // Else If peakAnnotHash[annotFileName]["defaultSequenceDirs"] differs from the sequenceDirsHash
+    else if (!arraysEqual(peakAnnotHash[annotFileName]["defaultSequenceDirs"], sequenceDirsHash["allSequenceDirs"])) {
+      // Save the current selected option
+      savedDefSeqVal = annotSeqDirSelectElem.value;
+
+      // Empty the innerHTML and peakAnnotHash[annotFileName]["defaultSequenceDirs"]
+      // Populate innerHTML and peakAnnotHash[annotFileName]["defaultSequenceDirs"] from the sequenceDirsHash
+      annotSeqDirSelectElem.innerHTML = sequenceDirsHash["sequenceSelectOptions"];
+      globalThis.peakAnnotHash[annotFileName]["defaultSequenceDirs"] = sequenceDirsHash["allSequenceDirs"].slice();
+
+      // If the saved selected option exists among the new options, select it
+      if (typeof savedDefSeqVal !== 'undefined' && savedDefSeqVal && peakAnnotHash[annotFileName]["defaultSequenceDirs"].includes(savedDefSeqVal)) {
+        annotSeqDirSelectElem.value = savedDefSeqVal;
+      }
+    }
+///////////////////LEFT OFF HERE
+    // If there is not a defaultSequenceDir select list selection
+    //   If an unambiguous defaultSequenceDir selection can be made
+    //     Set the selection
+    //
+    // If there is a defaultSequenceDir select list selection (check anew)
+    //   If peakAnnotHash[annotFileName]["defaultScanDirs"] is empty
+    //     Populate innerHTML and peakAnnotHash[annotFileName]["defaultSscanDirs"] from the sequenceDirsHash
+    //   Else If peakAnnotHash[annotFileName]["defaultScanDirs"] differs from the sequenceDirsHash
+    //     Save the current selected option
+    //     Empty innerHTML and peakAnnotHash[annotFileName]["defaultScanDirs"]
+    //     Populate innerHTML and peakAnnotHash[annotFileName]["defaultSscanDirs"]) from the sequenceDirsHash
+    //     If the saved selected option exists among the new options
+    //       Select it
+    //   If there is not a defaultScanDir select list selection
+    //     If an unambiguous defaultScanDir selection can be made
+    //       Set the selection
+    // Else
+    //   Empty the innerHTML and peakAnnotHash[annotFileName]["defaultScanDirs"]
+  }
+}
+
+// See: https://stackoverflow.com/a/16436975/2057516
+function arraysEqual(a, b) {
+  if (a === b) return true;
+  if (a == null || b == null) return false;
+  if (a.length !== b.length) return false;
+
+  // If you don't care about the order of the elements inside
+  // the array, you should sort both arrays here.
+  // Please note that calling sort on an array will modify that array.
+  // you might want to clone your array first.
+
+  for (var i = 0; i < a.length; ++i) {
+    if (a[i] !== b[i]) return false;
+  }
+  return true;
+}
+
+function refreshStudyMetadata (files) { // eslint-disable-line no-unused-vars
+  [studyDirs, filepaths, possibleStudyDocs, possiblePeakAnnotFiles] = getStudyMetadata(files)
+
+  // Save the possible peak annot paths to help automatically select the default sequence dir and default scan dir based
+  // on colocation with the saved sequence dirs and their scan dirs
+  globalThis.possibleAnnotPaths = possiblePeakAnnotFiles;
+
+  // Only allow 1 folder: 1 study folder or 1 submission folder (with multiple studies).
+  if (studyDirs.length > 1) {
+    alert('Only 1 study folder allowed.  ' + studyDirs.length + ' is too many: ["' + studyDirs.join('", "') + '"].\n\nIf you have multiple studies in this submission, put both study folders in a single submission folder and select/drop that folder.');
+    return
+  }
+
   console.log("filepaths:", filepaths)
+
+  // Clear out previously added sequence form rows and saved sequence directories
+  mzxmlFormsTable.innerHTML = ''
+  globalThis.sequenceDirsHash = {
+    "allSequenceDirs": [],
+    "sequenceSelectOptions": '',
+    "scanDirSelectLists": {} 
+  }
 
   // Update the mzxml_file_list form element
   mzxmlListInput = document.getElementById('mzxml_file_list_input_id')
   mzxmlListInput.value = JSON.stringify(filepaths)
 
-  mzxmldirpaths = getAllMzxmlDirectories(filepaths)
-  sequencedirpaths = getParentMzxmlDirectories(mzxmldirpaths)
+  let mzxmldirpaths = getAllMzxmlDirectories(filepaths)
+  let sequenceDirPathsHash = getParentMzxmlDirectories(mzxmldirpaths)
 
   // TODO: Build a seqdir select list and a series of scandir select lists keyed on seqdir in the loop below
 
   // For each sequence directory
-  for (i=0;i < sequencedirpaths.length;i++) {
-    seqdirpath = sequencedirpaths[i];
+  for (seqdirpath of Object.keys(sequenceDirPathsHash)) {
     // Create a form row (duplicating the template) and populate the parent directory in default_sequence_dir form elem
     addSequenceFormRow(seqdirpath);
+
+    globalThis.sequenceDirsHash["allSequenceDirs"].push(seqdirpath);
+
+    // Add this sequence directory to the template sequence select list options
+    var sequenceOption = document.createElement("option");
+    sequenceOption.value = seqdirpath;
+    sequenceOption.text = seqdirpath;
+    if (seqdirpath === '') {
+      sequenceOption.text += "'' (the study/root directory)";
+    }
+    globalThis.sequenceDirsHash["sequenceSelectOptions"] += sequenceOption;
+    
+    // Add this scan subdirectories to the template scan directory select list options
+    globalThis.sequenceDirsHash["scanDirSelectLists"][seqdirpath] = [];
+    for (var i = 0; i < sequenceDirPathsHash[seqdirpath].length; i++) {
+      scanSubDir = sequenceDirPathsHash[seqdirpath][i];
+      var scanSubDirOption = document.createElement("option");
+      scanSubDirOption.value = scanSubDir;
+      scanSubDirOption.text = scanSubDir;
+      if (scanSubDir === '') {
+        scanSubDirOption.text += "'' (the sequence directory: '" + seqdirpath + "')";
+      }
+      globalThis.sequenceDirsHash["scanDirSelectLists"][seqdirpath].push(scanSubDirOption);
+    }
+  
+    /////////////////////////////////LEFT OFF HERE - Trigger existing peak annotation files' select lists to update
     // getMzxmlsInDirectory
-    // Construct string (using .join()) of filepaths - use to populate the mzxml_metadata form elem
+    // Trigger existing peak annotation files' select lists to update
+    // Construct string (using .join()) of filepaths - use to populate the peak_annot_to_mzxml_metadata form elem
   }
+  globalThis.sequenceDirsHash = sequenceDirPathsHash
 
   // TODO: Update the peak annotation file row select lists
 
@@ -320,6 +517,9 @@ function makeSequenceFormModifications (formRow, seqdirpath) {
   // Set the file for the file input and don't let the user change it
   const seqDirInput = formRow.querySelector('#sequence_dir_input_id')
   seqDirInput.value = seqdirpath
+  if (seqdirpath === '') {
+    seqDirInput.placeholder = 'study directory contains data for a single sequence';
+  }
   // seqDirInput.readonly = true
   seqDirInput.setAttribute('readonly', true)
 
@@ -332,8 +532,15 @@ function makeSequenceFormModifications (formRow, seqdirpath) {
 /**
  * This function clears all of the previously added peak annotation form rows.
  */
-function clearPeakAnnotFiles () { // eslint-disable-line no-unused-vars
-  peakAnnotFormsTable.innerHTML = ''
+function clearSubmissionForm () { // eslint-disable-line no-unused-vars
+  peakAnnotFormsTable.innerHTML = '';
+  mzxmlFormsTable.innerHTML = ''
+  globalThis.peakAnnotHash = {};
+  globalThis.sequenceDirsHash = {};
+  globalThis.possibleAnnotPaths = {};
+  dataSubmissionForm.reset();
+  // TODO: Clear each peak annotation files' select lists (defaultSequenceDir and defaultScanDir)
+  disableSubmissionForm();
 }
 
 function getMzxmlFileNamesString (newFiles, curstring) {
@@ -370,23 +577,40 @@ function getMzxmlFileNamesString (newFiles, curstring) {
   return fileNamesString
 }
 
-function getAllMzxmlFilePaths(files) {
+function getStudyMetadata(files) {
   // See: https://stackoverflow.com/a/60538623/2057516
   let allMzxmlFilePathList = []
+  let studyDirs = []
+  let possibleStudyDocs = []
+  let possiblePeakAnnotFiles = {}
   for (let i = 0; i < files.length; ++i) {
-    console.log("Checking out file", files[i].name)
-    if (!files[i].name.toLowerCase().endsWith(".mzxml")) {
-      // We only want directories that directly contain mzXML files
-      continue
+    let fileName = files[i].name;
+
+    console.log("Checking out file", fileName)
+
+    // Extract the relative path of the file (not including the file name)
+    let [studyDir, dirPath, filePath] = getFilePath(files[i]);
+
+    if (!studyDirs.includes(studyDir)) {
+      studyDirs.push(studyDir);
     }
-    if (Object.hasOwn(files[i], 'webkitRelativePath')) {
-      filePath = files[i].webkitRelativePath;
-    } else {
-      filePath = files[i].name
+
+    if (fileName.toLowerCase().endsWith(".mzxml")) {
+      allMzxmlFilePathList.push(filePath)
+    } else if (fileName.toLowerCase().endsWith(".xlsx") || fileName.toLowerCase().endsWith(".csv") || fileName.toLowerCase().endsWith(".tsv")) {
+      // The study doc must be in the root directory
+      if (fileName.toLowerCase().endsWith(".xlsx") && dirPath === "") {
+        possibleStudyDocs.push(fileName)
+      }
+      if (dirPath === '') {
+        possiblePeakAnnotFiles[fileName] = fileName;
+      } else {
+        possiblePeakAnnotFiles[fileName] = filePath;
+      }
     }
-    allMzxmlFilePathList.push(filePath)
   }
-  return allMzxmlFilePathList
+  console.log("studyDirs:", studyDirs, "mzXML paths:", allMzxmlFilePathList, "possibleStudyDocs", possibleStudyDocs, "possiblePeakAnnotFiles", possiblePeakAnnotFiles)
+  return [studyDirs, allMzxmlFilePathList, possibleStudyDocs, possiblePeakAnnotFiles]
 }
 
 function getAllMzxmlDirectories(filepaths) {
@@ -399,7 +623,7 @@ function getAllMzxmlDirectories(filepaths) {
     filePath =filepaths[i];
     dirname = '';
     if (filePath.includes("/")) {
-      dirname = filePath.substr(0, filePath.lastIndexOf("/") + 1)
+      dirname = filePath.substr(0, filePath.lastIndexOf("/"))
     }
     if (!mzxmlDirList.includes(dirname)) {
       mzxmlDirList.push(dirname)
@@ -409,19 +633,54 @@ function getAllMzxmlDirectories(filepaths) {
   if (mzxmlDirList.length == 0) {
     mzxmlDirList.push('')
   }
+  console.log("mzXML dirs:", mzxmlDirList)
   return mzxmlDirList
 }
 
 function getParentMzxmlDirectories(allMzxmlDirList) {
+
+  let candidate
+  const isasubdir = (dir) => dir !== candidate && candidate.startsWith(dir);
+  // Get all of the parent directories
   let parentMzxmlDirList = []
-  for (i=0;i<allMzxmlDirList.length;i++) {
+  for (i=0; i < allMzxmlDirList.length; i++) {
     candidate = allMzxmlDirList[i];
     // If the candidate directory path does not start with any other path in the directory list
-    if (!allMzxmlDirList.some(function(dir) {dir !== candidate && candidate.startsWith(dir)})) {
+    if (!allMzxmlDirList.some(isasubdir)) {
+      console.log("Candidate:", candidate, "does not start with any of:", allMzxmlDirList)
       parentMzxmlDirList.push(candidate)
     }
   }
-  return parentMzxmlDirList
+  console.log("mzXML parent dirs:", parentMzxmlDirList)
+
+  // Now build a hash of the parent directories and their scan subdirectories
+  let parentMzxmlDirHash = {}
+  // Initialize empty lists
+  for (parentDir of parentMzxmlDirList) {
+    parentMzxmlDirHash[parentDir] = [];
+  }
+  // Add the scan subdirectories directories to the arrays
+  for (i=0; i < allMzxmlDirList.length; i++) {
+    candidate = allMzxmlDirList[i];
+    // If the candidate directory path starts with any other path in the directory list
+    if (allMzxmlDirList.some(isasubdir)) {
+      for (parentDir of parentMzxmlDirList) {
+        if (candidate.startsWith(parentDir)) {
+          subDir = candidate.replace(parentDir, '');
+          if (subDir.startsWith('/')) {
+            subDir = subDir.replace('/', '')
+          }
+          console.log("subDir:", subDir, "belongs to parentDir:", parentDir)
+          parentMzxmlDirHash[parentDir].push(subDir)
+        }
+      }
+    } else {
+      // Every parentDir can be its own scan directory
+      parentMzxmlDirHash[candidate].push('')
+    }
+  }
+  console.log("parentMzxmlDirHash:", parentMzxmlDirHash)
+  return parentMzxmlDirHash
 }
 
 function getMzxmlsInDirectory(allMzxmlFilePathList, parentDir) {
@@ -434,17 +693,3 @@ function getMzxmlsInDirectory(allMzxmlFilePathList, parentDir) {
   }
   return childMzxmls
 }
-
-// TODO:
-// 1. When a directory is dropped/selected:
-//    1. getAllMzxmlFilePaths
-//    2. getAllMzxmlDirectories  // Change this to take a list of strings from step 1
-//    3. getParentMzxmlDirectories
-//    4. For each parent directory
-//       1. Create a form row (duplicating the template form)
-//       2. Populate the parent directory in mzxml_dir form elem
-//       3. getMzxmlsInDirectory
-//       4. Construct string (using .join()) of filepaths - use to populate the mzxml_metadata form elem
-// 2. Move the peak annot file inputs into the single form elem inputs and make it a multiple file input (unassociated with sequence metadata)
-// 3. Merge the 2 forms (RawDataSubmissionForm and DataSubmissionForm) into 1 form
-// 4. Make the Start page accept study doc, annot files, and the study dir... In fact, just take the study dir and find all the files...???!!!

--- a/static/js/submission_start.js
+++ b/static/js/submission_start.js
@@ -6,6 +6,8 @@ var singleFormDiv = null // eslint-disable-line no-var
 var studyDocInput = null // eslint-disable-line no-var
 var annotFilesInput = null // eslint-disable-line no-var
 var peakAnnotHash = {} // eslint-disable-line no-var
+var annotToMzxmlInput = null // eslint-disable-line no-var
+var annotToMzxmlHash = {} // eslint-disable-line no-var
 
 var mzxmlFormTemplateContainer = null // eslint-disable-line no-var
 var mzxmlFormsTable = null // eslint-disable-line no-var
@@ -23,31 +25,48 @@ var possibleAnnotPaths = {} // eslint-disable-line no-var
  * @param {*} peakAnnotFormsTable [table] The table where the form rows will be added when files are dropped in the drop
  * area.
  */
-function initPeakAnnotUploads (peakAnnotFormTemplateContainer, peakAnnotFormsTable, peakAnnotDropAreaInput, dataSubmissionForm, singleFormDiv, studyDocInput, annotFilesInput) { // eslint-disable-line no-unused-vars
-  globalThis.peakAnnotFormTemplateContainer = peakAnnotFormTemplateContainer
-  globalThis.peakAnnotFormsTable = peakAnnotFormsTable
-  globalThis.peakAnnotDropAreaInput = peakAnnotDropAreaInput
-  globalThis.dataSubmissionForm = dataSubmissionForm
-  globalThis.singleFormDiv = singleFormDiv
-  globalThis.studyDocInput = studyDocInput
-  globalThis.annotFilesInput = annotFilesInput
+function initPeakAnnotUploads ( // eslint-disable-line no-unused-vars
+  peakAnnotFormTemplateContainer,
+  peakAnnotFormsTable,
+  peakAnnotDropAreaInput,
+  dataSubmissionForm,
+  singleFormDiv,
+  studyDocInput,
+  annotFilesInput,
+  annotToMzxmlInput
+) {
+  globalThis.peakAnnotFormTemplateContainer = peakAnnotFormTemplateContainer;
+  globalThis.peakAnnotFormsTable = peakAnnotFormsTable;
+  globalThis.peakAnnotDropAreaInput = peakAnnotDropAreaInput;
+  globalThis.dataSubmissionForm = dataSubmissionForm;
+  globalThis.singleFormDiv = singleFormDiv;
+  globalThis.studyDocInput = studyDocInput;
+  globalThis.annotFilesInput = annotFilesInput;
+  globalThis.annotToMzxmlInput = annotToMzxmlInput;
 
   // Add an event listener to the study doc input to enable the submit button
   studyDocInput.addEventListener('change', function () {
-    enableSubmissionForm()
-  })
+    enableSubmissionForm();
+  });
 
   // Disable the form submission button to start (because there are no peak annotation form rows yet).
-  disableSubmissionForm()
+  disableSubmissionForm();
 }
 
-function initStudyMetadataUploads (mzxmlFormTemplateContainer, mzxmlFormsTable, mzxmlDirDropAreaInput, mzxmlSubmissionForm, singleFormDiv, studyDocInput) { // eslint-disable-line no-unused-vars
-  globalThis.mzxmlFormTemplateContainer = mzxmlFormTemplateContainer
-  globalThis.mzxmlFormsTable = mzxmlFormsTable
-  globalThis.mzxmlDirDropAreaInput = mzxmlDirDropAreaInput
-  globalThis.mzxmlSubmissionForm = mzxmlSubmissionForm
-  globalThis.singleFormDiv = singleFormDiv
-  globalThis.studyDocInput = studyDocInput
+function initStudyMetadataUploads ( // eslint-disable-line no-unused-vars
+  mzxmlFormTemplateContainer,
+  mzxmlFormsTable,
+  mzxmlDirDropAreaInput,
+  mzxmlSubmissionForm,
+  singleFormDiv,
+  studyDocInput
+) {
+  globalThis.mzxmlFormTemplateContainer = mzxmlFormTemplateContainer;
+  globalThis.mzxmlFormsTable = mzxmlFormsTable;
+  globalThis.mzxmlDirDropAreaInput = mzxmlDirDropAreaInput;
+  globalThis.mzxmlSubmissionForm = mzxmlSubmissionForm;
+  globalThis.singleFormDiv = singleFormDiv;
+  globalThis.studyDocInput = studyDocInput;
 
   // TODO: Add ability to disable/enable the submit button, meaning, the ability to submit JUST the sequence metadata
   // for autofill of the sequences tab, though that would mean that the feature to select an existing study doc would be
@@ -62,8 +81,25 @@ function initStudyMetadataUploads (mzxmlFormTemplateContainer, mzxmlFormsTable, 
 function addPeakAnnotFileToUpload (file) { // eslint-disable-line no-unused-vars
   // Create a row for the metadata inputs associated with each file
   const newRow = createPeakAnnotFormRow();
+
   // Clone the form row template, unhide, and set the file name
   makeAnnotFormModifications(file, newRow);
+
+  // Add listeners
+  defSeqDirInput = newRow.querySelector("select[name='default_sequence_dir']");
+  defScanDirInput = newRow.querySelector("select[name='default_scan_dir']");
+
+  defSeqDirInput.addEventListener('change', function () {
+    console.log("CLEARING", file.name, "SCAN SELECT LIST:", defScanDirInput)
+    peakAnnotHash[file.name]["defaultScanDirSelectElem"].innerHTML = '';
+    peakAnnotHash[file.name]["defaultScanDirs"] = [];
+    updateAnnotDefaultScanSelectLists();
+    updateAnnotToMzxmlData();
+  });
+
+  defScanDirInput.addEventListener('change', function () {
+    updateAnnotToMzxmlData();
+  });
 
   // Append the row to the peak annotations form table
   peakAnnotFormsTable.appendChild(newRow);
@@ -79,7 +115,7 @@ function addPeakAnnotFileToUpload (file) { // eslint-disable-line no-unused-vars
  */
 function createPeakAnnotFormRow (template) {
   if (typeof template === 'undefined' || !template) {
-    template = peakAnnotFormTemplateContainer
+    template = peakAnnotFormTemplateContainer;
   }
   return template.cloneNode(true)
 }
@@ -193,21 +229,21 @@ function prepareFormsetForms () {
 function insertFormsetManagementInputs (numForms) {
   // dataSubmissionForm.innerHTML += '<input type="hidden" name="form-TOTAL_FORMS" ';
   // dataSubmissionForm.innerHTML += 'value="' + numForms.toString() + '" id="id_form-TOTAL_FORMS">';
-  const totalInput = document.createElement('input')
-  totalInput.setAttribute('type', 'hidden')
-  totalInput.setAttribute('name', 'form-TOTAL_FORMS')
-  totalInput.setAttribute('value', numForms.toString())
-  totalInput.setAttribute('id', 'id_form-TOTAL_FORMS')
-  dataSubmissionForm.appendChild(totalInput)
+  const totalInput = document.createElement('input');
+  totalInput.setAttribute('type', 'hidden');
+  totalInput.setAttribute('name', 'form-TOTAL_FORMS');
+  totalInput.setAttribute('value', numForms.toString());
+  totalInput.setAttribute('id', 'id_form-TOTAL_FORMS');
+  dataSubmissionForm.appendChild(totalInput);
 
   // dataSubmissionForm.innerHTML += '<input type="hidden" name="form-INITIAL_FORMS" value="0" ';
   // dataSubmissionForm.innerHTML += 'id="id_form-INITIAL_FORMS">';
-  const initialInput = document.createElement('input')
-  initialInput.setAttribute('type', 'hidden')
-  initialInput.setAttribute('name', 'form-INITIAL_FORMS')
-  initialInput.setAttribute('value', '0')
-  initialInput.setAttribute('id', 'id_form-INITIAL_FORMS')
-  dataSubmissionForm.appendChild(initialInput)
+  const initialInput = document.createElement('input');
+  initialInput.setAttribute('type', 'hidden');
+  initialInput.setAttribute('name', 'form-INITIAL_FORMS');
+  initialInput.setAttribute('value', '0');
+  initialInput.setAttribute('id', 'id_form-INITIAL_FORMS');
+  dataSubmissionForm.appendChild(initialInput);
 }
 
 /**
@@ -238,16 +274,20 @@ function disableSubmissionForm () {
  * This function clears the file picker input element inside the drop area after having created form rows.  It is called
  * from the annot-drop-area code after all dropped/picked files have been processed.  It intentionally leaves the
  * entries in the sequence metadata inputs for re-use upon additional drops/picks.
- * @param {*} newFiles [list of files]: The list of files from a DataTransfer object containing the newly dropped/selected files
+ * @param {*} newFiles [list of files]: The list of files from a DataTransfer object containing the newly dropped/
+ * selected files
  */
 function afterAddingPeakAnnotFiles (newFiles) { // eslint-disable-line no-unused-vars
-  
+  // This method resets the files in globalThis.annotFilesInput by creating a new DataTransfer object, adding the
+  // existing files, then adding the new files.  It also updates globalThis.peakAnnotHash with the newly added files.
+
   // Add the files to the hidden annotFilesInput
   // See: https://stackoverflow.com/questions/8006715/
   // Create a new DataTransfer object to contain the merged list of files
   const newDT = new DataTransfer();
-  let filenames = {}
-  let dupes = []
+  let filenames = {};
+  let dupes = [];
+  let possibleAnnotPath;
   // Add the existing files
   for (i=0;i < globalThis.annotFilesInput.files.length;i++) {
     if (Object.keys(filenames).includes(globalThis.annotFilesInput.files[i].name)) {
@@ -256,74 +296,143 @@ function afterAddingPeakAnnotFiles (newFiles) { // eslint-disable-line no-unused
       annotFile = annotFilesInput.files[i];
       annotName = annotFile.name;
       newDT.items.add(annotFile);
-      // TODO: Obtain the annot file path from the sequenceDirsHash, if it exists.
+
       [studyDir, annotDirPath, annotFilePath] = getFilePath(annotFile);
+
+      possibleAnnotPath = getPossibleAnnotPath(annotName);
 
       // If there wasn't (somehow) a path (annotDirPath) supplied with the file and the annot file name matches one from
       // the study directory, set the annot file path so that we can auto-select the correct sequence and scan dirs.
-      if (annotDirPath === '' && Object.keys(possibleAnnotPaths).length > 0 && Object.keys(possibleAnnotPaths).includes(annotName)) {
-        filenames[annotName] = possibleAnnotPaths[annotName];
+      if (
+        annotDirPath === ''
+        && typeof possibleAnnotPath !== 'undefined'
+        && possibleAnnotPath
+        && possibleAnnotPath !== 'null'
+      ) {
+        filenames[annotName] = possibleAnnotPath;
       } else {
         filenames[annotName] = annotDirPath;
       }
     }
   }
-  
+
   // Add the incoming files
   for (i=0;i < newFiles.length;i++) {
-    if (filenames.includes(newFiles[i].name)) {
+    if (Object.keys(filenames).includes(newFiles[i].name)) {
       dupes.push(newFiles[i].name)
     } else {
       newDT.items.add(newFiles[i]);
 
       // Update filenames in case the dragged and dropped files include 2 files with the same name
-      filenames.push(newFiles[i].name)
+      [studyDir, annotDirPath, annotFilePath] = getFilePath(newFiles[i]);
+
+      possibleAnnotPath = getPossibleAnnotPath(newFiles[i].name);
+      console.log("POSSIBLE ANNOT PATH IN SEQ:", possibleAnnotPath, "NONE OF THESE:", possibleAnnotPaths[newFiles[i].name], "WERE IN SEQDIRS:", sequenceDirsHash["allSequenceDirs"]);
+
+      if (
+        annotDirPath === ''
+        && typeof possibleAnnotPath !== 'undefined'
+        && possibleAnnotPath
+        && possibleAnnotPath !== 'null'
+      ) {
+        filenames[newFiles[i].name] = possibleAnnotPath;
+        annotFilePath = possibleAnnotPath;
+      } else {
+        filenames[newFiles[i].name] = annotDirPath;
+      }
 
       let annotFormRow = addPeakAnnotFileToUpload(newFiles[i])
-      
-      globalThis.peakAnnotHash[annotName] = {
+
+      globalThis.peakAnnotHash[newFiles[i].name] = {
         "annotFilePath": annotFilePath,
         "defaultSequenceDirSelectElem": annotFormRow.querySelector('select[name=default_sequence_dir]'),
         "defaultScanDirSelectElem": annotFormRow.querySelector('select[name=default_scan_dir]'),
         "defaultSequenceDirs": [],
         "defaultScanDirs": [],
-        "defaultSequenceSelectOptions": [],
-        "defaultScanSelectOptions": []
       };
     }
   }
   globalThis.annotFilesInput.files = newDT.files;
-  
+
   // Clear the drop area to accept new files
   peakAnnotDropAreaInput.value = null
-  
+
   if (dupes.length > 0) {
     alert("Peak annotation filenames must be unique.  Skipped these files with duplicate names:" + dupes)
   }
-  
+
   // Now that the peak annot form rows have been added, we can populate the select lists and try to make default
   // selections
-  updateAnnotSelectLists();
+  updateAnnotDefaultSequenceSelectLists();
+
+  updateAnnotToMzxmlData();
 
   // Now replace the input element's old files with the merged new files
   // Enable form submission
   enableSubmissionForm();
 }
 
+function getPossibleAnnotPath(annotName) {
+  // This takes a file name and looks in possibleAnnotPaths to see if a file by that name was seen in 1 sequence
+  // directory.  Returns null if not.
+  let possibleAnnotPath = null;
+  if (
+    !Object.keys(sequenceDirsHash).includes("allSequenceDirs")
+    || Object.keys(possibleAnnotPaths).length == 0
+    || !Object.keys(possibleAnnotPaths).includes(annotName)
+  ) {
+    return possibleAnnotPath;
+  }
+  let possibleAnnotPathsInSeqDirs = [];
+  // For each possible path
+  for (let i = 0; i < possibleAnnotPaths[annotName].length; i++) {
+    let possAnnPath = possibleAnnotPaths[annotName][i];
+    console.log("COMPARING possAnnPath", possAnnPath);
+    // For each sequence directory
+    for (let j=0; j < sequenceDirsHash["allSequenceDirs"].length; j++) {
+      let seqDirPath = sequenceDirsHash["allSequenceDirs"][j];
+      console.log("WITH seqDirPath", seqDirPath);
+      // If the possible path is in a sequence directory
+      if (possAnnPath.startsWith(seqDirPath + '/') || seqDirPath === '') {
+        console.log("GOT ONE", possAnnPath, "IS IN", seqDirPath);
+        // Add it to the possible matching paths
+        possibleAnnotPathsInSeqDirs.push(possAnnPath);
+        break;
+      }
+    }
+  }
+  if (possibleAnnotPathsInSeqDirs.length === 1) {
+    possibleAnnotPath = possibleAnnotPathsInSeqDirs[0];
+  }
+  return possibleAnnotPath;
+}
+
 function getFilePath(fileObject) {
   let tmpPath;
 
   // Extract the relative path of the file (not including the file name)
-  if ((Object.hasOwn(fileObject, 'webkitRelativePath') || 'webkitRelativePath' in fileObject) && typeof fileObject.webkitRelativePath !== 'undefined' && fileObject.webkitRelativePath && fileObject.webkitRelativePath !== '') {
-    console.log("Getting webkitRelativePath for file", fileObject)
+  if (
+    (Object.hasOwn(fileObject, 'webkitRelativePath') || 'webkitRelativePath' in fileObject)
+    && typeof fileObject.webkitRelativePath !== 'undefined'
+    && fileObject.webkitRelativePath
+    && fileObject.webkitRelativePath !== ''
+  ) {
     tmpPath = fileObject.webkitRelativePath;
-  } else if ((Object.hasOwn(fileObject, 'path') || 'path' in fileObject) && typeof fileObject.path !== 'undefined' && fileObject.path && fileObject.path !== '') {
-    console.log("Getting path for file", fileObject)
+  } else if (
+    (Object.hasOwn(fileObject, 'path') || 'path' in fileObject)
+    && typeof fileObject.path !== 'undefined'
+    && fileObject.path
+    && fileObject.path !== ''
+  ) {
     // Paths should be relative to the dropped directory, but the code that assigns the apth attribute includes the
     // dropped directory in the path, so here, we trim it off:
     tmpPath = fileObject.path
-  } else if ((Object.hasOwn(fileObject, 'fullpath') || 'fullpath' in fileObject) && typeof fileObject.fullpath !== 'undefined' && fileObject.fullpath && fileObject.fullpath !== '') {
-    console.log("Getting fullpath for file", fileObject)
+  } else if (
+    (Object.hasOwn(fileObject, 'fullpath') || 'fullpath' in fileObject)
+    && typeof fileObject.fullpath !== 'undefined'
+    && fileObject.fullpath
+    && fileObject.fullpath !== ''
+  ) {
     tmpPath = fileObject.fullpath;
   } else {
     console.log("Getting name for file", fileObject)
@@ -350,25 +459,32 @@ function getFilePath(fileObject) {
   return [root, dirPath, filePathList.join('/')];
 }
 
-function updateAnnotSelectLists() {
+function updateAnnotDefaultSequenceSelectLists() {
   // Return if either the sequenceDirsHash or peakAnnotHash are empty
-  if (Object.keys(sequenceDirsHash).length == 0 || Object.keys(peakAnnotHash).length == 0) {
+  if (Object.keys(sequenceDirsHash).length === 0 || Object.keys(peakAnnotHash).length === 0) {
+    console.log("There is either no study folder added or not peak annotation files added.");
     return;
   }
 
-  // For annotFileName in Object.keys(peakAnnotHash)
-  for (annotFileName in Object.keys(peakAnnotHash)) {
+  // For annotFileName in peakAnnotHash
+  for (const annotFileName in peakAnnotHash) {
     // Get the input defaultSequenceDir select list input element
+    console.log("Object.keys(peakAnnotHash)", Object.keys(peakAnnotHash), "peakAnnotHash", peakAnnotHash, "annotFileName", annotFileName, "peakAnnotHash", peakAnnotHash)
     annotSeqDirSelectElem = peakAnnotHash[annotFileName]["defaultSequenceDirSelectElem"];
     annotScanDirSelectElem = peakAnnotHash[annotFileName]["defaultScanDirSelectElem"];
     annotFilePath = peakAnnotHash[annotFileName]["annotFilePath"];
 
     // If peakAnnotHash[annotFileName]["defaultSequenceDirs"] is empty
-    if (peakAnnotHash[annotFileName]["defaultSequenceDirs"].length == 0) {
+    if (peakAnnotHash[annotFileName]["defaultSequenceDirs"].length === 0) {
       // Populate html options from the sequenceDirsHash
-      annotSeqDirSelectElem.innerHTML = sequenceDirsHash["sequenceSelectOptions"];
+      annotSeqDirSelectElem.innerHTML = '';
+      sequenceDirsHash["sequenceSelectOptions"].forEach(option => {annotSeqDirSelectElem.appendChild(option.cloneNode(true));});
       // Populate peakAnnotHash[annotFileName]["defaultSequenceDirs"] from the sequenceDirsHash
+      console.log("ADDED ALL SEQDIRS TO", annotFileName, "EMPTY annotSeqDirSelectElem", annotSeqDirSelectElem)
       globalThis.peakAnnotHash[annotFileName]["defaultSequenceDirs"] = sequenceDirsHash["allSequenceDirs"].slice();
+      // The default sequence directory select list changed, so empty the default scan directory select list
+      annotScanDirSelectElem.innerHTML = '';
+      peakAnnotHash[annotFileName]["defaultScanDirs"] = [];
     }
     // Else If peakAnnotHash[annotFileName]["defaultSequenceDirs"] differs from the sequenceDirsHash
     else if (!arraysEqual(peakAnnotHash[annotFileName]["defaultSequenceDirs"], sequenceDirsHash["allSequenceDirs"])) {
@@ -377,34 +493,143 @@ function updateAnnotSelectLists() {
 
       // Empty the innerHTML and peakAnnotHash[annotFileName]["defaultSequenceDirs"]
       // Populate innerHTML and peakAnnotHash[annotFileName]["defaultSequenceDirs"] from the sequenceDirsHash
-      annotSeqDirSelectElem.innerHTML = sequenceDirsHash["sequenceSelectOptions"];
+      annotSeqDirSelectElem.innerHTML = '';
+      sequenceDirsHash["sequenceSelectOptions"].forEach(option => {annotSeqDirSelectElem.appendChild(option.cloneNode(true));});
       globalThis.peakAnnotHash[annotFileName]["defaultSequenceDirs"] = sequenceDirsHash["allSequenceDirs"].slice();
 
       // If the saved selected option exists among the new options, select it
-      if (typeof savedDefSeqVal !== 'undefined' && savedDefSeqVal && peakAnnotHash[annotFileName]["defaultSequenceDirs"].includes(savedDefSeqVal)) {
+      if (
+        typeof savedDefSeqVal !== 'undefined'
+        && savedDefSeqVal
+        && peakAnnotHash[annotFileName]["defaultSequenceDirs"].includes(savedDefSeqVal)
+      ) {
+        console.log("annotFilePath", annotFilePath, "HAD A PREVIOUS SELECTION:", savedDefSeqVal)
         annotSeqDirSelectElem.value = savedDefSeqVal;
       }
+      console.log("ADDED ALL SEQDIRS TO", annotFileName, "DIFFERING annotSeqDirSelectElem", annotSeqDirSelectElem);
+      // The default sequence directory select list changed, so empty the default scan directory select list
+      annotScanDirSelectElem.innerHTML = '';
+      peakAnnotHash[annotFileName]["defaultScanDirs"] = [];
+    } else {
+      console.log("Apparently these arrays are equal:", peakAnnotHash[annotFileName]["defaultSequenceDirs"], sequenceDirsHash["allSequenceDirs"])
     }
-///////////////////LEFT OFF HERE
+
     // If there is not a defaultSequenceDir select list selection
-    //   If an unambiguous defaultSequenceDir selection can be made
-    //     Set the selection
-    //
-    // If there is a defaultSequenceDir select list selection (check anew)
-    //   If peakAnnotHash[annotFileName]["defaultScanDirs"] is empty
-    //     Populate innerHTML and peakAnnotHash[annotFileName]["defaultSscanDirs"] from the sequenceDirsHash
-    //   Else If peakAnnotHash[annotFileName]["defaultScanDirs"] differs from the sequenceDirsHash
-    //     Save the current selected option
-    //     Empty innerHTML and peakAnnotHash[annotFileName]["defaultScanDirs"]
-    //     Populate innerHTML and peakAnnotHash[annotFileName]["defaultSscanDirs"]) from the sequenceDirsHash
-    //     If the saved selected option exists among the new options
-    //       Select it
-    //   If there is not a defaultScanDir select list selection
-    //     If an unambiguous defaultScanDir selection can be made
-    //       Set the selection
-    // Else
-    //   Empty the innerHTML and peakAnnotHash[annotFileName]["defaultScanDirs"]
+    if (typeof annotSeqDirSelectElem.value === 'undefined' || !annotSeqDirSelectElem.value || annotSeqDirSelectElem.value === 'null') {
+      const annotInSeqDir = (seqDir) => annotFilePath.startsWith(seqDir + '/') || seqDir == '';
+      matchingSeqDirs = sequenceDirsHash["allSequenceDirs"].filter(annotInSeqDir);
+      // If an unambiguous defaultSequenceDir selection can be made
+      if (matchingSeqDirs.length === 1) {
+        // Set the selection
+        console.log("annotFilePath", annotFilePath, "MATCHED 1 SEQDIR:", matchingSeqDirs[0])
+        annotSeqDirSelectElem.value = matchingSeqDirs[0];
+      } else {
+        console.log("annotFilePath", annotFilePath, "MATCHED", matchingSeqDirs.length, "SEQDIR:", matchingSeqDirs, "ALL SEQDIRS:", sequenceDirsHash["allSequenceDirs"])
+      }
+    }
   }
+
+  updateAnnotDefaultScanSelectLists();
+}
+
+function updateAnnotDefaultScanSelectLists() {
+  // TODO: FIX BUG: DO NOT SELECT A SCAN DIRECTORY IF THERE ARE MULTIPLE TO CHOOSE FROM AND THE ANNOTATION FILE IS OUTSIDE ANY SEQUENCE DIRECTORY
+
+  // Return if either the sequenceDirsHash or peakAnnotHash are empty
+  if (Object.keys(sequenceDirsHash).length === 0 || Object.keys(peakAnnotHash).length === 0) {
+    console.log("There is either no study folder added or not peak annotation files added.");
+    return;
+  }
+
+  // For annotFileName in peakAnnotHash
+  for (const annotFileName in peakAnnotHash) {
+    // Get the input defaultSequenceDir select list input element
+    console.log("Object.keys(peakAnnotHash)", Object.keys(peakAnnotHash), "peakAnnotHash", peakAnnotHash, "annotFileName", annotFileName, "peakAnnotHash", peakAnnotHash)
+    annotSeqDirSelectElem = peakAnnotHash[annotFileName]["defaultSequenceDirSelectElem"];
+    annotScanDirSelectElem = peakAnnotHash[annotFileName]["defaultScanDirSelectElem"];
+    annotFilePath = peakAnnotHash[annotFileName]["annotFilePath"];
+
+    const annotInScanDir = (scanDir) => annotFilePath.startsWith(scanDir + '/') || scanDir == '';
+
+    // If there is a defaultSequenceDir select list selection (check anew)
+    if (typeof annotSeqDirSelectElem.value !== 'undefined' && ((annotSeqDirSelectElem.value && annotSeqDirSelectElem.value !== 'null') || annotSeqDirSelectElem.value === '')) {
+      seqdirpath = annotSeqDirSelectElem.value;
+      annotDefScanDirs = peakAnnotHash[annotFileName]["defaultScanDirs"];
+      // If peakAnnotHash[annotFileName]["defaultScanDirs"] is empty
+      if (typeof annotDefScanDirs === 'undefined' || !annotDefScanDirs || annotDefScanDirs.length === 0) {
+        // Populate innerHTML from the sequenceDirsHash
+        annotScanDirSelectElem.innerHTML = '';
+        console.log('seqdirpath', seqdirpath, 'sequenceDirsHash["allScanDirs"]', sequenceDirsHash["allScanDirs"])
+        sequenceDirsHash["allScanDirs"][seqdirpath]["scanSelectOptions"].forEach(
+          option => {annotScanDirSelectElem.appendChild(option.cloneNode(true));
+        });
+        // Populate peakAnnotHash[annotFileName]["defaultScanDirs"] from the sequenceDirsHash
+        peakAnnotHash[annotFileName]["defaultScanDirs"] = sequenceDirsHash["allScanDirs"][seqdirpath]["scanDirs"];
+        console.log("ADDED ALL SCANDIRS TO", annotFileName, "EMPTY annotScanDirSelectElem", annotScanDirSelectElem)
+      }
+      // Else If peakAnnotHash[annotFileName]["defaultScanDirs"] differs from the sequenceDirsHash
+      else if (
+        !arraysEqual(
+          peakAnnotHash[annotFileName]["defaultScanDirs"],
+          sequenceDirsHash["allScanDirs"][seqdirpath]["scanDirs"]
+        )
+      ) {
+        // Save the current selected option
+        savedDefScanVal = annotScanDirSelectElem.value;
+        // Empty innerHTML and peakAnnotHash[annotFileName]["defaultScanDirs"]
+        // Populate innerHTML from the sequenceDirsHash
+        annotScanDirSelectElem.innerHTML = '';
+        sequenceDirsHash["allScanDirs"][seqdirpath]["scanSelectOptions"].forEach(
+          option => {annotScanDirSelectElem.appendChild(option.cloneNode(true));
+        });
+        // Populate peakAnnotHash[annotFileName]["defaultScanDirs"]) from the sequenceDirsHash
+        peakAnnotHash[annotFileName]["defaultScanDirs"] = sequenceDirsHash["allScanDirs"][seqdirpath]["scanDirs"];
+        if (typeof savedDefScanVal !== 'undefined' && savedDefScanVal) {
+          // If the saved selected option exists among the new options
+          matchingScanDirs = peakAnnotHash[annotFileName]["defaultScanDirs"].filter(annotInScanDir);
+          if (matchingScanDirs.length > 0) {
+            // Select it
+            annotScanDirSelectElem.value = savedDefScanVal;
+          }
+        }
+        console.log("ADDED ALL SCANDIRS TO", annotFileName, "DIFFERING annotScanDirSelectElem", annotScanDirSelectElem)
+      } else {
+        console.log("Apparently these arrays are equal:", peakAnnotHash[annotFileName]["defaultScanDirs"], sequenceDirsHash["allScanDirs"][seqdirpath]["scanDirs"])
+      }
+      // If there is not a defaultScanDir select list selection
+      if (typeof annotScanDirSelectElem.value === 'undefined' || !annotScanDirSelectElem.value || annotScanDirSelectElem.value === 'null') {
+        // If an unambiguous defaultScanDir selection can be made
+        matchingScanDirs = peakAnnotHash[annotFileName]["defaultScanDirs"].filter(annotInScanDir);
+        if (matchingScanDirs.length === 1) {
+          // Set the selection
+          annotScanDirSelectElem.value = matchingScanDirs[0];
+        } else {
+          console.log("annotFilePath", annotFilePath, "MATCHED", matchingScanDirs.length, "SCANDIR:", matchingScanDirs, "ALL SCANDIRS:", peakAnnotHash[annotFileName]["defaultScanDirs"])
+        }
+      } else {
+        console.log("annotScanDirSelectElem.value:", annotScanDirSelectElem.value);
+      }
+    // Else
+    } else {
+      // Empty the innerHTML and peakAnnotHash[annotFileName]["defaultScanDirs"]
+      annotScanDirSelectElem.innerHTML = '';
+      peakAnnotHash[annotFileName]["defaultScanDirs"] = [];
+      console.log("EMPTIED SCANDIRS FOR", annotFileName, "BECAUSE THE DEFSEQDIRS SELECT LIST HAS NO SELECTION")
+    }
+  }
+}
+
+function updateAnnotToMzxmlData() {
+  // Start from scratch
+  globalThis.annotToMzxmlHash = {};
+  for (annotFileName in peakAnnotHash) {
+    globalThis.annotToMzxmlHash[annotFileName] = {
+      "annotFilePath": peakAnnotHash[annotFileName]["annotFilePath"],
+      "defaultSequenceDir": peakAnnotHash[annotFileName]["defaultSequenceDirSelectElem"].value,
+      "defaultScanDir": peakAnnotHash[annotFileName]["defaultScanDirSelectElem"].value
+    };
+  }
+  globalThis.annotToMzxmlInput.value = JSON.stringify(annotToMzxmlHash);
 }
 
 // See: https://stackoverflow.com/a/16436975/2057516
@@ -425,7 +650,7 @@ function arraysEqual(a, b) {
 }
 
 function refreshStudyMetadata (files) { // eslint-disable-line no-unused-vars
-  [studyDirs, filepaths, possibleStudyDocs, possiblePeakAnnotFiles] = getStudyMetadata(files)
+  let [studyDirs, filepaths, possibleStudyDocs, possiblePeakAnnotFiles] = getStudyMetadata(files)
 
   // Save the possible peak annot paths to help automatically select the default sequence dir and default scan dir based
   // on colocation with the saved sequence dirs and their scan dirs
@@ -433,18 +658,38 @@ function refreshStudyMetadata (files) { // eslint-disable-line no-unused-vars
 
   // Only allow 1 folder: 1 study folder or 1 submission folder (with multiple studies).
   if (studyDirs.length > 1) {
-    alert('Only 1 study folder allowed.  ' + studyDirs.length + ' is too many: ["' + studyDirs.join('", "') + '"].\n\nIf you have multiple studies in this submission, put both study folders in a single submission folder and select/drop that folder.');
+    alert(
+      'Only 1 study folder allowed.  '
+      + studyDirs.length
+      + ' is too many: ["'
+      + studyDirs.join('", "')
+      + '"].\n\n'
+      + 'If you have multiple studies in this submission, put both study folders in a single submission folder and '
+      + 'select/drop that folder.'
+    );
     return
   }
 
+  let studyDir = studyDirs[0];
+
   console.log("filepaths:", filepaths)
+
+  noSeqDirOption = document.createElement("option");
+  noSeqDirOption.value = null;
+  noSeqDirOption.text = " --- Select a sequence folder --- ";
+  noSeqDirOption.selected = true;
+
+  noScanDirOption = document.createElement("option");
+  noScanDirOption.value = null;
+  noScanDirOption.text = " --- Select a scan sub-folder --- ";
+  noScanDirOption.selected = true;
 
   // Clear out previously added sequence form rows and saved sequence directories
   mzxmlFormsTable.innerHTML = ''
   globalThis.sequenceDirsHash = {
     "allSequenceDirs": [],
-    "sequenceSelectOptions": '',
-    "scanDirSelectLists": {} 
+    "sequenceSelectOptions": [noSeqDirOption.cloneNode(true)],
+    "allScanDirs": {}
   }
 
   // Update the mzxml_file_list form element
@@ -453,8 +698,6 @@ function refreshStudyMetadata (files) { // eslint-disable-line no-unused-vars
 
   let mzxmldirpaths = getAllMzxmlDirectories(filepaths)
   let sequenceDirPathsHash = getParentMzxmlDirectories(mzxmldirpaths)
-
-  // TODO: Build a seqdir select list and a series of scandir select lists keyed on seqdir in the loop below
 
   // For each sequence directory
   for (seqdirpath of Object.keys(sequenceDirPathsHash)) {
@@ -468,39 +711,44 @@ function refreshStudyMetadata (files) { // eslint-disable-line no-unused-vars
     sequenceOption.value = seqdirpath;
     sequenceOption.text = seqdirpath;
     if (seqdirpath === '') {
-      sequenceOption.text += "'' (the study/root directory)";
+      sequenceOption.text += ". (" + studyDir + ")";
     }
-    globalThis.sequenceDirsHash["sequenceSelectOptions"] += sequenceOption;
-    
+    globalThis.sequenceDirsHash["sequenceSelectOptions"].push(sequenceOption);
+    console.log("ADDED SEQDIR OPTION sequenceOption", sequenceOption)
+
     // Add this scan subdirectories to the template scan directory select list options
-    globalThis.sequenceDirsHash["scanDirSelectLists"][seqdirpath] = [];
+    globalThis.sequenceDirsHash["allScanDirs"][seqdirpath] = {
+      "scanDirs": [],
+      "scanSelectOptions": [noScanDirOption.cloneNode(true)]
+    };
     for (var i = 0; i < sequenceDirPathsHash[seqdirpath].length; i++) {
       scanSubDir = sequenceDirPathsHash[seqdirpath][i];
       var scanSubDirOption = document.createElement("option");
       scanSubDirOption.value = scanSubDir;
       scanSubDirOption.text = scanSubDir;
       if (scanSubDir === '') {
-        scanSubDirOption.text += "'' (the sequence directory: '" + seqdirpath + "')";
+        if (seqdirpath === '') {
+          scanSubDirOption.text += ". (" + studyDir + ")";
+        } else {
+          scanSubDirOption.text += ". (" + seqdirpath + ")";
+        }
       }
-      globalThis.sequenceDirsHash["scanDirSelectLists"][seqdirpath].push(scanSubDirOption);
+      globalThis.sequenceDirsHash["allScanDirs"][seqdirpath]["scanDirs"].push(scanSubDir);
+      globalThis.sequenceDirsHash["allScanDirs"][seqdirpath]["scanSelectOptions"].push(scanSubDirOption);
     }
-  
-    /////////////////////////////////LEFT OFF HERE - Trigger existing peak annotation files' select lists to update
-    // getMzxmlsInDirectory
-    // Trigger existing peak annotation files' select lists to update
-    // Construct string (using .join()) of filepaths - use to populate the peak_annot_to_mzxml_metadata form elem
   }
-  globalThis.sequenceDirsHash = sequenceDirPathsHash
 
-  // TODO: Update the peak annotation file row select lists
+  // Now that the peak annot form rows have been added, we can populate the select lists and try to make default
+  // selections
+  updateAnnotDefaultSequenceSelectLists();
 
   // TODO: Populate a list of files for each sequence form row that only display when the user does something (like click a caret or hover or something)
 }
 
 function addSequenceFormRow (seqdirpath) {
-  let newRow = mzxmlFormTemplateContainer.cloneNode(true)
-  makeSequenceFormModifications(newRow, seqdirpath)
-  mzxmlFormsTable.appendChild(newRow)
+  let newRow = mzxmlFormTemplateContainer.cloneNode(true);
+  makeSequenceFormModifications(newRow, seqdirpath);
+  mzxmlFormsTable.appendChild(newRow);
 }
 
 function makeSequenceFormModifications (formRow, seqdirpath) {
@@ -534,10 +782,11 @@ function makeSequenceFormModifications (formRow, seqdirpath) {
  */
 function clearSubmissionForm () { // eslint-disable-line no-unused-vars
   peakAnnotFormsTable.innerHTML = '';
-  mzxmlFormsTable.innerHTML = ''
+  mzxmlFormsTable.innerHTML = '';
   globalThis.peakAnnotHash = {};
   globalThis.sequenceDirsHash = {};
   globalThis.possibleAnnotPaths = {};
+  globalThis.annotToMzxmlHash = {};
   dataSubmissionForm.reset();
   // TODO: Clear each peak annotation files' select lists (defaultSequenceDir and defaultScanDir)
   disableSubmissionForm();
@@ -579,10 +828,24 @@ function getMzxmlFileNamesString (newFiles, curstring) {
 
 function getStudyMetadata(files) {
   // See: https://stackoverflow.com/a/60538623/2057516
-  let allMzxmlFilePathList = []
-  let studyDirs = []
-  let possibleStudyDocs = []
-  let possiblePeakAnnotFiles = {}
+  let allMzxmlFilePathList = [];
+  let studyDirs = [];
+  let possibleStudyDocs = [];
+  let possiblePeakAnnotFiles = {};
+
+  // This method can take some time, and things won't work until it's done, so...
+  // Obtain the divs for graying out the page while dropped items are read
+  overlayDiv = document.getElementById("overlay");
+  popupDiv = document.getElementById("popup");
+  popupDiv.innerHTML = 'Processing files.  Please wait.';
+
+  console.log("graying out page");
+
+  // const start = Date.now();
+
+  overlayDiv.style.display = "block";
+  popupDiv.style.display = "block";
+
   for (let i = 0; i < files.length; ++i) {
     let fileName = files[i].name;
 
@@ -597,19 +860,42 @@ function getStudyMetadata(files) {
 
     if (fileName.toLowerCase().endsWith(".mzxml")) {
       allMzxmlFilePathList.push(filePath)
-    } else if (fileName.toLowerCase().endsWith(".xlsx") || fileName.toLowerCase().endsWith(".csv") || fileName.toLowerCase().endsWith(".tsv")) {
+    } else if (
+      fileName.toLowerCase().endsWith(".xlsx")
+      || fileName.toLowerCase().endsWith(".csv")
+      || fileName.toLowerCase().endsWith(".tsv")
+    ) {
       // The study doc must be in the root directory
       if (fileName.toLowerCase().endsWith(".xlsx") && dirPath === "") {
         possibleStudyDocs.push(fileName)
       }
+
+      // There can be multiple files with the same name, especially if original versions of files are saved in a
+      // subdirectory, so this accounts for all versions by storing an array of file paths keyed on filename.
+      if (!Object.keys(possiblePeakAnnotFiles).includes(fileName)) {
+        possiblePeakAnnotFiles[fileName] = [];
+      }
+
       if (dirPath === '') {
-        possiblePeakAnnotFiles[fileName] = fileName;
+        possiblePeakAnnotFiles[fileName].push(fileName);
       } else {
-        possiblePeakAnnotFiles[fileName] = filePath;
+        possiblePeakAnnotFiles[fileName].push(filePath);
       }
     }
   }
-  console.log("studyDirs:", studyDirs, "mzXML paths:", allMzxmlFilePathList, "possibleStudyDocs", possibleStudyDocs, "possiblePeakAnnotFiles", possiblePeakAnnotFiles)
+  console.log("Done reading folder")
+
+  // let elapsed = Date.now() - start;
+  // while (elapsed < 3000) {
+  //   if (elapsed % 1000 === 0) {console.log(elapsed)}
+  //   elapsed = Date.now() - start;
+  // }
+  console.log("Un-graying page");
+
+  // Hide the overlay and popup when the task is done
+  overlayDiv.style.display = "none";
+  popupDiv.style.display = "none";
+
   return [studyDirs, allMzxmlFilePathList, possibleStudyDocs, possiblePeakAnnotFiles]
 }
 
@@ -630,7 +916,7 @@ function getAllMzxmlDirectories(filepaths) {
     }
   }
   // In case there is no webkitRelativePath attribute
-  if (mzxmlDirList.length == 0) {
+  if (mzxmlDirList.length === 0) {
     mzxmlDirList.push('')
   }
   console.log("mzXML dirs:", mzxmlDirList)


### PR DESCRIPTION
## Summary Change Description

Proof of concept, to show that it's possible to drop and read a study folder and associate peak annotation files with sequence and scan directories.

Notes:

- The feature this is a POC for will not be implemented before the end of February publication deadline.  (I will proceed directly from this PR creation to resuming the extraction of legacy code.)
- No linting has been performed
- No tests have been run
- Debug code is present
- Views and loaders have not been updated
- It's possible to use this code with current study doc, but ideally, a new `MS Files` sheet will be added and schema changed
- After implementation, I realized the possibility of 2 improvements:
  - Formsets could be eliminated by storing the sequence metadata in a hidden json field
  - Javascript performance can be improved by looping on the result of the directory entry reading instead of on file objects

## Affected Issues/Pull Requests

- Discussion: #1417

## Reviewer Notes/Requests
<!-- Notes to help the reviewer or requests for specific scrutiny.
E.g. Please make sure I have accounted for all possible inputs. -->
See comments in-line.

## Checklist
<!-- If any requirements are not met, uncheck and explain.
E.g. Linting errors pre-date this PR. -->
This pull request will be merged once the following requirements are met.  The
author and/or reviewers should uncheck any unmet requirements:
<!-- Check/complete items if not applicable. -->
- Review Requirements
  - Minimum approvals: 1 <!-- Edit based on complexity. -->
  - No changes requested
  - All blocking issues resolved by reviewers
  - Specific reviewers: @__add_username_here__ <!-- Approvals required even if minimum met. -->
  - Review period: 2 days <!-- Edit based on complexity. -->
- Associated Issue/PR Requirements: <!-- Assert resolved issues/PRs are done/merged. -->
  - [x] All issue requirements are satisfied
  - [x] All PR dependencies are merged
- Basic Requirements <!-- Uncheck to indicate items you are yet to address. -->
  - [x] [Linters pass](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#linting)
  - [x] [Tests pass](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#quality-control)
  - [x] Conflicts resolved
- Overhead Requirements <!-- Requirements indirectly related to the issues. -->
  - [x] [Tests implemented/updated](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#test-implementation)
  - [ ] [Updated `CHANGELOG.md` *Unreleased* section](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/changelog.md)
