### PR TITLE
Mzxml download 500 server error bugfix

### DIFF
--- a/DataRepo/tests/views/search/test_download.py
+++ b/DataRepo/tests/views/search/test_download.py
@@ -346,7 +346,11 @@ class RecordToMzxmlZIPTests(BaseAdvancedSearchDownloadViewTests):
             export_path,
         )
         self.assertIn(
-            "archive_files/2025-02/ms_data/xzl4_sp",
+            "archive_files/",
+            file_obj.name,
+        )
+        self.assertIn(
+            "/ms_data/xzl4_sp",
             file_obj.name,
         )
         self.assertIn(
@@ -373,7 +377,11 @@ class RecordToMzxmlZIPTests(BaseAdvancedSearchDownloadViewTests):
             file_tuples[0][0],
         )
         self.assertIn(
-            "archive_files/2025-02/ms_data/xzl4_sp",
+            "archive_files/",
+            file_tuples[0][1].name,
+        )
+        self.assertIn(
+            "/ms_data/xzl4_sp",
             file_tuples[0][1].name,
         )
         self.assertIn(
@@ -393,7 +401,11 @@ class RecordToMzxmlZIPTests(BaseAdvancedSearchDownloadViewTests):
             file_tuples[0][0],
         )
         self.assertIn(
-            "archive_files/2025-02/ms_data/xzl5_panc",
+            "archive_files/",
+            file_tuples[0][1].name,
+        )
+        self.assertIn(
+            "/ms_data/xzl5_panc",
             file_tuples[0][1].name,
         )
         self.assertIn(

--- a/DataRepo/views/search/download.py
+++ b/DataRepo/views/search/download.py
@@ -281,14 +281,14 @@ class RecordToMzxmlTSV(ABC):
             msrsrec.sample.name,
             msrsrec.sample.tissue.name,
             date_to_string(msrsrec.sample.date),
-            str(
+            (
                 msrsrec.sample.time_collected.total_seconds() / 60
                 if msrsrec.sample.time_collected is not None
                 else None
             ),
             msrsrec.sample.researcher,
             msrsrec.sample.animal.name,
-            str(
+            (
                 msrsrec.sample.animal.age.total_seconds() / 604800
                 if msrsrec.sample.animal.age is not None
                 else None

--- a/DataRepo/views/search/download.py
+++ b/DataRepo/views/search/download.py
@@ -281,16 +281,28 @@ class RecordToMzxmlTSV(ABC):
             msrsrec.sample.name,
             msrsrec.sample.tissue.name,
             date_to_string(msrsrec.sample.date),
-            msrsrec.sample.time_collected.total_seconds() / 60,
+            str(
+                msrsrec.sample.time_collected.total_seconds() / 60
+                if msrsrec.sample.time_collected is not None
+                else None
+            ),
             msrsrec.sample.researcher,
             msrsrec.sample.animal.name,
-            msrsrec.sample.animal.age.total_seconds() / 604800,
+            str(
+                msrsrec.sample.animal.age.total_seconds() / 604800
+                if msrsrec.sample.animal.age is not None
+                else None
+            ),
             msrsrec.sample.animal.sex,
             msrsrec.sample.animal.genotype,
             msrsrec.sample.animal.body_weight,
             msrsrec.sample.animal.diet,
             msrsrec.sample.animal.feeding_status,
-            msrsrec.sample.animal.treatment.name,
+            str(
+                msrsrec.sample.animal.treatment.name
+                if msrsrec.sample.animal.treatment is not None
+                else None
+            ),
             # Relies on Infusate.__str__ and intentionally can return "None"
             str(msrsrec.sample.animal.infusate),
             msrsrec.msrun_sequence.researcher,


### PR DESCRIPTION
## Summary Change Description

Xi reported 500 server errors from the mzXML download button on the advanced search.

The web logs were devoid of errors and I could not reproduce the errors on either dev or prod, so I briefly enabled debug mode on prod and encountered the following exception:

```
Traceback (most recent call last):
  File "/usr/local/tracebase/lib/python3.9/site-packages/django/core/handlers/exception.py", line 55, in inner
    response = get_response(request)
  File "/usr/local/tracebase/lib/python3.9/site-packages/django/core/handlers/base.py", line 197, in _get_response
    response = wrapped_callback(request, *callback_args, **callback_kwargs)
  File "/usr/local/tracebase/lib/python3.9/site-packages/django/views/generic/base.py", line 104, in view
    return self.dispatch(request, *args, **kwargs)
  File "/usr/local/tracebase/lib/python3.9/site-packages/django/views/generic/base.py", line 143, in dispatch
    return handler(request, *args, **kwargs)
  File "/usr/local/tracebase/lib/python3.9/site-packages/django/views/generic/edit.py", line 153, in post
    return self.form_valid(form)
  File "/var/www/tracebase/DataRepo/views/search/download.py", line 585, in form_valid
    metadata_content = "".join(list(self.asdtv.tsv_iterator(metadata_tsv_writer)))
  File "/var/www/tracebase/DataRepo/views/search/download.py", line 433, in tsv_iterator
    for row in self.converter.queryset_to_rows_iterator(self.res):
  File "/var/www/tracebase/DataRepo/views/search/download.py", line 326, in queryset_to_rows_iterator
    yield self.msrun_sample_rec_to_row(msrsrec)
  File "/var/www/tracebase/DataRepo/views/search/download.py", line 284, in msrun_sample_rec_to_row
    msrsrec.sample.time_collected.total_seconds() / 60,

Exception Type: AttributeError at /DataRepo/search_advanced_mzxml/
Exception Value: 'NoneType' object has no attribute 'total_seconds'
```

It turned out that time_collected was null and had an mzXML file (which was why I couldn't reproduce - dev doesn't have the mzXML files loaded for the study with the null time_collected (perturbative infusions)).

So I accounted for all fields in the TSV generator that can be null (based on the models) and did not try accessing any attributes when None.

## Affected Issues/Pull Requests

- Resolves no documented issue
- Merges into branch `main`
- Previous PR #__pull_request_number__

## Reviewer Notes/Requests
<!-- Notes to help the reviewer or requests for specific scrutiny.
E.g. Please make sure I have accounted for all possible inputs. -->
See comments in-line.

## Checklist
<!-- If any requirements are not met, uncheck and explain.
E.g. Linting errors pre-date this PR. -->
This pull request will be merged once the following requirements are met.  The
author and/or reviewers should uncheck any unmet requirements:
<!-- Check/complete items if not applicable. -->
- Review Requirements
  - Minimum approvals: 1 <!-- Edit based on complexity. -->
  - No changes requested
  - All blocking issues resolved by reviewers
  - Specific reviewers: @__add_username_here__ <!-- Approvals required even if minimum met. -->
  - Review period: 2 days <!-- Edit based on complexity. -->
- Associated Issue/PR Requirements: <!-- Assert resolved issues/PRs are done/merged. -->
  - [x] All issue requirements are satisfied
  - [x] All PR dependencies are merged
- Basic Requirements <!-- Uncheck to indicate items you are yet to address. -->
  - [x] [Linters pass](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#linting)
  - [x] [Tests pass](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#quality-control)
  - [x] Conflicts resolved
- Overhead Requirements <!-- Requirements indirectly related to the issues. -->
  - [x] [Tests implemented/updated](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#test-implementation)
  - [ ] [Updated `CHANGELOG.md` *Unreleased* section](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/changelog.md)
