### PR TITLE
Proof of Concept: sample server-side pagination using parquet file and Polars data frame

### DIFF
--- a/DataRepo/fixtures/sample_list_summary_metadata.yaml
+++ b/DataRepo/fixtures/sample_list_summary_metadata.yaml
@@ -1,0 +1,185 @@
+---
+# define all columns in the data source (e.g. dataframe) for displaying or downloading sample summary table
+- column_name: "sample"
+  is_web_display: True
+  display_name: "Sample"
+  linking_id_column: "sample_id"
+  description: >-
+    The name of a sample stored in Sample model in the database
+- column_name: "sample_id"
+  is_web_display: False
+  description: >-
+    The id of the sample in the database record
+- column_name: "animal"
+  is_web_display: True
+  display_name: "Animal"
+  linking_id_column: "animal_id"
+  description: >-
+    The name of the animal in the database record associated with the sample
+- column_name: "animal_id"
+  is_web_display: False
+  description: >-
+    The id of the animal in the database record associated with the sample
+- column_name: "tissue"
+  is_web_display: True
+  display_name: "Tissue"
+  linking_id_column: "tissue_id"
+  description: >-
+    The tissue type in the database record associated with the sample
+- column_name: "tissue_id"
+  is_web_display: False
+  description: >-
+    The id of the tissue type in the database record associated with the sample
+- column_name: "studies"
+  is_web_display: True
+  display_name: "Studies"
+  linking_id_column: "study_id_name_list"
+  description: >-
+    The list of unique study names in the database record(s) associated with the animal
+- column_name: "study_id_name_list"
+  is_web_display: False
+  description: >-
+    The list of unique study ids and names seperated by defined delimiter for the animal
+- column_name: "genotype"
+  is_web_display: True
+  display_name: "Genotype"
+  description: >-
+    The Genotype of the animal
+- column_name: "infusate_name"
+  is_web_display: True
+  display_name: "Infusate"
+  linking_id_column: "infusate_id"
+  description: >-
+    The name of the infusate in the database record associated with the animal
+- column_name: "infusate_id"
+  is_web_display: False
+  description: >-
+    The id of the infusate in the database record associated with the animal
+- column_name: "tracers"
+  is_web_display: True
+  display_name: "Tracer(s)"
+  linking_id_column: "tracer_id_name_list"
+  description: >-
+    The list of tracer names in the database record(s) associated with the infusate
+- column_name: "tracer_id_name_list"
+  is_web_display: False
+  description: >-
+    The list of unique tracer ids and names seperated by defined delimiter for the infusate
+- column_name: "compound_id_name_list"
+  is_web_display: False
+  description: >-
+    The list of unique compound ids and names seperated by defined delimiter for the infusate
+- column_name: "tracer_group_name"
+  is_web_display: False
+  description: >-
+    The short name for the group of tracers associated with the infusate
+- column_name: "concentrations"
+  is_web_display: True
+  display_name: "Tracer Concentration(s) (mM)"
+  description: >-
+    The list of tracer concentrations for the tracers associated with the infusate
+- column_name: "labeled_elements"
+  is_web_display: True
+  display_name: "Tracer Elements"
+  description: >-
+    The list of unique labeled elements seperated by defined delimiter for the infusate
+- column_name: "infusion_rate"
+  is_web_display: True
+  display_name: "Infusion Rate (ul/min/g)"
+  description: >-
+    The rate of infusion of the tracer solution in microliters/min/gram of body weight of the animal
+- column_name: "treatment"
+  is_web_display: True
+  display_name: "Treatment"
+  linking_id_column: "treatment_id"
+  description: >-
+    The name of the protocol of a database record in animal treatment category associated with the animal
+- column_name: "treatment_id"
+  is_web_display: False
+  description: >-
+    The id of the protocol of a database record in animal treatment category associated with the animal
+- column_name: "treatment_category"
+  is_web_display: False
+  description: >-
+    The category of the treatment associated with the animal
+- column_name: "body_weight"
+  is_web_display: True
+  display_name: "Body Weight (g)"
+  description: >-
+    The weight (in grams) of the animal
+- column_name: "age"
+  is_web_display: False
+  description: >-
+    The age of the animal with the value stored as duration
+- column_name: "age_in_weeks"
+  is_web_display: True
+  display_name: "Age (weeks)"
+  description: >-
+    The age of the animal with the value in week(s)
+- column_name: "sex"
+  is_web_display: True
+  display_name: "Sex"
+  description: >-
+      The sex of the animal
+- column_name: "diet"
+  is_web_display: True
+  display_name: "Diet"
+  description: >-
+    The feeding descriptor for the animal
+- column_name: "feeding_status"
+  is_web_display: True
+  display_name: "Feeding status"
+  description: >-
+    The laboratory coded dietary state for the animal
+- column_name: "sample_owner"
+  is_web_display: True
+  display_name: "Sample Owner"
+  description: >-
+    The name of the researcher who prepared the sample
+- column_name: "sample_date"
+  is_web_display: False
+  description: >-
+    The date the sample was collected in iso date format
+- column_name: "sample_date_formatted"
+  is_web_display: True
+  display_name: "Sample Date"
+  description: >-
+    The date the sample was collected in yyyy-mm-dd format
+- column_name: "sample_time_collected"
+  is_web_display: True
+  display_name: "Time Collected"
+  description: >-
+    The time the sample was collected, with unit in nanoseconds
+- column_name: "sample_time_collected_m"
+  is_web_display: True
+  display_name: "Time Collected (m)"
+  description: >-
+    The time the sample was collected with unit in minutes
+- column_name: "msrunsample_id"
+  is_web_display: True
+  display_name: "MSRunSample Detail"
+  description: >-
+    The id of a database record in MSRunSample model
+- column_name: "msrunsample_owner"
+  is_web_display: True
+  display_name: "MSRun Owner"
+  description: >-
+    The name of the researcher who ran the mass spectrometer
+- column_name: "msrunsample_date"
+  is_web_display: False
+  description: >-
+    The date that the mass spectrometer was run, in iso date format
+- column_name: "msrunsample_date_formatted"
+  is_web_display: True
+  display_name: "MSRun Date"
+  description: >-
+    The date that the mass spectrometer was run in yyyy-mm-dd format
+- column_name: "lc_method_id"
+  is_web_display: False
+  description: >-
+    The id of a database record in LCMethod associated with the MSRun for the sample
+- column_name: "lc_method"
+  is_web_display: False
+  description: >-
+    The name of a database record in LCMethod associated with the MSRun for the sample
+...

