### PR TITLE
`BSTManyRelatedColumn`

### DIFF
--- a/DataRepo/tests/views/models/bst_list_view/column/sorter/test_annotation.py
+++ b/DataRepo/tests/views/models/bst_list_view/column/sorter/test_annotation.py
@@ -21,7 +21,7 @@ class BSTAnnotSorterTests(TracebaseTestCase):
         self.assertEqual(BSTAnnotSorter.CLIENT_SORTERS.NONE, s.sorter)
         self.assertEqual("name", s.name)
         self.assertEqual(s.SERVER_SORTERS.ALPHANUMERIC, s._server_sorter)
-        self.assertIsInstance(s.sort_expression, Lower)
+        self.assertIsInstance(s.expression, Lower)
         self.assertFalse(s.client_mode)
 
     @TracebaseTestCase.assertNotWarns()
@@ -31,29 +31,21 @@ class BSTAnnotSorterTests(TracebaseTestCase):
         )
         self.assertEqual(BSTAnnotSorter.CLIENT_SORTERS.ALPHANUMERIC, s.client_sorter)
         self.assertEqual("name", s.name)
-        self.assertIsInstance(s.sort_expression, Lower)
+        self.assertIsInstance(s.expression, Lower)
         self.assertEqual(s.SERVER_SORTERS.ALPHANUMERIC, s._server_sorter)
 
     def test_init_expression_nofield_only(self):
-        # We assert NOT warns because Upper has a default output_field type which we recognize and can apply our case
-        # insensitivity to (using Lower).  This is a nonsensical example, but where this makes sense is when for
-        # example, fields are being concatenated or other operations are happening.  The point is that 'Lower' is
-        # applied if the **output_field** is a compatible type.
         with self.assertWarns(DeveloperWarning) as aw:
             s = BSTAnnotSorter(Upper("name"))
-        self.assertEqual(2, len(aw.warnings))
+        self.assertEqual(1, len(aw.warnings))
         self.assertIn(
             "Unable to apply default server-side sort behavior",
             str(aw.warnings[0].message),
         )
-        self.assertIn(
-            "Server sort may differ from client",
-            str(aw.warnings[1].message),
-        )
         self.assertEqual(BSTAnnotSorter.CLIENT_SORTERS.NONE, s.client_sorter)
         self.assertEqual(BSTAnnotSorter.SERVER_SORTERS.UNKNOWN, s._server_sorter)
         self.assertEqual("name", s.name)
-        self.assertIsInstance(s.sort_expression, Upper)
+        self.assertIsInstance(s.expression, Upper)
 
     @TracebaseTestCase.assertNotWarns()
     def test_init_expression_nofield_server_sorter_known(self):
@@ -63,17 +55,13 @@ class BSTAnnotSorterTests(TracebaseTestCase):
 
     def test_init_expression_nofield_server_sorter_custom(self):
         # Allow users to craft their own server sorter, but warn that we cannot apply case insensitivity due to the lack
-        # of an output_field and we cannot guranatee that the client sort will match if a custom client_sorter is not
-        # also specified.
+        # of an output_field.
         with self.assertWarns(DeveloperWarning) as aw:
             BSTAnnotSorter(Upper("name"), _server_sorter=Upper)
+        self.assertEqual(1, len(aw.warnings))
         self.assertIn(
             "Upper(F(name)) has no output_field",
             str(aw.warnings[0].message),
-        )
-        self.assertIn(
-            "Server sort may differ from client",
-            str(aw.warnings[1].message),
         )
 
     def test_init_expression_nofield_client_sorter_known_debug(self):
@@ -116,14 +104,14 @@ class BSTAnnotSorterTests(TracebaseTestCase):
         self.assertEqual(Lower, s._server_sorter)
         self.assertEqual(BSTAnnotSorter.CLIENT_SORTERS.ALPHANUMERIC, s.client_sorter)
         self.assertEqual("name", s.name)
-        self.assertIsInstance(s.sort_expression, Lower)
+        self.assertIsInstance(s.expression, Lower)
 
     @TracebaseTestCase.assertNotWarns()
     def test_init_expression_nofield_and_clientsorter(self):
         s = BSTAnnotSorter(Upper("name"), client_sorter="upperSorter")
         self.assertEqual("upperSorter", s.client_sorter)
         self.assertEqual("name", s.name)
-        self.assertIsInstance(s.sort_expression, Upper)
+        self.assertIsInstance(s.expression, Upper)
         self.assertEqual(BSTAnnotSorter.SERVER_SORTERS.UNKNOWN, s._server_sorter)
 
     @TracebaseTestCase.assertNotWarns()

--- a/DataRepo/tests/views/models/bst_list_view/column/sorter/test_many_related_field.py
+++ b/DataRepo/tests/views/models/bst_list_view/column/sorter/test_many_related_field.py
@@ -1,0 +1,24 @@
+from django.db.models import CharField, F, IntegerField
+from django.db.models.functions import Lower, Upper
+from django.templatetags.static import static
+from django.test import override_settings
+
+from DataRepo.tests.tracebase_test_case import (
+    TracebaseTestCase,
+    create_test_model,
+)
+from DataRepo.utils.exceptions import DeveloperWarning
+from DataRepo.views.models.bst_list_view.column.sorter.field import BSTSorter
+
+BSTSTestModel = create_test_model(
+    "BSTSTestModel",
+    {
+        "name": CharField(max_length=255),
+        "value": IntegerField(),
+    },
+)
+
+
+@override_settings(DEBUG=True)
+class BSTManyRelatedSorterTests(TracebaseTestCase):
+    pass

