### PR TITLE
Added a `BSTColumn` class for a model's direct fields

### DIFF
--- a/.htmlhintrc
+++ b/.htmlhintrc
@@ -3,7 +3,7 @@
   "attr-lowercase": true,
   "attr-value-double-quotes": true,
   "attr-value-not-empty": false,
-  "attr-no-duplication": true,
+  "attr-no-duplication": false,
   "doctype-first": false,
   "tag-pair": false,
   "tag-self-close": false,

--- a/DataRepo/templates/models/bst_list_view/td.html
+++ b/DataRepo/templates/models/bst_list_view/td.html
@@ -1,0 +1,3 @@
+<td class="table-cell">
+    {% include column.value_template %}
+</td>

--- a/DataRepo/templates/models/bst_list_view/th.html
+++ b/DataRepo/templates/models/bst_list_view/th.html
@@ -1,0 +1,16 @@
+<th data-field="{{ column.name }}"
+    data-valign="top"
+    {% if column.searchable %}
+        data-filter-control="{{ column.filterer.input_method }}"
+        data-filter-custom-search="{{ column.filterer }}"
+        {% if column.filterer.initial %}
+            data-filter-default="{{ column.filterer.initial }}"
+        {% endif %}
+    {% endif %}
+    {% if column.sortable %}
+        data-sortable="{{ column.sortable|lower }}"
+        data-sorter="{{ column.sorter }}"
+    {% endif %}
+    data-visible="{{ column.visible }}">
+    {{ column.header }}
+</th>