--- a/DataRepo/management/commands/write_summary_tables_to_files.py
+++ b/DataRepo/management/commands/write_summary_tables_to_files.py
@@ -1,0 +1,45 @@
+import os
+from pathlib import Path
+from django.core.management import BaseCommand
+from TraceBase import settings
+from DataRepo.utils import SummaryTableData as std
+
+ARCHIVE_DIR = settings.MEDIA_ROOT
+
+
+def get_or_create_summary_dir():
+    summary_dir = os.path.join(ARCHIVE_DIR, "summary")
+    try:
+        Path(summary_dir).mkdir(parents=True, exist_ok=True)
+    except Exception as e:
+        print(e)
+    return Path(summary_dir)
+
+
+def sample_summary_to_files():
+    # directory for storing output files
+    summary_dir = get_or_create_summary_dir()
+    # output files
+    file_prefix = "sample_list_summary"
+    out_csv_file = os.path.join(summary_dir, file_prefix + ".csv")
+    out_tsv_file = os.path.join(summary_dir, file_prefix + ".tsv")
+    out_excel_file = os.path.join(summary_dir, file_prefix + ".xlsx")
+    out_parquet_file = os.path.join(summary_dir, file_prefix + ".all_columns.parquet")
+
+    # data frame for sample summary table
+    sam_df = std.get_sample_summary_df()
+    sam_download_df = std.get_sample_summary_download_df()
+
+    print("sam_df total rows:", sam_df.shape[0])
+    print("sam_download_df total rows:", sam_download_df.shape[0])
+    # write output files
+    sam_download_df.to_csv(out_csv_file, index=False)
+    sam_download_df.to_csv(out_tsv_file, sep="\t", index=False)
+    sam_download_df.to_excel(out_excel_file, index=False)
+    sam_df.to_parquet(out_parquet_file)
+
+
+class Command(BaseCommand):
+
+    def handle(self, *args, **options):
+        sample_summary_to_files()

--- a/DataRepo/management/commands/write_summary_tables_to_files.py
+++ b/DataRepo/management/commands/write_summary_tables_to_files.py
@@ -1,8 +1,10 @@
 import os
 from pathlib import Path
+
 from django.core.management import BaseCommand
-from TraceBase import settings
+
 from DataRepo.utils import SummaryTableData as std
+from TraceBase import settings
 
 ARCHIVE_DIR = settings.MEDIA_ROOT
 

--- a/DataRepo/templates/DataRepo/sample_list.html
+++ b/DataRepo/templates/DataRepo/sample_list.html
@@ -4,29 +4,83 @@
 {% block title %}Samples{% endblock %}
 
 {% block head_extras %}
-    <link href="{% static 'css/bootstrap_table_cus1.css' %}" rel="stylesheet">
+    <link href="{% static 'css/bootstrap_table_cus2.css' %}" rel="stylesheet">
 {% endblock %}
 
 {% block content %}
+
+    <!-- mapping of DetailView with url prefix without pk argument -->
+    {{ url_prefix_dict |json_script:"url_prefix_dict" }}
+
 <div>
-<h4>List of Samples</h4>
-<br>
-    {% with out_df=df %}
-        {% include "DataRepo/includes/animal_sample_msrun_table.html" %}
-    {% endwith %}
-<br>
+    <h4>List of Samples</h4>
+    <br>
+    <div id="toolbar">
+        <!-- add download button with dropdown menu to the toolbar -->
+        <button class="btn btn-primary dropdown-toggle"  href="#", id="dropdown-download-data", type="button" data-bs-toggle="dropdown",
+                title="Download all data" aria-haspopup="true" aria-expanded="false"><i class="fa fa-download"></i></button>
+            <div class="dropdown-menu" aria-labelledby="dropdown-download-data">
+                <a class="dropdown-item" href="{% static 'summary/sample_list_summary.csv' %}">All Data in CSV</a>
+                <a class="dropdown-item" href="{% static 'summary/sample_list_summary.tsv' %}">All Data in TSV</a>
+                <a class="dropdown-item" href="{% static 'summary/sample_list_summary.xlsx' %}">All Data in EXCEL</a>
+            </div>
+        </button>
+    </div>
+    <table
+        id="sample_table"
+        data-toggle="table"
+        data-toolbar="#toolbar"
+        data-buttons-class="primary"
+        data-buttons-align="left"
+        data-search="true"
+        data-search-align="left"
+        data-show-search-clear-button="true"
+        data-show-multi-sort="true"
+        data-show-columns="true"
+        data-show-columns-toggle-all="true"
+        data-show-fullscreen="true"
+        data-show-extended-pagination="true"
+        data-pagination="true"
+        data-side-pagination="server"
+        data-page-list="[10, 25, 50, 100, 200, 500]"
+        data-url="{% url 'sample_json_data' %}">
+        <thead>
+            <tr>
+                <th data-field="sample" data-formatter="sampleNameFormatter" data-sortable="true">{{col_mapping_dict.sample }}</th>
+                <th data-field="animal" data-formatter="animalNameFormatter" data-sortable="true">{{col_mapping_dict.animal }}</th>
+                <th data-field="tissue" data-formatter="tissueNameFormatter" data-sortable="true">{{col_mapping_dict.tissue }}</th>
+                <th data-field="studies" data-formatter="studyListFormatter">{{ col_mapping_dict.studies }}</th>
+                <th data-field="genotype" data-sortable="true">{{ col_mapping_dict.genotype }}</th>
+                <th data-field="infusate_name" data-formatter="infusateNameFormatter" data-sortable="true">{{ col_mapping_dict.infusate_name }}</th>
+                <th data-field="tracers" data-formatter="tracerListFormatter" data-sortable="true">{{ col_mapping_dict.tracers }}</th>
+                <th data-field="concentrations" data-sortable="true">{{ col_mapping_dict.concentrations }}</th>
+                <th data-field="labeled_elements" data-sortable="true">{{ col_mapping_dict.labeled_elements }}</th>
+                <th data-field="infusion_rate" data-visible="false">{{ col_mapping_dict.infusion_rate }}</th>
+                <th data-field="treatment" data-formatter="treatmentFormatter" data-sortable="true">{{ col_mapping_dict.treatment }}</th>
+                <th data-field="body_weight" data-visible="false">{{ col_mapping_dict.body_weight }}</th>
+                <th data-field="age_in_weeks" data-sortable="true">{{ col_mapping_dict.age_in_weeks }}</th>
+                <th data-field="sex" data-visible="false">{{ col_mapping_dict.sex }}</th>
+                <th data-field="diet" data-visible="false">{{ col_mapping_dict.diet }}</th>
+                <th data-field="feeding_status">{{ col_mapping_dict.feeding_status }}</th>
+                <th data-field="sample_owner">{{ col_mapping_dict.sample_owner }}</th>
+                <th data-field="sample_date_formatted" data-sortable="true">{{ col_mapping_dict.sample_date_formatted }}</th>
+                <th data-field="sample_time_collected_m" data-sortable="true">{{ col_mapping_dict.sample_time_collected_m }}</th>
+                <th data-field="msrunsample_owner" data-sortable="true">{{ col_mapping_dict.msrunsample_owner }}</th>
+                <th data-field="msrunsample_date_formatted" data-sortable="true">{{ col_mapping_dict.msrunsample_date_formatted }}</th>
+                <th data-field="msrunsample_id" data-formatter="msrunFormatter">MSrun Detail</th>
+            </tr>
+        </thead>
+    </table>
+</div>
+
 {% endblock %}
 
 {% block js_extras %}