--- a/DataRepo/tests/views/models/bst_list_view/column/sorter/test_many_related_field.py
+++ b/DataRepo/tests/views/models/bst_list_view/column/sorter/test_many_related_field.py
@@ -1,6 +1,13 @@
-from django.db.models import CharField, F, IntegerField
-from django.db.models.functions import Lower, Upper
-from django.templatetags.static import static
+from django.db.models import (
+    CASCADE,
+    CharField,
+    F,
+    ForeignKey,
+    IntegerField,
+    ManyToManyField,
+)
+from django.db.models.aggregates import Count
+from django.db.models.functions import Length, Lower, Upper
 from django.test import override_settings
 
 from DataRepo.tests.tracebase_test_case import (
@@ -8,17 +15,162 @@ from DataRepo.tests.tracebase_test_case import (
     create_test_model,
 )
 from DataRepo.utils.exceptions import DeveloperWarning
-from DataRepo.views.models.bst_list_view.column.sorter.field import BSTSorter
+from DataRepo.views.models.bst_list_view.column.sorter.many_related_field import (
+    BSTManyRelatedSorter,
+)
 
-BSTSTestModel = create_test_model(
-    "BSTSTestModel",
+BSTMRSManyTestModel = create_test_model(
+    "BSTMRSManyTestModel",
     {
         "name": CharField(max_length=255),
         "value": IntegerField(),
     },
 )
 
+BSTMRSMiddleTestModel = create_test_model(
+    "BSTMRSMiddleTestModel",
+    {
+        "name": CharField(max_length=255),
+        "mms": ManyToManyField(to="loader.BSTMRSManyTestModel", related_name="fms"),
+    },
+)
+
+BSTMRSChildTestModel = create_test_model(
+    "BSTMRSChildTestModel",
+    {
+        "name": CharField(max_length=255),
+        "parent": ForeignKey(
+            to="loader.BSTMRSMiddleTestModel",
+            related_name="children",
+            on_delete=CASCADE,
+        ),
+    },
+)
+
 
 @override_settings(DEBUG=True)
 class BSTManyRelatedSorterTests(TracebaseTestCase):
-    pass
+    def test_not_many_related(self):
+        with self.assertRaises(ValueError) as ar:
+            BSTManyRelatedSorter(
+                BSTMRSManyTestModel.name.field,  # pylint: disable=no-member
+                BSTMRSManyTestModel,
+                asc=True,
+            )
+        self.assertIn(
+            "field_path 'name' must be many-related with the model 'BSTMRSManyTestModel'",
+            str(ar.exception),
+        )
+
+    def test_init_str_char_asc(self):
+        s = BSTManyRelatedSorter("mms__name", BSTMRSMiddleTestModel, asc=True)
+        self.assertEqual("Min(Lower(F(mms__name)))", str(s.expression))
+
+    def test_init_str_char_desc(self):
+        s = BSTManyRelatedSorter("mms__name", BSTMRSMiddleTestModel, asc=False)
+        self.assertEqual("Max(Lower(F(mms__name)))", str(s.expression))
+
+    def test_init_str_int_asc(self):
+        s = BSTManyRelatedSorter("mms__value", BSTMRSMiddleTestModel, asc=True)
+        self.assertEqual("Min(F(mms__value))", str(s.expression))
+
+    def test_init_str_int_desc(self):
+        s = BSTManyRelatedSorter("mms__value", BSTMRSMiddleTestModel, asc=False)
+        self.assertEqual("Max(F(mms__value))", str(s.expression))
+
+    def test_init_lower_char_asc(self):
+        s = BSTManyRelatedSorter(Lower("mms__name"), BSTMRSMiddleTestModel, asc=True)
+        self.assertEqual("Min(Lower(F(mms__name)))", str(s.expression))
+
+    def test_init_lower_char_desc(self):
+        s = BSTManyRelatedSorter(Lower("mms__name"), BSTMRSMiddleTestModel, asc=False)
+        self.assertEqual("Max(Lower(F(mms__name)))", str(s.expression))
+
+    def test_init_f_int_asc(self):
+        s = BSTManyRelatedSorter(F("mms__value"), BSTMRSMiddleTestModel, asc=True)
+        self.assertEqual("Min(F(mms__value))", str(s.expression))
+
+    def test_init_f_int_desc(self):
+        s = BSTManyRelatedSorter(F("mms__value"), BSTMRSMiddleTestModel, asc=False)
+        self.assertEqual("Max(F(mms__value))", str(s.expression))
+
+    def test_init_upper_char_asc(self):
+        with self.assertWarns(DeveloperWarning) as aw:
+            s = BSTManyRelatedSorter(
+                Upper("mms__name"), BSTMRSMiddleTestModel, asc=True
+            )
+        self.assertEqual("Min(Upper(F(mms__name)))", str(s.expression))
+        self.assertEqual(1, len(aw.warnings))
+        self.assertIn("no output_field set", str(aw.warnings[0].message))
+
+    def test_init_upper_char_desc(self):
+        with self.assertWarns(DeveloperWarning) as aw:
+            s = BSTManyRelatedSorter(
+                Upper("mms__name"), BSTMRSMiddleTestModel, asc=False
+            )
+        self.assertEqual("Max(Upper(F(mms__name)))", str(s.expression))
+        self.assertEqual(1, len(aw.warnings))
+        self.assertIn("no output_field set", str(aw.warnings[0].message))
+
+    def test_init_length_char_asc(self):
+        # Length() has a default output_field, so no warning is generated:
+        # In [2]: l = Length("name")
+        # In [4]: l.output_field
+        # Out[4]: <django.db.models.fields.IntegerField>
+        s = BSTManyRelatedSorter(Length("mms__name"), BSTMRSMiddleTestModel, asc=True)
+        self.assertEqual("Min(Length(F(mms__name)))", str(s.expression))
+
+    def test_init_length_char_desc(self):
+        # Length() has a default output_field, so no warning is generated:
+        s = BSTManyRelatedSorter(Length("mms__name"), BSTMRSMiddleTestModel, asc=False)
+        self.assertEqual("Max(Length(F(mms__name)))", str(s.expression))
+
+    def test_init_count_char_asc(self):
+        with self.assertWarns(DeveloperWarning) as aw:
+            s = BSTManyRelatedSorter(
+                Count("mms__name", distinct=True), BSTMRSMiddleTestModel, asc=True
+            )
+        self.assertEqual("Count(F(mms__name), distinct=True)", str(s.expression))
+        self.assertEqual(1, len(aw.warnings))
+        self.assertIn(
+            "Unable to apply aggregate function 'Min'", str(aw.warnings[0].message)
+        )
+        self.assertIn("sorter for column 'mms__name'", str(aw.warnings[0].message))
+        self.assertIn(
+            "already has an aggregate function 'Count", str(aw.warnings[0].message)
+        )
+        self.assertIn(
+            "In order for the delimited values to be sorted",
+            str(aw.warnings[0].message),
+        )
+        self.assertIn(
+            "row sort to be based on either the first or last delimited value",
+            str(aw.warnings[0].message),
+        )
+        self.assertIn(
+            "must not already be wrapped in an aggregate", str(aw.warnings[0].message)
+        )
+        self.assertIn(
+            "Sorting on this column will not base row position on the min/max",
+            str(aw.warnings[0].message),
+        )
+        self.assertIn(
+            "sort of the delimited values will be static and appear unordered",
+            str(aw.warnings[0].message),
+        )
+        self.assertIn("use BSTAnnotColumn", str(aw.warnings[0].message))
+
+    def test_init_count_char_desc(self):
+        with self.assertWarns(DeveloperWarning) as aw:
+            s = BSTManyRelatedSorter(
+                Count("mms__name", distinct=True), BSTMRSMiddleTestModel, asc=False
+            )
+        self.assertEqual("Count(F(mms__name), distinct=True)", str(s.expression))
+        self.assertEqual(1, len(aw.warnings))
+        self.assertIn(
+            "Unable to apply aggregate function 'Max'", str(aw.warnings[0].message)
+        )
+
+    def test_init_reverse_relation(self):
+        s = BSTManyRelatedSorter(F("children__name"), BSTMRSMiddleTestModel, asc=False)
+        self.assertEqual("Max(Lower(F(children__name)))", str(s.expression))

--- a/DataRepo/tests/views/models/bst_list_view/column/test_many_related_field.py
+++ b/DataRepo/tests/views/models/bst_list_view/column/test_many_related_field.py
@@ -1,0 +1,234 @@
+from django.db.models import (
+    CASCADE,
+    CharField,
+    FloatField,
+    ForeignKey,
+    IntegerField,
+    ManyToManyField,
+)
+from django.db.models.aggregates import Count
+from django.db.models.functions import Length
+from django.test import override_settings
+
+from DataRepo.tests.tracebase_test_case import (
+    TracebaseTestCase,
+    create_test_model,
+)
+from DataRepo.utils.exceptions import DeveloperWarning
+from DataRepo.views.models.bst_list_view.column.many_related_field import (
+    BSTManyRelatedColumn,
+)
+from DataRepo.views.models.bst_list_view.column.sorter.many_related_field import (
+    BSTManyRelatedSorter,
+)
+
+BSTMRCStudyTestModel = create_test_model(
+    "BSTMRCStudyTestModel",
+    {"name": CharField(max_length=255, unique=True)},
+)
+BSTMRCAnimalTestModel = create_test_model(
+    "BSTMRCAnimalTestModel",
+    {
+        "name": CharField(max_length=255),
+        "body_weight": FloatField(verbose_name="Weight (g)"),
+        "studies": ManyToManyField(
+            to="loader.BSTMRCStudyTestModel", related_name="animals"
+        ),
+        "treatment": ForeignKey(
+            to="loader.BSTMRCTreatmentTestModel",
+            related_name="animals",
+            on_delete=CASCADE,
+        ),
+    },
+)
+BSTMRCSampleTestModel = create_test_model(
+    "BSTMRCSampleTestModel",
+    {
+        "animal": ForeignKey(
+            to="loader.BSTMRCAnimalTestModel", related_name="samples", on_delete=CASCADE
+        ),
+        "characteristic": CharField(),
+        "name": CharField(max_length=255, unique=True),
+        "tissue": ForeignKey(
+            to="loader.BSTMRCTissueTestModel", related_name="samples", on_delete=CASCADE
+        ),
+    },
+)
+BSTMRCMSRunSampleTestModel = create_test_model(
+    "BSTMRCMSRunSampleTestModel",
+    {
+        "name": CharField(max_length=255, unique=True),
+        "sample": ForeignKey(
+            to="loader.BSTMRCSampleTestModel",
+            related_name="msrun_samples",
+            on_delete=CASCADE,
+        ),
+    },
+)
+BSTMRCTissueTestModel = create_test_model(
+    "BSTMRCTissueTestModel",
+    {"name": CharField(max_length=255)},
+)
+BSTMRCTreatmentTestModel = create_test_model(
+    "BSTMRCTreatmentTestModel",
+    {"name": CharField(), "desc": CharField()},
+)
+
+
+@override_settings(DEBUG=True)
+class BSTManyRelatedColumnTests(TracebaseTestCase):
+
+    @TracebaseTestCase.assertNotWarns()
+    def test_init_basic_defaults(self):
+        # self.list_attr_name
+        # self.count_attr_name
+        # self.delim
+        # self.limit
+        c = BSTManyRelatedColumn("studies__name", BSTMRCAnimalTestModel)
+        self.assertEqual(
+            f"studies_name{BSTManyRelatedColumn.list_attr_tail}", c.list_attr_name
+        )
+        self.assertEqual(
+            f"studies_name{BSTManyRelatedColumn.count_attr_tail}", c.count_attr_name
+        )
+        self.assertEqual(BSTManyRelatedColumn.delimiter, c.delim)
+        self.assertEqual(BSTManyRelatedColumn.limit, c.limit)
+        self.assertEqual(BSTManyRelatedColumn.ascending, c.asc)
+
+    @TracebaseTestCase.assertNotWarns()
+    def test_init_fk_field_attrs(self):
+        c = BSTManyRelatedColumn("studies", BSTMRCAnimalTestModel)
+        self.assertEqual(
+            f"studies{BSTManyRelatedColumn.list_attr_tail}", c.list_attr_name
+        )
+        self.assertEqual(
+            f"studies{BSTManyRelatedColumn.count_attr_tail}", c.count_attr_name
+        )
+
+    @TracebaseTestCase.assertNotWarns()
+    def test_set_related_model_path_success(self):
+        c = BSTManyRelatedColumn("animals__samples__tissue__name", BSTMRCStudyTestModel)
+        c.set_related_model_path("animals")
+        self.assertEqual("animals", c.related_model_path)
+
+    @TracebaseTestCase.assertNotWarns()
+    def test_set_related_model_path_error_empty(self):
+        c = BSTManyRelatedColumn("animals__samples__tissue__name", BSTMRCStudyTestModel)
+        with self.assertRaises(ValueError) as ar:
+            c.set_related_model_path("")
+        self.assertIn("must be a non-empty string", str(ar.exception))
+
+    @TracebaseTestCase.assertNotWarns()
+    def test_set_related_model_path_error_conflict(self):
+        c = BSTManyRelatedColumn("animals__samples__tissue__name", BSTMRCStudyTestModel)
+        with self.assertRaises(ValueError) as ar:
+            c.set_related_model_path("animals__treatment")
+        self.assertIn(
+            "field path 'animals__samples__tissue__name' must start with",
+            str(ar.exception),
+        )
+        self.assertIn("related_model_path 'animals__treatment'", str(ar.exception))
+
+    @TracebaseTestCase.assertNotWarns()
+    def test_create_sorter_default_char(self):
+        c = BSTManyRelatedColumn("animals__samples__tissue", BSTMRCStudyTestModel)
+        self.assertIsInstance(c.sorter, BSTManyRelatedSorter)
+        self.assertEqual("animals__samples__tissue", c.sorter.name)
+        self.assertTrue(c.sorter.asc)
+        self.assertEqual(
+            "Min(Lower(F(animals__samples__tissue__name)))", str(c.sorter.expression)
+        )
+
+    @TracebaseTestCase.assertNotWarns()
+    def test_create_sorter_default_float(self):
+        c = BSTManyRelatedColumn("animals__body_weight", BSTMRCStudyTestModel)
+        self.assertIsInstance(c.sorter, BSTManyRelatedSorter)
+        self.assertEqual("animals__body_weight", c.sorter.name)
+        self.assertTrue(c.sorter.asc)
+        self.assertEqual("Min(F(animals__body_weight))", str(c.sorter.expression))
+
+    @TracebaseTestCase.assertNotWarns()
+    def test_create_sorter_max_char(self):
+        c = BSTManyRelatedColumn(
+            "animals__samples__tissue", BSTMRCStudyTestModel, asc=False
+        )
+        self.assertIsInstance(c.sorter, BSTManyRelatedSorter)
+        self.assertEqual("animals__samples__tissue", c.sorter.name)
+        self.assertFalse(c.sorter.asc)
+        self.assertEqual(
+            "Max(Lower(F(animals__samples__tissue__name)))", str(c.sorter.expression)
+        )
+
+    @TracebaseTestCase.assertNotWarns()
+    def test_create_sorter_max_float(self):
+        c = BSTManyRelatedColumn(
+            "animals__body_weight", BSTMRCStudyTestModel, asc=False
+        )
+        self.assertIsInstance(c.sorter, BSTManyRelatedSorter)
+        self.assertEqual("animals__body_weight", c.sorter.name)
+        self.assertFalse(c.sorter.asc)
+        self.assertEqual("Max(F(animals__body_weight))", str(c.sorter.expression))
+
+    @TracebaseTestCase.assertNotWarns()
+    def test_create_sorter_custom_sort_expression(self):
+        c = BSTManyRelatedColumn(
+            "samples__characteristic",
+            BSTMRCAnimalTestModel,
+            sort_expression=Length(
+                "samples__characteristic", output_field=IntegerField
+            ),
+            asc=False,
+        )
+        self.assertIsInstance(c.sorter, BSTManyRelatedSorter)
+        self.assertEqual("samples__characteristic", c.sorter.name)
+        self.assertFalse(c.sorter.asc)
+        self.assertEqual(
+            "Max(Length(F(samples__characteristic)))", str(c.sorter.expression)
+        )
+
+    @TracebaseTestCase.assertNotWarns()
+    def test_create_sorter_custom_sort_field(self):
+        c = BSTManyRelatedColumn(
+            "samples__characteristic",
+            BSTMRCAnimalTestModel,
+            sort_expression="samples__name",
+        )
+        self.assertIsInstance(c.sorter, BSTManyRelatedSorter)
+        self.assertEqual("samples__characteristic", c.sorter.name)
+        self.assertTrue(c.sorter.asc)
+        self.assertEqual("Min(Lower(F(samples__name)))", str(c.sorter.expression))
+
+    def test_create_sorter_custom_agg_warning(self):
+        with self.assertWarns(DeveloperWarning) as aw:
+            BSTManyRelatedColumn(
+                "samples__characteristic",
+                BSTMRCAnimalTestModel,
+                sort_expression=Count(
+                    "samples__characteristic", output_field=IntegerField, distinct=True
+                ),
+            )
+        self.assertEqual(1, len(aw.warnings))
+        self.assertIn(
+            "Unable to apply aggregate function 'Min' to the sorter for column 'samples__characteristic'",
+            str(aw.warnings[0].message),
+        )
+        self.assertIn(
+            "already has an aggregate function 'Count(F(samples__characteristic), distinct=True)'",
+            str(aw.warnings[0].message),
+        )
+        self.assertIn("first or last delimited value", str(aw.warnings[0].message))
+        self.assertIn("delimited values to be sorted", str(aw.warnings[0].message))
+        self.assertIn(
+            "must not already be wrapped in an aggregate", str(aw.warnings[0].message)
+        )
+        self.assertIn(
+            "will not base row position on the min/max related value",
+            str(aw.warnings[0].message),
+        )
+        self.assertIn(
+            "sort of the delimited values will be static", str(aw.warnings[0].message)
+        )
+        self.assertIn(
+            "intended to be an annotation column, use BSTAnnotColumn",
+            str(aw.warnings[0].message),
+        )

--- a/DataRepo/tests/views/models/bst_list_view/column/test_related_field.py
+++ b/DataRepo/tests/views/models/bst_list_view/column/test_related_field.py
@@ -103,7 +103,7 @@ class BSTRelatedColumnTests(TracebaseTestCase):
 
     @TracebaseTestCase.assertNotWarns()
     def test_init_display_field_fk(self):
-        c = BSTRelatedColumn("sample", model=BSTRCMSRunSampleTestModel)
+        c = BSTRelatedColumn("sample", BSTRCMSRunSampleTestModel)
         self.assertEqual(
             "sample__name",
             c.display_field_path,
@@ -112,7 +112,7 @@ class BSTRelatedColumnTests(TracebaseTestCase):
         self.assertTrue(c.sortable)
         self.assertTrue(c.searchable)
 
-        c = BSTRelatedColumn("sample__animal", model=BSTRCMSRunSampleTestModel)
+        c = BSTRelatedColumn("sample__animal", BSTRCMSRunSampleTestModel)
         self.assertEqual(
             "sample__animal__name",
             c.display_field_path,
@@ -121,7 +121,7 @@ class BSTRelatedColumnTests(TracebaseTestCase):
         self.assertTrue(c.sortable)
         self.assertTrue(c.searchable)
 
-        c = BSTRelatedColumn("tissue", model=BSTRCSampleTestModel)
+        c = BSTRelatedColumn("tissue", BSTRCSampleTestModel)
         self.assertEqual(
             "tissue__name",
             c.display_field_path,
@@ -132,7 +132,7 @@ class BSTRelatedColumnTests(TracebaseTestCase):
 
         c = BSTRelatedColumn(
             "sample",
-            model=BSTRCMSRunSampleTestModel,
+            BSTRCMSRunSampleTestModel,
             display_field_path="sample__characteristic",
         )
         self.assertEqual(
@@ -145,7 +145,7 @@ class BSTRelatedColumnTests(TracebaseTestCase):
 
         c = BSTRelatedColumn(
             "sample",
-            model=BSTRCMSRunSampleTestModel,
+            BSTRCMSRunSampleTestModel,
             display_field_path="sample__animal__name",
         )
         self.assertEqual(
@@ -158,7 +158,7 @@ class BSTRelatedColumnTests(TracebaseTestCase):
 
     @TracebaseTestCase.assertNotWarns()
     def test_init_display_field_nonfk(self):
-        c = BSTRelatedColumn("sample__characteristic", model=BSTRCMSRunSampleTestModel)
+        c = BSTRelatedColumn("sample__characteristic", BSTRCMSRunSampleTestModel)
         self.assertEqual(
             "sample__characteristic",
             c.display_field_path,
@@ -173,7 +173,7 @@ class BSTRelatedColumnTests(TracebaseTestCase):
             # Different field
             BSTRelatedColumn(
                 "sample__characteristic",
-                model=BSTRCMSRunSampleTestModel,
+                BSTRCMSRunSampleTestModel,
                 display_field_path="sample__name",
             ),
         self.assertEqual(
@@ -190,7 +190,7 @@ class BSTRelatedColumnTests(TracebaseTestCase):
             # Different field not under path
             BSTRelatedColumn(
                 "sample__animal",
-                model=BSTRCMSRunSampleTestModel,
+                BSTRCMSRunSampleTestModel,
                 display_field_path="sample__name",
             ),
         self.assertEqual(
@@ -200,12 +200,13 @@ class BSTRelatedColumnTests(TracebaseTestCase):
 
     def test_init_searchable_disabled(self):
         with self.assertWarns(DeveloperWarning) as aw:
-            c = BSTRelatedColumn("treatment", model=BSTRCAnimalTestModel)
+            c = BSTRelatedColumn("treatment", BSTRCAnimalTestModel)
         self.assertFalse(c.searchable)
-        self.assertIsNone(c.display_field_path)
+        self.assertEqual("treatment", c.display_field_path)
+        self.assertIsInstance(c.display_field, ForeignKey)
         self.assertEqual(1, len(aw.warnings))
         self.assertIn(
-            "Unable to automatically select an appropriate display_field_path",
+            "Unable to automatically select a searchable/sortable display_field_path",
             str(aw.warnings[0].message),
         )
         self.assertIn("foreign key field_path 'treatment'", str(aw.warnings[0].message))
@@ -220,32 +221,28 @@ class BSTRelatedColumnTests(TracebaseTestCase):
         self.assertIn(
             "only field if there is only 1 non-ID field", str(aw.warnings[0].message)
         )
-        self.assertIn("cannot be searchable or sortable", str(aw.warnings[0].message))
-        self.assertIn(
-            "unless a display_field_path is supplied", str(aw.warnings[0].message)
-        )
 
     def test_init_sortable_disabled(self):
         with self.assertWarns(DeveloperWarning) as aw:
-            c = BSTRelatedColumn("treatment", model=BSTRCAnimalTestModel)
+            c = BSTRelatedColumn("treatment", BSTRCAnimalTestModel)
         self.assertFalse(c.sortable)
-        self.assertIsNone(c.display_field_path)
+        self.assertEqual("treatment", c.display_field_path)
+        self.assertIsInstance(c.display_field, ForeignKey)
         self.assertEqual(1, len(aw.warnings))
 
     def test_init_searchable_sortable_disabled(self):
         with self.assertWarns(DeveloperWarning) as aw:
-            c = BSTRelatedColumn("treatment", model=BSTRCAnimalTestModel)
+            c = BSTRelatedColumn("treatment", BSTRCAnimalTestModel)
         self.assertFalse(c.sortable)
         self.assertFalse(c.searchable)
-        self.assertIsNone(c.display_field_path)
+        self.assertEqual("treatment", c.display_field_path)
+        self.assertIsInstance(c.display_field, ForeignKey)
         self.assertEqual(1, len(aw.warnings))
 
     def test_init_searchable_disallowed(self):
         with self.assertWarns(DeveloperWarning):
             with self.assertRaises(ValueError) as ar:
-                BSTRelatedColumn(
-                    "treatment", model=BSTRCAnimalTestModel, searchable=True
-                )
+                BSTRelatedColumn("treatment", BSTRCAnimalTestModel, searchable=True)
         self.assertIn("['searchable'] cannot be True", str(ar.exception))
         self.assertIn("field_path is a foreign key", str(ar.exception))
         self.assertIn(
@@ -258,7 +255,7 @@ class BSTRelatedColumnTests(TracebaseTestCase):
     def test_init_sortable_disallowed(self):
         with self.assertWarns(DeveloperWarning):
             with self.assertRaises(ValueError) as ar:
-                BSTRelatedColumn("treatment", model=BSTRCAnimalTestModel, sortable=True)
+                BSTRelatedColumn("treatment", BSTRCAnimalTestModel, sortable=True)
         self.assertIn("['sortable'] cannot be True", str(ar.exception))
         self.assertIn("field_path is a foreign key", str(ar.exception))
         self.assertIn(
@@ -273,7 +270,7 @@ class BSTRelatedColumnTests(TracebaseTestCase):
             with self.assertRaises(ValueError) as ar:
                 BSTRelatedColumn(
                     "treatment",
-                    model=BSTRCAnimalTestModel,
+                    BSTRCAnimalTestModel,
                     searchable=True,
                     sortable=True,
                 )

--- a/DataRepo/views/models/bst_list_view/column/base.py
+++ b/DataRepo/views/models/bst_list_view/column/base.py
@@ -105,7 +105,7 @@ class BSTBaseColumn(ABC):
         self.sorter: BSTBaseSorter
         self.filterer: BSTBaseFilterer
 
-        if getattr(self, "is_fk", None) is None:
+        if not hasattr(self, "is_fk") or getattr(self, "is_fk", None) is None:
             self.is_fk = False
 
         if self.linked:

--- a/DataRepo/views/models/bst_list_view/column/field.py
+++ b/DataRepo/views/models/bst_list_view/column/field.py
@@ -135,7 +135,8 @@ class BSTColumn(BSTBaseColumn):
             )
 
         self.field = field_path_to_field(self.model, self.field_path)
-        self.is_fk = is_key_field(self.field)
+        if not hasattr(self, "is_fk") or getattr(self, "is_fk", None) is None:
+            self.is_fk = is_key_field(self.field)
 
         super().__init__(name, *args, **kwargs)
 
@@ -197,6 +198,7 @@ class BSTColumn(BSTBaseColumn):
         self, field: Optional[Union[Combinable, Field, str]] = None, **kwargs
     ) -> BSTSorter:
         field_expression = field if field is not None else self.field_path
+        kwargs.update({"name": kwargs.get("name", self.name)})
         return BSTSorter(field_expression, self.model, **kwargs)
 
     def create_filterer(self, field: Optional[str] = None, **kwargs) -> BSTFilterer:

--- a/DataRepo/views/models/bst_list_view/column/many_related_field.py
+++ b/DataRepo/views/models/bst_list_view/column/many_related_field.py
@@ -1,0 +1,174 @@
+from __future__ import annotations
+
+from typing import Optional, Type, Union, cast
+
+from django.db.models import Field, Model
+from django.db.models.expressions import Combinable
+
+from DataRepo.models.utilities import field_path_to_model_path
+from DataRepo.views.models.bst_list_view.column.related_field import (
+    BSTRelatedColumn,
+)
+from DataRepo.views.models.bst_list_view.column.sorter.many_related_field import (
+    BSTManyRelatedSorter,
+)
+
+
+class BSTManyRelatedColumn(BSTRelatedColumn):
+    """Class to represent the interface between a bootstrap column and a many-related Model field.  Many-related fields
+    are displayed as delimited values in a table cell.
+
+    Usage:
+        You can create a simple model field column using field paths like this:
+
+            studycol = BSTManyRelatedColumn("studies", model=Animal)
+            labelcol = BSTManyRelatedColumn("labels__element", model=Animal)
+
+        Use django "field path lookups" relative to the base model.
+        See https://docs.djangoproject.com/en/5.1/topics/db/queries/#lookups-that-span-relationships
+
+        This creates attribute names that can be used to assign many-related data to root model objects in the queryset.
+        For example:
+
+            study_list = []
+            for object in BSTListView.paginate_queryset():
+                for study in object.studies.distinct():
+                    study_list.append(study)
+                setattr(object, studycol.list_attr_name, study_list)
+
+        Then, in the template, you can iterate over those objects:
+
+            {% for study in object|get_attr:studycol.list_attr_name %}
+                <a href="{{ study|get_detail_url }}">{{ study }}</a>{% if not forloop.last %}{{ studycol.delim }}<br>
+                {% endif %}
+            {% endfor %}
+    """
+
+    is_many_related: bool = True
+    delimiter: str = "; "
+    limit: int = 3
+    ascending: bool = True
+    more_msg = "... (+{0} more)"
+    list_attr_tail = "_mm_list"
+    count_attr_tail = "_mm_count"
+
+    def __init__(
+        self,
+        *args,
+        list_attr_name: Optional[str] = None,
+        count_attr_name: Optional[str] = None,
+        delim: Optional[str] = delimiter,
+        limit: int = limit,
+        sort_expression: Optional[Union[Combinable, Field, str]] = None,
+        asc: bool = ascending,
+        **kwargs,
+    ):
+        """Defines options used to populate the Bootstrap Table columns for a BootstrapListView and a single reference
+        model.
+
+        Args:
+            list_attr_name (Optional[str]) [auto]: The name of the attribute to create on each queryset object that will
+                hold model objects or field values from the many-related model.
+            count_attr_name (Optional[str]) [auto]: The name of the attribute to create on each queryset object that
+                will hold a count of the many-related objects/field-values.
+            delim (Optional[str]) [BSTManyRelatedColumn.delimiter]: The delimiter used to join values from the related
+                model (NOTE: the template may add delimiting HTML).
+            limit (int) [BSTManyRelatedColumn.limit]: A limit to the number of related model objects/field-values to
+                include.  Set to 0 for unlimited.
+            sort_expression (Optional[Union[Combinable, Field, str]]) [auto]: Initial 'field' used to sort the delimited
+                values in the resulting Bootstrap Table.  The purpose of this argument is to provide a means of sorting
+                multiple fields (all from the same many-related model) the same, so that they visually align.  The
+                default value is the display_field (which is based on field_path).
+            asc (bool) [BSTManyRelatedColumn.ascending]: Initial sort of the delimited values in each table cell.
+                NOTE: This will be changed when the user sorts based on this column.  If the initial value here is
+                False, the first time a user sorts the table based on this column, it will be changed to True to match
+                the table row sort.
+        Exceptions:
+            None
+        Returns:
+            None
+        """
+        self.list_attr_name = list_attr_name
+        self.count_attr_name = count_attr_name
+        self.delim = delim
+        self.limit = limit
+        self.sort_expression = sort_expression
+        self.asc = asc
+
+        # Create attribute names to use to assign a list of related model objects and their count to the root model
+        if self.list_attr_name is None or self.count_attr_name is None:
+            # Get the required superclass constructor arguments we need for checks
+            field_path: str = cast(str, args[0])
+            model: Type[Model] = cast(Type[Model], args[1])
+
+            self.related_model_path = field_path_to_model_path(model, field_path)
+            if self.related_model_path == field_path:
+                stub = field_path.split("__")[-1]
+            else:
+                stub = "_".join(field_path.split("__")[-2:])
+
+            if self.list_attr_name is None:
+                self.list_attr_name = stub + self.list_attr_tail
+
+            if self.count_attr_name is None:
+                self.count_attr_name = stub + self.count_attr_tail
+
+        # NOTE: I don't think setting related_model_path to the last many-related model is necessary for
+        # BSTManyRelatedColumn.  I only need to do that for BSTColumnGroup.
+        # self.related_model_path = field_path_to_model_path(model, field_path, many_related=True)
+
+        super().__init__(*args, **kwargs)
+
+        if self.sort_expression is None:
+            self.sort_expression = self.display_field_path
+
+    def set_related_model_path(self, related_model_path: str):
+        """This validates and sets self.related_model_path, overwriting any previous value.
+
+        The intended purpose of this method is for use in BSTColumnGroup, in order to control the delimited value
+        sorting such that fields under the same related model are sorted the same way.
+
+        Args:
+            related_model_path (str): A dunderscore-delimited field path ending in a many-related model foreign key
+        Exceptions:
+            ValueError when self.field_path is invalid
+        Returns:
+            None
+        """
+        self.related_model_path = related_model_path
+
+        if (
+            related_model_path is None
+            or not isinstance(related_model_path, str)
+            or related_model_path == ""
+        ):
+            raise ValueError(
+                f"related_model_path '{related_model_path}' must be a non-empty string."
+            )
+        elif not self.field_path.startswith(related_model_path):
+            raise ValueError(
+                f"The field path '{self.field_path}' must start with the supplied related_model_path "
+                f"'{related_model_path}'."
+            )
+
+    def create_sorter(
+        self, field: Optional[Union[Combinable, Field, str]] = None, **kwargs
+    ) -> BSTManyRelatedSorter:
+
+        if field is not None:
+            field_expression = field
+        elif self.sort_expression is not None:
+            field_expression = self.sort_expression
+        elif self.display_field_path is not None:
+            field_expression = self.display_field_path
+        else:
+            field_expression = self.name
+
+        kwargs.update(
+            {
+                "name": kwargs.get("name", self.name),
+                "asc": kwargs.get("asc", self.asc),
+            }
+        )
+
+        return BSTManyRelatedSorter(field_expression, self.model, **kwargs)

--- a/DataRepo/views/models/bst_list_view/column/sorter/base.py
+++ b/DataRepo/views/models/bst_list_view/column/sorter/base.py
@@ -126,7 +126,7 @@ class BSTBaseSorter(ABC):
                 # field type, so that we can know whether applying case insensitivity is feasible.
                 # NOTE: If you want to guarantee that default sorting is applied, a derived class must do it.
                 sort_field = expression.output_field
-            except AttributeError as ae:
+            except AttributeError:
                 # TODO: Implement a fallback to infer the field from the outer expression type, e.g. Upper -> CharField
                 # The user must set output_field when defining the expression object, otherwise, you get:
                 # AttributeError: 'F' object has no attribute '_output_field_or_none'.

--- a/DataRepo/views/models/bst_list_view/column/sorter/field.py
+++ b/DataRepo/views/models/bst_list_view/column/sorter/field.py
@@ -51,7 +51,7 @@ class BSTSorter(BSTBaseSorter):
         *args,
         **kwargs,
     ):
-        """Construct a BSTSorter object.
+        """Constructor.  Extends BSTBaseSorter.__init__.
 
         Assumptions:
             1. In the case of field_expression being a Field, the "field path" returned assumes that the context of the
@@ -74,7 +74,7 @@ class BSTSorter(BSTBaseSorter):
         """
         self.model = model
         self.field_path: str = resolve_field_path(field_expression)
-        self.model_field = None
+        self.field = None
         expression = kwargs.get("expression")
         client_sorter = kwargs.get("client_sorter")
 
@@ -91,10 +91,10 @@ class BSTSorter(BSTBaseSorter):
 
         # Set self.model_field
         if isinstance(field_expression, Field):
-            self.model_field = field_expression
+            self.field = field_expression
         else:
             try:
-                self.model_field = field_path_to_field(self.model, self.field_path)
+                self.field = field_path_to_field(self.model, self.field_path)
             except AttributeError as ae:
                 if "__" not in self.field_path:
                     raise AttributeError(
@@ -105,13 +105,13 @@ class BSTSorter(BSTBaseSorter):
 
         # Set _server_sorter
         _server_sorter: Type[Combinable] = self.SERVER_SORTERS.UNKNOWN
-        if self.model_field is not None and (
+        if self.field is not None and (
             # The field_expression is a raw field
             isinstance(field_expression, str)
             or isinstance(field_expression, F)
             or isinstance(field_expression, Field)
         ):
-            if is_number_field(self.model_field):
+            if is_number_field(self.field):
                 if self.SERVER_SORTERS.NUMERIC is not None:
                     _server_sorter = self.SERVER_SORTERS.NUMERIC
             elif self.SERVER_SORTERS.ALPHANUMERIC is not None:
@@ -120,9 +120,9 @@ class BSTSorter(BSTBaseSorter):
         # Set expression
         if isinstance(field_expression, Field):
             if _server_sorter is not IdentityServerSorter:
-                expression = _server_sorter(self.model_field.name)
+                expression = _server_sorter(self.field.name)
             else:
-                expression = F(self.model_field.name)
+                expression = F(self.field.name)
         elif isinstance(field_expression, F):
             if _server_sorter is not IdentityServerSorter:
                 expression = _server_sorter(self.field_path)

--- a/DataRepo/views/models/bst_list_view/column/sorter/many_related_field.py
+++ b/DataRepo/views/models/bst_list_view/column/sorter/many_related_field.py
@@ -1,0 +1,59 @@
+from warnings import warn
+
+from django.conf import settings
+from django.db.models import Max, Min
+from django.db.models.aggregates import Aggregate
+
+from DataRepo.utils.exceptions import DeveloperWarning
+from DataRepo.views.models.bst_list_view.column.sorter.field import BSTSorter
+
+
+class BSTManyRelatedSorter(BSTSorter):
+    """Class that defines sorting rows for a column that contains delimited values from a many-related model.
+
+    Sorting rows based on a many-related model field causes the number of objects returned in a queryset to increase,
+    with duplicate root model records containing different many-related values, based on the number of related records.
+    So we apply an aggregate function to prevent that.  We use Min and Max based on whether we want an ascending or
+    descending sort, so that the position of this row in the context of the other rows always puts the least value first
+    in ascending or the greatest value first in descending.
+
+    Assumptions:
+        None
+    Limitations:
+        1. Only supports row sort based on the min/max value.  Multiple rows containing the same min/max value will
+            not further sort based on the next value.
+    """
+
+    def __init__(self, *args, **kwargs):
+        """Constructor.
+
+        Args:
+            None
+        Exceptions:
+            None
+        Returns:
+            None
+        """
+        # First, apply default sort metrics, like case insensitivity
+        super().__init__(*args, **kwargs)
+
+        # Then, apply the aggregate Min/Max based on asc or desc
+        agg: Aggregate = Min if self.asc else Max
+
+        if (
+            settings.DEBUG
+            and isinstance(self.expression, Aggregate)
+            and not isinstance(self.expression, agg)
+        ):
+            warn(
+                f"Unable to apply aggregate function '{agg.__name__}' to the sorter for column '{self.name}' because "
+                f"the supplied field already has an aggregate function '{self.expression}'.  In order for the "
+                "delimited values to be sorted and for the row sort to be based on either the first or last delimited "
+                "value, the supplied field must not already be wrapped in an aggregate function.  Sorting on this "
+                "column will not base row position on the min/max related value and the sort of the delimited values "
+                "will be static and appear unordered until this is addressed.  If this is intended to be an annotation "
+                "column, use BSTAnnotColumn instead.",
+                DeveloperWarning,
+            )
+        elif not isinstance(self.expression, Aggregate):
+            self.expression = agg(self.expression)

--- a/DataRepo/views/models/bst_list_view/column/sorter/many_related_field.py
+++ b/DataRepo/views/models/bst_list_view/column/sorter/many_related_field.py
@@ -1,9 +1,10 @@
 from warnings import warn
 
 from django.conf import settings
-from django.db.models import Max, Min
+from django.db.models import Field, Max, Min
 from django.db.models.aggregates import Aggregate
 
+from DataRepo.models.utilities import is_many_related_to_root
 from DataRepo.utils.exceptions import DeveloperWarning
 from DataRepo.views.models.bst_list_view.column.sorter.field import BSTSorter
 
@@ -25,10 +26,13 @@ class BSTManyRelatedSorter(BSTSorter):
     """
 
     def __init__(self, *args, **kwargs):
-        """Constructor.
+        """Constructor.  Extends BSTSorter.__init__.
 
         Args:
-            None
+            *args (field_expression, model): This class uses self.expression set by field_expression and model in the
+                superclass.  See superclass.
+            **kwargs (asc, name, client_sorter, client_mode, _server_sorter): This class uses self.asc set by the asc
+                arg.  See superclass.
         Exceptions:
             None
         Returns:
@@ -57,3 +61,10 @@ class BSTManyRelatedSorter(BSTSorter):
             )
         elif not isinstance(self.expression, Aggregate):
             self.expression = agg(self.expression)
+
+        if isinstance(self.field, Field) and not is_many_related_to_root(
+            self.field_path, self.model
+        ):
+            raise ValueError(
+                f"field_path '{self.field_path}' must be many-related with the model '{self.model.__name__}'."
+            )


### PR DESCRIPTION
## Summary Change Description

Added `BSTManyRelatedColumn` and `BSTManyRelatedSorter`.

- Renamed `BSTSorter.sort_expression` to just `expression`.
- Changed the logic for initializing `_server_sorter` to be based only on `expression` such that an `output_field` is required.  It no longer infers the field type based on the field alone (because the transform can change it, e.g. `Length()` could be called on a `CharField`).
- Added `BSTSorter.ascending` and `bstsorter_object.asc`, since the many related column needs it to apply `Min`/`Max`.
- Added a requirement that `client_sorter` not be `self.CLIENT_SORTERS.NONE` in order to issue a warning about server sorter differing from client sorter behavior.
- Added `BSTRelatedField.display_field`.
- Fixed an issue where the model argument was being obtained from `kwargs` instead of `args`.
- Added `BSTRelatedColumn.related_model_path`.  Only the many-related column needs it, but the related columns also have it.  I thought it could be necessary down the road, so I initialized it there.
- Made sure that `BSTSorter.name` matches the column name.
- Fixed an issue where `getattr` was throwing an error when the attribute didn't exist by checking `hasattr` before it.
- Added a `many_related` argument (boolean) to `field_path_to_model_path` to allow it to return the last many-related model.  I didn't end up using it in the many-related column or sorter classes, but it will be used in `BSTColumnGroup`, once I start to implement that.  It will serve to select a default many-related model when one is not supplied.
- Renamed `BSTSorter`'s `model_field` instance member to just `field`.
- Added a check in `create_test_model` for models that already exist to help avoid confusion over a typo and cryptic errors.

## Affected Issues/Pull Requests

- Resolves #1497
- Merges into branch `bst_related_column`
- Previous PR #1500

## Reviewer Notes/Requests
<!-- Notes to help the reviewer or requests for specific scrutiny.
E.g. Please make sure I have accounted for all possible inputs. -->
See comments in-line.

## Checklist
<!-- If any requirements are not met, uncheck and explain.
E.g. Linting errors pre-date this PR. -->
This pull request will be merged once the following requirements are met.  The
author and/or reviewers should uncheck any unmet requirements:
<!-- Check/complete items if not applicable. -->
- Review Requirements
  - Minimum approvals: 1 <!-- Edit based on complexity. -->
  - No changes requested
  - All blocking issues resolved by reviewers
  - Specific reviewers: @__add_username_here__ <!-- Approvals required even if minimum met. -->
  - Review period: 2 days <!-- Edit based on complexity. -->
- Associated Issue/PR Requirements: <!-- Assert resolved issues/PRs are done/merged. -->
  - [x] All issue requirements are satisfied
  - [x] All PR dependencies are merged
- Basic Requirements <!-- Uncheck to indicate items you are yet to address. -->
  - [x] [Linters pass](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#linting)
  - [x] [Tests pass](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#quality-control)
  - [x] Conflicts resolved
- Overhead Requirements <!-- Requirements indirectly related to the issues. -->
  - [x] [Tests implemented/updated](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#test-implementation)
  - [ ] [Updated `CHANGELOG.md` *Unreleased* section](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/changelog.md)