--- a/DataRepo/templates/models/bst_list_view/value.html
+++ b/DataRepo/templates/models/bst_list_view/value.html
@@ -1,0 +1,14 @@
+{% load bsl_list_view %}
+
+{% with columnValue=object|get_attr:column.name %}
+    {% if columnValue|is_model_obj and columnValue|has_attr:"get_absolute_url" %}
+        {# Render model object in string context for the link's display value #}
+        <a href="{{ columnValue|get_absolute_url }}">{{ columnValue }}</a>
+    {% else %}
+        {% if columnValue is None %}
+            <span class="text-muted">None</span>
+        {% else %}
+            {{ columnValue }}
+        {% endif %}
+    {% endif %}
+{% endwith %}

--- a/DataRepo/tests/views/models/bst_list_view/test_column.py
+++ b/DataRepo/tests/views/models/bst_list_view/test_column.py
@@ -1,0 +1,267 @@
+from django.db.models import (
+    CASCADE,
+    CharField,
+    FloatField,
+    ForeignKey,
+    ManyToManyField,
+)
+
+from DataRepo.tests.tracebase_test_case import (
+    TracebaseTestCase,
+    create_test_model,
+)
+from DataRepo.utils.text_utils import camel_to_title, underscored_to_title
+from DataRepo.views.models.bst_list_view.column import BSTColumn
+from DataRepo.views.models.bst_list_view.filterer import BSTFilterer
+from DataRepo.views.models.bst_list_view.sorter import BSTSorter
+
+BSTCStudyTestModel = create_test_model(
+    "BSTCStudyTestModel",
+    {"name": CharField(max_length=255, unique=True)},
+    attrs={
+        "Meta": type(
+            "Meta",
+            (),
+            {"app_label": "loader", "verbose_name": "Study"},
+        ),
+    },
+)
+BSTCAnimalTestModel = create_test_model(
+    "BSTCAnimalTestModel",
+    {
+        "name": CharField(max_length=255, unique=True),
+        "sex": CharField(choices=[("F", "female"), ("M", "male")]),
+        "body_weight": FloatField(verbose_name="Weight (g)"),
+        "studies": ManyToManyField(
+            to="loader.BSTCStudyTestModel", related_name="animals"
+        ),
+    },
+    attrs={
+        "get_absolute_url": lambda self: f"/DataRepo/animal/{self.pk}/",
+        "Meta": type(
+            "Meta",
+            (),
+            {"app_label": "loader", "verbose_name": "animal"},
+        ),
+    },
+)
+BSTCSampleTestModel = create_test_model(
+    "BSTCSampleTestModel",
+    {
+        "name": CharField(max_length=255, unique=True),
+        "animal": ForeignKey(
+            to="loader.BSTCAnimalTestModel", related_name="samples", on_delete=CASCADE
+        ),
+    },
+)
+BSTCMSRunSampleTestModel = create_test_model(
+    "BSTCMSRunSampleTestModel",
+    {
+        "name": CharField(max_length=255, unique=True),
+        "sample": ForeignKey(
+            to="loader.BSTCSampleTestModel",
+            related_name="msrun_samples",
+            on_delete=CASCADE,
+        ),
+    },
+)
+BSTCTissueTestModel = create_test_model(
+    "BSTCTissueTestModel",
+    {"name": CharField(max_length=255)},
+)
+
+
+class BSTColumnTests(TracebaseTestCase):
+    def setUp(self):
+        # Some tests change these class attributes, so they need to be reset for each test to the default
+        BSTColumn.is_annotation = False
+        BSTColumn.is_many_related = False
+        BSTColumn.is_fk = False
+        super().setUp()
+
+    def test_init_field_path_required(self):
+        # Test ValueError - "field_path is required"
+        with self.assertRaises(ValueError) as ar:
+            BSTColumn(BSTCStudyTestModel, None)
+        self.assertIn("field_path is required", str(ar.exception))
+
+    def test_init_annot_requires_name(self):
+        # Test when name not set and self.is_annotation - ValueError - "name not set by BSTAnnotColumn"
+        BSTColumn.is_annotation = True
+        with self.assertRaises(ValueError) as ar:
+            BSTColumn(BSTCStudyTestModel, "annot")
+        self.assertIn("name not set by BSTAnnotColumn", str(ar.exception))
+
+    def test_init_name_set_to_field_path(self):
+        # Test self.name == self.field_path
+        mdl = BSTCStudyTestModel
+        fld = "name"
+        c = BSTColumn(mdl, fld)
+        self.assertEqual(fld, c.name)
+        # Test if sorter is None - self.sorter = BSTSorter(self.field_path, model=self.model)
+        self.assertEqual(BSTSorter(fld, model=mdl), c.sorter)
+        # Test if filterer is None - self.filterer = BSTFilterer(model=self.model, field_path=self.field_path)
+        self.assertEqual(BSTFilterer(field_path=fld, model=mdl), c.filterer)
+
+    def test_init_no_many_related(self):
+        # Test if is_many_related and not self.is_many_related and not self.is_annotation - ValueError
+        with self.assertRaises(ValueError) as ar:
+            BSTColumn(BSTCAnimalTestModel, "studies__name")
+        self.assertIn("must not be many-related", str(ar.exception))
+        self.assertIn("Use BSTAnnotColumn or BSTManyRelatedColumn", str(ar.exception))
+
+    def test_init_donot_link_many_related(self):
+        # Test if self.link and is_many_related - ValueError
+        BSTColumn.is_many_related = True
+        with self.assertRaises(ValueError) as ar:
+            BSTColumn(BSTCSampleTestModel, "animal__studies__name", link=True)
+        self.assertIn(
+            "link must not be true when field_path 'animal__studies__name' is many-related",
+            str(ar.exception),
+        )
+
+    def test_init_donot_link_related(self):
+        # Test if self.link and "__" in self.field_path - ValueError
+        with self.assertRaises(ValueError) as ar:
+            BSTColumn(BSTCSampleTestModel, "animal__body_weight", link=True)
+        self.assertIn(
+            "link must not be true when field_path 'animal__body_weight' passes through a related model",
+            str(ar.exception),
+        )
+
+    def test_init_link_needs_get_abs_url(self):
+        # Test if self.link and no get_absolute_url - ValueError
+        with self.assertRaises(ValueError) as ar:
+            BSTColumn(BSTCStudyTestModel, "name", link=True)
+        self.assertIn(
+            "link must not be true when model 'BSTCStudyTestModel' does not have a 'get_absolute_url'",
+            str(ar.exception),
+        )
+        # No error = successful test:
+        BSTColumn(BSTCAnimalTestModel, "body_weight", link=True)
+
+    def test_init_sorter_filterer_str(self):
+        # Test if sorter is None - self.sorter = BSTSorter(self.field_path, model=self.model)
+        # Test if filterer is None - self.filterer = BSTFilterer(model=self.model, field_path=self.field_path)
+        mdl = BSTCStudyTestModel
+        fld = "name"
+        my_sorter = "mySorter"
+        my_filterer = "myFilterer"
+        c = BSTColumn(mdl, fld, sorter=my_sorter, filterer=my_filterer)
+        self.assertEqual(
+            str(BSTSorter(fld, model=mdl, client_sorter=my_sorter)), str(c.sorter)
+        )
+        self.assertEqual(
+            str(BSTFilterer(field_path=fld, model=mdl, client_filterer=my_filterer)),
+            str(c.filterer),
+        )
+
+    def test_init_sorter_filterer_object(self):
+        # Test if isinstance(sorter, BSTSorter) - self.sorter = sorter
+        # Test if isinstance(filterer, BSTFilterer) - self.filterer = filterer
+        mdl = BSTCStudyTestModel
+        fld = "name"
+        my_sorter = "mySorter"
+        my_filterer = "myFilterer"
+        bsts = BSTSorter(fld, model=mdl, client_sorter=my_sorter)
+        bstf = BSTFilterer(field_path=fld, model=mdl, client_filterer=my_filterer)
+        c = BSTColumn(mdl, fld, sorter=bsts, filterer=bstf)
+        self.assertEqual(bsts, c.sorter)
+        self.assertEqual(bstf, c.filterer)
+
+    def test_init_sorter_wrong_type(self):
+        # Test if sorter type wrong - ValueError - "sorter must be a str or a BSTSorter"
+        mdl = BSTCStudyTestModel
+        fld = "name"
+        with self.assertRaises(ValueError) as ar:
+            BSTColumn(mdl, fld, sorter=1)
+        self.assertIn("sorter must be a str or a BSTSorter", str(ar.exception))
+
+    def test_init_filterer_wrong_type(self):
+        # Test if filterer type wrong - ValueError("filterer must be a str or a BSTFilterer.")
+        mdl = BSTCStudyTestModel
+        fld = "name"
+        with self.assertRaises(ValueError) as ar:
+            BSTColumn(mdl, fld, filterer=1)
+        self.assertIn("filterer must be a str or a BSTFilterer", str(ar.exception))
+
+    def test_eq(self):
+        # Test __eq__ works when other val is string
+        sexfldp = "sex"
+        bwfldp = "body_weight"
+        sexcol = BSTColumn(BSTCAnimalTestModel, sexfldp)
+        sexcol2 = BSTColumn(BSTCAnimalTestModel, sexfldp)
+        bwcol = BSTColumn(BSTCAnimalTestModel, bwfldp)
+        self.assertTrue(sexcol == sexfldp)
+        self.assertFalse(sexcol == bwfldp)
+        self.assertTrue(bwcol == bwfldp)
+        self.assertFalse(bwcol == sexfldp)
+        self.assertTrue(sexcol2 == sexcol)
+
+    def test_generate_header_annotation(self):
+        # Test if self.is_annotation is None - return underscored_to_title(self.name)
+        c = BSTColumn(BSTCStudyTestModel, "name")
+        c.is_annotation = True
+        ann = "unique_count"
+        c.name = ann
+        an = c.generate_header()
+        self.assertEqual(underscored_to_title(ann), an)
+        self.assertEqual("Unique Count", an)
+
+    def test_generate_header_field_verbose_name(self):
+        # Test if field has verbose name with caps - return field.verbose_name
+        c = BSTColumn(BSTCAnimalTestModel, "body_weight")
+        bwh = c.generate_header()
+        self.assertEqual(
+            BSTCAnimalTestModel.body_weight.field.verbose_name,  # pylint: disable=no-member
+            bwh,
+        )
+        self.assertEqual("Weight (g)", bwh)
+
+    def test_generate_header_field_name_to_model_name(self):
+        # Test if self.field_path == "name" and is_unique_field(field) - Use the model's name
+        c = BSTColumn(BSTCSampleTestModel, "name")
+        sh = c.generate_header()
+        self.assertEqual(camel_to_title("BSTCSampleTestModel"), sh)
+
+    def test_generate_header_field_name_to_model_cap_verbose_name(self):
+        # Test caps model verbose_name used as-is
+        c = BSTColumn(BSTCStudyTestModel, "name")
+        sh = c.generate_header()
+        self.assertEqual(
+            BSTCStudyTestModel._meta.__dict__[  # pylint: disable=no-member
+                "verbose_name"
+            ],
+            sh,
+        )
+
+    def test_generate_header_field_name_to_model_diff_verbose_name(self):
+        # Test diff model verbose_name used as-is
+        c = BSTColumn(BSTCAnimalTestModel, "name")
+        ah = c.generate_header()
+        self.assertEqual(
+            underscored_to_title(
+                BSTCAnimalTestModel._meta.__dict__[  # pylint: disable=no-member
+                    "verbose_name"
+                ]
+            ),
+            ah,
+        )
+
+    def test_generate_header_field_name_not_unique_not_changed_to_model_name(self):
+        # Test diff model verbose_name used as-is
+        c = BSTColumn(BSTCTissueTestModel, "name")
+        th = c.generate_header()
+        self.assertEqual(underscored_to_title("name"), th)
+
+    def test_generate_header_related_model_name_field_to_fkey_name(self):
+        # Test when related model unique field, uses foreign key name when field is "name"
+        c = BSTColumn(BSTCSampleTestModel, "animal__name")
+        ah = c.generate_header()
+        self.assertEqual(underscored_to_title("animal"), ah)
+
+    def test_generate_header_related_model_uses_last_fkey(self):
+        # Test that every other field uses - underscored_to_title("_".join(path_tail))
+        c = BSTColumn(BSTCMSRunSampleTestModel, "sample__animal__sex")
+        sh = c.generate_header()
+        self.assertEqual(underscored_to_title("animal_sex"), sh)

--- a/DataRepo/views/models/bst_list_view/column.py
+++ b/DataRepo/views/models/bst_list_view/column.py
@@ -1,0 +1,282 @@
+from __future__ import annotations
+
+from typing import Optional, Type, Union
+
+from django.db.models import Model
+
+from DataRepo.models.utilities import (
+    field_path_to_field,
+    is_many_related_to_root,
+    is_unique_field,
+)
+from DataRepo.utils.text_utils import camel_to_title, underscored_to_title
+from DataRepo.views.models.bst_list_view.filterer import BSTFilterer
+from DataRepo.views.models.bst_list_view.sorter import BSTSorter
+
+
+class BSTColumn:
+    """Class to represent the interface between a bootstrap column and a Model field.
+
+    Usage: You can create a simple model field column using field paths like this:
+
+        filecol = BSTColumn("filename", model=ArchiveFile)
+        timecol = BSTColumn("imported_timestamp", model=ArchiveFile)
+        frmtcol = BSTColumn("data_format__name", model=ArchiveFile)
+        typecol = BSTColumn("data_type__name", model=ArchiveFile)
+
+    Use django "field path lookups" relative to the base model.
+    See https://docs.djangoproject.com/en/5.1/topics/db/queries/#lookups-that-span-relationships
+
+    Alter whatever settings you want in the constructor calls.  In the BootstrapTableListView's template, all you have
+    to do to render the th element for each column is just include the associated generic template:
+
+        {% include filecol.th_template %}
+        {% include timecol.th_template %}
+        {% include frmtcol.th_template %}
+        {% include typecol.th_template %}
+
+    Note that the column headers (by default) will use a title version of the last 2 values in django's dunderscore-
+    delimited field path.  For example, the header generated from the above objects would be:
+
+        Filename
+        Imported Timestamp
+        Data Format Name
+        Data Type Name
+
+    You can supply custom templates for the th, td, and value (rendered inside the td element).  To include the td
+    element:
+
+        {% include filecol.td_template %}
+        {% include timecol.td_template %}
+        {% include frmtcol.td_template %}
+        {% include typecol.td_template %}
+
+    It's also important to note that in order for search and sort to work as expected, each column should be converted
+    to a simple string or number annotation that is compatible with django's annotate method.  To supply the annotation,
+    see BSTAnnotColumn.
+    """
+
+    is_annotation: bool = False
+    # See: BSTAnnotColumn (For rendering an annotation)
+
+    is_fk: bool = False
+    # See: BSTRelatedColumn (For rendering a one-related foreign key using the related object)
+
+    is_many_related: bool = False
+    # See: BSTManyRelatedColumn (For rendering a many-related foreign key using the related object)
+
+    def __init__(
+        self,
+        model: Type[Model],
+        field_path: Optional[str],
+        header: Optional[str] = None,
+        searchable: bool = True,
+        sortable: bool = True,
+        visible: bool = True,
+        exported: bool = True,
+        link: bool = False,
+        sorter: Optional[Union[str, BSTSorter]] = None,
+        filterer: Optional[Union[str, BSTFilterer]] = None,
+        th_template: str = "models/bst_list_view/th.html",
+        td_template: str = "models/bst_list_view/bst_td.html",
+        value_template: str = "models/bst_list_view/bst_value.html",
+    ):
+        """Defines options used to populate the bootstrap table columns for a BootstrapListView and a single reference
+        model.
+
+        Args:
+            model (Type[Model]): Model class that the field_path starts from.
+            field_path (Optional[str]): Name of the database field (including the field path) corresponding to the
+                column.  A value must be supplied, but that value may be None (to support derived classes that do not
+                use it).
+                NOTE: Adding a many-related field will increase the number of resulting rows in the table.  See
+                BSTManyRelatedColumn to prevent this (and display many-related records as delimited values).
+            header (Optional[str]) [auto]: The column header to display in the template.  Will be automatically
+                generated using the title case conversion of the last (2, if present) dunderscore-delimited name values.
+
+            searchable (bool) [True]: Whether or not a column is searchable.  This affects whether the column is
+                searched as a part of the table's search box and whether the column filter input will be enabled.
+            sortable (bool) [True]: Whether or not a column's values can be used to sort the table rows.
+            visible (bool) [True]: Controls whether a column is initially visible.
+            exported (bool) [True]: Adds to BST's exportOptions' ignoreColumn attribute if False.
+            link (bool) [False]: Whether or not to link the value in the column to a detail page for the model record
+                the row represents.  The model must have a "get_absolute_url" method.
+
+            sorter (Optional[Union[str, BSTSorter]]) [auto]: If the value is a str, must be in BSTSorter.SORTERS.
+                Default will be based on the model field type.
+            filterer (Optional[Union[str, BSTFilterer]]) [auto]: If the value is a str, must be in
+                BSTFilterer.FILTERERS.  Default will be based on the model field type.
+
+            th_template (str) ["models/bst_list_view/th.html"]: Template path to an html file used to render the th
+                element for the column header.  This must handle the initial sort field, search term, and filter term.
+            td_template (str) ["models/bst_list_view/bst_td.html"]: Template path to an html file used to render the td
+                element for a column cell.
+            value_template (str) ["models/bst_list_view/bst_value.html"]: Template path to an html file used to render
+                the value inside the td element for a column cell.
+        Exceptions:
+            ValueError when arguments are invalid
+        Returns:
+            None
+        """
+
+        self.model = model
+        self.field_path = field_path
+        self.header = header
+        self.searchable = searchable
+        self.sortable = sortable
+        self.visible = visible
+        self.exported = exported
+        self.link = link
+        self.th_template = th_template
+        self.td_template = td_template
+        self.value_template = value_template
+        # Initialized below
+        self.sorter: BSTSorter
+        self.filterer: BSTFilterer
+        self.name: str  # Used in derived classes
+
+        if self.field_path is None and not self.is_annotation:
+            raise ValueError(
+                "field_path is required for non-annotation fields.  Use BSTAnnotColumn for annotation fields."
+            )
+
+        if not hasattr(self, "name") or self.name is None:
+            if self.is_annotation:
+                raise ValueError("name not set by BSTAnnotColumn.")
+            if self.field_path is not None:
+                self.name = self.field_path
+            else:
+                raise ValueError("field_path is required (when not a BSTAnnotColumn).")
+
+        if self.header is None:
+            self.header = self.generate_header()
+
+        if self.field_path is not None:
+            is_many_related = is_many_related_to_root(self.field_path, self.model)
+            if is_many_related and not self.is_many_related and not self.is_annotation:
+                raise ValueError(
+                    f"field_path '{field_path}' must not be many-related with model '{self.model.__name__}'.  Use "
+                    "BSTAnnotColumn or BSTManyRelatedColumn instead."
+                )
+
+        if self.link:
+            if self.field_path is None:
+                raise ValueError("link must not be true when field_path is None.")
+            elif is_many_related:
+                raise ValueError(
+                    f"link must not be true when field_path '{field_path}' is many-related with model "
+                    f"'{self.model.__name__}'."
+                )
+            elif "__" in self.field_path:
+                raise ValueError(
+                    f"link must not be true when field_path '{field_path}' passes through a related model."
+                )
+            elif not hasattr(self.model, "get_absolute_url"):
+                raise ValueError(
+                    f"link must not be true when model '{self.model.__name__}' does not have a 'get_absolute_url' "
+                    "method."
+                )
+
+        if sorter is None:
+            self.sorter = BSTSorter(self.field_path, model=self.model)
+        elif isinstance(sorter, str):
+            self.sorter = BSTSorter(
+                self.field_path, model=self.model, client_sorter=sorter
+            )
+        elif isinstance(sorter, BSTSorter):
+            self.sorter = sorter
+        else:
+            raise ValueError("sorter must be a str or a BSTSorter.")
+
+        if filterer is None:
+            self.filterer = BSTFilterer(model=self.model, field_path=self.field_path)
+        elif isinstance(filterer, str):
+            self.filterer = BSTFilterer(
+                model=self.model,
+                field_path=self.field_path,
+                client_filterer=filterer,
+            )
+        elif isinstance(filterer, BSTFilterer):
+            self.filterer = filterer
+        else:
+            raise ValueError("filterer must be a str or a BSTFilterer.")
+
+    def __eq__(self, other):
+        """This is a convenience override to be able to compare a column name with a column object to see if the object
+        is for that column.  It also enables the `in` operator to work between strings and objects.
+
+        Args:
+            other (Optional[Union[str, BSTColumn]]): A value to equate with self
+                NOTE: Cannot apply this type hint due to mypy superclass requirements that it be 'object'.
+        Exceptions:
+            NotImplementedError when the type of other is invalid
+        Returns:
+            (bool)
+        """
+        if isinstance(other, __class__):  # type: ignore
+            return self.__dict__ == other.__dict__
+        elif isinstance(other, str):
+            return self.name == other
+        elif other is None:
+            return False
+        else:
+            raise NotImplementedError(
+                f"Equivalence of {__class__.__name__} to {type(other).__name__} not implemented."  # type: ignore
+            )
+
+    def generate_header(self):
+        """Generate a column header from the field_path, model name, or column name.
+
+        Args:
+            None
+        Exceptions:
+            None
+        Returns:
+            None
+        """
+        # If this column is an annotation, use self.name
+        if self.is_annotation is True:
+            return underscored_to_title(self.name)
+
+        # Get the field
+        field = field_path_to_field(self.model, self.field_path)
+
+        # If the field has a verbose name different from name, use it
+        if field.name != field.verbose_name:
+            if any(c.isupper() for c in field.verbose_name):
+                # If the field has a verbose name with caps, use it as-is
+                return field.verbose_name
+            else:
+                # Otherwise convert it to a title
+                return underscored_to_title(field.verbose_name)
+
+        # Special case: If the name of the field is name, use the model name
+        if self.field_path == "name" and is_unique_field(field):
+            verbose_model_name_without_automods = self.model._meta.__dict__[
+                "verbose_name"
+            ].replace(" ", "")
+            if (
+                self.model.__name__.lower()
+                != verbose_model_name_without_automods.lower()
+            ):
+                # Use the model's verbose name
+                if any(c.isupper() for c in self.model._meta.__dict__["verbose_name"]):
+                    # If the verbose name contains upper-case characters
+                    return self.model._meta.__dict__["verbose_name"]
+                else:
+                    return underscored_to_title(
+                        self.model._meta.__dict__["verbose_name"]
+                    )
+            else:
+                # Use the model name
+                return camel_to_title(self.model.__name__)
+
+        # Grab as many of the last 2 items from the field_path as is present
+        path_tail = self.field_path.split("__")[-2:]
+
+        # If the length is 2, the last element is "name", and the field is unique, use the related model name
+        if len(path_tail) == 2 and path_tail[1] == "name" and is_unique_field(field):
+            return underscored_to_title(path_tail[0])
+
+        # Default is to use the last 2 elements of the path
+        return underscored_to_title("_".join(path_tail))

--- a/DataRepo/views/models/bst_list_view/filterer.py
+++ b/DataRepo/views/models/bst_list_view/filterer.py
@@ -4,7 +4,6 @@ from typing import Dict, List, Optional, Union
 
 from django.conf import settings
 from django.db.models import Model
-from django.db.models.expressions import Expression
 from django.templatetags.static import static
 from django.utils.functional import classproperty
 from django.utils.safestring import mark_safe


### PR DESCRIPTION
## Summary Change Description

Details:

- `BSTColumn` was made as a base class that only supports direct fields of a root model.
  - It is planned to be used as a superclass for the following planned classes:
    - `BSTAnnotColumn`
    - `BSTRelatedColumn`
    - `BSTManyRelatedColumn`
  - It takes a set of simple arguments:
    - Basics defining the column:
      - `model`
      - `field_path`
      - `header`
    - Boolean settings:
      - `searchable`
      - `sortable`
      - `visible`
      - `exported`
      - `link` (whether it should link to the detail record)
    - Functionality customization:
      - `sorter` (a `BSTSorter`)
      - `filterer` (a `BSTFilterer`)
    - Templates (with generic defaults):
      - `th_template` (`"models/bst_list_view/th.html"`)
      - `td_template` (`"models/bst_list_view/bst_td.html"`)
      - `value_template` (`"models/bst_list_view/bst_value.html"`)
  - Class attributes used for validation and support for planned derived classes
    - `is_annotation`
    - `is_fk`
    - `is_many_related`
  - Method `generate_header` encapsulates the default header value, which uses the `field_path` and `model` to craft the best capitalized header, deferring to `model` and `field` `verbose_name` values.
- I changed the `.htmlhintrc` setting for attr-no-duplication from true to false because it is incompatible with templates (it marks `{%` as duplicate attributes if all the code is not on 1 line).

## Affected Issues/Pull Requests

- Partially addresses #1477
- Merges into branch `filterer_streamlining`
- Previous PR #1489

## Reviewer Notes/Requests
<!-- Notes to help the reviewer or requests for specific scrutiny.
E.g. Please make sure I have accounted for all possible inputs. -->
See comments in-line.

## Checklist
<!-- If any requirements are not met, uncheck and explain.
E.g. Linting errors pre-date this PR. -->
This pull request will be merged once the following requirements are met.  The
author and/or reviewers should uncheck any unmet requirements:
<!-- Check/complete items if not applicable. -->
- Review Requirements
  - Minimum approvals: 1 <!-- Edit based on complexity. -->
  - No changes requested
  - All blocking issues resolved by reviewers
  - Specific reviewers: @__add_username_here__ <!-- Approvals required even if minimum met. -->
  - Review period: 2 days <!-- Edit based on complexity. -->
- Associated Issue/PR Requirements: <!-- Assert resolved issues/PRs are done/merged. -->
  - [x] All issue requirements are satisfied
  - [x] All PR dependencies are merged
- Basic Requirements <!-- Uncheck to indicate items you are yet to address. -->
  - [x] [Linters pass](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#linting)
  - [x] [Tests pass](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#quality-control)
  - [x] Conflicts resolved
- Overhead Requirements <!-- Requirements indirectly related to the issues. -->
  - [x] [Tests implemented/updated](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#test-implementation)
  - [ ] [Updated `CHANGELOG.md` *Unreleased* section](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/changelog.md)
