### PR TITLE
The comparison select list on the advanced search gets reset each time you search

### DIFF
--- a/static/js/hierarchical_formsets.js
+++ b/static/js/hierarchical_formsets.js
@@ -243,8 +243,30 @@ function addSearchFieldForm (myDiv, query, templateId) {
   }
 
   // Initialize the ncmp choices
-  ncmpClone.value = ncmpInitVal
   updateNcmpChoices(fldInitVal, ncmpClone, templateId)
+  // We need to update the selected ncmp selection to what was previously selected, but upon the initial load of the
+  // advanced search, the initial ncmp choices are those of the selected template.  Those choices are updated by
+  // updateNcmpChoices, but the ncmpInitVal is NOT.  There is VERY likely a better solution than this check to see if
+  // ncmpInitVal is valid, but for now, this is the fix.
+  // TODO: Figure out how to select an ncmpInitVal that is specific to the template without having to do this loop.
+  // Notes: The above "ncmpInitVal = ncmpClone[0].value" assignment is wrong for the fctemplate, because the default
+  // ncmp choices are based on the selected template, which by default is for PeakGroup Age (a number), which gets the
+  // "is" ncmp value of "exact".  The first field in the FCirc template is Animal (a string), which gets the "is" ncmp
+  // value of "iexact".  This is the problem that the loop below solves: it determines that "exact" isn't among the
+  // choices and defaults to the first choice "iexact".
+  const initFldType = fldTypes[templateId][fldInitVal].type
+  const initChoices = ncmpChoices[initFldType]
+  let initMatch = false
+  for (let i = 0; i < initChoices.length; i++) {
+    if (ncmpInitVal === initChoices[i][0]) {
+      initMatch = true
+      break
+    }
+  }
+  if (!initMatch) {
+    ncmpInitVal = initChoices[0][0]
+  }
+  ncmpClone.value = ncmpInitVal
 
   // Initialize the units choices
   unitsClone.value = unitsInitVal


### PR DESCRIPTION
## Summary Change Description

Fixes a bug [introduced by commit a8f0c5c](https://github.com/Princeton-LSI-ResearchComputing/tracebase/commit/a8f0c5c4a91240b00f86f58fd23ecfd7ffbe81a6#diff-14871afcb6de82fdad4c581f0b55df1198b066799d0e935dc1db8e1e364e9e82L246-R247) which was trying to fix THIS bug.

The problem was that the FCirc format's initial ncmp select list had no default selection.  The fix had been to set the initial value BEFORE updating the choices.  However, the side-effect of that was to always set the first item in the select list.  So whenever a user selected a different value and submited a search, their search parameter for the ncmp select list would be changed.

The actual problem is that the ncmp choices are initially dictated by the first field in the selected template.  That first field in the peak group template is Age (a number), but the first field in the fcirc template is animal (name) (a string).  Therefore, the first item in each ncmp select list ("is") gets the value of "exact" for the number type.  It should be "iexact" for the string type.  The code dynamically updates the choices, but the initial value is stale.

To fix it, I search the ncmp choices after the choices update and if the initial value isn't there, I set the first value.

There has to be a better way to do this, but for now, this works.

## Affected Issues/Pull Requests

- Resolves #1532
- Merges into branch `main`

## Reviewer Notes/Requests
<!-- Notes to help the reviewer or requests for specific scrutiny.
E.g. Please make sure I have accounted for all possible inputs. -->
See comments in-line.

## Checklist
<!-- If any requirements are not met, uncheck and explain.
E.g. Linting errors pre-date this PR. -->
This pull request will be merged once the following requirements are met.  The
author and/or reviewers should uncheck any unmet requirements:
<!-- Check/complete items if not applicable. -->
- Review Requirements
  - Minimum approvals: 1 <!-- Edit based on complexity. -->
  - No changes requested
  - All blocking issues resolved by reviewers
  - Specific reviewers: @__add_username_here__ <!-- Approvals required even if minimum met. -->
  - Review period: 2 days <!-- Edit based on complexity. -->
- Associated Issue/PR Requirements: <!-- Assert resolved issues/PRs are done/merged. -->
  - [x] All issue requirements are satisfied
  - [x] All PR dependencies are merged
- Basic Requirements <!-- Uncheck to indicate items you are yet to address. -->
  - [x] [Linters pass](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#linting)
  - [x] [Tests pass](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#quality-control)
  - [x] Conflicts resolved
- Overhead Requirements <!-- Requirements indirectly related to the issues. -->
  - [x] [Tests implemented/updated](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#test-implementation)
  - [ ] [Updated `CHANGELOG.md` *Unreleased* section](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/changelog.md)
