### PR TITLE
Integrated base class support for foreign keys

### DIFF
--- a/DataRepo/tests/views/models/bst_list_view/column/test_field.py
+++ b/DataRepo/tests/views/models/bst_list_view/column/test_field.py
@@ -112,7 +112,7 @@ class BSTColumnTests(TracebaseTestCase):
             BSTColumn("studies__name", model=BSTCAnimalTestModel)
         self.assertIn("must not be many-related", str(ar.exception))
         self.assertIn(
-            "use BSTAnnotColumn to create an annotation or BSTManyRelatedColumn",
+            "use BSTManyRelatedColumn to create a delimited-value column",
             str(ar.exception),
         )
 
@@ -185,6 +185,13 @@ class BSTColumnTests(TracebaseTestCase):
             "filterer must be a str or a BSTBaseFilterer, not a 'int'",
             str(ar.exception),
         )
+
+    def test_init_is_fk(self):
+        self.assertTrue(BSTColumn("animal", model=BSTCSampleTestModel).is_fk)
+        self.assertFalse(BSTColumn("name", model=BSTCSampleTestModel).is_fk)
+        # TODO: Put this test in the tests for BSTRelatedColumn
+        # self.assertTrue(BSTColumn("animal__studies", model=BSTCSampleTestModel).is_fk)
+        # self.assertFalse(BSTColumn("animal__studies__name", model=BSTCSampleTestModel).is_fk)
 
     def test_eq(self):
         # Test __eq__ works when other val is string

--- a/DataRepo/views/models/bst_list_view/column/base.py
+++ b/DataRepo/views/models/bst_list_view/column/base.py
@@ -28,9 +28,6 @@ class BSTBaseColumn(ABC):
     is_annotation: bool = False
     # See: BSTAnnotColumn (For rendering an annotation)
 
-    is_fk: bool = False
-    # See: BSTRelatedColumn (For rendering a one-related foreign key using the related object)
-
     is_many_related: bool = False
     # See: BSTManyRelatedColumn (For rendering a many-related foreign key using the related object)
 
@@ -98,6 +95,9 @@ class BSTBaseColumn(ABC):
         # Initialized below
         self.sorter: BSTBaseSorter
         self.filterer: BSTBaseFilterer
+
+        if getattr(self, "is_fk", None) is None:
+            self.is_fk = False
 
         if self.linked:
             if self.is_many_related:

--- a/DataRepo/views/models/bst_list_view/column/base.py
+++ b/DataRepo/views/models/bst_list_view/column/base.py
@@ -28,6 +28,9 @@ class BSTBaseColumn(ABC):
     is_annotation: bool = False
     # See: BSTAnnotColumn (For rendering an annotation)
 
+    is_related: bool = False
+    # See: BSTRelatedColumn (For rendering a related foreign key using the related object)
+
     is_many_related: bool = False
     # See: BSTManyRelatedColumn (For rendering a many-related foreign key using the related object)
 
@@ -35,8 +38,8 @@ class BSTBaseColumn(ABC):
         self,
         name: str,
         header: Optional[str] = None,
-        searchable: bool = True,
-        sortable: bool = True,
+        searchable: Optional[bool] = None,
+        sortable: Optional[bool] = None,
         visible: bool = True,
         exported: bool = True,
         linked: bool = False,
@@ -53,9 +56,15 @@ class BSTBaseColumn(ABC):
             header (Optional[str]) [auto]: The column header to display in the template.  Will be automatically
                 generated using the title case conversion of the last (2, if present) dunderscore-delimited name values.
 
-            searchable (bool) [True]: Whether or not a column is searchable.  This affects whether the column is
-                searched as a part of the table's search box and whether the column filter input will be enabled.
-            sortable (bool) [True]: Whether or not a column's values can be used to sort the table rows.
+            searchable (Optional[bool]) [auto]: Whether or not a column is searchable.  This affects whether the column
+                is searched as a part of the table's search box and whether the column filter input will be enabled.
+                The default is based on whether the column is a foreign key or not, because Django turns keys into model
+                objects that do not render the actual numeric key value, so what the user sees would not behave as
+                expected when searched.
+            sortable (Optional[bool]) [auto]: Whether or not a column's values can be used to sort the table rows.  The
+                default is based on whether the column is a foreign key or not, because Django turns keys into model
+                objects that do not render the actual numeric key value, so what the user sees would not behave as
+                expected when sorted.
             visible (bool) [True]: Controls whether a column is initially visible.
             exported (bool) [True]: Adds to BST's exportOptions' ignoreColumn attribute if False.
             linked (bool) [False]: Whether or not the value in the column should link to a detail page for the model
@@ -100,19 +109,50 @@ class BSTBaseColumn(ABC):
             self.is_fk = False
 
         if self.linked:
-            if self.is_many_related:
+            if self.is_related:
                 raise ValueError(
-                    f"Argument 'linked' must not be true when the column '{self.name}' is many-related."
+                    f"Column {self.name} cannot be linked to the root model when it is from a related model."
                 )
             elif self.is_fk:
                 raise ValueError(
-                    f"Argument 'linked' must not be true when the column '{self.name}' is a foreign key."
+                    f"Column {self.name} cannot be linked to the root model when it is a foreign key."
                 )