-    {{ block.super }}
-    <script src="{% static 'js/setTableHeight.js' %}"></script>
+    <!-- functions for formatting column values -->
+    <script src="{% static 'js/summary_table_column_formatters.js' %}"></script>
     <script>
-        let divID = "div_out_tab";
-        let pctVH = 0.80;
-        let vHeight = setTableHeight(divID, pctVH);
-        $('#sample_list').bootstrapTable({
-            height: vHeight,
-            virtualScroll: true
+        $('#sample_table').bootstrapTable({
+            undefinedText: 'None'
         })
     </script>
 {% endblock %}

--- a/DataRepo/urls.py
+++ b/DataRepo/urls.py
@@ -65,6 +65,7 @@ urlpatterns = [
     path("tissues/<int:pk>/", views.TissueDetailView.as_view(), name="tissue_detail"),
     path("samples/", views.SampleListView.as_view(), name="sample_list"),
     path("samples/<int:pk>/", views.SampleDetailView.as_view(), name="sample_detail"),
+    path("samples/sample_json_data/", views.sample_json_data, name="sample_json_data"),
     path("msrunsamples/", views.MSRunSampleListView.as_view(), name="msrunsample_list"),
     path(
         "msrunsamples/<int:pk>/",

--- a/DataRepo/utils/__init__.py
+++ b/DataRepo/utils/__init__.py
@@ -35,6 +35,10 @@ from DataRepo.utils.queryset_to_pandas_dataframe import (
     QuerysetToPandasDataFrame,
 )
 
+from DataRepo.utils.summary_table_data_parser import (
+    SummaryTableData,
+)
+
 __all__ = [
     "AggregatedErrors",
     "AggregatedErrorsSet",
@@ -59,6 +63,7 @@ __all__ = [
     "SheetMergeError",
     "DryRun",
     "QuerysetToPandasDataFrame",
+    "SummaryTableData",
     "SynonymExistsAsMismatchedCompound",
     "UnknownHeaders",
     "parse_infusate_name",

--- a/DataRepo/utils/__init__.py
+++ b/DataRepo/utils/__init__.py
@@ -34,10 +34,7 @@ from DataRepo.utils.infusate_name_parser import (
 from DataRepo.utils.queryset_to_pandas_dataframe import (
     QuerysetToPandasDataFrame,
 )
-
-from DataRepo.utils.summary_table_data_parser import (
-    SummaryTableData,
-)
+from DataRepo.utils.summary_table_data_parser import SummaryTableData
 
 __all__ = [
     "AggregatedErrors",

--- a/DataRepo/utils/summary_table_data_parser.py
+++ b/DataRepo/utils/summary_table_data_parser.py
@@ -1,0 +1,123 @@
+import os
+import yaml
+
+from collections import namedtuple
+from django.utils import dateparse
+from DataRepo.utils import QuerysetToPandasDataFrame as qs2df
+from TraceBase import settings
+
+import pandas as pd
+
+
+class SummaryTableData:
+    """
+    Contains methods for generating pandas dataframes as well as other data structures that serves
+    as data sources for displaying summary tables on webspages as well as in output files
+    """
+
+    # sample yaml file for metadata
+    sample_metadata_yaml_file = "DataRepo/fixtures/sample_list_summary_metadata.yaml"
+
+    @staticmethod
+    def yaml_file_to_df(file_path):
+        # convert input yaml file to a Pandas dataframe or raise error
+        if not os.path.isfile(file_path):
+            raise FileNotFoundError(file_path)
+        else:
+            try:
+                with open(file_path, "r") as infile:
+                    yaml_data = yaml.safe_load(infile)
+                # convert data to Pandas dataframe
+                df = pd.DataFrame(yaml_data)
+            except yaml.YAMLError as exception:
+                raise exception
+            return df
+
+    def get_summary_column_info(self, yaml_file):
+        """
+        parse the metadata yaml file and output the column info as
+          Namedtuple.
+        """
+        self.yaml_file = yaml_file
+        metadata_yaml_path = os.path.join(settings.BASE_DIR, yaml_file)
+        # convert yaml file to pandas dataframe
+        metadata_df = self.yaml_file_to_df(metadata_yaml_path)
+        # filter the dataframes for web display
+        display_df = metadata_df[metadata_df["is_web_display"]]
+        # a list for all columns
+        all_col_list = metadata_df["column_name"].unique().tolist()
+        # a list of columns for web display only
+        display_col_list = display_df["column_name"].unique().tolist()
+        # a dictionary mapping column names with display names
+        col_display_mapping_dict = dict(
+            zip(display_df["column_name"], display_df["display_name"])
+        )
+        # output in namedtuple
+        SummColInfo = namedtuple(
+            "SummColInfo",
+            "yaml_file, all_col_list, display_col_list, col_display_mapping_dict",
+        )
+        summ_col_info = SummColInfo(
+            yaml_file, all_col_list, display_col_list, col_display_mapping_dict
+        )
+        return summ_col_info
+
+    @classmethod
+    def get_sample_summary_column_info(cls):
+        sample_yaml_file = cls.sample_metadata_yaml_file
+        sample_summ_col_info = cls.get_summary_column_info(cls, sample_yaml_file)
+        return sample_summ_col_info
+
+    @classmethod
+    def get_sample_summary_df(cls):
+
+        # get all sample data in data frame before formatting age, dates
+        all_anim_msrun_df = qs2df.get_animal_msrun_all_df()
+        sam_df = all_anim_msrun_df.copy()
+        # add field to convert age to weeks
+        sam_df["age_in_weeks"] = sam_df["age"].apply(
+            lambda x: (
+                dateparse.parse_duration(str(x)).days // 7 if not pd.isna(x) else x
+            )
+        )
+        # add field to convert collection time to minutes
+        sam_df["sample_time_collected_m"] = sam_df["sample_time_collected"].apply(
+            lambda x: (
+                dateparse.parse_duration(str(x)).seconds // 60 if not pd.isna(x) else x
+            )
+        )
+        # convert sample_date to string using yyyy-mm-dd format
+        sam_df["sample_date_formatted"] = sam_df["sample_date"].apply(lambda x: str(x))
+        # convert msrun_date to string using yyyy-mm-dd format
+        sam_df["msrunsample_date_formatted"] = sam_df["msrunsample_date"].apply(
+            lambda x: str(x)
+        )
+
+        # check if columns in dataframe are not defined in yaml file
+        sam_df_columns = sam_df.columns.to_list()
+        # defined columns in yaml file
+        sample_summ_all_columns = cls.get_sample_summary_column_info().all_col_list
+        # missing column list
+        missing_columns = list(set(sam_df_columns) - set(sample_summ_all_columns))
+        if len(missing_columns) > 0:
+            raise ValueError(
+                f"Sample dataframe columns are not defined in yaml file: {missing_columns}"
+            )
+        else:
+            return sam_df
+
+    @classmethod
+    def get_sample_summary_download_df(cls):
+        # get dataframe with all columns
+        sam_df = cls.get_sample_summary_df()
+        sample_summ_col_info = cls.get_sample_summary_column_info()
+        sam_col_display_mapping_dict = sample_summ_col_info.col_display_mapping_dict
+        # remove an item
+        sam_col_display_mapping_dict.pop("msrunsample_id")
+        sam_download_col_list = list(sam_col_display_mapping_dict.keys())
+        sam_download_df = sam_df[sam_download_col_list]
+        # rename column to get display names
+        sam_download_rename_df = sam_download_df.rename(
+            columns=sam_col_display_mapping_dict
+        )
+        return sam_download_rename_df

--- a/DataRepo/utils/summary_table_data_parser.py
+++ b/DataRepo/utils/summary_table_data_parser.py
@@ -1,12 +1,12 @@
 import os
-import yaml
-
 from collections import namedtuple
-from django.utils import dateparse
-from DataRepo.utils import QuerysetToPandasDataFrame as qs2df
-from TraceBase import settings
 
 import pandas as pd
+import yaml
+from django.utils import dateparse
+
+from DataRepo.utils import QuerysetToPandasDataFrame as qs2df
+from TraceBase import settings
 
 
 class SummaryTableData:

--- a/DataRepo/views/__init__.py
+++ b/DataRepo/views/__init__.py
@@ -20,6 +20,7 @@ from .models import (
     ProtocolDetailView,
     SampleDetailView,
     SampleListView,
+    sample_json_data,
     StudyDetailView,
     StudyListView,
     TissueDetailView,
@@ -63,6 +64,7 @@ __all__ = [
     "TissueDetailView",
     "SampleListView",
     "SampleDetailView",
+    "sample_json_data"
     "MSRunSampleDetailView",
     "MSRunSampleListView",
     "MSRunSequenceDetailView",

--- a/DataRepo/views/__init__.py
+++ b/DataRepo/views/__init__.py
@@ -20,11 +20,11 @@ from .models import (
     ProtocolDetailView,
     SampleDetailView,
     SampleListView,
-    sample_json_data,
     StudyDetailView,
     StudyListView,
     TissueDetailView,
     TissueListView,
+    sample_json_data,
     study_summary,
 )
 from .nav import home

--- a/DataRepo/views/__init__.py
+++ b/DataRepo/views/__init__.py
@@ -64,7 +64,7 @@ __all__ = [
     "TissueDetailView",
     "SampleListView",
     "SampleDetailView",
-    "sample_json_data"
+    "sample_json_data",
     "MSRunSampleDetailView",
     "MSRunSampleListView",
     "MSRunSequenceDetailView",

--- a/DataRepo/views/models/__init__.py
+++ b/DataRepo/views/models/__init__.py
@@ -8,7 +8,7 @@ from .msrun_sequence import MSRunSequenceDetailView, MSRunSequenceListView
 from .peakdata import PeakDataListView
 from .peakgroup import PeakGroupDetailView, PeakGroupListView
 from .protocol import AnimalTreatmentListView, ProtocolDetailView
-from .sample import SampleDetailView, SampleListView
+from .sample import SampleDetailView, SampleListView, sample_json_data
 from .study import StudyDetailView, StudyListView, study_summary
 from .tissue import TissueDetailView, TissueListView
 
@@ -32,6 +32,7 @@ __all__ = [
     "TissueDetailView",
     "SampleListView",
     "SampleDetailView",
+    "sample_json_data",
     "MSRunSampleListView",
     "MSRunSampleDetailView",
     "MSRunSequenceListView",

--- a/DataRepo/views/models/sample.py
+++ b/DataRepo/views/models/sample.py
@@ -1,14 +1,12 @@
 import os
+
 import polars as pl
-
-from django.urls import reverse
 from django.http import JsonResponse
-
+from django.urls import reverse
 from django.views.generic import DetailView, ListView
 
 from DataRepo.models import Sample
 from DataRepo.utils import SummaryTableData as std
-
 from TraceBase import settings
 
 

--- a/DataRepo/views/models/sample.py
+++ b/DataRepo/views/models/sample.py
@@ -1,32 +1,158 @@
+import os
+import polars as pl
+
+from django.urls import reverse
+from django.http import JsonResponse
+
 from django.views.generic import DetailView, ListView
 
 from DataRepo.models import Sample
-from DataRepo.utils import QuerysetToPandasDataFrame as qs2df
+from DataRepo.utils import SummaryTableData as std
+
+from TraceBase import settings
+
+
+def sample_json_data(request):
+    """
+    This view is for formatting pagination data into json format based on the query
+    parameters for server-side pagination defined by bootstrap-table plugin
+    ref: https://bootstrap-table.com/docs/api/table-options/#queryparams
+
+    use parquet file as data source for fast reading of sumarry data
+    use polars dataframe for fast in-memory text search and data filtering
+    """
+    ARCHIVE_DIR = settings.MEDIA_ROOT
+    summary_dir = os.path.join(ARCHIVE_DIR, "summary")
+    sample_parquet_file = os.path.join(
+        summary_dir, "sample_list_summary.all_columns.parquet"
+    )
+    if not os.path.exists(sample_parquet_file):
+        # re-generate the parquet file from pandas dataframe
+        sam_df = std.get_sample_summary_df()
+        sam_df.to_parquet(sample_parquet_file)
+    # read file to polars dataframe
+    pl_sam_df = pl.read_parquet(sample_parquet_file)
+    out_col_list = pl_sam_df.columns
+
+    # default values for page data
+    start = 0
+    page_size = 10
+    search_text = None
+    # use polars dataframe default sorting setting
+    is_descending = False
+    # sort on sample as deafult
+    sort_col = "sample"
+
+    param_dict = dict(request.GET)
+
+    # parse page parameters/values
+    for k in param_dict:
+        v = param_dict[k]
+        if k == "offset" and v != []:
+            start = start + int(v[0])
+        if k == "limit" and v != []:
+            page_size = int(v[0])
+        if k == "search" and v != []:
+            search_text = v[0]
+        if k == "sort" and v != []:
+            sort_col = v[0]
+        if k == "order" and v != []:
+            sort_order = v[0]
+            if sort_order == "desc":
+                is_descending = True
+
+    # use polars "with_columns" expression to add columns for fast data search/filtering
+    # note that the added columns were not in the output dataframe for search results
+    if search_text:
+        search_list = search_text.split()
+        pl_sam_out_df = (
+            pl_sam_df.with_columns(
+                # concatenate all string columns
+                pl.concat_str(pl.col(pl.String), ignore_nulls=True).alias(
+                    "str_combined"
+                ),
+                # concatenate selected list columns
+                pl.concat_list(
+                    "tracers", "labeled_elements", "concentrations", "studies"
+                ).alias("list_combined"),
+            )
+            .with_columns(
+                # convert joined list values to string
+                pl.col("list_combined")
+                .list.join("|")
+                .alias("list_combined_str"),
+            )
+            .with_columns(
+                # concatenate selected column values for search purpose, remove "|" from string
+                pl.concat_str(
+                    pl.col("str_combined", "list_combined_str"), ignore_nulls=True
+                )
+                .str.replace_all(r"\|", "")
+                .alias("row_str_combined"),
+            )
+            .filter(
+                pl.col("row_str_combined").str.contains_any(
+                    search_list, ascii_case_insensitive=True
+                )
+            )
+            .select(out_col_list)
+            .sort(sort_col, descending=is_descending)
+        )
+    else:
+        pl_sam_out_df = pl_sam_df.clone().sort(
+            sort_col, descending=is_descending, nulls_last=True
+        )
+
+    total_rows = pl_sam_out_df.shape[0]
+    total_rows_with_search = total_rows
+    # get output based on page parameters
+    pl_sliced_df = pl_sam_out_df.slice(start, page_size)
+    data_filtered_dict = pl_sliced_df.to_dicts()
+
+    # output based on format required by boostrap-table data-url
+    out_dict = {
+        "totalnotfiltered": total_rows,
+        "total": total_rows_with_search,
+        "rows": data_filtered_dict,
+    }
+    return JsonResponse(out_dict, safe=False)
 
 
 class SampleListView(ListView):
     """
     Generic class-based view for a list of samples
-    "model = Sample" is shorthand for queryset = Sample.objects.all()
-    use queryset syntax for sample list with or without filtering
     """
 
-    # return all samples without query filter
-    queryset = Sample.objects.all()
-    context_object_name = "sample_list"
+    model = Sample
     template_name = "DataRepo/sample_list.html"
-    ordering = ["animal_id", "name"]
 
     def get_context_data(self, **kwargs):
-        # Call the base implementation first to get the context
+        # customize the context
         context = super().get_context_data(**kwargs)
-        #  add data from the DataFrame to the context
-        all_anim_msrun_df = qs2df.get_animal_msrun_all_df()
+        # get mapping of column names to display names
+        sample_summ_col_info = std.get_sample_summary_column_info()
+        sam_col_display_mapping_dict = sample_summ_col_info.col_display_mapping_dict
 
-        # convert DataFrame to a list of dictionary
-        data = qs2df.df_to_list_of_dict(all_anim_msrun_df)
+        # get url prefix without pk argument for each of DetailViews
+        url_prefix_dict = {}
+        obj_list = [
+            "animal",
+            "compound",
+            "infusate",
+            "msrunsample",
+            "protocol",
+            "sample",
+            "study",
+            "tissue",
+        ]
+        for i in range(len(obj_list)):
+            view_name = obj_list[i] + "_detail"
+            k = obj_list[i] + "_detail_url_prefix"
+            url_prefix_dict[k] = reverse(view_name, kwargs={"pk": 1})[:-2]
 
-        context["df"] = data
+        context["col_mapping_dict"] = sam_col_display_mapping_dict
+        context["url_prefix_dict"] = url_prefix_dict
+
         return context
 
 

--- a/TraceBase/settings.py
+++ b/TraceBase/settings.py
@@ -176,18 +176,20 @@ USE_I18N = True
 USE_L10N = True
 USE_TZ = True
 
-
-# Static files (CSS, JavaScript, Images)
-# https://docs.djangoproject.com/en/4.2/howto/static-files/
-STATIC_URL = "/static/"
-STATICFILES_DIRS = [os.path.join(BASE_DIR, "static")]
-
 # File storage location
 MEDIA_URL = "/archive/"
 MEDIA_ROOT = env.str("ARCHIVE_DIR", default=os.path.join(BASE_DIR, "archive"))
 TEST_MEDIA_ROOT = env.str(
     "TEST_ARCHIVE_DIR", default=os.path.join(BASE_DIR, "archive_test")
 )
+
+# Static files (CSS, JavaScript, Images)
+# https://docs.djangoproject.com/en/4.2/howto/static-files/
+STATIC_URL = "/static/"
+STATICFILES_DIRS = [
+    os.path.join(BASE_DIR, "static"),
+     ("summary", os.path.join(MEDIA_ROOT, "summary")),
+]
 
 DEFAULT_STORAGES = {
     # Django defaults:

--- a/TraceBase/settings.py
+++ b/TraceBase/settings.py
@@ -188,7 +188,7 @@ TEST_MEDIA_ROOT = env.str(
 STATIC_URL = "/static/"
 STATICFILES_DIRS = [
     os.path.join(BASE_DIR, "static"),
-     ("summary", os.path.join(MEDIA_ROOT, "summary")),
+    ("summary", os.path.join(MEDIA_ROOT, "summary")),
 ]
 
 DEFAULT_STORAGES = {

--- a/requirements/common.txt
+++ b/requirements/common.txt
@@ -15,3 +15,5 @@ xmltodict==0.13.0
 parameterized>=0.9.0
 xlsxwriter>=3.2.0
 numpy==1.26.4
+pyarrow>=1.8.1
+polars>=1.21.0

--- a/static/css/bootstrap_table_cus2.css
+++ b/static/css/bootstrap_table_cus2.css
@@ -1,0 +1,18 @@
+/* customize Bootstrap-table settings for th */
+.bootstrap-table .fixed-table-container .table thead th .th-inner {
+  padding: 0.75rem;
+  vertical-align: top; /* change from bottom to top  */
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: normal !important; /* change from nowrap to normal */
+  height: 5rem; /* added new variable and value */
+  min-width: 2rem !important; /* added new variable and value */
+}
+
+/* customize Bootstrap-table settings for td */
+.bootstrap-table .fixed-table-container .table tbody tr.no-records-found td {
+  text-align: center;
+  overflow-wrap: word-wrap !important; /* added new variable and value */
+  word-wrap: break-all !important; /* added new variable and value */
+  word-break: break-all !important; /* added new variable and value */
+}

--- a/static/js/summary_table_column_formatters.js
+++ b/static/js/summary_table_column_formatters.js
@@ -4,25 +4,26 @@ const urlPrefixDict = JSON.parse(
 
 function animalNameFormatter (value, row) { // eslint-disable-line no-unused-vars
   const k = 'animal_detail_url_prefix'
-  let urlPrefix = urlPrefixDict[k]
+  const urlPrefix = urlPrefixDict[k]
   return '<a href=' + urlPrefix + row.animal_id + '>' + value + '</a>'
 }
 
 function sampleNameFormatter (value, row) { // eslint-disable-line no-unused-vars
   const k = 'sample_detail_url_prefix'
-  let urlPrefix = urlPrefixDict[k]
+  const urlPrefix = urlPrefixDict[k]
   return '<a href=' + urlPrefix + row.sample_id + '>' + value + '</a>'
 }
 
 function tissueNameFormatter (value, row) { // eslint-disable-line no-unused-vars
   const k = 'tissue_detail_url_prefix'
-  let urlPrefix = urlPrefixDict[k]
+  const urlPrefix = urlPrefixDict[k]
   return '<a href=' + urlPrefix + row.tissue_id + '>' + value + '</a>'
 }
 
 function infusateNameFormatter (value, row) { // eslint-disable-line no-unused-vars
   const k = 'infusate_detail_url_prefix'
-  let urlPrefix = urlPrefixDict[k]
+  const urlPrefix = urlPrefixDict[k]
+  var url
   if (row.infusate_id === null) {
     url = None
   } else {
@@ -33,26 +34,26 @@ function infusateNameFormatter (value, row) { // eslint-disable-line no-unused-v
 
 function treatmentFormatter (value, row) { // eslint-disable-line no-unused-vars
   const k = 'protocol_detail_url_prefix'
-  let urlPrefix = urlPrefixDict[k]
+  const urlPrefix = urlPrefixDict[k]
   return '<a href=' + urlPrefix + row.treatment_id + '>' + value + '</a>'
 }
 
 function msrunFormatter (value, row) { // eslint-disable-line no-unused-vars
   const k = 'msrunsample_detail_url_prefix'
-  let urlPrefix = urlPrefixDict[k]
+  const urlPrefix = urlPrefixDict[k]
   return '<a href=' + urlPrefix + row.msrunsample_id + '>' + 'MSRun Details' + '</a>'
 }
 
 // format url based on id_name_list, items are seperated by ||
-function format_url_for_id_name_list (value, urlPrefix) { // eslint-disable-line no-unused-vars
-  let outputWithLink = []
+function formatUrlWithList (value, urlPrefix) { // eslint-disable-line no-unused-vars
+  var outputWithLink = []
 
   for (let i = 0; i < value.length; i++) {
     // get id and name for each item
     let objId = value[i].split('||')[0]
     let objName = value[i].split('||')[1]
-    url = urlPrefix + objId
-    objWithLink = '<a href=' + url + '>' + objName + '</a>'
+    let url = urlPrefix + objId
+    let objWithLink = '<a href=' + url + '>' + objName + '</a>'
     outputWithLink.push(objWithLink)
     }
     return outputWithLink
@@ -60,30 +61,30 @@ function format_url_for_id_name_list (value, urlPrefix) { // eslint-disable-line
 
 function studyListFormatter (value, row) { // eslint-disable-line no-unused-vars
   let studyList = row.study_id_name_list
-  let urlPrefix = urlPrefixDict['study_detail_url_prefix']
-  return format_url_for_id_name_list(studyList, urlPrefix)
+  let urlPrefix = urlPrefixDict.study_detail_url_prefix
+  return formatUrlWithList(studyList, urlPrefix)
 }
 
 function compoundListFormatter (value, row) { // eslint-disable-line no-unused-vars
   let compoundList = row.compound_id_name_list
-  let urlPrefix = urlPrefixDict['compound_detail_url_prefix']
-  return format_url_for_id_name_list(compoundList, urlPrefix)
+  let urlPrefix = urlPrefixDict.compound_detail_url_prefix
+  return formatUrlWithList(compoundList, urlPrefix)
 }
 
 function tracerListFormatter (value, row) { // eslint-disable-line no-unused-vars
   let tracerList = row.tracer_id_name_list
-  let urlPrefix = urlPrefixDict['compound_detail_url_prefix']
-  return format_url_for_id_name_list(tracerList, urlPrefix)
+  let urlPrefix = urlPrefixDict.compound_detail_url_prefix
+  return formatUrlWithList(tracerList, urlPrefix)
 }
 
 function infusateListFormatter (value, row) { // eslint-disable-line no-unused-vars
   let infusateList = row.infusate_id_name_list
-  let urlPrefix = urlPrefixDict['infusate_detail_url_prefix']
-  return format_url_for_id_name_list(infusateList, urlPrefix)
+  let urlPrefix = urlPrefixDict.infusate_detail_url_prefix
+  return formatUrlWithList(infusateList, urlPrefix)
 }
 
 function treatmentListFormatter (value, row) { // eslint-disable-line no-unused-vars
   let treatmentList = row.treatment_id_name_list
-  let urlPrefix = urlPrefixDict['treamnet_detail_url_prefix']
-  return format_url_for_id_name_list(treatmentList, urlPrefix)
+  let urlPrefix = urlPrefixDict.treamnet_detail_url_prefix
+  return formatUrlWithList(treatmentList, urlPrefix)
 }

--- a/static/js/summary_table_column_formatters.js
+++ b/static/js/summary_table_column_formatters.js
@@ -1,90 +1,89 @@
-const url_prefix_dict = JSON.parse(
+const urlPrefixDict = JSON.parse(
   document.getElementById('url_prefix_dict').textContent
-);
+)
 
-function animalNameFormatter (value, row) {
-  let k = "animal_detail_url_prefix"
-  let url_prefix = url_prefix_dict[k]
-  return "<a href=" + url_prefix + row.animal_id  + ">"+ value + "</a>"
+function animalNameFormatter (value, row) { // eslint-disable-line no-unused-vars
+  const k = 'animal_detail_url_prefix'
+  let urlPrefix = urlPrefixDict[k]
+  return '<a href=' + urlPrefix + row.animal_id + '>' + value + '</a>'
 }
 
-function sampleNameFormatter (value, row) {
-  let k = "sample_detail_url_prefix"
-  let url_prefix = url_prefix_dict[k]
-  return "<a href=" + url_prefix + row.sample_id  + ">"+ value + "</a>"
+function sampleNameFormatter (value, row) { // eslint-disable-line no-unused-vars
+  const k = 'sample_detail_url_prefix'
+  let urlPrefix = urlPrefixDict[k]
+  return '<a href=' + urlPrefix + row.sample_id + '>' + value + '</a>'
 }
 
-function tissueNameFormatter (value, row) {
-  let k = "tissue_detail_url_prefix"
-  let url_prefix = url_prefix_dict[k]
-  return "<a href=" + url_prefix + row.tissue_id  + ">"+ value + "</a>"
+function tissueNameFormatter (value, row) { // eslint-disable-line no-unused-vars
+  const k = 'tissue_detail_url_prefix'
+  let urlPrefix = urlPrefixDict[k]
+  return '<a href=' + urlPrefix + row.tissue_id + '>' + value + '</a>'
 }
 
-function infusateNameFormatter (value, row) {
-  let k = "infusate_detail_url_prefix"
-  let url_prefix = url_prefix_dict[k]
+function infusateNameFormatter (value, row) { // eslint-disable-line no-unused-vars
+  const k = 'infusate_detail_url_prefix'
+  let urlPrefix = urlPrefixDict[k]
   if (row.infusate_id === null) {
     url = None
   } else {
-    url = "<a href=" + url_prefix + row.infusate_id  + ">"+ value + "</a>"
+    url = '<a href=' + urlPrefix + row.infusate_id + '>' + value + '</a>'
   }
-  return url 
+  return url
 }
 
-function treatmentFormatter (value, row) {
-  let k = "protocol_detail_url_prefix"
-  let url_prefix = url_prefix_dict[k]
-  return "<a href=" + url_prefix + row.treatment_id  + ">"+ value + "</a>"
+function treatmentFormatter (value, row) { // eslint-disable-line no-unused-vars
+  const k = 'protocol_detail_url_prefix'
+  let urlPrefix = urlPrefixDict[k]
+  return '<a href=' + urlPrefix + row.treatment_id + '>' + value + '</a>'
 }
 
-function msrunFormatter (value, row) {
-  let k = "msrunsample_detail_url_prefix"
-  let url_prefix = url_prefix_dict[k]
-  return "<a href=" + url_prefix + row.msrunsample_id  + ">"+ "MSRun Details" + "</a>"
+function msrunFormatter (value, row) { // eslint-disable-line no-unused-vars
+  const k = 'msrunsample_detail_url_prefix'
+  let urlPrefix = urlPrefixDict[k]
+  return '<a href=' + urlPrefix + row.msrunsample_id + '>' + 'MSRun Details' + '</a>'
 }
 
 // format url based on id_name_list, items are seperated by ||
-function format_url_for_id_name_list (value, url_prefix) {
-  let output_with_link = []
-  
+function format_url_for_id_name_list (value, urlPrefix) { // eslint-disable-line no-unused-vars
+  let outputWithLink = []
+
   for (let i = 0; i < value.length; i++) {
-    let obj_array = []
     // get id and name for each item
-    obj_id = value[i].split('||')[0];
-    obj_name = value[i].split('||')[1];
-    url = url_prefix + obj_id;
-    obj_with_link= "<a href=" + url + ">" + obj_name + "</a>";
-    output_with_link.push(obj_with_link);
+    let objId = value[i].split('||')[0]
+    let objName = value[i].split('||')[1]
+    url = urlPrefix + objId
+    objWithLink = '<a href=' + url + '>' + objName + '</a>'
+    outputWithLink.push(objWithLink)
     }
-    return output_with_link
+    return outputWithLink
 }
 
-function studyListFormatter (value, row) {
-  study_id_name_list = row.study_id_name_list
-  url_prefix = url_prefix_dict["study_detail_url_prefix"]
-  return format_url_for_id_name_list(study_id_name_list, url_prefix)
+function studyListFormatter (value, row) { // eslint-disable-line no-unused-vars
+  let studyList = row.study_id_name_list
+  let urlPrefix = urlPrefixDict['study_detail_url_prefix']
+  return format_url_for_id_name_list(studyList, urlPrefix)
 }
 
-function compoundListFormatter (value, row) {
-  compound_id_name_list = row.compound_id_name_list
-  url_prefix = url_prefix_dict["compound_detail_url_prefix"]
-  return format_url_for_id_name_list(compound_id_name_list, url_prefix)
+function compoundListFormatter (value, row) { // eslint-disable-line no-unused-vars
+  let compoundList = row.compound_id_name_list
+  let urlPrefix = urlPrefixDict['compound_detail_url_prefix']
+  return format_url_for_id_name_list(compoundList, urlPrefix)
 }
 
-function tracerListFormatter (value, row) {
-  tracer_id_name_list = row.tracer_id_name_list
-  url_prefix = url_prefix_dict["compound_detail_url_prefix"]
-  return format_url_for_id_name_list(tracer_id_name_list, url_prefix)
+function tracerListFormatter (value, row) { // eslint-disable-line no-unused-vars
+  let tracerList = row.tracer_id_name_list
+  let urlPrefix = urlPrefixDict['compound_detail_url_prefix']
+  return format_url_for_id_name_list(tracerList, urlPrefix)
 }
 
-function infusateListFormatter (value, row) {
-  infusate_id_name_list = row.infusate_id_name_list
-  url_prefix = url_prefix_dict["infusate_detail_url_prefix"]
-  return format_url_for_id_name_list(infusate_id_name_list, url_prefix)
+function infusateListFormatter (value, row) { // eslint-disable-line no-unused-vars
+  let infusateList = row.infusate_id_name_list
+  let urlPrefix = urlPrefixDict['infusate_detail_url_prefix']
+  return format_url_for_id_name_list(infusateList, urlPrefix)
 }
 
-function treatmentListFormatter (value, row) {
-  treatement_id_name_list = row.treatment_id_name_list
-  url_prefix = url_prefix_dict["treamnet_detail_url_prefix"]
-  return format_url_for_id_name_list(treatment_id_name_list, url_prefix)
+function treatmentListFormatter (value, row) { // eslint-disable-line no-unused-vars
+  let treatmentList = row.treatment_id_name_list
+  let urlPrefix = urlPrefixDict['treamnet_detail_url_prefix']
+  return format_url_for_id_name_list(treatmentList, urlPrefix)
 }

--- a/static/js/summary_table_column_formatters.js
+++ b/static/js/summary_table_column_formatters.js
@@ -1,0 +1,90 @@
+const url_prefix_dict = JSON.parse(
+  document.getElementById('url_prefix_dict').textContent
+);
+
+function animalNameFormatter (value, row) {
+  let k = "animal_detail_url_prefix"
+  let url_prefix = url_prefix_dict[k]
+  return "<a href=" + url_prefix + row.animal_id  + ">"+ value + "</a>"
+}
+
+function sampleNameFormatter (value, row) {
+  let k = "sample_detail_url_prefix"
+  let url_prefix = url_prefix_dict[k]
+  return "<a href=" + url_prefix + row.sample_id  + ">"+ value + "</a>"
+}
+
+function tissueNameFormatter (value, row) {
+  let k = "tissue_detail_url_prefix"
+  let url_prefix = url_prefix_dict[k]
+  return "<a href=" + url_prefix + row.tissue_id  + ">"+ value + "</a>"
+}
+
+function infusateNameFormatter (value, row) {
+  let k = "infusate_detail_url_prefix"
+  let url_prefix = url_prefix_dict[k]
+  if (row.infusate_id === null) {
+    url = None
+  } else {
+    url = "<a href=" + url_prefix + row.infusate_id  + ">"+ value + "</a>"
+  }
+  return url 
+}
+
+function treatmentFormatter (value, row) {
+  let k = "protocol_detail_url_prefix"
+  let url_prefix = url_prefix_dict[k]
+  return "<a href=" + url_prefix + row.treatment_id  + ">"+ value + "</a>"
+}
+
+function msrunFormatter (value, row) {
+  let k = "msrunsample_detail_url_prefix"
+  let url_prefix = url_prefix_dict[k]
+  return "<a href=" + url_prefix + row.msrunsample_id  + ">"+ "MSRun Details" + "</a>"
+}
+
+// format url based on id_name_list, items are seperated by ||
+function format_url_for_id_name_list (value, url_prefix) {
+  let output_with_link = []
+  
+  for (let i = 0; i < value.length; i++) {
+    let obj_array = []
+    // get id and name for each item
+    obj_id = value[i].split('||')[0];
+    obj_name = value[i].split('||')[1];
+    url = url_prefix + obj_id;
+    obj_with_link= "<a href=" + url + ">" + obj_name + "</a>";
+    output_with_link.push(obj_with_link);
+    }
+    return output_with_link
+}
+
+function studyListFormatter (value, row) {
+  study_id_name_list = row.study_id_name_list
+  url_prefix = url_prefix_dict["study_detail_url_prefix"]
+  return format_url_for_id_name_list(study_id_name_list, url_prefix)
+}
+
+function compoundListFormatter (value, row) {
+  compound_id_name_list = row.compound_id_name_list
+  url_prefix = url_prefix_dict["compound_detail_url_prefix"]
+  return format_url_for_id_name_list(compound_id_name_list, url_prefix)
+}
+
+function tracerListFormatter (value, row) {
+  tracer_id_name_list = row.tracer_id_name_list
+  url_prefix = url_prefix_dict["compound_detail_url_prefix"]
+  return format_url_for_id_name_list(tracer_id_name_list, url_prefix)
+}
+
+function infusateListFormatter (value, row) {
+  infusate_id_name_list = row.infusate_id_name_list
+  url_prefix = url_prefix_dict["infusate_detail_url_prefix"]
+  return format_url_for_id_name_list(infusate_id_name_list, url_prefix)
+}
+
+function treatmentListFormatter (value, row) {
+  treatement_id_name_list = row.treatment_id_name_list
+  url_prefix = url_prefix_dict["treamnet_detail_url_prefix"]
+  return format_url_for_id_name_list(treatment_id_name_list, url_prefix)
+}


### PR DESCRIPTION
<!-- markdownlint-disable-next-line first-line-heading -->
## Summary Change Description
  - Share new strategies and code for server-side pagination for sample summary table
    - Use yaml file as design file
    - Use parquet file as pre-generated data source
    - Use Polars dataframe for fast text search/ filtering
    - Use pre-generated files for fast download
    - POC, no test code yet
    - More details in [discussion 1460](https://github.com/Princeton-LSI-ResearchComputing/tracebase/discussions/1460)

## Affected Issues/Pull Requests
- Resolves #518 


## Reviewer Notes/Requests
- To test this PR in your sandbox:
   - Create subdirectory "summary" under ARCHIVE_DIR
   - pip install requirements
   - run `python manage.py write_summary_tables_to_file` to generate output files for sample summary table


## Checklist
<!-- If any requirements are not met, uncheck and explain.
E.g. Linting errors pre-date this PR. -->
This pull request will be merged once the following requirements are met.  The
author and/or reviewers should uncheck any unmet requirements:
<!-- Check/complete items if not applicable. -->
- Review Requirements
  - Minimum approvals: 1 <!-- Edit based on complexity. -->
  - No changes requested
  - All blocking issues resolved by reviewers
  - Specific reviewers: @__add_username_here__ <!-- Approvals required even if minimum met. -->
  - Review period: 2 days <!-- Edit based on complexity. -->
- Associated Issue/PR Requirements: <!-- Assert resolved issues/PRs are done/merged. -->
  - [x] All issue requirements are satisfied
  - [x] All PR dependencies are merged
- Basic Requirements <!-- Uncheck to indicate items you are yet to address. -->
  - [] [Linters pass](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#linting)
  - [] [Tests pass](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#quality-control)
  - [] Conflicts resolved
- Overhead Requirements <!-- Requirements indirectly related to the issues. -->
  - [] [Tests implemented/updated](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#test-implementation)
  - [ ] [Updated `CHANGELOG.md` *Unreleased* section](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/changelog.md)
