### PR TITLE
BSTFilterer

### DIFF
--- a/DataRepo/models/utilities.py
+++ b/DataRepo/models/utilities.py
@@ -161,6 +161,32 @@ def is_many_related(field: Field, source_model: Optional[Model] = None):
     )
 
 
+def is_many_related_to_root(field_path: Union[str, List[str]], source_model: Model):
+    """Takes a field path and source model and returns whether the leaf field is many-related relative to the first
+    source model.
+
+    Args:
+        field_path (Union[str, List[str]]): A dunderscore delimited field path (or list).
+        source_model (Model): The model that the first field in the field path belongs to.
+    Exceptions:
+        ValueError when the field path is invalid
+    Returns:
+        (bool): Whether the leaf field in the field path is many-related with the root model.
+    """
+    if len(field_path) == 0:
+        raise ValueError("field_path string/list must have a non-zero length.")
+    if isinstance(field_path, str):
+        return is_many_related_to_root(field_path.split("__"), source_model)
+    field = resolve_field(getattr(source_model, field_path[0]))
+    if is_many_related(field, source_model=source_model):
+        return True
+    if len(field_path) == 1:
+        return False
+    return is_many_related_to_root(
+        field_path[1:], get_next_model(source_model, field_path[0])
+    )
+
+
 def field_path_to_field(
     model: Type[Model], path: Union[str, List[str]]
 ) -> Optional[Field]:

--- a/DataRepo/static/js/bst_list_view/filterer.js
+++ b/DataRepo/static/js/bst_list_view/filterer.js
@@ -1,0 +1,64 @@
+/**
+ * In order to make Bootstrap Table provide its sorting controls, but make sorting handled server-side by django, we
+ * need to provide the name of a sorting method to Bootstrap Table's data-filter-custom-search attribute that effects no
+ * actual filtering.  Without this, whenever a page loads, you run the risk of non-matching filtering behavior where a
+ * served result is filtered out by the client's browser.  This is that method.
+ * @param {*} term Ignored
+ * @param {*} colval Ignored
+ * @param {*} colname Ignored
+ * @param {*} alldata Ignored
+ * @returns true
+ */
+function djangoFilterer (term, colval, colname, alldata) { // eslint-disable-line no-unused-vars
+  return true
+}
+
+/**
+ * When the BSTListView is displaying ALL rows, it is faster and more efficient to allow BST to do the filtering.
+ * This method applies a filter using the visible content, ignoring differences inside the HTML elements' attributes.
+ * Returns true when the term is contained in the colval (ignoring case differences), false otherwise.
+ * @param {*} term The search term
+ * @param {*} colval A value from the table column to see if it matches the search term
+ * @param {*} colname The name of the column being filtered
+ * @param {*} alldata All of the table data
+ * @returns true if matches, false otherwise
+ */
+function containsFilterer (term, colval, colname, alldata) { // eslint-disable-line no-unused-vars
+  /* eslint-env jquery */
+
+  let val = getVisibleValue(colval) // eslint-disable-line no-undef
+
+  if (typeof val === 'undefined') return false
+
+  val = val.toLowerCase()
+
+  // There should be no HTML in the search term, but there could be leading/trailing spaces.
+  term = getVisibleValue(term) // eslint-disable-line no-undef
+
+  return val.includes(term)
+}
+
+/**
+ * When the BSTListView is displaying ALL rows, it is faster and more efficient to allow BST to do the filtering.
+ * This method applies a filter using the visible content, ignoring differences inside the HTML elements' attributes.
+ * Returns true when the term is equal to the colval (ignoring case differences), false otherwise.
+ * @param {*} term The search term
+ * @param {*} colval A value from the table column to see if it matches the search term
+ * @param {*} colname The name of the column being filtered
+ * @param {*} alldata All of the table data
+ * @returns true if matches, false otherwise
+ */
+function strictFilterer (term, colval, colname, alldata) { // eslint-disable-line no-unused-vars
+  /* eslint-env jquery */
+
+  let val = getVisibleValue(colval) // eslint-disable-line no-undef
+
+  if (typeof val === 'undefined') return false
+
+  val = val.toLowerCase()
+
+  // There should be no HTML in the search term, but there could be leading/trailing spaces.
+  term = getVisibleValue(term) // eslint-disable-line no-undef
+
+  return val === term
+}

--- a/DataRepo/static/js/bst_list_view/filterer.js
+++ b/DataRepo/static/js/bst_list_view/filterer.js
@@ -26,16 +26,17 @@ function djangoFilterer (term, colval, colname, alldata) { // eslint-disable-lin
 function containsFilterer (term, colval, colname, alldata) { // eslint-disable-line no-unused-vars
   /* eslint-env jquery */
 
-  let val = getVisibleValue(colval) // eslint-disable-line no-undef
-
-  if (typeof val === 'undefined') return false
-
-  val = val.toLowerCase()
-
-  // There should be no HTML in the search term, but there could be leading/trailing spaces.
+  colval = getVisibleValue(colval) // eslint-disable-line no-undef
   term = getVisibleValue(term) // eslint-disable-line no-undef
 
-  return val.includes(term)
+  if (typeof colval === 'undefined' || typeof term === 'undefined') {
+    return (typeof term === 'undefined') === (typeof colval === 'undefined')
+  }
+
+  colval = colval.toLowerCase()
+  term = term.toLowerCase()
+
+  return colval.includes(term)
 }
 
 /**
@@ -51,14 +52,15 @@ function containsFilterer (term, colval, colname, alldata) { // eslint-disable-l
 function strictFilterer (term, colval, colname, alldata) { // eslint-disable-line no-unused-vars
   /* eslint-env jquery */
 
-  let val = getVisibleValue(colval) // eslint-disable-line no-undef
-
-  if (typeof val === 'undefined') return false
-
-  val = val.toLowerCase()
-
-  // There should be no HTML in the search term, but there could be leading/trailing spaces.
   term = getVisibleValue(term) // eslint-disable-line no-undef
+  colval = getVisibleValue(colval) // eslint-disable-line no-undef
 
-  return val === term
+  if (typeof colval === 'undefined' || typeof term === 'undefined') {
+    return (typeof term === 'undefined') === (typeof colval === 'undefined')
+  }
+
+  term = term.toLowerCase()
+  colval = colval.toLowerCase()
+
+  return colval === term
 }