+
+        # Handle the defaults for searchable and sortable
+        if not self.is_related:
+            # The defaults are False if this is not a related column.  In fact, they cannot be True if the fiueld is a
+            # foreign key, because Django turns foreign key fields into model objects that do not render the actual
+            # numeric key value, so what the user sees would not behave as expected when searched or sorted.
+            if self.is_fk:
+                if self.searchable is True:
+                    raise ValueError(
+                        f"Column {self.name} cannot be searchable when it is a foreign key unless the column class is "
+                        "either BSTRelatedColumn or BSTManyRelatedColumn."
+                    )
+                if self.sortable is True:
+                    raise ValueError(
+                        f"Column {self.name} cannot be sortable when it is a foreign key unless the column class is "
+                        "either BSTRelatedColumn or BSTManyRelatedColumn."
+                    )
+                self.searchable = False
+                self.sortable = False
+            else:
+                if self.searchable is None:
+                    self.searchable = True
+                if self.sortable is None:
+                    self.sortable = True
+        else:
+            # The defaults are True if this is a related column
+            if self.searchable is None:
+                self.searchable = True
+            if self.sortable is None:
+                self.sortable = True
 
         if self.header is None:
             self.header = self.generate_header()
 
         # NOTE: self.name will be either a field_path or an annotation field.
+        # NOTE: We set a sorter even if the field is not sortable.
         if sorter is None:
             self.sorter = self.create_sorter()
         elif isinstance(sorter, str):
@@ -125,6 +165,7 @@ class BSTBaseColumn(ABC):
             )
 
         # NOTE: self.name will be either a field_path or an annotation field.
+        # NOTE: We set a filterer even if the field is not searchable.
         if filterer is None:
             self.filterer = self.create_filterer()
         elif isinstance(filterer, str):

--- a/DataRepo/views/models/bst_list_view/column/field.py
+++ b/DataRepo/views/models/bst_list_view/column/field.py
@@ -6,6 +6,7 @@ from django.db.models import Model
 
 from DataRepo.models.utilities import (
     field_path_to_field,
+    is_key_field,
     is_many_related_to_root,
     is_unique_field,
 )
@@ -127,13 +128,15 @@ class BSTColumn(BSTBaseColumn):
         ):
             raise ValueError(
                 f"field_path '{field_path}' must not be many-related with model '{model.__name__}'.  Instead, use "
-                "BSTAnnotColumn to create an annotation or BSTManyRelatedColumn to create a delimited-value column."
+                "BSTManyRelatedColumn to create a delimited-value column."
             )
         elif linked and "__" in self.field_path:
             raise ValueError(
                 f"Argument 'linked' must not be true when 'field_path' '{field_path}' passes through a related "
                 "model."
             )
+
+        self.is_fk = is_key_field(self.model, self.field_path)
 
         # Set a default sorter, if necessary
         if sorter is None:


### PR DESCRIPTION
## Summary Change Description

Turned `is_fk` into an instance attribute of the `BSTColumn` class instead of a class attribute of the `BSTBaseColumn` class.

I realized that `is_fk` is not necessarily a characteristic exclusive to the planned `BSTRelatedColumn`.  A regular `Field` column (i.e. `BSTColumn`) can have fields that are foreign keys and they can be linked whether or not we've defined a `BSTRelatedColumn`.  The features that `BSTRelatedColumn` will allow is the specification of a display value instead of how a related model object happens to render in str context.  Just note that the foreign key cannot be searched or sorted based on that string-context value.  That's what defining a `BSTRelatedColumn` will provide.

Details:

- Created a model utility method named `is_key_field`
- Defaulted `is_fk` in the `BSTBaseColumn` as `False` if it is not set/defined.
- Added doc strings to a bunch of model utility methods.
- Added a class attribute named `is_related` to `BSTBaseColumn` and made `searchable` and `sortable` automatically defaulted based on whether the field was a foreign key.

## Affected Issues/Pull Requests

- Resolves no documented issue
- Merges into branch `bst_annot_col`
- Previous PR #1494
- Next PR #1500

## Reviewer Notes/Requests
<!-- Notes to help the reviewer or requests for specific scrutiny.
E.g. Please make sure I have accounted for all possible inputs. -->
See comments in-line.

## Checklist
<!-- If any requirements are not met, uncheck and explain.
E.g. Linting errors pre-date this PR. -->
This pull request will be merged once the following requirements are met.  The
author and/or reviewers should uncheck any unmet requirements:
<!-- Check/complete items if not applicable. -->
- Review Requirements
  - Minimum approvals: 1 <!-- Edit based on complexity. -->
  - No changes requested
  - All blocking issues resolved by reviewers
  - Specific reviewers: @__add_username_here__ <!-- Approvals required even if minimum met. -->
  - Review period: 2 days <!-- Edit based on complexity. -->
- Associated Issue/PR Requirements: <!-- Assert resolved issues/PRs are done/merged. -->
  - [x] All issue requirements are satisfied
  - [x] All PR dependencies are merged
- Basic Requirements <!-- Uncheck to indicate items you are yet to address. -->
  - [x] [Linters pass](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#linting)
  - [x] [Tests pass](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#quality-control)
  - [x] Conflicts resolved
- Overhead Requirements <!-- Requirements indirectly related to the issues. -->
  - [x] [Tests implemented/updated](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#test-implementation)
  - [ ] [Updated `CHANGELOG.md` *Unreleased* section](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/changelog.md)
