### PR TITLE
BST4: Javascript sort & export improvements

### DIFF
--- a/static/js/browser_download.js
+++ b/static/js/browser_download.js
@@ -10,12 +10,11 @@
  *      </a>
  *
  * This code was based on the following article:
- * https://ourcodeworld.com/articles/read/189/how-to-create-a-file-and-generate-a-download-with-javascript-in-the-
- * browser-without-a-server
+ * https://ourcodeworld.com/articles/read/189/how-to-create-a-file-and-generate-a-download-with-javascript-in-the-browser-without-a-server
  */
 function browserDownloadText (filename, text) { // eslint-disable-line no-unused-vars
   const element = document.createElement('a')
-  element.setAttribute('href', 'data:text/plain;charset=utf-8,' + encodeURIComponent(text))
+  element.setAttribute('href', 'data:text/plain;base64,' + encodeURIComponent(text))
   element.setAttribute('download', filename)
   element.style.display = 'none'
   document.body.appendChild(element)
@@ -34,4 +33,14 @@ function browserDownloadExcel (filename, base64Text) { // eslint-disable-line no
   document.body.appendChild(element)
   element.click()
   document.body.removeChild(element)
+}
+
+function browserDownloadBase64 (filename, content, type) { // eslint-disable-line no-unused-vars
+  if (type === 'text') {
+    browserDownloadText(filename, content)
+  } else if (type === 'excel') {
+    browserDownloadExcel(filename, content)
+  } else {
+    console.error('Download type invalid: ' + type)
+  }
 }

--- a/static/js/htmlSorter.js
+++ b/static/js/htmlSorter.js
@@ -2,9 +2,79 @@
 // ref: https://github.com/wenzhixin/bootstrap-table/issues/461
 function htmlSorter (a, b) { // eslint-disable-line no-unused-vars
   /* eslint-env jquery */
-  a = $(a).text()
-  b = $(b).text()
+
+  a = getSortValue(a)
+  b = getSortValue(b)
+
+  // Do not alphabetically sort "None" (special case from Python/Django)
+  // Nones should appear first (or last if desc sorting)
+  if (typeof a === 'undefined' && typeof b !== 'undefined') return -1
+  if (typeof a !== 'undefined' && typeof b === 'undefined') return 1
+  if (typeof a === 'undefined' && typeof b === 'undefined') return 0
+
+  a = a.toLowerCase()
+  b = b.toLowerCase()
+
   if (a < b) return -1
   if (a > b) return 1
   return 0
+}
+
+function alphanumericSorter (a, b) { // eslint-disable-line no-unused-vars
+  /* eslint-env jquery */
+
+  a = getSortValue(a)
+  b = getSortValue(b)
+
+  // Do not alphabetically sort "None" (special case from Python/Django)
+  // Nones should appear first (or last if desc sorting)
+  if (typeof a === 'undefined' && typeof b !== 'undefined') return -1
+  if (typeof a !== 'undefined' && typeof b === 'undefined') return 1
+  if (typeof a === 'undefined' && typeof b === 'undefined') return 0
+
+  a = a.toLowerCase()
+  b = b.toLowerCase()
+
+  if (a < b) return -1
+  if (a > b) return 1
+  return 0
+}
+
+function numericSorter (a, b) { // eslint-disable-line no-unused-vars
+  /* eslint-env jquery */
+
+  a = getSortValue(a)
+  b = getSortValue(b)
+
+  console.log("Sort val a: '" + a + "' b: '" + b + "'")
+
+  // Do not alphabetically sort "None" (special case from Python/Django)
+  // Nones should appear first (or last if desc sorting)
+  if (typeof a === 'undefined' && typeof b !== 'undefined') return -1
+  if (typeof a !== 'undefined' && typeof b === 'undefined') return 1
+  if (typeof a === 'undefined' && typeof b === 'undefined') return 0
+
+  a = parseFloat(a)
+  b = parseFloat(b)
+
+  if (a < b) return -1
+  if (a > b) return 1
+  return 0
+}
+
+function getSortValue (v) {
+  /* eslint-env jquery */
+
+  // Regular expression to see if the a string starts with an html element
+  // See: https://stackoverflow.com/a/23076716/2057516
+  isHTMLregex = /^(?:\s*(<[\w\W]+>)[^>]*|#([\w-]*))$/
+
+  // Extract the inner HTML, if the content is inside an HTML element
+  if (isHTMLregex.test(v)) v = $(v).text().trim()
+
+  // Do not alphabetically sort "None" (special case from Python/Django)
+  // Nones should appear first (or last if desc sorting)
+  if (v === 'None') v = undefined
+
+  return v
 }

--- a/static/js/htmlSorter.js
+++ b/static/js/htmlSorter.js
@@ -2,22 +2,7 @@
 // ref: https://github.com/wenzhixin/bootstrap-table/issues/461
 function htmlSorter (a, b) { // eslint-disable-line no-unused-vars
   /* eslint-env jquery */
-
-  a = getSortValue(a)
-  b = getSortValue(b)
-
-  // Do not alphabetically sort "None" (special case from Python/Django)
-  // Nones should appear first (or last if desc sorting)
-  if (typeof a === 'undefined' && typeof b !== 'undefined') return -1
-  if (typeof a !== 'undefined' && typeof b === 'undefined') return 1
-  if (typeof a === 'undefined' && typeof b === 'undefined') return 0
-
-  a = a.toLowerCase()
-  b = b.toLowerCase()
-
-  if (a < b) return -1
-  if (a > b) return 1
-  return 0
+  return alphanumericSorter(a, b)
 }
 
 function alphanumericSorter (a, b) { // eslint-disable-line no-unused-vars
@@ -67,7 +52,7 @@ function getSortValue (v) {
 
   // Regular expression to see if the a string starts with an html element
   // See: https://stackoverflow.com/a/23076716/2057516
-  isHTMLregex = /^(?:\s*(<[\w\W]+>)[^>]*|#([\w-]*))$/
+  const isHTMLregex = /^(?:\s*(<[\w\W]+>)[^>]*|#([\w-]*))$/
 
   // Extract the inner HTML, if the content is inside an HTML element
   if (isHTMLregex.test(v)) v = $(v).text().trim()


### PR DESCRIPTION
## Summary Change Description

Improved the htmlSorter, added alphanumeric and numeric sorters that will work on text with or without html, and make the browser download work on base64 encoded text.

## Affected Issues/Pull Requests

- Partially addresses #518
- Merges into branch `main`

## Reviewer Notes/Requests
<!-- Notes to help the reviewer or requests for specific scrutiny.
E.g. Please make sure I have accounted for all possible inputs. -->
See comments in-line.

## Checklist
<!-- If any requirements are not met, uncheck and explain.
E.g. Linting errors pre-date this PR. -->
This pull request will be merged once the following requirements are met.  The
author and/or reviewers should uncheck any unmet requirements:
<!-- Check/complete items if not applicable. -->
- Review Requirements
  - Minimum approvals: 1 <!-- Edit based on complexity. -->
  - No changes requested
  - All blocking issues resolved by reviewers
  - Specific reviewers: @__add_username_here__ <!-- Approvals required even if minimum met. -->
  - Review period: 2 days <!-- Edit based on complexity. -->
- Associated Issue/PR Requirements: <!-- Assert resolved issues/PRs are done/merged. -->
  - [x] All issue requirements are satisfied
  - [x] All PR dependencies are merged
- Basic Requirements <!-- Uncheck to indicate items you are yet to address. -->
  - [x] [Linters pass](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#linting)
  - [x] [Tests pass](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#quality-control)
  - [x] Conflicts resolved
- Overhead Requirements <!-- Requirements indirectly related to the issues. -->
  - [x] [Tests implemented/updated](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#test-implementation)
  - [ ] [Updated `CHANGELOG.md` *Unreleased* section](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/changelog.md)
