### PR TITLE
Single label position bug fix

### DIFF
--- a/DataRepo/loaders/tracers_loader.py
+++ b/DataRepo/loaders/tracers_loader.py
@@ -929,17 +929,15 @@ class TracersLoader(TableLoader):
 
         return rec, created
 
-    def parse_label_positions(self, positions_str):
+    def parse_label_positions(self, positions_str: str):
         """Create a list of integers from a delimited string of integers.
 
         Args:
-            positions_str (string): delimited string of integers
-
-        Raises:
-            Nothing
-
+            positions_str (str): delimited string of integers
+        Exceptions:
+            None
         Returns:
-            positions (Optional[list of integers])
+            positions (Optional[List[int]])
         """
         positions = None
         if positions_str is None:
@@ -961,7 +959,7 @@ class TracersLoader(TableLoader):
                 )
                 # Package errors (like IntegrityError and ValidationError) with relevant details
                 # This also updates the skip row indexes
-                self.aggregated_errors_object.buffer_error(exc)
+                self.aggregated_errors_object.buffer_error(exc, orig_exception=e)
 
         return positions
 


### PR DESCRIPTION
## Summary Change Description

Addressed a column value type issue where the Label Positions column in the Tracers sheet was raising an exception when it contained only a single digit.

Some time back, casting of values to the expected type was removed from TableLoader.get_row_val because the type handling was left to Pandas.  It turned out that this might not have been a great improvement because Pandas has an issue with excel cells that are empty when the type doesn't permit null values.  This was mitigated by some related typing that only applies the type constraint when the column type is specified as `str`.  All other values are dynamically typed by Pandas, which deals fine with columns whose types don't allow null values, but they are mixed with values that are null.

The problem here was that the mecahnism to parse all sheets and return a dataframe dict does not handle typing well.  Only 1 type is allowed per unique header (regardless of sheet), so the typing had been skipped when parsing the entire study doc.

The fix was to read in each sheet individually and build the df_dict key by key.

Details:

- Looped through StudyLoader.Loaders and called each loader's _get_column_types to get the dtype dict and then supplied that to read_from_file.
- The wrapper to read_from_file was used to document any exceptions (which was not done before).
- Exceptions from _get_column_types were also handled and all exceptions were put into the conversion heading of the status report.
- Also updated the TracersLoader to include the original exception in the exception raised when such errors occur again (even though this specific error no longer happens).

## Affected Issues/Pull Requests

- Resolves #1519
- Merges into branch `main`

## Reviewer Notes/Requests
<!-- Notes to help the reviewer or requests for specific scrutiny.
E.g. Please make sure I have accounted for all possible inputs. -->
See comments in-line.

## Checklist
<!-- If any requirements are not met, uncheck and explain.
E.g. Linting errors pre-date this PR. -->
This pull request will be merged once the following requirements are met.  The
author and/or reviewers should uncheck any unmet requirements:
<!-- Check/complete items if not applicable. -->
- Review Requirements
  - Minimum approvals: 1 <!-- Edit based on complexity. -->
  - No changes requested
  - All blocking issues resolved by reviewers
  - Specific reviewers: @__add_username_here__ <!-- Approvals required even if minimum met. -->
  - Review period: 2 days <!-- Edit based on complexity. -->
- Associated Issue/PR Requirements: <!-- Assert resolved issues/PRs are done/merged. -->
  - [x] All issue requirements are satisfied
  - [x] All PR dependencies are merged
- Basic Requirements <!-- Uncheck to indicate items you are yet to address. -->
  - [x] [Linters pass](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#linting)
  - [x] [Tests pass](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#quality-control)
  - [x] Conflicts resolved
- Overhead Requirements <!-- Requirements indirectly related to the issues. -->
  - [x] [Tests implemented/updated](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#test-implementation)
  - [ ] [Updated `CHANGELOG.md` *Unreleased* section](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/changelog.md)
