### PR TITLE
Fix for cryptic validation error when the field is a foreign key

### DIFF
--- a/DataRepo/loaders/base/table_loader.py
+++ b/DataRepo/loaders/base/table_loader.py
@@ -2962,14 +2962,27 @@ class TableLoader(ABC):
                 if match:
                     fldname = match.group("fldname")
                     colname = fldname
+                    altfldname = (
+                        fldname.replace("_id", "")
+                        if fldname.endswith("_id")
+                        else fldname
+                    )
+
                     # Convert the database column name to the file column header, if available
                     if (
                         self.FieldToHeader is not None
-                        and colname in self.FieldToHeader[model.__name__].keys()
+                        and fldname in self.FieldToHeader[model.__name__].keys()
                     ):
                         colname = self.FieldToHeader[model.__name__][fldname]
+                    elif (
+                        self.FieldToHeader is not None
+                        and altfldname in self.FieldToHeader[model.__name__].keys()
+                    ):
+                        colname = self.FieldToHeader[model.__name__][altfldname]
+                        fldname = altfldname
                     elif columns is not None:
                         colname += f" ({columns})"
+
                     self.aggregated_errors_object.buffer_exception(
                         RequiredValueError(
                             column=colname,

--- a/DataRepo/tests/loaders/base/test_table_loader.py
+++ b/DataRepo/tests/loaders/base/test_table_loader.py
@@ -195,8 +195,16 @@ class TableLoaderTests(TracebaseTestCase):
         self.assertEqual(
             RequiredValueError, type(tl.aggregated_errors_object.exceptions[0])
         )
-        self.assertEqual(
+        self.assertIn(
             "Value required for 'name' in the load file data.  Record extracted from row: 2.",
+            str(tl.aggregated_errors_object.exceptions[0]),
+        )
+        self.assertIn(
+            "This error only happens when related data failed to load",
+            str(tl.aggregated_errors_object.exceptions[0]),
+        )
+        self.assertIn(
+            "Fixing errors above this one will fix this error",
             str(tl.aggregated_errors_object.exceptions[0]),
         )
 
@@ -991,14 +999,21 @@ class TableLoaderTests(TracebaseTestCase):
         # The 2 exceptions should be summarized as 1
         self.assertEqual(1, len(aes.exceptions))
         self.assertEqual(RequiredValueErrors, type(aes.exceptions[0]))
-        self.assertEqual(
-            (
-                "Required values found missing during loading:\n"
-                "\tthe load file data:\n"
-                "\t\tField: [TestModel.name] Column: [Name] on row(s): 2\n"
-                "\t\tField: [TestModel.choice] Column: [Choice] on row(s): 3\n"
-            ),
+        self.assertIn(
+            "Required values found missing during loading", str(aes.exceptions[0])
+        )
+        self.assertIn("Column: [Name] on row(s): 2", str(aes.exceptions[0]))
+        self.assertIn("Column: [Choice] on row(s): 3", str(aes.exceptions[0]))
+        self.assertIn(
+            "Errors like this only happen when related data failed to load",
             str(aes.exceptions[0]),
+        )
+        self.assertIn(
+            "evidenced by the fact that the indicated column/rows have values",
+            str(aes.exceptions[0]),
+        )
+        self.assertIn(
+            "Fixing errors above this will fix this error", str(aes.exceptions[0])
         )
 
     def test_load_wrapper_summarizes_DuplicateValueErrors(self):

--- a/DataRepo/tests/utils/test_exceptions.py
+++ b/DataRepo/tests/utils/test_exceptions.py
@@ -800,12 +800,16 @@ class ExceptionTests(TracebaseTestCase):
             ),
         ]
         rve = RequiredValueErrors(rves)
-        expected = (
-            "Required values found missing during loading:\n"
-            "\tsheet [tissues] in tissues.tsv:\n"
-            "\t\tField: [Tissue.name] Column: [Tissue Name] on row(s): 3-4\n"
+        self.assertIn("Required values found missing", str(rve))
+        self.assertIn("sheet [tissues] in tissues.tsv", str(rve))
+        self.assertIn("Column: [Tissue Name] on row(s): 3-4", str(rve))
+        self.assertIn(
+            "Errors like this only happen when related data failed to load", str(rve)
         )
-        self.assertEqual(expected, str(rve))
+        self.assertIn(
+            "evidenced by the fact that the indicated column/rows have values", str(rve)
+        )
+        self.assertIn("Fixing errors above this will fix this error.", str(rve))
 
     def test_ExcelSheetsNotFound(self):
         esnf = ExcelSheetsNotFound(

--- a/DataRepo/utils/exceptions.py
+++ b/DataRepo/utils/exceptions.py
@@ -332,11 +332,14 @@ class RequiredValueErrors(Exception):
                         [r.rownum for r in missing_dict[filesheet][colname]["rves"]]
                     )
                 )
-                message += (
-                    f"\t\tField: [{missing_dict[filesheet][colname]['fld']}] "
-                    f"Column: [{colname}] "
-                    f"on row(s): {deets}\n"
-                )
+                message += f"\t\tColumn: [{colname}] on row(s): {deets}\n"
+
+        # Append a suggestion
+        message += (
+            "Errors like this only happen when related data failed to load and is evidenced by the fact that the "
+            "indicated column/rows have values.  Fixing errors above this will fix this error."
+        )
+
         super().__init__(message)
         self.required_value_errors = required_value_errors
 
@@ -358,6 +361,14 @@ class RequiredValueError(InfileError, SummarizableError):
             message = f"Value required for '{field_name}' in %s."
             if rownum is not None:
                 message += f"  Record extracted from row: {rownum}."
+
+        if "suggestion" not in kwargs.keys():
+            suggestion = (
+                "This error only happens when related data failed to load.  Fixing errors above this one will fix this "
+                "error."
+            )
+            kwargs["suggestion"] = suggestion
+
         super().__init__(message, **kwargs)
         self.column = column
         self.rownum = rownum


### PR DESCRIPTION
## Summary Change Description

When an integrity error about a null required value comes up and the reported field ends with "_id", that string is removed to see if a field to column mapping exists.

Details:

- Also added a suggestion to the related errors, suggesting that it is likely the result of an upstream load (because otherwise there would be an error from the column requirements instead of the value error.
- Removed the field name from the error, as it is irrelevant to the user.

## Affected Issues/Pull Requests

- Resolves #1517
- Merges into branch `main`

## Reviewer Notes/Requests
<!-- Notes to help the reviewer or requests for specific scrutiny.
E.g. Please make sure I have accounted for all possible inputs. -->
See comments in-line.

## Checklist
<!-- If any requirements are not met, uncheck and explain.
E.g. Linting errors pre-date this PR. -->
This pull request will be merged once the following requirements are met.  The
author and/or reviewers should uncheck any unmet requirements:
<!-- Check/complete items if not applicable. -->
- Review Requirements
  - Minimum approvals: 1 <!-- Edit based on complexity. -->
  - No changes requested
  - All blocking issues resolved by reviewers
  - Specific reviewers: @__add_username_here__ <!-- Approvals required even if minimum met. -->
  - Review period: 2 days <!-- Edit based on complexity. -->
- Associated Issue/PR Requirements: <!-- Assert resolved issues/PRs are done/merged. -->
  - [x] All issue requirements are satisfied
  - [x] All PR dependencies are merged
- Basic Requirements <!-- Uncheck to indicate items you are yet to address. -->
  - [x] [Linters pass](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#linting)
  - [x] [Tests pass](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#quality-control)
  - [x] Conflicts resolved
- Overhead Requirements <!-- Requirements indirectly related to the issues. -->
  - [x] [Tests implemented/updated](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#test-implementation)
  - [ ] [Updated `CHANGELOG.md` *Unreleased* section](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/changelog.md)
