### PR TITLE
BSTSorter

### DIFF
--- a/DataRepo/static/js/bst_list_view/sorter.js
+++ b/DataRepo/static/js/bst_list_view/sorter.js
@@ -79,7 +79,7 @@ function getSortValue (v) {
 
   // Regular expression to see if the a string starts with an html element
   // See: https://stackoverflow.com/a/23076716/2057516
-  isHTMLregex = /^(?:\s*(<[\w\W]+>)[^>]*|#([\w-]*))$/
+  const isHTMLregex = /^(?:\s*(<[\w\W]+>)[^>]*|#([\w-]*))$/
 
   // Extract the inner HTML, if the content is inside an HTML element
   if (isHTMLregex.test(v)) v = $(v).text().trim()

--- a/DataRepo/static/js/bst_list_view/sorter.js
+++ b/DataRepo/static/js/bst_list_view/sorter.js
@@ -1,0 +1,93 @@
+/**
+ * In order to make Bootstrap Table provide its sorting controls, but make sorting handled server-side by django, we
+ * need to provide the name of a sorting method to Bootstrap Table's sorter attribute that effects no actual sort.  This
+ * is that method.
+ * @param {*} a Ignored
+ * @param {*} b Ignored
+ * @returns 0
+ */
+function djangoSorter (a, b) { // eslint-disable-line no-unused-vars
+  return 0
+}
+
+/**
+ * When the BSTListView is displaying ALL rows, it is faster and more efficient to allow BST to do the sorting.
+ * This method sorts the visible content, ignoring differences inside the HTML elements' attributes.
+ * Compare values a and b as alphanumeric values, ignoring case.
+ * @param {*} a First value to compare, potentially containing html evements whose attributes should be ignored.
+ * @param {*} b Second value to compare, potentially containing html evements whose attributes should be ignored.
+ * @returns -1, 0, or 1 indicating a<b, a==b, or a>b
+ */
+function alphanumericSorter (a, b) { // eslint-disable-line no-unused-vars
+  /* eslint-env jquery */
+
+  a = getSortValue(a)
+  b = getSortValue(b)
+
+  // Do not alphabetically sort "None" (special case from Python/Django)
+  // Nones should appear first (or last if desc sorting)
+  if (typeof a === 'undefined' && typeof b !== 'undefined') return -1
+  if (typeof a !== 'undefined' && typeof b === 'undefined') return 1
+  if (typeof a === 'undefined' && typeof b === 'undefined') return 0
+
+  a = a.toLowerCase()
+  b = b.toLowerCase()
+
+  if (a < b) return -1
+  if (a > b) return 1
+  return 0
+}
+
+/**
+ * When the BSTListView is displaying ALL rows, it is faster and more efficient to allow BST to do the sorting.
+ * This method sorts the visible content, ignoring differences inside the HTML elements' attributes.
+ * Compare values a and b as floats/numbers.
+ * @param {*} a First value to compare, potentially containing html evements whose attributes should be ignored.
+ * @param {*} b Second value to compare, potentially containing html evements whose attributes should be ignored.
+ * @returns -1, 0, or 1 indicating a<b, a==b, or a>b
+ */
+function numericSorter (a, b) { // eslint-disable-line no-unused-vars
+  /* eslint-env jquery */
+
+  a = getSortValue(a)
+  b = getSortValue(b)
+
+  console.log("Sort val a: '" + a + "' b: '" + b + "'")
+
+  // Do not alphabetically sort "None" (special case from Python/Django)
+  // Nones should appear first (or last if desc sorting)
+  if (typeof a === 'undefined' && typeof b !== 'undefined') return -1
+  if (typeof a !== 'undefined' && typeof b === 'undefined') return 1
+  if (typeof a === 'undefined' && typeof b === 'undefined') return 0
+
+  a = parseFloat(a)
+  b = parseFloat(b)
+
+  if (a < b) return -1
+  if (a > b) return 1
+  return 0
+}
+
+/**
+ * Take a string possibly containing html and return the content without the html elements.
+ * Assumes proper html syntax.
+ * @param {*} v String possibly containing html elements.
+ * @returns The input v with html elements and leading/trailing whitespace extracted
+ */
+function getSortValue (v) {
+  /* eslint-env jquery */
+
+  // Regular expression to see if the a string starts with an html element
+  // See: https://stackoverflow.com/a/23076716/2057516
+  isHTMLregex = /^(?:\s*(<[\w\W]+>)[^>]*|#([\w-]*))$/
+
+  // Extract the inner HTML, if the content is inside an HTML element
+  if (isHTMLregex.test(v)) v = $(v).text().trim()
+  else v = v.trim()
+
+  // Do not alphabetically sort "None" (special case from Python/Django)
+  // Nones should appear first (or last if desc sorting)
+  if (v === 'None') v = undefined
+
+  return v
+}

--- a/DataRepo/tests/static/js/bst_list_view/test_sorter.js
+++ b/DataRepo/tests/static/js/bst_list_view/test_sorter.js
@@ -1,3 +1,5 @@
+/* eslint-disable no-undef */
+
 QUnit.test('djangoSorter', function (assert) {
   assert.equal(djangoSorter('a', 'b'), 0)
   assert.equal(djangoSorter('b', 'a'), 0)
@@ -24,3 +26,5 @@ QUnit.test('numericSorter', function (assert) {
   assert.equal(numericSorter('xyz', 'abc'), 0)
   assert.equal(numericSorter('<a href="xyz"> 5 </a><br>', '5'), 0)
 })
+
+/* eslint-enable no-undef */

--- a/DataRepo/tests/static/js/bst_list_view/test_sorter.js
+++ b/DataRepo/tests/static/js/bst_list_view/test_sorter.js
@@ -1,0 +1,26 @@
+QUnit.test('djangoSorter', function (assert) {
+  assert.equal(djangoSorter('a', 'b'), 0)
+  assert.equal(djangoSorter('b', 'a'), 0)
+  assert.equal(djangoSorter('a', 'a'), 0)
+})
+
+QUnit.test('getSortValue', function (assert) {
+  assert.equal(getSortValue(' abc '), 'abc')
+  assert.equal(getSortValue(' 123.456 '), '123.456')
+  assert.equal(getSortValue(' 123.456 789 '), '123.456 789')
+  assert.equal(getSortValue(' <a href="xyz"> abc </a> <br> '), 'abc')
+})
+
+QUnit.test('alphanumericSorter', function (assert) {
+  assert.equal(alphanumericSorter(' abc ', 'abc'), 0)
+  assert.equal(alphanumericSorter(' abc ', 'xyz'), -1)
+  assert.equal(alphanumericSorter(' xyz ', 'abc'), 1)
+  assert.equal(alphanumericSorter(' <a href="xyz"> abc </a> <br> ', 'xyz abc'), -1)
+})
+
+QUnit.test('numericSorter', function (assert) {
+  assert.equal(numericSorter(' 2 ', '10'), -1)
+  assert.equal(numericSorter('10', '2'), 1)
+  assert.equal(numericSorter('xyz', 'abc'), 0)
+  assert.equal(numericSorter('<a href="xyz"> 5 </a><br>', '5'), 0)
+})

--- a/DataRepo/tests/static/js/tests.html
+++ b/DataRepo/tests/static/js/tests.html
@@ -38,7 +38,7 @@
         To add more tests, like for the tests in package:
 
             /static/js/{whatever-folder}/{package-name}.js
-        
+
         1. Create files like:
 
             DataRepo/tests/js_tests/{whatever-folder}/test_{package-name}.js

--- a/DataRepo/tests/static/js/tests.html
+++ b/DataRepo/tests/static/js/tests.html
@@ -1,0 +1,60 @@
+<!DOCTYPE html>
+<html>
+    <meta charset="utf-8">
+    <title>QUnit</title>
+    <link rel="stylesheet" href="https://code.jquery.com/qunit/qunit-2.24.1.css">
+    <body>
+        <div id="qunit"></div>
+        <div id="qunit-fixture"></div>
+        <script src="https://code.jquery.com/qunit/qunit-2.24.1.js"></script>
+
+        <!-- jQuery JS -->
+        <script src="https://cdn.jsdelivr.net/npm/jquery/dist/jquery.min.js"></script>
+        <script src="https://unpkg.com/tableexport.jquery.plugin/tableExport.min.js"></script>
+
+        <!-- Bootstrap JS -->
+        <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.1.3/dist/js/bootstrap.bundle.min.js"
+            integrity="sha384-ka7Sk0Gln4gmtz2MlQnikT1wXgYsOg+OMhuP+IlRH9sENBO0LRn5q+8nbTov4+1p"
+            crossorigin="anonymous">
+        </script>
+
+        <!-- Bootstrap Table JS -->
+        <script src="https://unpkg.com/bootstrap-table@1.21.1/dist/bootstrap-table.min.js"></script>
+        <script src="https://unpkg.com/bootstrap-table@1.21.1/dist/extensions/filter-control/bootstrap-table-filter-control.min.js"></script>
+        <script src="https://unpkg.com/bootstrap-table@1.21.1/dist/extensions/export/bootstrap-table-export.min.js"></script>
+
+        <!-- Javascript tests
+
+        To run these tests...
+
+        From the tracebase root directory, run:
+
+            python -m http.server
+
+        In a browser, go to:
+
+            http://127.0.0.1:8000/DataRepo/tests/static/js/tests.html
+
+        To add more tests, like for the tests in package:
+
+            /static/js/{whatever-folder}/{package-name}.js
+        
+        1. Create files like:
+
+            DataRepo/tests/js_tests/{whatever-folder}/test_{package-name}.js
+
+        2. Add a script tag importing the package below using an absolute URL, e.g.
+
+            <script src="/static/js/{whatever-folder}/{package-name}.js"></script>
+
+        3. Add a script tag importing the corresponding test package below (leaving off 'js_tests'), e.g.
+
+            <script src="{whatever-folder}/test_{package-name}.js"></script>
+        -->
+
+        <!-- Sorter Tests -->
+        <script src="/DataRepo/static/js/bst_list_view/sorter.js"></script>
+        <script src="bst_list_view/test_sorter.js"></script>
+
+    </body>
+</html>

--- a/DataRepo/tests/views/models/bst_list_view/test_sorter.py
+++ b/DataRepo/tests/views/models/bst_list_view/test_sorter.py
@@ -1,0 +1,78 @@
+from django.db.models import CharField, IntegerField
+from django.db.models.functions import Lower, Upper
+from django.templatetags.static import static
+from django.test import override_settings
+
+from DataRepo.tests.tracebase_test_case import TracebaseTestCase
+from DataRepo.views.models.bst_list_view.sorter import BSTSorter
+
+
+class BSTSorterTests(TracebaseTestCase):
+    def test_init_none(self):
+        s = BSTSorter()
+        self.assertEqual(BSTSorter.identity, s.transform)
+        self.assertEqual(BSTSorter.SORTER_JS_DJANGO, s.sorter)
+        self.assertEqual(BSTSorter.SORTER_JS_ALPHANUMERIC, s.client_sorter)
+
+    def test_init_charfield(self):
+        s = BSTSorter(field=CharField())
+        self.assertEqual(Lower, s.transform)
+        self.assertEqual(BSTSorter.SORTER_JS_DJANGO, s.sorter)
+        self.assertEqual(BSTSorter.SORTER_JS_ALPHANUMERIC, s.client_sorter)
+
+    def test_init_integerfield(self):
+        s = BSTSorter(field=IntegerField())
+        self.assertEqual(BSTSorter.identity, s.transform)
+        self.assertEqual(BSTSorter.SORTER_JS_DJANGO, s.sorter)
+        self.assertEqual(BSTSorter.SORTER_JS_NUMERIC, s.client_sorter)
+
+    def test_init_transform(self):
+        s = BSTSorter(transform=Upper)
+        self.assertEqual(Upper, s.transform)
+        self.assertEqual(BSTSorter.SORTER_JS_DJANGO, s.sorter)
+        self.assertEqual(BSTSorter.SORTER_JS_ALPHANUMERIC, s.client_sorter)
+
+    def test_init_sorter_bst(self):
+        s = BSTSorter(client_sorter=BSTSorter.SORTER_BST_NUMERIC)
+        self.assertEqual(BSTSorter.SORTER_JS_DJANGO, s.sorter)
+        self.assertEqual(BSTSorter.SORTER_BST_NUMERIC, s.client_sorter)
+
+    @override_settings(DEBUG=True)
+    def test_init_sorter_custom(self):
+        with self.assertWarns(UserWarning):
+            s = BSTSorter(client_sorter="mySorter")
+        self.assertEqual(BSTSorter.SORTER_JS_DJANGO, s.sorter)
+        self.assertEqual("mySorter", s.client_sorter)
+
+    def test_init_invalid_transform_object(self):
+        with self.assertRaises(ValueError) as ar:
+            BSTSorter(transform="name")
+        ve = ar.exception
+        self.assertEqual(
+            "transform must be a Combinable, e.g. type Transform.", str(ve)
+        )
+
+    def test_init_invalid_transform_class(self):
+        with self.assertRaises(ValueError) as ar:
+            BSTSorter(transform=str)
+        ve = ar.exception
+        self.assertEqual(
+            "transform must be a Combinable, e.g. type Transform.", str(ve)
+        )
+
+    def test_identity_transform(self):
+        order_by_val = BSTSorter.identity(Upper("name"))
+        self.assertEqual(Upper("name"), order_by_val)
+
+    def test_identity_str(self):
+        order_by_val = BSTSorter.identity("-name")
+        self.assertEqual("-name", order_by_val)
+
+    def test_str(self):
+        self.assertEqual(BSTSorter.SORTER_JS_DJANGO, str(BSTSorter()))
+
+    def test_javascript(self):
+        self.assertEqual(
+            f"<script src='{static(BSTSorter.JAVASCRIPT)}'></script>",
+            BSTSorter.javascript,
+        )

--- a/DataRepo/views/models/bst_list_view/sorter.py
+++ b/DataRepo/views/models/bst_list_view/sorter.py
@@ -1,0 +1,127 @@
+import warnings
+from typing import Optional, Union
+
+from django.conf import settings
+from django.db.models import Field
+from django.db.models.expressions import Combinable
+from django.db.models.functions import Lower
+from django.templatetags.static import static
+from django.utils.functional import classproperty
+from django.utils.safestring import mark_safe
+
+from DataRepo.models.utilities import is_number_field, is_string_field
+
+
+class BSTSorter:
+    """This class manages sorting of rows/objects based on a column in the Bootstrap Table of a ListView by providing a
+    sorter for each column to both the Bootstrap Table javascript code and a transform to the field supplied to the
+    Django ORM's order_by.
+
+    If the Django Model Field is provided
+    - The default transform for string fields will be Lower (i.e. case insensitive), otherwise no transform.
+    - The default sorter will be djangoSorter for all fields.
+
+    Example:
+        # BSTListView.__init__
+            self.sorter = BSTSorter(field=Model.name.field)  # name is a CharField
+
+        # BSTListView.get_context_data
+            context["sorter"] = self.sorter
+
+        # Template
+            {{ sorter.javascript }}
+            <th data-sorter="{% if total|lte:raw_total %}{{ sorter }}{% else %}{{ sorter.client_sorter }}{% endif %}">
+
+        # Template result
+            <script src='{settings.STATIC_URL}js/bst_list_view/sorter.js'></script>
+            <th data-sorter="djangoSorter">
+
+        # BSTListView.get_queryset
+            return self.model.objects.order_by(self.sorter.transform("name"))
+    """
+
+    SORTER_BST_ALPHANUMERIC = "alphanumeric"
+    SORTER_BST_NUMERIC = "numericOnly"
+    SORTER_JS_ALPHANUMERIC = "alphanumericSorter"
+    SORTER_JS_NUMERIC = "numericSorter"
+    SORTER_JS_DJANGO = "djangoSorter"
+    SORTERS = [
+        SORTER_BST_ALPHANUMERIC,
+        SORTER_BST_NUMERIC,
+        SORTER_JS_ALPHANUMERIC,
+        SORTER_JS_NUMERIC,
+        SORTER_JS_DJANGO,
+    ]
+    JAVASCRIPT = "js/bst_list_view/sorter.js"
+
+    # The default sorter - sorting handled server-side by Django.  Use client_sorter for client-side sorting.
+    sorter = SORTER_JS_DJANGO
+
+    def __init__(
+        self,
+        field: Optional[Field] = None,
+        client_sorter: Optional[str] = None,
+        transform=None,
+    ):
+        """Construct a BSTSorter object.
+
+        Args:
+            field (Optional[Field]): A Model field, used for automatically selecting a sorter and transform.
+            client_sorter (Optional[str]) [auto]: The string to set the Bootstrap Table data-sorter attribute.  The
+                default is alphanumericSorter if field is not supplied, otherwise if the field type is a number field,
+                numericSorter is set.
+            transform (Combinable) [BSTSorter.identity]: A method used for transforming the Django ORM order_by field,
+                e.g. django.db.models.functions.Lower.  The default is an identity function (i.e. no transform).
+        Exceptions:
+            ValueError when transform is invalid.
+        Returns:
+            None
+        """
+        if transform is not None:
+            try:
+                if not issubclass(transform, Combinable):
+                    raise ValueError(
+                        "transform must be a Combinable, e.g. type Transform."
+                    )
+            except TypeError:
+                raise ValueError("transform must be a Combinable, e.g. type Transform.")
+            self.transform = transform
+        elif is_string_field(field):
+            self.transform = Lower
+        else:
+            self.transform = BSTSorter.identity
+
+        if client_sorter is not None:
+            if settings.DEBUG and client_sorter not in self.SORTERS:
+                warnings.warn(f"Custom client_sorter '{client_sorter}' supplied.")
+            self.client_sorter = client_sorter
+        elif is_number_field(field):
+            self.client_sorter = self.SORTER_JS_NUMERIC
+        else:
+            # Rely on Django for the sorting.  Don't apply a javascript sort on top of it.
+            self.client_sorter = self.SORTER_JS_ALPHANUMERIC
+
+    def __str__(self) -> str:
+        return self.sorter
+
+    @classmethod
+    def identity(cls, expression: Union[str, Combinable]) -> Union[str, Combinable]:
+        """identity() needs to work on any combinable or string it is given.  In other words, and value you can give to
+        .order_by()"""
+        return expression
+
+    @classproperty
+    def javascript(cls) -> str:  # pylint: disable=no-self-argument
+        """Returns an HTML script tag whose source points to cls.BST_JAVASCRIPT.
+
+        Example:
+            # BSTListView.__init__
+                self.sorter = BSTSorter(field=Model.name.field)  # name is a CharField
+            # BSTListView.get_context_data
+                context["sorter"] = self.sorter
+            # Template
+                {{ sorter.javascript }}
+            # Template result (assuming settings.STATIC_URL = "static/")
+                <script src='static/js/bst_list_view/sorter.js'></script> -->
+        """
+        return mark_safe(f"<script src='{static(cls.JAVASCRIPT)}'></script>")


### PR DESCRIPTION
## Summary Change Description

Created a class named `BSTSorter` that can be user per BSTColumn to set how sorting of the BST table should be performed.  Key points:

- Sorting by default will be done by a django ORM order_by query
- In order to make BST show sorting controls, but not do sorting, a simple sorting method (`djangoSorter`) was added to simply return 0 to effect no change in the sort.
- Other javascript sort methods were supplied for HTML sorting in the event the user took the time to wait for all rows to load, in which case, having BST do the sorting is the fastest means.
- I created an app level static directory.  This may need further config once I start incorporating it into templates.
- I also took this opportunity to implement Django's recommended `QUnit` tests for javascript code.  The `CONTRIBUTING` doc should be updated for this, but I'm still figuring out the details, so things may change, thus, I didn't add the doc.  The `tests.html` file has some notes however.  When you run the tests, the test output looks like this:

<img width="947" alt="qunit_bst_sorter_tests" src="https://github.com/user-attachments/assets/202f52b6-e516-4020-b223-a5ad9434b03c" />

## Affected Issues/Pull Requests

- Partially addresses #1477
- Merges into branch `main`

## Reviewer Notes/Requests
<!-- Notes to help the reviewer or requests for specific scrutiny.
E.g. Please make sure I have accounted for all possible inputs. -->
See comments in-line.

## Checklist
<!-- If any requirements are not met, uncheck and explain.
E.g. Linting errors pre-date this PR. -->
This pull request will be merged once the following requirements are met.  The
author and/or reviewers should uncheck any unmet requirements:
<!-- Check/complete items if not applicable. -->
- Review Requirements
  - Minimum approvals: 1 <!-- Edit based on complexity. -->
  - No changes requested
  - All blocking issues resolved by reviewers
  - Specific reviewers: @__add_username_here__ <!-- Approvals required even if minimum met. -->
  - Review period: 2 days <!-- Edit based on complexity. -->
- Associated Issue/PR Requirements: <!-- Assert resolved issues/PRs are done/merged. -->
  - [x] All issue requirements are satisfied
  - [x] All PR dependencies are merged
- Basic Requirements <!-- Uncheck to indicate items you are yet to address. -->
  - [x] [Linters pass](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#linting)
  - [x] [Tests pass](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#quality-control)
  - [x] Conflicts resolved
- Overhead Requirements <!-- Requirements indirectly related to the issues. -->
  - [x] [Tests implemented/updated](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#test-implementation)
  - [ ] [Updated `CHANGELOG.md` *Unreleased* section](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/changelog.md)