--- a/DataRepo/static/js/bst_list_view/sorter.js
+++ b/DataRepo/static/js/bst_list_view/sorter.js
@@ -21,8 +21,8 @@ function djangoSorter (a, b) { // eslint-disable-line no-unused-vars
 function alphanumericSorter (a, b) { // eslint-disable-line no-unused-vars
   /* eslint-env jquery */
 
-  a = getSortValue(a)
-  b = getSortValue(b)
+  a = getVisibleValue(a) // eslint-disable-line no-undef
+  b = getVisibleValue(b) // eslint-disable-line no-undef
 
   // Do not alphabetically sort "None" (special case from Python/Django)
   // Nones should appear first (or last if desc sorting)
@@ -42,52 +42,26 @@ function alphanumericSorter (a, b) { // eslint-disable-line no-unused-vars
  * When the BSTListView is displaying ALL rows, it is faster and more efficient to allow BST to do the sorting.
  * This method sorts the visible content, ignoring differences inside the HTML elements' attributes.
  * Compare values a and b as floats/numbers.
- * @param {*} a First value to compare, potentially containing html evements whose attributes should be ignored.
- * @param {*} b Second value to compare, potentially containing html evements whose attributes should be ignored.
+ * @param {*} x First value to compare, potentially containing html evements whose attributes should be ignored.
+ * @param {*} y Second value to compare, potentially containing html evements whose attributes should be ignored.
  * @returns -1, 0, or 1 indicating a<b, a==b, or a>b
  */
-function numericSorter (a, b) { // eslint-disable-line no-unused-vars
+function numericSorter (x, y) { // eslint-disable-line no-unused-vars
   /* eslint-env jquery */
 
-  a = getSortValue(a)
-  b = getSortValue(b)
-
-  console.log("Sort val a: '" + a + "' b: '" + b + "'")
+  x = getVisibleValue(x) // eslint-disable-line no-undef
+  y = getVisibleValue(y) // eslint-disable-line no-undef
 
   // Do not alphabetically sort "None" (special case from Python/Django)
   // Nones should appear first (or last if desc sorting)
-  if (typeof a === 'undefined' && typeof b !== 'undefined') return -1
-  if (typeof a !== 'undefined' && typeof b === 'undefined') return 1
-  if (typeof a === 'undefined' && typeof b === 'undefined') return 0
+  if (typeof x === 'undefined' && typeof y !== 'undefined') return -1
+  if (typeof x !== 'undefined' && typeof y === 'undefined') return 1
+  if (typeof x === 'undefined' && typeof y === 'undefined') return 0
 
-  a = parseFloat(a)
-  b = parseFloat(b)
+  x = parseFloat(x)
+  y = parseFloat(y)
 
-  if (a < b) return -1
-  if (a > b) return 1
+  if (x < y) return -1
+  if (x > y) return 1
   return 0
-}
-
-/**
- * Take a string possibly containing html and return the content without the html elements.
- * Assumes proper html syntax.
- * @param {*} v String possibly containing html elements.
- * @returns The input v with html elements and leading/trailing whitespace extracted
- */
-function getSortValue (v) {
-  /* eslint-env jquery */
-
-  // Regular expression to see if the a string starts with an html element
-  // See: https://stackoverflow.com/a/23076716/2057516
-  const isHTMLregex = /^(?:\s*(<[\w\W]+>)[^>]*|#([\w-]*))$/
-
-  // Extract the inner HTML, if the content is inside an HTML element
-  if (isHTMLregex.test(v)) v = $(v).text().trim()
-  else v = v.trim()
-
-  // Do not alphabetically sort "None" (special case from Python/Django)
-  // Nones should appear first (or last if desc sorting)
-  if (v === 'None') v = undefined
-
-  return v
 }

--- a/DataRepo/static/js/bst_list_view/value.js
+++ b/DataRepo/static/js/bst_list_view/value.js
@@ -1,0 +1,24 @@
+
+/**
+ * Take a string possibly containing html and return the content without the html elements.
+ * Assumes proper html syntax.
+ * @param {*} v String possibly containing html elements.
+ * @returns The input v with html elements and leading/trailing whitespace extracted
+ */
+function getVisibleValue (v) {
+  /* eslint-env jquery */
+
+  // Regular expression to see if the a string starts with an html element
+  // See: https://stackoverflow.com/a/23076716/2057516
+  const isHTMLregex = /^(?:\s*(<[\w\W]+>)[^>]*|#([\w-]*))$/
+
+  // Extract the inner HTML, if the content is inside an HTML element
+  if (isHTMLregex.test(v)) v = $(v).text().trim()
+  else v = v.trim()
+
+  // Do not alphabetically sort "None" (special case from Python/Django)
+  // Nones should appear first (or last if desc sorting)
+  if (v === 'None') v = undefined
+
+  return v
+}

--- a/DataRepo/static/js/bst_list_view/value.js
+++ b/DataRepo/static/js/bst_list_view/value.js
@@ -5,8 +5,11 @@
  * @param {*} v String possibly containing html elements.
  * @returns The input v with html elements and leading/trailing whitespace extracted
  */
-function getVisibleValue (v) {
+function getVisibleValue (v) { // eslint-disable-line no-unused-vars
   /* eslint-env jquery */
+
+  if (typeof v === 'undefined') return v
+  if (typeof v !== 'string') v = v.toString()
 
   // Regular expression to see if the a string starts with an html element
   // See: https://stackoverflow.com/a/23076716/2057516

--- a/DataRepo/static/js/bst_list_view/value.js
+++ b/DataRepo/static/js/bst_list_view/value.js
@@ -1,4 +1,3 @@
-
 /**
  * Take a string possibly containing html and return the content without the html elements.
  * Assumes proper html syntax.

--- a/DataRepo/tests/models/test_utilities.py
+++ b/DataRepo/tests/models/test_utilities.py
@@ -19,6 +19,7 @@ from DataRepo.models.utilities import (
     get_model_by_name,
     get_next_model,
     is_many_related,
+    is_many_related_to_root,
     is_number_field,
     is_string_field,
     is_unique_field,
@@ -139,6 +140,20 @@ class ModelUtilitiesTests(TracebaseTransactionTestCase):
         self.assertFalse(is_many_related(ArchiveFile.peak_groups.field))
         # But if we're asking from the perspective of ArchiveFile, it is many to ...
         self.assertTrue(is_many_related(ArchiveFile.peak_groups.field, ArchiveFile))
+
+    def test_is_many_related_to_root(self):
+        self.assertFalse(is_many_related_to_root("filename", ArchiveFile))
+        self.assertFalse(is_many_related_to_root("data_format__code", ArchiveFile))
+        self.assertTrue(is_many_related_to_root("peak_groups__name", ArchiveFile))
+        self.assertTrue(
+            is_many_related_to_root(
+                "msrun_sample__sample__animal__studies__name", PeakGroup
+            )
+        )
+        self.assertFalse(
+            is_many_related_to_root("msrun_sample__sample__animal__name", PeakGroup)
+        )
+        self.assertFalse(is_many_related_to_root("description", Study))
 
     def test_field_path_to_field(self):
         ra_field = field_path_to_field(

--- a/DataRepo/tests/static/js/bst_list_view/test_filterer.js
+++ b/DataRepo/tests/static/js/bst_list_view/test_filterer.js
@@ -7,7 +7,7 @@ QUnit.test('djangoFilterer defined', function (assert) {
 })
 
 QUnit.test('djangoFilterer undefined', function (assert) {
-  const undef = void 0
+  const undef = undefined
   assert.equal(djangoFilterer('a', undef), true)
   assert.equal(djangoFilterer(undef, undef), true)
   assert.equal(djangoFilterer('a', 'None'), true)
@@ -25,7 +25,7 @@ QUnit.test('containsFilterer defined', function (assert) {
 })
 
 QUnit.test('containsFilterer undefined', function (assert) {
-  const undef = void 0
+  const undef = undefined
   assert.equal(containsFilterer('a', undef), false)
   assert.equal(containsFilterer('a', 'None'), false)
   assert.equal(containsFilterer(undef, undef), true)
@@ -41,7 +41,7 @@ QUnit.test('strictFilterer defined', function (assert) {
 })
 
 QUnit.test('strictFilterer undefined', function (assert) {
-  const undef = void 0
+  const undef = undefined
   assert.equal(strictFilterer('a', undef), false)
   assert.equal(strictFilterer('a', 'None'), false)
   assert.equal(strictFilterer(undef, undef), true)

--- a/DataRepo/tests/static/js/bst_list_view/test_filterer.js
+++ b/DataRepo/tests/static/js/bst_list_view/test_filterer.js
@@ -1,0 +1,26 @@
+/* eslint-disable no-undef */
+
+QUnit.test('djangoFilterer', function (assert) {
+  assert.equal(djangoFilterer('a', 'b'), true)
+  assert.equal(djangoFilterer('b', 'a'), true)
+  assert.equal(djangoFilterer('a', 'a'), true)
+})
+
+QUnit.test('containsFilterer', function (assert) {
+  assert.equal(containsFilterer(' abc ', 'abcd'), true)
+  assert.equal(containsFilterer(' abc ', 'ab'), false)
+  assert.equal(containsFilterer(' bc ', 'abcd'), true)
+  assert.equal(containsFilterer('xyz', ' <a href="xyz"> abc </a> <br> '), false)
+  assert.equal(containsFilterer('bc', ' <a href="xyz"> abc </a> <br> '), true)
+  assert.equal(containsFilterer('b', ' <a href="xyz"> xyz </a> <br> '), false)
+})
+
+QUnit.test('strictFilterer', function (assert) {
+  assert.equal(strictFilterer(' abc ', 'abcd'), false)
+  assert.equal(strictFilterer(' abc ', 'abc'), true)
+  assert.equal(strictFilterer('bc', 'abcd'), false)
+  assert.equal(strictFilterer('abc', ' <a href="xyz"> abc </a> <br> '), true)
+  assert.equal(strictFilterer('xyz', ' <a href="xyz"> abc </a> <br> '), false)
+})
+
+/* eslint-enable no-undef */

--- a/DataRepo/tests/static/js/bst_list_view/test_filterer.js
+++ b/DataRepo/tests/static/js/bst_list_view/test_filterer.js
@@ -1,12 +1,21 @@
 /* eslint-disable no-undef */
 
-QUnit.test('djangoFilterer', function (assert) {
+QUnit.test('djangoFilterer defined', function (assert) {
   assert.equal(djangoFilterer('a', 'b'), true)
   assert.equal(djangoFilterer('b', 'a'), true)
   assert.equal(djangoFilterer('a', 'a'), true)
 })
 
-QUnit.test('containsFilterer', function (assert) {
+QUnit.test('djangoFilterer undefined', function (assert) {
+  const undef = void 0
+  assert.equal(djangoFilterer('a', undef), true)
+  assert.equal(djangoFilterer(undef, undef), true)
+  assert.equal(djangoFilterer('a', 'None'), true)
+  assert.equal(djangoFilterer('None', undef), true)
+  assert.equal(djangoFilterer('None', 'None'), true)
+})
+
+QUnit.test('containsFilterer defined', function (assert) {
   assert.equal(containsFilterer(' abc ', 'abcd'), true)
   assert.equal(containsFilterer(' abc ', 'ab'), false)
   assert.equal(containsFilterer(' bc ', 'abcd'), true)
@@ -15,12 +24,28 @@ QUnit.test('containsFilterer', function (assert) {
   assert.equal(containsFilterer('b', ' <a href="xyz"> xyz </a> <br> '), false)
 })
 
-QUnit.test('strictFilterer', function (assert) {
+QUnit.test('containsFilterer undefined', function (assert) {
+  const undef = void 0
+  assert.equal(containsFilterer('a', undef), false)
+  assert.equal(containsFilterer('a', 'None'), false)
+  assert.equal(containsFilterer(undef, undef), true)
+  assert.equal(containsFilterer('None', undef), true)
+})
+
+QUnit.test('strictFilterer defined', function (assert) {
   assert.equal(strictFilterer(' abc ', 'abcd'), false)
   assert.equal(strictFilterer(' abc ', 'abc'), true)
   assert.equal(strictFilterer('bc', 'abcd'), false)
   assert.equal(strictFilterer('abc', ' <a href="xyz"> abc </a> <br> '), true)
   assert.equal(strictFilterer('xyz', ' <a href="xyz"> abc </a> <br> '), false)
+})
+
+QUnit.test('strictFilterer undefined', function (assert) {
+  const undef = void 0
+  assert.equal(strictFilterer('a', undef), false)
+  assert.equal(strictFilterer('a', 'None'), false)
+  assert.equal(strictFilterer(undef, undef), true)
+  assert.equal(strictFilterer('None', undef), true)
 })
 
 /* eslint-enable no-undef */

--- a/DataRepo/tests/static/js/bst_list_view/test_sorter.js
+++ b/DataRepo/tests/static/js/bst_list_view/test_sorter.js
@@ -1,23 +1,57 @@
 /* eslint-disable no-undef */
 
-QUnit.test('djangoSorter', function (assert) {
+QUnit.test('djangoSorter defined', function (assert) {
   assert.equal(djangoSorter('a', 'b'), 0)
   assert.equal(djangoSorter('b', 'a'), 0)
   assert.equal(djangoSorter('a', 'a'), 0)
 })
 
-QUnit.test('alphanumericSorter', function (assert) {
+QUnit.test('djangoSorter undefined', function (assert) {
+  const undef = void 0
+  assert.equal(djangoSorter('a', undef), 0)
+  assert.equal(djangoSorter(undef, undef), 0)
+  assert.equal(djangoSorter('a', 'None'), 0)
+  assert.equal(djangoSorter('None', undef), 0)
+  assert.equal(djangoSorter('None', 'None'), 0)
+})
+
+QUnit.test('alphanumericSorter defined', function (assert) {
   assert.equal(alphanumericSorter(' abc ', 'abc'), 0)
   assert.equal(alphanumericSorter(' abc ', 'xyz'), -1)
   assert.equal(alphanumericSorter(' xyz ', 'abc'), 1)
   assert.equal(alphanumericSorter(' <a href="xyz"> abc </a> <br> ', 'xyz abc'), -1)
 })
 
-QUnit.test('numericSorter', function (assert) {
+QUnit.test('alphanumericSorter undefined', function (assert) {
+  const undef = void 0
+  assert.equal(alphanumericSorter(undef, 'abc'), -1)
+  assert.equal(alphanumericSorter('abc', undef), 1)
+  assert.equal(alphanumericSorter(undef, undef), 0)
+  // "None" is a special django case
+  assert.equal(alphanumericSorter('None', 'abc'), -1)
+  assert.equal(alphanumericSorter('xyz', 'None'), 1)
+  assert.equal(alphanumericSorter('None', 'None'), 0)
+})
+
+QUnit.test('numericSorter defined', function (assert) {
   assert.equal(numericSorter(' 2 ', '10'), -1)
   assert.equal(numericSorter('10', '2'), 1)
   assert.equal(numericSorter('xyz', 'abc'), 0)
   assert.equal(numericSorter('<a href="xyz"> 5 </a><br>', '5'), 0)
+  assert.equal(numericSorter('<a href="xyz"> 5 </a><br>', '5'), 0)
+  assert.equal(numericSorter('<a href="xyz"> 5 </a><br>', '5'), 0)
+  assert.equal(numericSorter('<a href="xyz"> 5 </a><br>', '5'), 0)
+})
+
+QUnit.test('numericSorter undefined', function (assert) {
+  const undef = void 0
+  assert.equal(numericSorter(undef, '-5'), -1)
+  assert.equal(numericSorter('5', undef), 1)
+  assert.equal(numericSorter(undef, undef), 0)
+  // "None" is a special django case
+  assert.equal(numericSorter('None', '-5'), -1)
+  assert.equal(numericSorter('5', 'None'), 1)
+  assert.equal(numericSorter('None', 'None'), 0)
 })
 
 /* eslint-enable no-undef */

--- a/DataRepo/tests/static/js/bst_list_view/test_sorter.js
+++ b/DataRepo/tests/static/js/bst_list_view/test_sorter.js
@@ -7,7 +7,7 @@ QUnit.test('djangoSorter defined', function (assert) {
 })
 
 QUnit.test('djangoSorter undefined', function (assert) {
-  const undef = void 0
+  const undef = undefined
   assert.equal(djangoSorter('a', undef), 0)
   assert.equal(djangoSorter(undef, undef), 0)
   assert.equal(djangoSorter('a', 'None'), 0)
@@ -23,7 +23,7 @@ QUnit.test('alphanumericSorter defined', function (assert) {
 })
 
 QUnit.test('alphanumericSorter undefined', function (assert) {
-  const undef = void 0
+  const undef = undefined
   assert.equal(alphanumericSorter(undef, 'abc'), -1)
   assert.equal(alphanumericSorter('abc', undef), 1)
   assert.equal(alphanumericSorter(undef, undef), 0)
@@ -44,7 +44,7 @@ QUnit.test('numericSorter defined', function (assert) {
 })
 
 QUnit.test('numericSorter undefined', function (assert) {
-  const undef = void 0
+  const undef = undefined
   assert.equal(numericSorter(undef, '-5'), -1)
   assert.equal(numericSorter('5', undef), 1)
   assert.equal(numericSorter(undef, undef), 0)

--- a/DataRepo/tests/static/js/bst_list_view/test_sorter.js
+++ b/DataRepo/tests/static/js/bst_list_view/test_sorter.js
@@ -6,13 +6,6 @@ QUnit.test('djangoSorter', function (assert) {
   assert.equal(djangoSorter('a', 'a'), 0)
 })
 
-QUnit.test('getSortValue', function (assert) {
-  assert.equal(getSortValue(' abc '), 'abc')
-  assert.equal(getSortValue(' 123.456 '), '123.456')
-  assert.equal(getSortValue(' 123.456 789 '), '123.456 789')
-  assert.equal(getSortValue(' <a href="xyz"> abc </a> <br> '), 'abc')
-})
-
 QUnit.test('alphanumericSorter', function (assert) {
   assert.equal(alphanumericSorter(' abc ', 'abc'), 0)
   assert.equal(alphanumericSorter(' abc ', 'xyz'), -1)

--- a/DataRepo/tests/static/js/bst_list_view/test_value.js
+++ b/DataRepo/tests/static/js/bst_list_view/test_value.js
@@ -1,0 +1,10 @@
+/* eslint-disable no-undef */
+
+QUnit.test('getVisibleValue', function (assert) {
+  assert.equal(getVisibleValue(' abc '), 'abc')
+  assert.equal(getVisibleValue(' 123.456 '), '123.456')
+  assert.equal(getVisibleValue(' 123.456 789 '), '123.456 789')
+  assert.equal(getVisibleValue(' <a href="xyz"> abc </a> <br> '), 'abc')
+})
+
+/* eslint-enable no-undef */

--- a/DataRepo/tests/static/js/bst_list_view/test_value.js
+++ b/DataRepo/tests/static/js/bst_list_view/test_value.js
@@ -6,7 +6,7 @@ QUnit.test('getVisibleValue', function (assert) {
   assert.equal(getVisibleValue(' 123.456 789 '), '123.456 789')
   assert.equal(getVisibleValue(' <a href="xyz"> abc </a> <br> '), 'abc')
   // undefined case
-  const undef = void 0
+  const undef = undefined
   assert.equal(typeof getVisibleValue(undef) === 'undefined', true)
   // Special django case where "None" should be undefined
   assert.equal(typeof getVisibleValue('None') === 'undefined', true)

--- a/DataRepo/tests/static/js/bst_list_view/test_value.js
+++ b/DataRepo/tests/static/js/bst_list_view/test_value.js
@@ -5,6 +5,11 @@ QUnit.test('getVisibleValue', function (assert) {
   assert.equal(getVisibleValue(' 123.456 '), '123.456')
   assert.equal(getVisibleValue(' 123.456 789 '), '123.456 789')
   assert.equal(getVisibleValue(' <a href="xyz"> abc </a> <br> '), 'abc')
+  // undefined case
+  const undef = void 0
+  assert.equal(typeof getVisibleValue(undef) === 'undefined', true)
+  // Special django case where "None" should be undefined
+  assert.equal(typeof getVisibleValue('None') === 'undefined', true)
 })
 
 /* eslint-enable no-undef */

--- a/DataRepo/tests/static/js/tests.html
+++ b/DataRepo/tests/static/js/tests.html
@@ -52,9 +52,17 @@
             <script src="{whatever-folder}/test_{package-name}.js"></script>
         -->
 
+        <!-- Value Tests -->
+        <script src="/DataRepo/static/js/bst_list_view/value.js"></script>
+        <script src="bst_list_view/test_value.js"></script>
+
         <!-- Sorter Tests -->
         <script src="/DataRepo/static/js/bst_list_view/sorter.js"></script>
         <script src="bst_list_view/test_sorter.js"></script>
+
+        <!-- Filterer Tests -->
+        <script src="/DataRepo/static/js/bst_list_view/filterer.js"></script>
+        <script src="bst_list_view/test_filterer.js"></script>
 
     </body>
 </html>

--- a/DataRepo/tests/tracebase_test_case.py
+++ b/DataRepo/tests/tracebase_test_case.py
@@ -120,8 +120,8 @@ def test_case_class_factory(base_class: Type[T]) -> Type[T]:
         class Meta:
             abstract = True
 
-        @classmethod
-        def assertNotWarns(cls, unexpected_warning=UserWarning):
+        @staticmethod
+        def assertNotWarns(unexpected_warning=UserWarning):
             """This is a decorator.  Apply it to tests that should not raise a warning.
 
             Usage:
@@ -133,13 +133,12 @@ def test_case_class_factory(base_class: Type[T]) -> Type[T]:
                 def test_no_SpecificWarning(self):
                     do_something_that_does_not_raise_specific_warning()
             """
-            tmp_instance = cls()
 
             def decorator(fn):
-                def wrapper(*args, **kwargs):
-                    with tmp_instance.assertRaises(AssertionError) as ar:
-                        with tmp_instance.assertWarns(unexpected_warning):
-                            return fn(*args, **kwargs)
+                def wrapper(testcase_obj, *args, **kwargs):
+                    with testcase_obj.assertRaises(AssertionError) as ar:
+                        with testcase_obj.assertWarns(unexpected_warning):
+                            return fn(testcase_obj, *args, **kwargs)
                     if (
                         str(ar.exception)
                         != f"{unexpected_warning.__name__} not triggered"

--- a/DataRepo/tests/views/models/bst_list_view/test_filterer.py
+++ b/DataRepo/tests/views/models/bst_list_view/test_filterer.py
@@ -1,0 +1,149 @@
+from django.db.models import CharField, IntegerField
+from django.templatetags.static import static
+from django.test import override_settings
+
+from DataRepo.tests.tracebase_test_case import TracebaseTestCase
+from DataRepo.views.models.bst_list_view.filterer import BSTFilterer
+
+
+class BSTFiltererTests(TracebaseTestCase):
+    def test_init_none(self):
+        f = BSTFilterer()
+        self.assertEqual(f.INPUT_METHOD_TEXT, f.input_method)
+        self.assertEqual(f.FILTERER_CONTAINS, f.client_filterer)
+        self.assertIsNone(f.choices)
+        self.assertIsNone(f.lookup)
+        self.assertFalse(f.client_mode)
+
+    def test_init_charfield(self):
+        f = BSTFilterer(field=CharField())
+        self.assertEqual(f.INPUT_METHOD_TEXT, f.input_method)
+        self.assertEqual(f.FILTERER_CONTAINS, f.client_filterer)
+        self.assertIsNone(f.choices)
+        self.assertEqual(f.LOOKUP_CONTAINS, f.lookup)
+        self.assertFalse(f.client_mode)
+
+    def test_init_integerfield(self):
+        f = BSTFilterer(field=IntegerField())
+        self.assertEqual(f.INPUT_METHOD_TEXT, f.input_method)
+        self.assertEqual(f.FILTERER_STRICT, f.client_filterer)
+        self.assertIsNone(f.choices)
+        self.assertIsNone(f.lookup)
+        self.assertFalse(f.client_mode)
+
+    def test_init_choicesfield(self):
+        f = BSTFilterer(field=CharField(choices=[("A", "A"), ("B", "B")]))
+        self.assertEqual(f.INPUT_METHOD_SELECT, f.input_method)
+        self.assertEqual(f.FILTERER_STRICT, f.client_filterer)
+        self.assertEqual({"A": "A", "B": "B"}, f.choices)
+        self.assertIsNone(f.lookup)
+        self.assertFalse(f.client_mode)
+
+    def test_init_input_method_select_error(self):
+        with self.assertRaises(ValueError) as ar:
+            BSTFilterer(input_method=BSTFilterer.INPUT_METHOD_SELECT)
+        self.assertIn("choices", str(ar.exception))
+
+    def test_init_input_method_select_works(self):
+        f = BSTFilterer(
+            input_method=BSTFilterer.INPUT_METHOD_SELECT, choices=["A", "B"]
+        )
+        self.assertEqual(f.INPUT_METHOD_SELECT, f.input_method)
+        self.assertEqual(f.FILTERER_STRICT, f.client_filterer)
+        self.assertEqual(["A", "B"], f.choices)
+        self.assertIsNone(f.lookup)
+        self.assertFalse(f.client_mode)
+
+    def test_init_input_method_text(self):
+        f = BSTFilterer(input_method=BSTFilterer.INPUT_METHOD_TEXT)
+        self.assertEqual(f.INPUT_METHOD_TEXT, f.input_method)
+        self.assertEqual(f.FILTERER_CONTAINS, f.client_filterer)
+        self.assertIsNone(f.lookup)
+        self.assertIsNone(f.choices)
+        self.assertFalse(f.client_mode)
+
+    def test_init_client_filterer_works(self):
+        f = BSTFilterer(
+            input_method=BSTFilterer.INPUT_METHOD_SELECT,
+            choices=["A", "B"],
+            client_filterer=BSTFilterer.FILTERER_CONTAINS,
+        )
+        self.assertEqual(f.INPUT_METHOD_SELECT, f.input_method)
+        self.assertEqual(f.FILTERER_CONTAINS, f.client_filterer)
+        self.assertEqual(["A", "B"], f.choices)
+        self.assertIsNone(f.lookup)
+        self.assertFalse(f.client_mode)
+
+    @override_settings(DEBUG=True)
+    def test_init_client_filterer_custom_warns(self):
+        with self.assertWarns(UserWarning):
+            f = BSTFilterer(client_filterer="myFilterer")
+        self.assertEqual(f.INPUT_METHOD_TEXT, f.input_method)
+        self.assertEqual("myFilterer", f.client_filterer)
+        self.assertIsNone(f.choices)
+        self.assertIsNone(f.lookup)
+        self.assertFalse(f.client_mode)
+
+    @override_settings(DEBUG=False)
+    @TracebaseTestCase.assertNotWarns()
+    def test_init_client_filterer_custom_nowarn_prod(self):
+        BSTFilterer(client_filterer="myFilterer")
+
+    @override_settings(DEBUG=False)
+    @TracebaseTestCase.assertNotWarns()
+    def test_init_client_filterer_custom_nowarn_valid(self):
+        BSTFilterer(client_filterer="myFilterer", lookup="mylookup")
+
+    def test_init_lookup(self):
+        f = BSTFilterer(lookup="istartswith")
+        self.assertEqual(f.INPUT_METHOD_TEXT, f.input_method)
+        # TODO: Enforce somehow that the client filterer must match the lookup (e.g. "startswith" instead of "contains")
+        self.assertEqual(f.FILTERER_CONTAINS, f.client_filterer)
+        self.assertIsNone(f.choices)
+        self.assertEqual("istartswith", f.lookup)
+        self.assertFalse(f.client_mode)
+
+    def test_init_client_mode(self):
+        f = BSTFilterer(client_mode=True)
+        self.assertEqual(f.INPUT_METHOD_TEXT, f.input_method)
+        self.assertEqual(f.FILTERER_CONTAINS, f.client_filterer)
+        self.assertIsNone(f.choices)
+        self.assertIsNone(f.lookup)
+        self.assertTrue(f.client_mode)
+
+    def test_filterer_client_mode(self):
+        self.assertEqual(BSTFilterer.FILTERER_DJANGO, str(BSTFilterer()))
+
+    def test_filterer_server_mode(self):
+        self.assertEqual(
+            BSTFilterer.FILTERER_CONTAINS, str(BSTFilterer(client_mode=True))
+        )
+
+    def test_str_client_mode(self):
+        self.assertEqual(BSTFilterer.FILTERER_DJANGO, str(BSTFilterer()))
+
+    def test_str_server_mode(self):
+        self.assertEqual(
+            BSTFilterer.FILTERER_CONTAINS, str(BSTFilterer(client_mode=True))
+        )
+
+    def test_javascript(self):
+        self.assertEqual(
+            f"<script src='{static(BSTFilterer.JAVASCRIPT)}'></script>",
+            BSTFilterer.javascript,
+        )
+
+    def test_set_client_mode(self):
+        f = BSTFilterer()
+        self.assertFalse(f.client_mode)
+        f.set_client_mode()
+        self.assertTrue(f.client_mode)
+        f.set_client_mode(enabled=False)
+        self.assertFalse(f.client_mode)
+
+    def test_set_server_mode(self):
+        f = BSTFilterer()
+        f.set_server_mode()
+        self.assertFalse(f.client_mode)
+        f.set_server_mode(enabled=False)
+        self.assertTrue(f.client_mode)

--- a/DataRepo/tests/views/models/bst_list_view/test_filterer.py
+++ b/DataRepo/tests/views/models/bst_list_view/test_filterer.py
@@ -1,7 +1,8 @@
-from django.db.models import CharField, IntegerField
 from django.templatetags.static import static
 from django.test import override_settings
 
+from DataRepo.models.sample import Sample
+from DataRepo.models.study import Study
 from DataRepo.tests.tracebase_test_case import TracebaseTestCase
 from DataRepo.views.models.bst_list_view.filterer import BSTFilterer
 
@@ -16,7 +17,7 @@ class BSTFiltererTests(TracebaseTestCase):
         self.assertFalse(f.client_mode)
 
     def test_init_charfield(self):
-        f = BSTFilterer(field=CharField())
+        f = BSTFilterer(field_path="name", source_model=Sample)
         self.assertEqual(f.INPUT_METHOD_TEXT, f.input_method)
         self.assertEqual(f.FILTERER_CONTAINS, f.client_filterer)
         self.assertIsNone(f.choices)
@@ -24,7 +25,7 @@ class BSTFiltererTests(TracebaseTestCase):
         self.assertFalse(f.client_mode)
 
     def test_init_integerfield(self):
-        f = BSTFilterer(field=IntegerField())
+        f = BSTFilterer(field_path="animal__body_weight", source_model=Sample)
         self.assertEqual(f.INPUT_METHOD_TEXT, f.input_method)
         self.assertEqual(f.FILTERER_STRICT, f.client_filterer)
         self.assertIsNone(f.choices)
@@ -32,10 +33,18 @@ class BSTFiltererTests(TracebaseTestCase):
         self.assertFalse(f.client_mode)
 
     def test_init_choicesfield(self):
-        f = BSTFilterer(field=CharField(choices=[("A", "A"), ("B", "B")]))
+        f = BSTFilterer(field_path="animal__sex", source_model=Sample)
         self.assertEqual(f.INPUT_METHOD_SELECT, f.input_method)
         self.assertEqual(f.FILTERER_STRICT, f.client_filterer)
-        self.assertEqual({"A": "A", "B": "B"}, f.choices)
+        self.assertDictEqual({"F": "female", "M": "male"}, f.choices)
+        self.assertIsNone(f.lookup)
+        self.assertFalse(f.client_mode)
+
+    def test_init_choicesmanyrelatedfield(self):
+        f = BSTFilterer(field_path="animals__sex", source_model=Study)
+        self.assertEqual(f.INPUT_METHOD_SELECT, f.input_method)
+        self.assertEqual(f.FILTERER_CONTAINS, f.client_filterer)
+        self.assertDictEqual({"F": "female", "M": "male"}, f.choices)
         self.assertIsNone(f.lookup)
         self.assertFalse(f.client_mode)
 

--- a/DataRepo/tests/views/models/bst_list_view/test_sorter.py
+++ b/DataRepo/tests/views/models/bst_list_view/test_sorter.py
@@ -76,3 +76,18 @@ class BSTSorterTests(TracebaseTestCase):
             f"<script src='{static(BSTSorter.JAVASCRIPT)}'></script>",
             BSTSorter.javascript,
         )
+
+    def test_set_client_mode(self):
+        s = BSTSorter()
+        self.assertFalse(s.client_mode)
+        s.set_client_mode()
+        self.assertTrue(s.client_mode)
+        s.set_client_mode(enabled=False)
+        self.assertFalse(s.client_mode)
+
+    def test_set_server_mode(self):
+        s = BSTSorter()
+        s.set_server_mode()
+        self.assertFalse(s.client_mode)
+        s.set_server_mode(enabled=False)
+        self.assertTrue(s.client_mode)

--- a/DataRepo/views/models/bst_list_view/filterer.py
+++ b/DataRepo/views/models/bst_list_view/filterer.py
@@ -1,0 +1,191 @@
+# BSTFilterer
+#   Class Attributes
+#     BST_FILTER_CHOICES
+#     LV_FILTER_CHOICES
+#   Instance Attributes
+#     bst_filterer, default INPUT (SELECT requires select_list)
+#     lv_filterer, default None
+#     filter_control, default based on bst_filterer
+#     select_list, default None
+#     strict_select, default False
+#   Methods
+#     init_filters
+
+from functools import reduce
+from typing import Dict, List, Optional, Union
+
+from django.db.models import Field
+from django.templatetags.static import static
+from django.utils.functional import classproperty
+from django.utils.safestring import mark_safe
+
+from DataRepo.models.utilities import is_number_field
+
+
+class BSTFilterer:
+    """This class manages filtering of rows/objects based on a column in the Bootstrap Table of a ListView by providing
+    a means of filtering rows based in the values in each column using a server-side or client-side method.  Server-side
+    filtering uses Django field lookups in a query (e.g. 'field__icontains="term"').  Client-side filtering should only
+    ever happen if the user has loaded the entire table and is accomplished using Bootstrap Table javascript code.
+
+    Bootstrap Table column (th) attributes controlled:
+    - data-filter-control
+    - data-filter-custom-search
+    See BSTListView for control of:
+    - data-filter-data
+
+    If the Django Model Field is provided
+    - The default server-side Django lookup for string fields will be icontains (i.e. case insensitive), otherwise
+      (effectively) exact.
+    - The default client-side Bootstrap Table filter-control will be "select" if the field has "choices".
+      'data-filter-strict-search' will be true.
+    """
+
+    INPUT_METHOD_TEXT = "input"
+    INPUT_METHOD_SELECT = "select"
+    INPUT_METHOD_DATEPICKER = "datepicker"
+    INPUT_METHODS = [
+        INPUT_METHOD_TEXT,
+        INPUT_METHOD_SELECT,
+        INPUT_METHOD_DATEPICKER,
+    ]
+
+    FILTERER_CONTAINS = "containsFilterer"
+    FILTERER_STRICT = "strictFilterer"
+    FILTERER_DJANGO = "djangoFilterer"
+    FILTERERS = [
+        FILTERER_CONTAINS,
+        FILTERER_STRICT,
+        FILTERER_DJANGO,
+    ]
+
+    JAVASCRIPT = "js/bst_list_view/filterer.js"
+
+    # The default filterer - filtering handled server-side by Django.  Use client_filterer for client-side filtering.
+    server_filterer = FILTERER_DJANGO
+
+    def __init__(
+        self,
+        field: Optional[Field] = None,
+        input_method: Optional[str] = None,
+        client_filterer: Optional[str] = None,
+        lookup: Optional[str] = None,
+        choices: Optional[Union[Dict[str, str], List[str]]] = None,
+        client_mode: bool = False,
+    ):
+        """Construct a BSTFilterer object.
+
+        Args:
+            field (Optional[Field]): A Model field, used for automatically selecting a client_filterer and input_method.
+            input_method (Optional[str]) [auto]: The string to set the Bootstrap Table data-filter-control attribute.
+                The default is "select" int he field has a populated choices attribute.  Otherwise it is "input".
+                TODO: "datepicker" is not yet supported.
+            client_filterer (Optional[str]) [auto]: The string to set the Bootstrap Table data-filter-custom-search
+                attribute.  The default is strictFilterer if self.choices is None or field is numeric, otherwise
+                containsFilterer is set.
+                Note that the client_filterer behavior should match the lookup behavior.
+            lookup (Optional[str]): A Django Field Lookup.  Note, this should match the behavior of client_filterer.
+                Note that the lookup behavior should match the client_filterer behavior.
+                See https://docs.djangoproject.com/en/5.1/topics/db/queries/#field-lookups.
+            choices (Optional[Union[Dict[str, str], List[str]]]): Values to populate a select list, if input_method is
+                "select".
+                TODO: choices could be used for auto-complete in the text input method.
+            client_mode (bool): Set to True if the initial table is not filtered and the page queryset is the same size
+                as the total queryset.
+        Exceptions:
+            ValueError when an argument is invalid.
+        Returns:
+            None
+        """
+        if input_method is not None:
+            self.input_method = input_method
+
+            if input_method not in self.INPUT_METHODS:
+                raise ValueError(
+                    f"input_method '{input_method}' must be one of {self.INPUT_METHODS}."
+                )
+
+            if input_method == self.INPUT_METHOD_SELECT:
+                self.client_filterer = self.FILTERER_STRICT
+                self.choices = choices
+                if choices is None:
+                    raise ValueError(
+                        f"input_method '{input_method}' requires that choices be supplied."
+                    )
+            else:
+                self.client_filterer = self.FILTERER_CONTAINS
+                self.choices = None
+
+        elif choices is not None and len(choices) > 0:
+            self.input_method = self.INPUT_METHOD_SELECT
+            self.client_filterer = self.FILTERER_STRICT
+
+            if isinstance(choices, dict):
+                self.choices = choices
+            else:  # list (by process of elimination)
+                # NOTE: This filters for a unique case-insensitive sorted dict, and arbitrarily uses the first case
+                # instance encountered.  I.e., it does not produce a lower-cased output dict - just a dict that is
+                # unique when case is ignored for uniqueness.
+                self.choices = dict(  # type: ignore
+                    (opt, opt)
+                    for opt in sorted(
+                        reduce(
+                            (
+                                lambda lst, val: (  # type: ignore
+                                    lst + [val]  # type: ignore
+                                    if str(val).lower()
+                                    not in [str(v).lower() for v in lst]  # type: ignore
+                                    else lst
+                                )
+                            ),
+                            choices,
+                            [],
+                        ),
+                        key=str.casefold,
+                    )
+                )
+
+        elif field is not None:
+            if field.choices is not None and len(field.choices) > 0:
+                self.client_filterer = self.FILTERER_STRICT
+                self.input_method = self.INPUT_METHOD_SELECT
+                self.choices = dict(*field.choices)
+            else:
+                self.client_filterer = (
+                    self.FILTERER_CONTAINS
+                    if not is_number_field(field)
+                    else self.FILTERER_STRICT
+                )
+                self.input_method = self.INPUT_METHOD_TEXT
+                self.choices = None
+
+        else:
+            self.client_filterer = self.FILTERER_CONTAINS
+            self.input_method = self.INPUT_METHOD_TEXT
+            self.choices = None
+
+        # Let the caller override the default client filterer
+        if client_filterer is not None:
+            self.client_filterer = client_filterer
+
+        self.lookup: Optional[str]
+        if lookup is not None:
+            self.lookup = lookup
+        else:
+            self.lookup = None
+
+        self.client_mode = client_mode
+
+    def __str__(self) -> str:
+        return self.client_filterer if self.client_mode else self.server_filterer
+
+    def set_client_mode(self, enabled: bool = True):
+        self.client_mode = enabled
+
+    def set_server_mode(self, enabled: bool = True):
+        self.client_mode = not enabled
+
+    @classproperty
+    def javascript(cls) -> str:  # pylint: disable=no-self-argument
+        """Returns an HTML script tag whose source points to cls.JAVASCRIPT."""
+        return mark_safe(f"<script src='{static(cls.JAVASCRIPT)}'></script>")

--- a/DataRepo/views/models/bst_list_view/sorter.py
+++ b/DataRepo/views/models/bst_list_view/sorter.py
@@ -97,8 +97,16 @@ class BSTSorter:
             self.transform = BSTSorter.identity
 
         if client_sorter is not None:
-            if settings.DEBUG and client_sorter not in self.SORTERS:
-                warnings.warn(f"Custom client_sorter '{client_sorter}' supplied.")
+            if (
+                settings.DEBUG
+                and client_sorter not in self.SORTERS
+                and not client_mode
+                and transform is None
+            ):
+                warnings.warn(
+                    f"Custom client_sorter '{client_sorter}' supplied in server mode without a custom transform.  "
+                    "Server sort may differ from client sort."
+                )
             self.client_sorter = client_sorter
         elif is_number_field(field):
             self.client_sorter = self.SORTER_JS_NUMERIC
@@ -109,6 +117,10 @@ class BSTSorter:
         self.client_mode = client_mode
 
     def __str__(self) -> str:
+        return self.sorter
+
+    @property
+    def sorter(self):
         return self.client_sorter if self.client_mode else self.server_sorter
 
     def set_client_mode(self, enabled: bool = True):

--- a/DataRepo/views/models/bst_list_view/sorter.py
+++ b/DataRepo/views/models/bst_list_view/sorter.py
@@ -52,16 +52,18 @@ class BSTSorter:
         SORTER_JS_NUMERIC,
         SORTER_JS_DJANGO,
     ]
+
     JAVASCRIPT = "js/bst_list_view/sorter.js"
 
     # The default sorter - sorting handled server-side by Django.  Use client_sorter for client-side sorting.
-    sorter = SORTER_JS_DJANGO
+    server_sorter = SORTER_JS_DJANGO
 
     def __init__(
         self,
         field: Optional[Field] = None,
         client_sorter: Optional[str] = None,
         transform=None,
+        client_mode: bool = False,
     ):
         """Construct a BSTSorter object.
 
@@ -71,7 +73,10 @@ class BSTSorter:
                 default is alphanumericSorter if field is not supplied, otherwise if the field type is a number field,
                 numericSorter is set.
             transform (Combinable) [BSTSorter.identity]: A method used for transforming the Django ORM order_by field,
-                e.g. django.db.models.functions.Lower.  The default is an identity function (i.e. no transform).
+                e.g. django.db.models.functions.Lower.  The default is an identity function (i.e. no transform).  Note,
+                this should match the behavior of client_sorter.
+            client_mode (bool): Set to True if the initial table is not filtered and the page queryset is the same size
+                as the total queryset.
         Exceptions:
             ValueError when transform is invalid.
         Returns:
@@ -101,8 +106,16 @@ class BSTSorter:
             # Rely on Django for the sorting.  Don't apply a javascript sort on top of it.
             self.client_sorter = self.SORTER_JS_ALPHANUMERIC
 
+        self.client_mode = client_mode
+
     def __str__(self) -> str:
-        return self.sorter
+        return self.client_sorter if self.client_mode else self.server_sorter
+
+    def set_client_mode(self, enabled: bool = True):
+        self.client_mode = enabled
+
+    def set_server_mode(self, enabled: bool = True):
+        self.client_mode = not enabled
 
     @classmethod
     def identity(cls, expression: Union[str, Combinable]) -> Union[str, Combinable]:
@@ -112,7 +125,7 @@ class BSTSorter:
 
     @classproperty
     def javascript(cls) -> str:  # pylint: disable=no-self-argument
-        """Returns an HTML script tag whose source points to cls.BST_JAVASCRIPT.
+        """Returns an HTML script tag whose source points to cls.JAVASCRIPT.
 
         Example:
             # BSTListView.__init__


### PR DESCRIPTION
## Summary Change Description

Added BSTFilterer and made minor improvements to the BSTSorter.
- Fixed some stale sorter documentation
- Moved `getSortValue` (and changed the name to `getVisibleValue`) to its own file (`value.js`)
- Changed the sorter behavior in string context to return the server or client sorter based on a new member: `client_mode`.
- Created an `assertNotWarns` decorator in the `TracebaseTestCase` classes.
- Created properties that render the sorter/filterer based on client mode.
- Added conditions to the warning about custom sorter/filterer arguments, to only happen when a corresponding transform/lookup is not provided
- Made `lookup` default to `contains` when a supplied field is a string field and choices are not provided
- Added client/server mode tests to the `BSTSorter` tests
- Added consistent handling of `undefined` values in the javascript sorter and filterer methods, allowing matches of "None" with `undefined`.

Javascript test results:

<img width="924" alt="undefjstestresults" src="https://github.com/user-attachments/assets/8c7d12dc-101e-4fe8-9be7-cec962c76604" />

## Affected Issues/Pull Requests

- Partially addresses #1477
- Merges into branch `bst_sorter`

## Reviewer Notes/Requests
<!-- Notes to help the reviewer or requests for specific scrutiny.
E.g. Please make sure I have accounted for all possible inputs. -->
See comments in-line.

## Checklist
<!-- If any requirements are not met, uncheck and explain.
E.g. Linting errors pre-date this PR. -->
This pull request will be merged once the following requirements are met.  The
author and/or reviewers should uncheck any unmet requirements:
<!-- Check/complete items if not applicable. -->
- Review Requirements
  - Minimum approvals: 1 <!-- Edit based on complexity. -->
  - No changes requested
  - All blocking issues resolved by reviewers
  - Specific reviewers: @__add_username_here__ <!-- Approvals required even if minimum met. -->
  - Review period: 2 days <!-- Edit based on complexity. -->
- Associated Issue/PR Requirements: <!-- Assert resolved issues/PRs are done/merged. -->
  - [x] All issue requirements are satisfied
  - [x] All PR dependencies are merged
- Basic Requirements <!-- Uncheck to indicate items you are yet to address. -->
  - [x] [Linters pass](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#linting)
  - [x] [Tests pass](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#quality-control)
  - [x] Conflicts resolved
- Overhead Requirements <!-- Requirements indirectly related to the issues. -->
  - [x] [Tests implemented/updated](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#test-implementation)
  - [ ] [Updated `CHANGELOG.md` *Unreleased* section](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/changelog.md)
