### PR TITLE
Rearranged tags and added a model utility named `resolve_field_path`

### DIFF
--- a/DataRepo/models/utilities.py
+++ b/DataRepo/models/utilities.py
@@ -6,7 +6,9 @@ from chempy import Substance
 from chempy.util.periodic import atomic_number
 from django.apps import apps
 from django.core.exceptions import ObjectDoesNotExist, ValidationError
-from django.db.models import Field, Model
+from django.db import ProgrammingError
+from django.db.models import Expression, F, Field, Model
+from django.db.models.expressions import Combinable
 from django.db.models.fields.related_descriptors import (
     ForwardManyToOneDescriptor,
     ManyToManyDescriptor,
@@ -129,7 +131,7 @@ def resolve_field(
         ManyToManyDescriptor,
         ReverseManyToOneDescriptor,
     ]
-):
+) -> Field:
     """A field at the end of a model path can be a deferred attribute or any of a series of 4 descriptors.  This method
     takes the field and returns the actual field (if it is deferred or a descriptor, otherwise, the supplied field).
     """
@@ -142,6 +144,63 @@ def resolve_field(
     return (
         field.field if any(isinstance(field, fc) for fc in field_containers) else field
     )
+
+
+def resolve_field_path(
+    field_or_expression: Union[str, Combinable, DeferredAttribute, Field]
+) -> str:
+    """Takes a representation of a field, e.g. from Model._meta.ordering, which can have transform functions applied
+    (like Lower('field_name')) and returns the field path.
+
+    Examples:
+        Assumed base model = Sample
+            resolve_field_path("animal__sex")  # Outputs: "animal__sex"
+            resolve_field_path(Lower("animal__sex"))  # Outputs: "animal__sex"
+            resolve_field_path(F("animal__sex"))  # Outputs: "animal__sex"
+        Assumed base model = Animal
+            resolve_field_path(Animal.sex)  # Outputs: "sex"
+            resolve_field_path(CharField(name="sex"))  # Outputs: "sex"
+        Unsupported:
+            resolve_field_path(CONCAT(F("animal__sex"), F("animal__body_weight")))  # ERROR
+    Assumptions:
+        1. In the case of field_or_expression being a Field, the "field path" returned assumes that the context of the
+            field path is the immediate model that the Field belongs to.
+    Limitations:
+        1. Only supports a single source field path.
+    Args:
+        field_or_expression (Union[str, Combinable]): A str (e.g. a field path), Combinable (e.g. an F, Transform [like
+            Lower("name")], Expression, etc object), or a Model Field.
+    Exceptions:
+        ValueError when the field_or_expression contains multiple field paths.
+    Returns
+        field_path (str): The field path that either was the field_or_expression or its wrapper
+    """
+    if isinstance(field_or_expression, str):
+        return field_or_expression
+    elif isinstance(field_or_expression, Field):
+        return field_or_expression.name
+    elif isinstance(field_or_expression, DeferredAttribute):
+        return field_or_expression.field.name
+    elif isinstance(field_or_expression, Expression):
+        field_reps = field_or_expression.get_source_expressions()
+        if len(field_reps) != 1:
+            raise ValueError(
+                f"Not one field name in field representation {[f.name for f in field_reps]}."
+            )
+        if isinstance(field_reps[0], Expression):
+            return resolve_field_path(field_reps[0])
+        elif isinstance(field_reps[0], F):
+            return field_reps[0].name
+        else:
+            raise ProgrammingError(
+                f"Unexpected field_or_expression type: '{type(field_or_expression).__name__}'."
+            )
+    elif isinstance(field_or_expression, F):
+        return field_or_expression.name
+    else:
+        raise ProgrammingError(
+            f"Unexpected field_or_expression type: '{type(field_or_expression).__name__}'."
+        )
 
 
 def is_many_related(field: Field, source_model: Optional[Model] = None):

--- a/DataRepo/templatetags/bst_list_view_tags.py
+++ b/DataRepo/templatetags/bst_list_view_tags.py
@@ -11,9 +11,9 @@ def is_model_obj(field):
 
 
 @register.filter
-def has_detail_url(model_object_or_class):
-    """Check if a model object or class has a get_absolute_url method."""
-    return hasattr(model_object_or_class, "get_absolute_url")
+def has_attr(object, attr: str):
+    """This allows you to check if a template variable has an attribute."""
+    return hasattr(object, attr)
 
 
 @register.filter
@@ -28,3 +28,12 @@ def get_attr(object, attr, default=None):
         )
         v = default
     return v
+
+
+@register.filter
+def get_absolute_url(model_object: Model):
+    """Get a model object's detail URL."""
+    url = model_object.get_absolute_url()
+    if url is not None and url != "":
+        return url
+    return None

