### PR TITLE
Advanced Search Stats bug fix

### DIFF
--- a/DataRepo/formats/dataformat.py
+++ b/DataRepo/formats/dataformat.py
@@ -1008,7 +1008,7 @@ class Format:
         # Get a model object
         mdl = get_model_by_name(mdl_nm)
 
-        # Retreive any custom ordering
+        # Retrieve any custom ordering
         if "ordering" in mdl._meta.__dict__:
             return get_distinct_fields(mdl)
 

--- a/DataRepo/models/utilities.py
+++ b/DataRepo/models/utilities.py
@@ -1,10 +1,11 @@
 import importlib
-import warnings
 from typing import List, Optional, Type, Union
+from warnings import warn
 
 from chempy import Substance
 from chempy.util.periodic import atomic_number
 from django.apps import apps
+from django.conf import settings
 from django.core.exceptions import ObjectDoesNotExist, ValidationError
 from django.db import ProgrammingError
 from django.db.models import Expression, F, Field, Model
@@ -46,9 +47,7 @@ ALL_MODELS_IN_SAFE_DELETION_ORDER = [
 
 
 def value_from_choices_label(label, choices):
-    """
-    Return the choices value for a given label
-    """
+    """Return the choices value for a given label"""
     # Search choices by label
     result = None
     for choices_value, choices_label in choices:
@@ -76,7 +75,7 @@ def atom_count_in_formula(formula, atom):
     try:
         count = substance.composition.get(atomic_number(atom))
     except (ValueError, AttributeError):
-        warnings.warn(f"{atom} not found in list of elements")
+        warn(f"{atom} not found in list of elements")
         count = None
     else:
         if count is None:
@@ -86,11 +85,9 @@ def atom_count_in_formula(formula, atom):
 
 
 def get_all_models():
-    """
-    Retrieves all models (that were explicitly defined, i.e. no hidden related models) from DataRepo and returns them
+    """Retrieves all models (that were explicitly defined, i.e. no hidden related models) from DataRepo and returns them
     as a list ordered in a way that they can all have their contents deleted without running afould of "restrict"
-    constraints
-    """
+    constraints"""
     module = importlib.import_module("DataRepo.models")
     mdls = [
         getattr(module, class_name) for class_name in ALL_MODELS_IN_SAFE_DELETION_ORDER
@@ -98,10 +95,8 @@ def get_all_models():
     return mdls
 
 
-def get_model_fields(model):
-    """
-    Retrieves all non-auto- and non-relation- fields from the supplied model and returns as a list
-    """
+def get_model_fields(model: Type[Model]):
+    """Retrieves all non-auto- and non-relation- fields from the supplied model and returns as a list"""
     return [
         f
         for f in model._meta.get_fields()
@@ -110,9 +105,7 @@ def get_model_fields(model):
 
 
 def get_all_fields_named(target_field):
-    """
-    Dynamically retrieves all fields from any model with a specific name
-    """
+    """Dynamically retrieves all fields from any model with a specific name"""
     models = get_all_models()
     found_fields = []
     for model in models:
@@ -134,6 +127,14 @@ def resolve_field(
 ) -> Field:
     """A field at the end of a model path can be a deferred attribute or any of a series of 4 descriptors.  This method
     takes the field and returns the actual field (if it is deferred or a descriptor, otherwise, the supplied field).
+
+    Args:
+        field (Union[Field, DeferredAttribute, ForwardManyToOneDescriptor, ManyToManyDescriptor,
+            ReverseManyToOneDescriptor]): A representation of a Field.
+    Exceptions:
+        None
+    Returns:
+        (Field): A Field instance, resolved from one of a number of representations of a Field.
     """
     field_containers = [
         DeferredAttribute,
@@ -176,21 +177,29 @@ def resolve_field_path(
         field_path (str): The field path that either was the field_or_expression or its wrapper
     """
     if isinstance(field_or_expression, str):
-        return field_or_expression
+        return (
+            field_or_expression
+            if not field_or_expression.startswith("-")
+            else field_or_expression[1:]
+        )
     elif isinstance(field_or_expression, Field):
         return field_or_expression.name
     elif isinstance(field_or_expression, DeferredAttribute):
         return field_or_expression.field.name
     elif isinstance(field_or_expression, Expression):
         field_reps = field_or_expression.get_source_expressions()
-        if len(field_reps) != 1:
-            raise ValueError(
-                f"Not one field name in field representation {[f.name for f in field_reps]}."
+
+        if len(field_reps) == 0:
+            raise NoFields("No field name in field representation.")
+        elif len(field_reps) > 1:
+            raise MultipleFields(
+                f"Multiple field names in field representation {[f.name for f in field_reps]}."
             )
+
         if isinstance(field_reps[0], Expression):
             return resolve_field_path(field_reps[0])
         elif isinstance(field_reps[0], F):
-            return field_reps[0].name
+            return resolve_field_path(field_reps[0].name)
         else:
             raise ProgrammingError(
                 f"Unexpected field_or_expression type: '{type(field_or_expression).__name__}'."
@@ -203,9 +212,43 @@ def resolve_field_path(
         )
 
 
+def is_related(field_path: str, model: Type[Model]):
+    """Takes a field path and root model and returns whether the first field in the path is a foreign key.
+
+    Args:
+        field_path (Union[str, List[str]]): A dunderscore delimited field path.
+        model (Model): The model that the first field in the field path belongs to.
+    Exceptions:
+        None
+    Returns:
+        (bool): Whether the first field in the field path is a foreign key.
+    """
+    first_field_name = field_path.split("__")
+    first_field = field_path_to_field(model, first_field_name)
+    return "__" in field_path or first_field.is_relation
+
+
 def is_many_related(field: Field, source_model: Optional[Model] = None):
     """Takes a field (and optional source model) and returns whether that field is many-related relative to the source
-    model, (which is assumed to the the model where the field was defined, if source_model is None).
+    model.
+
+    Example:
+        is_many_related(ArchiveFile.data_format.field, DataFormat) -> True (many to one)
+        # ArchiveFile.data_format describes its field as a one_to_many relationship with DataFormat, so from the
+        # perspective of the DataFormat model, the relationship from DataFormat to ArchiveFile is many_to_one.
+        is_many_related(ArchiveFile.data_format.field, ArchiveFile) -> False (one to many)
+        is_many_related(Animal.studies.field) -> True (many to many)
+    Assumptions:
+        1. source_model is assumed to be the model where the field was defined, if source_model is None.
+    Args:
+        field (Field): A Field instance.
+        source_model (Optional[Model]): The model where field is being accessed.
+            NOTE: A related field has 2 associated models, one of which may not be many-related with the other that is,
+            so the result depends on the source_model from which you are accessing the field.
+    Exceptions:
+        None
+    Returns:
+        (bool): Whether the field is many-related from the perspective of source_model.
     """
     return (
         field.many_to_many
@@ -220,15 +263,17 @@ def is_many_related(field: Field, source_model: Optional[Model] = None):
     )
 
 
-def is_many_related_to_root(field_path: Union[str, List[str]], source_model: Model):
+def is_many_related_to_root(
+    field_path: Union[str, List[str]], source_model: Type[Model]
+):
     """Takes a field path and source model and returns whether the leaf field is many-related relative to the first
     source model.
 
     Args:
         field_path (Union[str, List[str]]): A dunderscore delimited field path (or list).
-        source_model (Model): The model that the first field in the field path belongs to.
+        source_model (Type[Model]): The model that the first field in the field path belongs to.
     Exceptions:
-        ValueError when the field path is invalid
+        ValueError when the field path is invalid.
     Returns:
         (bool): Whether the leaf field in the field path is many-related with the root model.
     """
@@ -246,46 +291,148 @@ def is_many_related_to_root(field_path: Union[str, List[str]], source_model: Mod
     )
 
 
-def field_path_to_field(
-    model: Type[Model], path: Union[str, List[str]]
-) -> Optional[Field]:
+def is_many_related_to_parent(
+    field_path: Union[str, List[str]], source_model: Type[Model]
+):
+    """Takes a field path and source model and returns whether the leaf field is many-related to its immediate parent
+    model.
+
+    Args:
+        field_path (Union[str, List[str]]): A dunderscore delimited field path (or list)
+        source_model (Type[Model]): The model that the first field in the field path belongs to
+    Exceptions:
+        ValueError when the field path is invalid
+    Returns:
+        (bool): Whether the leaf field in the field path is many-related with its parent model.
+    """
+    if len(field_path) == 0:
+        raise ValueError("field_path string/list must have a non-zero length.")
+    if isinstance(field_path, str):
+        return is_many_related_to_parent(field_path.split("__"), source_model)
+    if len(field_path) == 1:
+        field = resolve_field(getattr(source_model, field_path[0]))
+        return is_many_related(field, source_model=source_model)
+    elif len(field_path) == 2:
+        field = resolve_field(getattr(source_model, field_path[0]))
+        next_model = get_next_model(source_model, field_path[0])
+        # if the last field in the field_path is not a foreign key
+        if not resolve_field(getattr(next_model, field_path[1])).is_relation:
+            # Return whether the last foreign key is many-related to its parent
+            return is_many_related(field, source_model=source_model)
+    return is_many_related_to_parent(
+        field_path[1:], get_next_model(source_model, field_path[0])
+    )
+
+
+def field_path_to_field(model: Type[Model], path: Union[str, List[str]]) -> Field:
     """Recursive method to take a root model and a dunderscore-delimited path and return the Field class at the end of
     the path.  The intention is so that the Field can be interrogated as to type or retrieve choices, etc.
+
+    Args:
+        model (Type[Model]): Model class at the root of the path.
+        path (Union[str, List[str]]): Dunderscore-delimited field path string or list of dunderscore-split fields.
+    Exceptions:
+        ValueError when an argument is invalid.
+        AttributeError when any field in the path is not present on the associated model.
+    Returns:
+        (Field): A Field instance for the field at the end of the path
     """
-    if len(path) == 0:
+    if model is None:
+        raise ValueError("model must not be None.")
+    if path is None or len(path) == 0:
         raise ValueError("path string/list must have a non-zero length.")
     if isinstance(path, str):
         return field_path_to_field(model, path.split("__"))
     if len(path) == 1:
-        if hasattr(model, path[0]):
-            return resolve_field(getattr(model, path[0]))
-        raise ValueError(
-            f"Model: {model.__name__} does not have a field attribute named: '{path[0]}'."
+        name = resolve_field_path(path[0])
+        if hasattr(model, name):
+            return resolve_field(getattr(model, name))
+        raise AttributeError(
+            f"Model: {model.__name__} does not have a field attribute named: '{name}'."
         )
     return field_path_to_field(get_next_model(model, path[0]), path[1:])
 
 
-def get_next_model(current_model: Model, field_name: str):
+def get_next_model(current_model: Model, field_name: str) -> Type[Model]:
     """Given a current model and a foreign key field name from a field path, return the model associated with the
     field.
+
+    Args:
+        current_model (Model): The model referencing field_name.  In a field path, this is the model associated with the
+            foreign key just before the supplied field_name.
+        field_name (str): A field name accessible from a model.  This can be a forward or reverse relation, which is why
+            current_model is necessary, because the field has a 'model' attribute that is the model where the field is
+            defined, and a 'related_model' attribute which is the model the field references.  The supplied field name
+            however can be either of those models.  current_model thus indicates the direction and the returned model is
+            the 'other' one.
+    Exceptions:
+        None
+    Returns:
+        (Type[Model]): The model class that does not match the current_model, i.e. the "next" model.
     """
     field = resolve_field(getattr(current_model, field_name))
     return field.model if current_model != field.model else field.related_model
 
 
 def field_path_to_model_path(
-    model: Type[Model], path: Union[str, List[str]], _output: str = ""
+    model: Type[Model],
+    path: Union[str, List[str]],
+    many_related: bool = False,
+    _output: str = "",
+    _mr_output: str = "",
 ) -> Optional[str]:
-    """Recursive method to take a root model and a dunderscore-delimited path and return the path to the model at the
-    end of the path (excluding the field).  The utility here is to be able to supply all related models to
-    prefetch_related."""
+    """Recursive method to take a root model and a dunderscore-delimited path and return the path to the last foreign
+    key (treated here as "a model", because a queryset constructed using this field path results in a model object (or
+    related manager, if it is many-related)).  If the last element in the field path is not a foreign key, it is
+    ignored, but if it *is* a foreign key, it is retained.  This can be used to later infer if the field_path ends in a
+    foreign key/model or not.  The original intention of this method is its utility in being able to supply all related
+    models to prefetch_related.
+
+    Args:
+        model (Type[Model]): The Django Model class upon which the path can be used in filtering, etc.
+        path (Union[str, List[str]]): A dunderscore-delimited lookup string (or list of the dunderscore-split) field
+            path, which can be used in filtering, etc. off the model.
+        many_related (bool) [False]: Return the path to the last many-related model in the supplied path, instead of the
+            last model.
+        _output (str) [""]: Used in recursion to build up the resulting model path.
+        _mr_output (str) [""]: Used in recursion to build up the resulting many-related model path (only used if
+            many_related is True).
+    Exceptions:
+        ValueError if the field path is too short, a model is missing a field in the field path, or if a many-related
+            model was requested and none was found.
+    Returns:
+        _output (Optional[str]): The path to the last foreign key ("model") in the supplied path or None if there are no
+            foreign keys in the path (i.e. it's just a field name).
+    """
     if len(path) == 0:
         raise ValueError("path string/list must have a non-zero length.")
     if isinstance(path, str):
-        return field_path_to_model_path(model, path.split("__"))
+        return field_path_to_model_path(
+            model, path.split("__"), many_related=many_related
+        )
+
     new_output = path[0] if _output == "" else f"{_output}__{path[0]}"
-    if len(path) == 1:
+
+    # If we only want the last many-related model, update _mr_output
+    if many_related:
         if hasattr(model, path[0]):
+            fld = resolve_field(getattr(model, path[0]))
+            if fld.is_relation and is_many_related(fld, model):
+                _mr_output = new_output
+        else:
+            raise ValueError(
+                f"Model: '{model.__name__}' does not have a field attribute named: '{path[0]}'."
+            )
+
+    # If we're at the end of the path - no more recursion - return the result
+    if len(path) == 1:
+        if many_related:
+            if _mr_output == "":
+                raise ValueError(
+                    f"No many-related model was found in the path '{new_output}'."
+                )
+            return _mr_output
+        elif hasattr(model, path[0]):
             tail = resolve_field(getattr(model, path[0]))
             if tail.is_relation:
                 return new_output
@@ -294,14 +441,140 @@ def field_path_to_model_path(
         raise ValueError(
             f"Model: '{model.__name__}' does not have a field attribute named: '{path[0]}'."
         )
+
+    # Recurse
     return field_path_to_model_path(
-        get_next_model(model, path[0]), path[1:], new_output
+        get_next_model(model, path[0]),
+        path[1:],
+        many_related=many_related,
+        _output=new_output,
+        _mr_output=_mr_output,
+    )
+
+
+def select_representative_field(
+    model: Type[Model], force=False, include_expression=False
+) -> Optional[Union[str, Expression]]:
+    """(Arbitrarily) select the best single field to represent a model.
+
+    A field is chosen based on the following criteria, in order of precedence:
+
+    1. The model's _meta.ordering field is chosen, if only 1 exists.
+    2. The first non-ID field that is unique is chosen, if one exists.
+    3. The first non-ID field is chosen, if only 1 exists.
+    4. The first non-ID field, if any exist and force=True, and a warning is issued^.
+    5. The first non-foreign key field, if any exist and force=True, and a warning is issued^.
+    6. If force=True, pk, and a warning is issued^.
+    7. Otherwise None
+
+    ^ Warnings are only issued in DEBUG mode.
+
+    Args:
+        model (Type[Model])
+        force (bool) [False]: Force a field to be selected as a representative when there is no single ordering field
+            and there are no unique fields that are not the arbitrary primary key or foreign keys.
+        include_expression (bool) [False]: If a suitable single field is selected from the model's ordering, return it
+            as-is, instead of just returning a string version of the field name.
+    Exceptions:
+        None
+    Returns:
+        (Optional[str]): The name of the selected field to represent the model.
+    """
+    if len(model._meta.ordering) == 1:
+        # If there's only 1 ordering field, use it
+        if include_expression:
+            return model._meta.ordering[0]
+        return resolve_field_path(model._meta.ordering[0])
+
+    all_fields = model._meta.get_fields()
+
+    # Grab the first non-ID field from the related model that is unique, if one exists
+    f: Field
+    non_relations: List[Field] = []
+    for f in all_fields:
+        related_field = resolve_field(f)
+        if not related_field.is_relation and related_field.name != "id":
+            if related_field.unique:
+                return related_field.name
+            else:
+                non_relations.append(related_field)
+
+    if len(non_relations) == 1:
+        return non_relations[0].name
+
+    if not force:
+        return None
+
+    fldname = "pk"
+    if len(non_relations) > 0:
+        fldname = non_relations[0].name
+    elif "id" in all_fields:
+        fldname = "id"
+
+    if settings.DEBUG:
+        warn(
+            f"Unable to select a representative field for model '{model.__name__}'.  Defaulting to '{fldname}'."
+        )
+
+    return fldname
+
+
+def is_key_field(
+    path: Union[
+        str,
+        List[str],
+        Field,
+        DeferredAttribute,
+        ForwardManyToOneDescriptor,
+        ManyToManyDescriptor,
+        ReverseManyToOneDescriptor,
+    ],
+    model: Optional[Type[Model]] = None,
+) -> bool:
+    """Takes a path (or field representation) and a model and returns whether or not the field at the end of the path is
+    a foreign key.
+
+    Args:
+        path (Union[str, List[str], Field, DeferredAttribute, ForwardManyToOneDescriptor, ManyToManyDescriptor,
+            ReverseManyToOneDescriptor]): A field or dunderscore-delimited field path (i.e. a Django lookup).
+        model (Optional[Type[Model]]): A Model.  Must not be None if path is a str or list.
+    Exceptions:
+        ValueError when model is None and field is a str or list, or when path is None
+        TypeError when field is an unsupported type
+    Returns:
+        (bool): Whether the field at the end of the path is a foreign key.
+    """
+    if path is None:
+        raise ValueError("path must not be None")
+    if not isinstance(path, str) and not isinstance(path, list):
+        return resolve_field(path).is_relation
+    if isinstance(path, str) or isinstance(path, list):
+        if model is not None and issubclass(model, Model):
+            field_path = path
+            if isinstance(path, list):
+                field_path = "__".join(path)
+            model_path = field_path_to_model_path(model, path)
+            return field_path == model_path
+        raise ValueError("model is required when path is a str or list.")
+    raise TypeError(
+        f"Invalid path type: '{type(path).__name__}'.  Must be one of: [str, list, Field, DeferredAttribute, "
+        "ForwardManyToOneDescriptor, ManyToManyDescriptor, or ReverseManyToOneDescriptor]."
     )
 
 
 def model_path_to_model(model: Type[Model], path: Union[str, List[str]]) -> Type[Model]:
     """Recursive method to take a root model and a dunderscore-delimited path and return the model class at the end of
-    the path."""
+    the path.
+
+    Args:
+        model (Type[Model]): Model class at the root of the path.
+        path (Union[str, List[str]]): Dunderscore-delimited field path string or list of dunderscore-split fields.
+    Exceptions:
+        ValueError when an argument is invalid.
+        AttributeError when any field in the path is not present on the associated model.
+    Returns:
+        (Type[Model]): The model class associated with the last foreign key field in the path.
+    """
     if len(path) == 0:
         raise ValueError("path string/list must have a non-zero length.")
     if isinstance(path, str):
@@ -309,10 +582,64 @@ def model_path_to_model(model: Type[Model], path: Union[str, List[str]]) -> Type
     if len(path) == 1:
         if hasattr(model, path[0]):
             return get_next_model(model, path[0])
-        raise ValueError(
+        raise AttributeError(
             f"Model: '{model.__name__}' does not have a field attribute named: '{path[0]}'."
         )
     return model_path_to_model(get_next_model(model, path[0]), path[1:])
+
+
+def get_distinct_fields(model: Type[Model], field_path: str):
+    """Collects all of the order-by fields associated with self.field_path.  For non-foreign-key fields, it just
+    returns a single-member list containing self.field_path.  Otherwise, it returns all of the fields in the related
+    model's Meta.ordering.  It calls a recursive helper method in case any related model's meta ordering also contains a
+    foreign key field.
+
+    Args:
+        model (Type[Model])
+        field_path (str)
+    Exceptions:
+        None
+    Returns:
+        distinct_fields (List[str]): A list of field_paths from the provided field_path that are either just the
+            field_path supplied or a series of field_paths from the related model's ordering, if the field at the end of
+            the path is a foreign key.
+    """
+    return _get_distinct_fields_helper(model, field_path)
+
+
+def _get_distinct_fields_helper(model: Type[Model], field_path: str):
+    """Collects all of the order-by fields associated with field_path.  For non-foreign-key fields, it just returns
+    a single-member list containing field_path.  Otherwise, it returns all of the fields in the related model's
+    Meta.ordering.  It recursively retrieves any other related model's meta ordering if the current ordering also
+    contains a foreign key field.
+
+    Args:
+        model (Type[Model])
+        field_path (str)
+    Exceptions:
+        None
+    Returns:
+        distinct_fields (List[str]): A list of field_paths from the provided field_path that are either just the
+            field_path supplied or a series of field_paths from the related model's ordering, if the field at the end of
+            the path is a foreign key.
+    """
+    related_model_path = field_path_to_model_path(model, field_path)
+    distinct_fields = []
+    if field_path != related_model_path:
+        distinct_fields.append(field_path)
+    else:
+        related_model = model_path_to_model(model, related_model_path)
+        # To use .distinct(), you need the ordering fields from the related model, otherwise you get an exception
+        # about the order_by and distinct fields being different
+        for obf_exp in related_model._meta.ordering:
+            obf = resolve_field_path(obf_exp)
+            obf_path = f"{field_path}__{obf}"
+            obf_related_model_path = field_path_to_model_path(model, obf_path)
+            if obf_path != obf_related_model_path:
+                distinct_fields.append(obf_path)
+            else:
+                distinct_fields.extend(_get_distinct_fields_helper(model, obf_path))
+    return distinct_fields
 
 
 def is_string_field(
@@ -327,6 +654,18 @@ def is_string_field(
     ],
     default: bool = False,
 ) -> bool:
+    """Returns whether the supplied field is a string/text-type field.  Intended for use in deciding whether to apply
+    case-insensitive sorting and/or substring searching.
+
+    Args:
+        field (Optional[Union[Field, DeferredAttribute, ForwardManyToOneDescriptor, ManyToManyDescriptor,
+            ReverseManyToOneDescriptor]): A field or field representation.
+        default (bool) [False]: What to return if field is None.
+    Exceptions:
+        None
+    Returns:
+        (bool): Whether the supplied field is a string/text-type field.
+    """
     str_field_names = [
         "CharField",
         "EmailField",
@@ -355,6 +694,18 @@ def is_number_field(
     ],
     default: bool = False,
 ) -> bool:
+    """Returns whether the supplied field is a numeric-type field.  Intended for use in deciding whether to apply
+    case-insensitive sorting and/or substring searching.
+
+    Args:
+        field (Optional[Union[Field, DeferredAttribute, ForwardManyToOneDescriptor, ManyToManyDescriptor,
+            ReverseManyToOneDescriptor]): A field or field representation.
+        default (bool) [False]: What to return if field is None.
+    Exceptions:
+        None
+    Returns:
+        (bool): Whether the supplied field is a numeric-type field.
+    """
     num_field_names = [
         "AutoField",
         "BigAutoField",
@@ -384,14 +735,41 @@ def is_unique_field(
             ReverseManyToOneDescriptor,
         ]
     ],
+    default: bool = False,
 ) -> bool:
+    """Returns whether the supplied field is unique.  Intended for use in deciding whether a field is appropriate to be
+    linked to a detail record by default.
+
+    Args:
+        field (Optional[Union[Field, DeferredAttribute, ForwardManyToOneDescriptor, ManyToManyDescriptor,
+            ReverseManyToOneDescriptor]): A field or field representation.
+        default (bool) [False]: What to return if field is None.
+    Exceptions:
+        None
+    Returns:
+        (bool): Whether the supplied field is unique.
+    """
     if field is not None:
         field = resolve_field(field)
         return field.unique
-    return False
+    return default
 
 
-def dereference_field(field_name, model_name):
+def dereference_field(field_name: str, model_name: str) -> str:
+    """Takes a model name and a field name and returns a dunderscore-delimited path to a non-foreign-key field.  If a
+    field is a foreign key, "__pk" is appended.  The intended purpose of this method is to aid in compiling a list of
+    distinct fields, where order is unimportant.  The reason this is useful is that fields supplied to .distinct() must
+    also be supplied to .order_by(), and .order_by() does something not entirely transparent when given a foreign key -
+    it expands the foreign key to all of the related models' ordering fields defined in its Meta.
+
+    Args:
+        field_name (str): Name of a model field.
+        model_name (str): Name of a model.
+    Exceptions:
+        None
+    Returns:
+        (Field): A Field instance for the field at the end of the path
+    """
     mdl = get_model_by_name(model_name)
     fld = getattr(mdl, field_name)
     deref_field = field_name
@@ -406,8 +784,7 @@ def get_model_by_name(model_name):
 
 
 def create_is_null_field(field_with_null):
-    """
-    The Django ORM's order_by always puts null fields at the end, which can be a problem if you want the last record
+    """The Django ORM's order_by always puts null fields at the end, which can be a problem if you want the last record
     ordered by a date field.  This method will return a dict that contains the `select` and `order_by arguments for the
     .extra(method, along with the name of the added "is null field that you can use as an argument to `order_by`)`.
 
@@ -445,10 +822,9 @@ def create_is_null_field(field_with_null):
 
 
 def exists_in_db(mdl_obj):
-    """
-    This takes a model object and returns a boolean to indicate whether the object exists in the database.
+    """This takes a model object and returns a boolean to indicate whether the object exists in the database.
 
-    Note, it does not assert that the values of the fields are the same.
+    NOTE: it does not assert that the values of the fields are the same.
     """
     if not hasattr(mdl_obj, "pk"):
         return False
@@ -466,6 +842,7 @@ def update_rec(rec: Model, rec_dict: dict):
     This could be accomplished using a queryset.update() call, but if it changes a field that was used in the original
     query, and that query no longer matches, you cannot iterate through the records of the queryset to save the changes
     you've made, thus the need for this method.
+
     Args:
         rec (Model)
         rec_dict (dict): field values keyed on field name
@@ -482,3 +859,64 @@ def update_rec(rec: Model, rec_dict: dict):
 
 def get_detail_url_name(model_object: Model):
     return resolve(model_object.get_absolute_url()).url_name
+
+
+def model_title(model: Type[Model]) -> str:
+    """Creates a title-case string from the supplied model, accounting for potentially set verbose settings.  Pays
+    particular attention to pre-capitalized values in the model name, and ignores the potentially poorly automated
+    title-casing in existing verbose values of the model so as to not lower-case acronyms in the model name, e.g.
+    MSRunSample (which automatically gets converted to Msrun Sample instead of the preferred MS Run Sample).
+
+    Args:
+        model (Type[Model])
+    Exceptions:
+        None
+    Returns:
+        (str): The title-case version of the model name.
+    """
+    from DataRepo.utils.text_utils import camel_to_title, underscored_to_title
+
+    try:
+        vname: str = model._meta.__dict__["verbose_name"]
+        sanitized = vname.replace(" ", "")
+        sanitized = sanitized.replace("_", "")
+        if any([c.isupper() for c in vname]) and model.__name__.lower() == sanitized:
+            return underscored_to_title(vname)
+        else:
+            return camel_to_title(model.__name__)
+    except Exception:
+        return camel_to_title(model.__name__)
+
+
+def model_title_plural(model: Type[Model]) -> str:
+    """Creates a title-case string from self.model, accounting for potentially set verbose settings.  Pays
+    particular attention to pre-capitalized values in the model name, and ignores the potentially poorly automated
+    title-casing in existing verbose values of the model so as to not lower-case acronyms in the model name, e.g.
+    MSRunSample (which automatically gets converted to Msrun Sample instead of the preferred MS Run Sample).
+
+    Args:
+        model (Type[Model])
+    Exceptions:
+        None
+    Returns:
+        (str): The title-case version of the model name.
+    """
+    from DataRepo.utils.text_utils import camel_to_title, underscored_to_title
+
+    try:
+        vname: str = model._meta.__dict__["verbose_name_plural"]
+        if any([c.isupper() for c in vname]):
+            return underscored_to_title(vname)
+        else:
+            return f"{camel_to_title(model.__name__)}s"
+    except Exception:
+        return f"{camel_to_title(model.__name__)}s"
+
+
+# TODO: Figure out a way to move these exception classes to exceptions.py without hitting a circular import
+class NoFields(Exception):
+    pass
+
+
+class MultipleFields(Exception):
+    pass

--- a/DataRepo/models/utilities.py
+++ b/DataRepo/models/utilities.py
@@ -607,8 +607,8 @@ def get_distinct_fields(model: Type[Model], field_path: Optional[str] = None):
             either just the field_path supplied or a series of field_paths from the related model's ordering,
             (if the field at the end of the path is a foreign key).
     """
-    distinct_fields = []
     if field_path is None:
+        distinct_fields = []
         if "ordering" in model._meta.ordering:
             for obf_exp in model._meta.ordering:
                 obf = resolve_field_path(obf_exp)

--- a/DataRepo/tests/views/search/test_download.py
+++ b/DataRepo/tests/views/search/test_download.py
@@ -136,24 +136,25 @@ class AdvancedSearchDownloadViewTests(BaseAdvancedSearchDownloadViewTests):
             "Infusion Rate (ul/min/g)\tStudies\n"
         ).encode()
         expected_content = (
-            "zl4_sp\tspleen\t150.0\talanine\talanine\talanine/L-alanine/ala\tC3H7NO2\tC\txzl4_sp.mzXML\t"
-            "19638321.41044186\t0.18878668492773729\t3707453.596622725\t1.177783652743335\talafasted_cor.xlsx\txzl4\tWT"
-            "\t27.5\t14.0\tM\tPicoLab Rodent 20 5053\tfasted\tno treatment\talanine-[13C3,15N1][180]\t"
-            "alanine-[13C3,15N1]\talanine\t180.0\t0.1\ttest v3 study\nxzl4_sp\tspleen\t150.0\talanine\talanine\t"
-            "alanine/L-alanine/ala\tC3H7NO2\tN\txzl4_sp.mzXML\t19638321.41044186\t0.23467986399113755\t"
-            "4608718.5976167405\t1.117954714164765\talafasted_cor.xlsx\txzl4\tWT\t27.5\t14.0\tM\tPicoLab Rodent 20 5053"
-            "\tfasted\tno treatment\talanine-[13C3,15N1][180]\talanine-[13C3,15N1]\talanine\t180.0\t0.1\ttest v3 study"
-            "\nxzl4_t\tserum_plasma_tail\t150.0\talanine\talanine\talanine/L-alanine/ala\tC3H7NO2\tC\txzl4_t.mzXML\t"
-            "10779143.674823906\t0.1602897819884057\t1727786.5896592264\t1.0\talafasted_cor.xlsx\txzl4\tWT\t27.5\t14.0"
-            "\tM\tPicoLab Rodent 20 5053\tfasted\tno treatment\talanine-[13C3,15N1][180]\talanine-[13C3,15N1]\talanine"
-            "\t180.0\t0.1\ttest v3 study\nxzl4_t\tserum_plasma_tail\t150.0\talanine\talanine\talanine/L-alanine/ala\t"
-            "C3H7NO2\tN\txzl4_t.mzXML\t10779143.674823906\t0.20991893590830213\t2262746.3702217396\t1.0\t"
-            "alafasted_cor.xlsx\txzl4\tWT\t27.5\t14.0\tM\tPicoLab Rodent 20 5053\tfasted\tno treatment\t"
-            "alanine-[13C3,15N1][180]\talanine-[13C3,15N1]\talanine\t180.0\t0.1\ttest v3 study\nxzl5_panc\tpancreas\t"
-            "150.0\talanine\talanine\talanine/L-alanine/ala\tC3H7NO2\tC\txzl5_panc.mzXML\t43695995.42306948\t"
-            "0.06929539990964839\t3027931.477291765\t0.31001266740429617\talafasted_cor.xlsx\txzl5\tWT\t27.5\t14.0\tM\t"
-            "PicoLab Rodent 20 5053\tfasted\tno treatment\talanine-[13C3,15N1][180]\talanine-[13C3,15N1]\talanine\t"
-            "180.0\t0.1\ttest v3 study\nxzl5_panc\tpancreas\t150.0"  # A portion of the file
+            "xzl1_brain\tbrain\t150.0\tglutamine\tglutamine\tglutamine/gln\tC5H10N2O3\tC\txzl1_brain.mzXML\t"
+            "66443429.298358865\t0.020587090360701568\t1367876.8828401999\tNone\tglnfasted1_cor.xlsx\txzl1\tWT\t26.4\t"
+            "14.0\tM\tPicoLab Rodent 20 5053\tfasted\tno treatment\tglutamine-[13C5,15N2][200]\tglutamine-[13C5,15N2]\t"
+            "glutamine\t200.0\t0.1\ttest v3 study\nxzl1_brain\tbrain\t150.0\tglutamine\tglutamine\tglutamine/gln\t"
+            "C5H10N2O3\tN\txzl1_brain.mzXML\t66443429.298358865\t0.033253605355009624\t2209483.5763211097\tNone\t"
+            "glnfasted1_cor.xlsx\txzl1\tWT\t26.4\t14.0\tM\tPicoLab Rodent 20 5053\tfasted\tno treatment\t"
+            "glutamine-[13C5,15N2][200]\tglutamine-[13C5,15N2]\tglutamine\t200.0\t0.1\ttest v3 study\nxzl1_brain\tbrain"
+            "\t150.0\tserine\tserine\tserine/ser\tC3H7NO3\tC\txzl1_brain.mzXML\t3683190.721911725\t"
+            "0.00004820032977290798\t177.53100741266016\tNone\tglnfasted1_cor.xlsx\txzl1\tWT\t26.4\t14.0\tM\t"
+            "PicoLab Rodent 20 5053\tfasted\tno treatment\tglutamine-[13C5,15N2][200]\tglutamine-[13C5,15N2]\tglutamine"
+            "\t200.0\t0.1\ttest v3 study\nxzl1_brain\tbrain\t150.0\tserine\tserine\tserine/ser\tC3H7NO3\tN\t"
+            "xzl1_brain.mzXML\t3683190.721911725\t0.007010304615747614\t25820.288918496553\tNone\tglnfasted1_cor.xlsx\t"
+            "xzl1\tWT\t26.4\t14.0\tM\tPicoLab Rodent 20 5053\tfasted\tno treatment\tglutamine-[13C5,15N2][200]\t"
+            "glutamine-[13C5,15N2]\tglutamine\t200.0\t0.1\ttest v3 study\nxzl1_brownFat\tbrown_adipose_tissue\t150.0\t"
+            "glutamine\tglutamine\tglutamine/gln\tC5H10N2O3\tC\txzl1_brownFat.mzXML\t22616674.701348945\t"
+            "0.14624710984003733\t3307623.309264573\tNone\tglnfasted1_cor.xlsx\txzl1\tWT\t26.4\t14.0\tM\t"
+            "PicoLab Rodent 20 5053\tfasted\tno treatment\tglutamine-[13C5,15N2][200]\tglutamine-[13C5,15N2]\tglutamine"
+            "\t200.0\t0.1\ttest v3 study\nxzl1_brownFat\tbrown_adipose_tissue\t150.0\tglutamine\tglutamine\tglutamine/"
+            # A portion of the file
         ).encode()
         content = str(response.getvalue())
         # `[2:-1]` removes the "b'" and last "'" from the beginning and end of the converted bytes to string
@@ -203,28 +204,28 @@ class RecordToMzxmlTSVTests(BaseAdvancedSearchDownloadViewTests):
         row = pgtmt.msrun_sample_rec_to_row(self.res.first().msrun_sample)
         self.assertEqual(
             [
-                "2020-07-22/Xianfeng Zeng/QE2/polar-HILIC-25-min/positive/1-503/xzl4_sp.mzXML",
+                "2021-06-08/Xianfeng Zeng/QE2/polar-HILIC-25-min/positive/1-503/xzl1_brain.mzXML",
                 "positive",
                 1.0,
                 502.9,
-                "xzl4_sp",
-                "spleen",
-                "2020-07-22",
+                "xzl1_brain",
+                "brain",
+                "2021-06-08",
                 150.0,
                 "Xianfeng Zeng",
-                "xzl4",
+                "xzl1",
                 14.0,
                 "M",
                 "WT",
-                27.5,
+                26.4,
                 "PicoLab Rodent 20 5053",
                 "fasted",
                 "no treatment",
-                "alanine-[13C3,15N1][180]",
+                "glutamine-[13C5,15N2][200]",
                 "Xianfeng Zeng",
                 "QE2",
                 "polar-HILIC-25-min",
-                "2020-07-22",
+                "2021-06-08",
             ],
             row,
         )
@@ -236,28 +237,28 @@ class RecordToMzxmlTSVTests(BaseAdvancedSearchDownloadViewTests):
         self.assertEqual(
             [
                 [
-                    "2020-07-22/Xianfeng Zeng/QE2/polar-HILIC-25-min/positive/1-503/xzl4_sp.mzXML",
+                    "2021-06-08/Xianfeng Zeng/QE2/polar-HILIC-25-min/positive/1-503/xzl1_brain.mzXML",
                     "positive",
                     1.0,
                     502.9,
-                    "xzl4_sp",
-                    "spleen",
-                    "2020-07-22",
+                    "xzl1_brain",
+                    "brain",
+                    "2021-06-08",
                     150.0,
                     "Xianfeng Zeng",
-                    "xzl4",
+                    "xzl1",
                     14.0,
                     "M",
                     "WT",
-                    27.5,
+                    26.4,
                     "PicoLab Rodent 20 5053",
                     "fasted",
                     "no treatment",
-                    "alanine-[13C3,15N1][180]",
+                    "glutamine-[13C5,15N2][200]",
                     "Xianfeng Zeng",
                     "QE2",
                     "polar-HILIC-25-min",
-                    "2020-07-22",
+                    "2021-06-08",
                 ],
             ],
             rows,
@@ -313,15 +314,13 @@ class AdvancedSearchDownloadMzxmlTSVViewTests(BaseAdvancedSearchDownloadViewTest
         assert_StreamingHttpResponse(self, response, "PeakGroups_", "application/text")
         expected1 = "# Download Time: ".encode()
         expected2 = (
-            "mzXML File\tPolarity\tMZ Min\tMZ Max\tSample\tTissue\tDate Collected\tCollection Time (m)\tHandler\tAnimal"
-            "\tAge\tSex\tGenotype\tWeight (g)\tDiet\tFeeding Status\tTreatment\tInfusate\tOperator\tInstrument\t"
-            "LC Protocol\tDate\r\n2020-07-22/Xianfeng Zeng/QE2/polar-HILIC-25-min/positive/1-503/xzl4_sp.mzXML\t"
-            "positive\t1.0\t502.9\txzl4_sp\tspleen\t2020-07-22\t150.0\tXianfeng Zeng\txzl4\t14.0\tM\tWT\t27.5\tPicoLab "
-            "Rodent 20 5053\tfasted\tno treatment\talanine-[13C3,15N1][180]\tXianfeng Zeng\tQE2\tpolar-HILIC-25-min\t"
-            "2020-07-22\r\n2020-07-22/Xianfeng Zeng/QE2/polar-HILIC-25-min/positive/1-503/xzl4_t.mzXML\tpositive\t1.0\t"
-            "502.9\txzl4_t\tserum_plasma_tail\t2020-07-22\t150.0\tXianfeng Zeng\txzl4\t14.0\tM\tWT\t27.5\tPicoLab "
-            "Rodent 20 5053\tfasted\tno treatment\talanine-[13C3,15N1][180]\tXianfeng Zeng\tQE2\tpolar-HILIC-25-min\t"
-            "2020-07-22\r\n"  # There is more, but this is sufficient
+            "2020-07-22/Xianfeng Zeng/QE2/polar-HILIC-25-min/positive/1-503/xzl4_sp.mzXML\tpositive\t1.0\t502.9\t"
+            "xzl4_sp\tspleen\t2020-07-22\t150.0\tXianfeng Zeng\txzl4\t14.0\tM\tWT\t27.5\tPicoLab Rodent 20 5053\tfasted"
+            "\tno treatment\talanine-[13C3,15N1][180]\tXianfeng Zeng\tQE2\tpolar-HILIC-25-min\t2020-07-22\r\n2020-07-22"
+            "/Xianfeng Zeng/QE2/polar-HILIC-25-min/positive/1-503/xzl4_t.mzXML\tpositive\t1.0\t502.9\txzl4_t\t"
+            "serum_plasma_tail\t2020-07-22\t150.0\tXianfeng Zeng\txzl4\t14.0\tM\tWT\t27.5\tPicoLab Rodent 20 5053\t"
+            "fasted\tno treatment\talanine-[13C3,15N1][180]\tXianfeng Zeng\tQE2\tpolar-HILIC-25-min\t2020-07-22\r\n"
+            # There is more, but this is sufficient
         ).encode()
         content = str(response.getvalue())
         # `[2:-1]` removes the "b'" and last "'" from the beginning and end of the converted bytes to string
@@ -342,7 +341,7 @@ class RecordToMzxmlZIPTests(BaseAdvancedSearchDownloadViewTests):
             self.res.first().msrun_sample
         )
         self.assertEqual(
-            "2020-07-22/Xianfeng Zeng/QE2/polar-HILIC-25-min/positive/1-503/xzl4_sp.mzXML",
+            "2021-06-08/Xianfeng Zeng/QE2/polar-HILIC-25-min/positive/1-503/xzl1_brain.mzXML",
             export_path,
         )
         self.assertIn(
@@ -350,7 +349,7 @@ class RecordToMzxmlZIPTests(BaseAdvancedSearchDownloadViewTests):
             file_obj.name,
         )
         self.assertIn(
-            "/ms_data/xzl4_sp",
+            "/ms_data/xzl1_brain",
             file_obj.name,
         )
         self.assertIn(
@@ -369,7 +368,7 @@ class RecordToMzxmlZIPTests(BaseAdvancedSearchDownloadViewTests):
         # Slicing the queryset to make the expected test data more manageable
         file_tuples = list(pgtmt.queryset_to_files_iterator(self.res[0:1]))
         self.assertIn(
-            "2020-07-22/Xianfeng Zeng/QE2/polar-HILIC-25-min/positive/1-503/xzl4_sp",
+            "2021-06-08/Xianfeng Zeng/QE2/polar-HILIC-25-min/positive/1-503/xzl1_brain",
             file_tuples[0][0],
         )
         self.assertIn(
@@ -381,7 +380,7 @@ class RecordToMzxmlZIPTests(BaseAdvancedSearchDownloadViewTests):
             file_tuples[0][1].name,
         )
         self.assertIn(
-            "/ms_data/xzl4_sp",
+            "/ms_data/xzl1_brain",
             file_tuples[0][1].name,
         )
         self.assertIn(


### PR DESCRIPTION
## Summary Change Description

Pulled changes to `DataRepo/models/utilities.py` from branch `bstlv4_paginate_queryset` in order to obtain the `get_distinct_fields` method, then modified that method to be able to only take the `model` argument and return all ordering fields.  Then I called that from `DataRepo.formats.dataformat.Format.getOrderByFields` when a given model **has** and ordering.

The problem was that `DataRepo.formats.dataformat.Format.getOrderByFields` assumed that a model's ordering only contained fields from its own model.  A recent change to `ArchiveFile` added fields to its ordering that included fields from other models, which caused the stats generation to fail with an `AttributeError`.

## Affected Issues/Pull Requests

- Resolves #1533
- Merges into branch `main`
- Checks out common code from:
  - PR #1535
  - branch `bstlv4_paginate_queryset`

## Reviewer Notes/Requests
<!-- Notes to help the reviewer or requests for specific scrutiny.
E.g. Please make sure I have accounted for all possible inputs. -->
See comments in-line.

## Checklist
<!-- If any requirements are not met, uncheck and explain.
E.g. Linting errors pre-date this PR. -->
This pull request will be merged once the following requirements are met.  The
author and/or reviewers should uncheck any unmet requirements:
<!-- Check/complete items if not applicable. -->
- Review Requirements
  - Minimum approvals: 1 <!-- Edit based on complexity. -->
  - No changes requested
  - All blocking issues resolved by reviewers
  - Specific reviewers: @__add_username_here__ <!-- Approvals required even if minimum met. -->
  - Review period: 2 days <!-- Edit based on complexity. -->
- Associated Issue/PR Requirements: <!-- Assert resolved issues/PRs are done/merged. -->
  - [x] All issue requirements are satisfied
  - [x] All PR dependencies are merged
- Basic Requirements <!-- Uncheck to indicate items you are yet to address. -->
  - [x] [Linters pass](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#linting)
  - [x] [Tests pass](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#quality-control)
  - [x] Conflicts resolved
- Overhead Requirements <!-- Requirements indirectly related to the issues. -->
  - [x] [Tests implemented/updated](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#test-implementation)
  - [ ] [Updated `CHANGELOG.md` *Unreleased* section](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/changelog.md)