--- a/DataRepo/templatetags/customtags.py
+++ b/DataRepo/templatetags/customtags.py
@@ -3,7 +3,6 @@ from typing import Union
 
 from django import template
 from django.core.exceptions import MultipleObjectsReturned, ObjectDoesNotExist
-from django.db.models import Model
 from django.template.defaultfilters import floatformat
 from django.urls import reverse
 from django.utils import dateparse
@@ -84,15 +83,6 @@ def index(indexable, i):
         )
         v = None
     return v
-
-
-@register.filter
-def get_detail_url(model_object: Model):
-    """Get a model object's detail URL."""
-    url = model_object.get_absolute_url()
-    if url is not None and url != "":
-        return url
-    return None
 
 
 @register.simple_tag

--- a/DataRepo/tests/templatetags/test_bst_list_view_tags.py
+++ b/DataRepo/tests/templatetags/test_bst_list_view_tags.py
@@ -2,8 +2,9 @@ from django.db.models import CharField
 from django.urls import reverse
 
 from DataRepo.templatetags.bst_list_view_tags import (
+    get_absolute_url,
     get_attr,
-    has_detail_url,
+    has_attr,
     is_model_obj,
 )
 from DataRepo.tests.tracebase_test_case import (
@@ -49,6 +50,10 @@ class BSTListViewTagsTests(TracebaseTestCase):
         self.assertEqual(s.name, get_attr(s, "name"))
 
     def test_has_detail_url(self):
-        self.assertTrue(has_detail_url(BSTLVStudy.objects.first()))
-        self.assertTrue(has_detail_url(BSTLVStudy))
-        self.assertFalse(has_detail_url(BSTLVCompoundSynonym))
+        self.assertTrue(has_attr(BSTLVStudy.objects.first(), "get_absolute_url"))
+        self.assertTrue(has_attr(BSTLVStudy, "get_absolute_url"))
+        self.assertFalse(has_attr(BSTLVCompoundSynonym, "get_absolute_url"))
+
+    def test_get_detail_url(self):
+        s = BSTLVStudy.objects.first()
+        self.assertEqual(f"/DataRepo/studies/{s.pk}/", get_absolute_url(s))

--- a/DataRepo/tests/templatetags/test_customtags.py
+++ b/DataRepo/tests/templatetags/test_customtags.py
@@ -9,7 +9,6 @@ from DataRepo.templatetags.customtags import (
     display_filter,
     format_date,
     get_case_insensitive_synonyms,
-    get_detail_url,
     get_many_related_rec,
     intmultiply,
     lte,
@@ -120,10 +119,6 @@ class CustomTagsTests(TracebaseTestCase):
 
     def test_intmultiply(self):
         self.assertEqual(6, intmultiply(2.0, 3.1))
-
-    def test_get_detail_url(self):
-        s = Study.objects.first()
-        self.assertEqual(f"/DataRepo/studies/{s.pk}/", get_detail_url(s))
 
     def test_format_date(self):
         self.assertEqual("1977.02.11", format_date("1977-02-11", "%Y.%m.%d"))


### PR DESCRIPTION
## Summary Change Description

- resolve_field_path takes a Combinable, Field, or str and returns a field path, e.g. `msrun_sample__sample__animal__studies__name`
- Moved tags regarding detail urls, since they will/are only used in bst list view code.

## Affected Issues/Pull Requests

- Partially addresses #1477
- Merges into branch `main`

## Reviewer Notes/Requests
<!-- Notes to help the reviewer or requests for specific scrutiny.
E.g. Please make sure I have accounted for all possible inputs. -->
See comments in-line.

## Checklist
<!-- If any requirements are not met, uncheck and explain.
E.g. Linting errors pre-date this PR. -->
This pull request will be merged once the following requirements are met.  The
author and/or reviewers should uncheck any unmet requirements:
<!-- Check/complete items if not applicable. -->
- Review Requirements
  - Minimum approvals: 1 <!-- Edit based on complexity. -->
  - No changes requested
  - All blocking issues resolved by reviewers
  - Specific reviewers: @__add_username_here__ <!-- Approvals required even if minimum met. -->
  - Review period: 2 days <!-- Edit based on complexity. -->
- Associated Issue/PR Requirements: <!-- Assert resolved issues/PRs are done/merged. -->
  - [x] All issue requirements are satisfied
  - [x] All PR dependencies are merged
- Basic Requirements <!-- Uncheck to indicate items you are yet to address. -->
  - [x] [Linters pass](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#linting)
  - [x] [Tests pass](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#quality-control)
  - [x] Conflicts resolved
- Overhead Requirements <!-- Requirements indirectly related to the issues. -->
  - [x] [Tests implemented/updated](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#test-implementation)
  - [ ] [Updated `CHANGELOG.md` *Unreleased* section](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/changelog.md)
