### PR TITLE
`BSTListView` 7: Templates

### DIFF
--- a/DataRepo/static/js/bst/cookies.js
+++ b/DataRepo/static/js/bst/cookies.js
@@ -1,0 +1,96 @@
+var cookieViewPrefix = null // eslint-disable-line no-var
+
+// To use this code, static/js/cookies.js must be imported.
+
+/**
+ * Gets a cookie specific to this view/page.
+ * @param {*} name Cookie name.
+ * @param {*} defval Default if cookie not found.
+ * @returns Cookie value.
+ */
+function initViewCookies (cookieViewPrefix) { // eslint-disable-line no-unused-vars
+  globalThis.cookieViewPrefix = cookieViewPrefix
+}
+
+/**
+ * Gets a cookie specific to this view/page.
+ * @param {*} name Cookie name.
+ * @param {*} defval Default if cookie not found.
+ * @returns Cookie value.
+ */
+function getViewCookie (name, defval) { // eslint-disable-line no-unused-vars
+  return getCookie(cookieViewPrefix + name, defval) // eslint-disable-line no-undef
+}
+
+/**
+ * Sets a cookie specific to this view/page.
+ * @param {*} name Cookie name.
+ * @param {*} val Cookie value.
+ * @returns Cookie value.
+ */
+function setViewCookie (name, val) { // eslint-disable-line no-unused-vars
+  return setCookie(cookieViewPrefix + name, val) // eslint-disable-line no-undef
+}
+
+/**
+ * Deletes a cookie specific to this view/page.
+ * @param {*} name Cookie name.
+ * @returns Cookie value.
+ */
+function deleteViewCookie (name) { // eslint-disable-line no-unused-vars
+  return deleteCookie(cookieViewPrefix + name) // eslint-disable-line no-undef
+}
+
+/**
+ * Gets a cookie specific to this view/page and column.
+ * @param {*} column Column name.
+ * @param {*} name Cookie name.
+ * @param {*} defval Default if cookie not found.
+ * @returns Cookie value.
+ */
+function getViewColumnCookie (column, name, defval) { // eslint-disable-line no-unused-vars
+  return getViewCookie(name + '-' + column, defval)
+}
+
+/**
+ * Sets a cookie specific to this view/page and column.
+ * @param {*} column Column name.
+ * @param {*} name Cookie name.
+ * @param {*} val Cookie value.
+ * @returns Cookie value.
+ */
+function setViewColumnCookie (column, name, val) { // eslint-disable-line no-unused-vars
+  return setViewCookie(name + '-' + column, val)
+}
+
+/**
+ * Deletes a cookie specific to this view/page and column.
+ * @param {*} column Column name.
+ * @param {*} name Cookie name.
+ * @returns Cookie value.
+ */
+function deleteViewColumnCookie (column, name) { // eslint-disable-line no-unused-vars
+  return deleteViewCookie(name + '-' + column)
+}
+
+/**
+ * Get all cookie names of a view.
+ * @returns List of cookie names belonging to the view.
+ */
+function getViewCookieNames () { // eslint-disable-line no-unused-vars
+  return document.cookie.split(';').filter(function (c) {
+    return c.trim().indexOf(cookieViewPrefix) === 0 && c.trim().split('=')[1] !== ''
+  }).map(function (c) {
+    return c.trim().split('=')[0]
+  })
+}
+
+/**
+ * Deletes all cookies of a view.
+ * @returns A list of the names of the deleted cookies.
+ */
+function deleteViewCookies () { // eslint-disable-line no-unused-vars
+  const cookieNames = getViewCookieNames()
+  deleteCookies(cookieNames) // eslint-disable-line no-undef
+  return cookieNames
+}

--- a/DataRepo/templates/models/bst/list_view.html
+++ b/DataRepo/templates/models/bst/list_view.html
@@ -1,9 +1,22 @@
-{% extends "base.html" %}
+{% extends "base/base.html" %}
 {% load customtags %}
 
 {% block title %}{{ table_name }}{% endblock %}
 
 {% block content %}
+
+    {# Script imports #}
+
+    {# Variables needed for the scripts #}
+    {{ warnings|json_script:"warnings" }}
+    {{ cookie_resets|json_script:"cookie_resets" }}
+
+    {# The scripts #}
+    {% for script in scripts %}<script src="{{ script }}"></script>
+    {% endfor %}
+
+    {# The table/page #}
+
     <h4>{{ table_name }}</h4>
     <br>
     <div>
@@ -19,10 +32,14 @@
             data-search="true"
             data-search-align="left"
             data-search-on-enter-key="true"
-            data-search-text="{{ search_term }}"
-            data-sort-name="{{ sortcol }}"
-            data-sort-order="{% if asc %}asc{% else %}desc{% endif %}"
+            {% if search %}
+                data-search-text="{{ search }}"
+            {% endif %}
             data-show-search-clear-button="true"
+            {% if sortcol %}
+                data-sort-name="{{ sortcol }}"
+                data-sort-order="{% if asc %}asc{% else %}desc{% endif %}"
+            {% endif %}
             data-show-multi-sort="true"
             data-show-columns="true"
             data-show-columns-toggle-all="true"
@@ -30,7 +47,7 @@
             data-show-export="false">
             <thead>
                 <tr>
-                    {% for column in columns %}
+                    {% for column in columns.values %}
                         {% include column.th_template %}
                     {% endfor %}
                 </tr>
@@ -38,7 +55,7 @@
             <tbody>
                 {% for object in object_list %}
                     <tr>
-                        {% for column in columns %}
+                        {% for column in columns.values %}
                             {% include column.td_template %}
                         {% endfor %}
                     </tr>

--- a/DataRepo/templates/models/bst/th.html
+++ b/DataRepo/templates/models/bst/th.html
@@ -1,16 +1,18 @@
 <th data-field="{{ column.name }}"
+
+{% if column.searchable %}
+    data-filter-control="{{ column.filterer.input_method }}"
+    data-filter-custom-search="{{ column.filterer }}"
+    {# See: live.bootstrap-table.com/code/hepcat72/18815 #}
+    {% if column.filterer.input_method == column.filterer.INPUT_METHODS.SELECT %}data-filter-data="json:{{ column.filterer.choices_json }}"{% endif %}
+    {% if column.filterer.initial %}data-filter-default="{{ column.filterer.initial }}"{% endif %}{% endif %}
+
+{% if column.sortable %}
+    data-sortable="{{ column.sortable|lower }}"
+    data-sorter="{{ column.sorter }}"{% endif %}
+
     data-valign="top"
-    {% if column.searchable %}
-        data-filter-control="{{ column.filterer.input_method }}"
-        data-filter-custom-search="{{ column.filterer }}"
-        {% if column.filterer.initial %}
-            data-filter-default="{{ column.filterer.initial }}"
-        {% endif %}
-    {% endif %}
-    {% if column.sortable %}
-        data-sortable="{{ column.sortable|lower }}"
-        data-sorter="{{ column.sorter }}"
-    {% endif %}
-    data-visible="{{ column.visible }}">
+    data-visible="{{ column.visible|lower }}">
     {{ column.header }}
+
 </th>

--- a/DataRepo/tests/static/js/bst/test_cookies.js
+++ b/DataRepo/tests/static/js/bst/test_cookies.js
@@ -1,0 +1,71 @@
+/* eslint-disable no-undef */
+
+QUnit.test('initViewCookies', function (assert) {
+  initViewCookies('myview-')
+  assert.equal(cookieViewPrefix, 'myview-')
+})
+
+QUnit.test('getViewCookie', function (assert) {
+  initViewCookies('myview-')
+  deleteViewCookies()
+  const result = getViewCookie('mycookie1', 'y')
+  assert.equal(result, 'y')
+  setViewCookie('mycookie1', 'x')
+  assert.equal(getViewCookie('mycookie1', 'y'), 'x')
+})
+
+QUnit.test('setViewCookie', function (assert) {
+  const result = setViewCookie('mycookie2', 'x')
+  assert.equal(result, 'x')
+  assert.equal(getViewCookie('mycookie2', 'y'), 'x')
+})
+
+QUnit.test('deleteViewCookie', function (assert) {
+  setViewCookie('mycookie3', 'x')
+  const result = deleteViewCookie('mycookie3')
+  assert.equal(result, 'x')
+  assert.equal(getViewCookie('mycookie3', 'y'), 'y')
+})
+
+QUnit.test('getViewColumnCookie', function (assert) {
+  initViewCookies('myview-')
+  deleteViewCookies()
+  assert.equal(getViewColumnCookie('col1', 'mycookie4', 'y'), 'y')
+  setViewColumnCookie('col1', 'mycookie4', 'x')
+  assert.equal(getViewColumnCookie('col1', 'mycookie4', 'y'), 'x')
+})
+
+QUnit.test('setViewColumnCookie', function (assert) {
+  assert.equal(setViewColumnCookie('col2', 'mycookie5', 'x'), 'x')
+  assert.equal(getViewColumnCookie('col2', 'mycookie5', 'y'), 'x')
+})
+
+QUnit.test('deleteViewColumnCookie', function (assert) {
+  setViewColumnCookie('col3', 'mycookie6', 'x')
+  const result = deleteViewColumnCookie('col3', 'mycookie6')
+  assert.equal(result, 'x')
+  assert.equal(getViewColumnCookie('col3', 'mycookie6', 'y'), 'y')
+})
+
+QUnit.test('getViewCookieNames', function (assert) {
+  initViewCookies('myview-')
+  deleteViewCookies()
+  setViewCookie('mycookie7', 'x')
+  setViewCookie('mycookie8', 'x')
+  setViewColumnCookie('col4', 'mycookie9', 'x')
+  const result = getViewCookieNames()
+  assert.deepEqual(result, ['myview-mycookie7', 'myview-mycookie8', 'myview-mycookie9-col4'])
+})
+
+QUnit.test('deleteViewCookies', function (assert) {
+  initViewCookies('myview-')
+  deleteViewCookies()
+  setViewCookie('mycookie7', 'x')
+  setViewCookie('mycookie8', 'x')
+  setViewColumnCookie('col4', 'mycookie9', 'x')
+  const result = deleteViewCookies()
+  assert.equal(result.length, 3)
+  assert.deepEqual(result, ['myview-mycookie7', 'myview-mycookie8', 'myview-mycookie9-col4'])
+})
+
+/* eslint-enable no-undef */

--- a/DataRepo/tests/static/js/tests.html
+++ b/DataRepo/tests/static/js/tests.html
@@ -64,5 +64,10 @@
         <script src="/DataRepo/static/js/bst/filterer.js"></script>
         <script src="bst/test_filterer.js"></script>
 
+        <!-- Cookie Tests -->
+        <script src="/static/js/cookies.js"></script>
+        <script src="/DataRepo/static/js/bst/cookies.js"></script>
+        <script src="bst/test_cookies.js"></script>
+
     </body>
 </html>

--- a/DataRepo/tests/templates/models/bst/base_template_test.py
+++ b/DataRepo/tests/templates/models/bst/base_template_test.py
@@ -1,0 +1,74 @@
+from django.db.models import CASCADE, CharField, ForeignKey, ManyToManyField
+from django.db.models.functions import Lower
+
+from DataRepo.tests.tracebase_test_case import (
+    TracebaseTestCase,
+    create_test_model,
+)
+
+BTTStudyTestModel = create_test_model(
+    "BTTStudyTestModel",
+    {
+        "name": CharField(max_length=255, unique=True),
+        "desc": CharField(max_length=255),
+    },
+    attrs={
+        "Meta": type(
+            "Meta",
+            (),
+            {"app_label": "loader", "ordering": [Lower("name").desc()]},
+        ),
+    },
+)
+
+BTTAnimalTestModel = create_test_model(
+    "BTTAnimalTestModel",
+    {
+        "name": CharField(max_length=255, unique=True),
+        "desc": CharField(max_length=255),
+        "studies": ManyToManyField(
+            to="loader.BTTStudyTestModel", related_name="animals"
+        ),
+        "treatment": ForeignKey(
+            to="loader.BTTTreatmentTestModel",
+            related_name="animals",
+            on_delete=CASCADE,
+        ),
+    },
+    attrs={
+        "Meta": type(
+            "Meta",
+            (),
+            {"app_label": "loader", "ordering": ["-name"]},
+        ),
+    },
+)
+
+BTTTreatmentTestModel = create_test_model(
+    "BTTTreatmentTestModel",
+    {"name": CharField(unique=True), "desc": CharField()},
+    attrs={
+        "get_absolute_url": lambda _: "thisisaurl",
+        "__str__": lambda slf: slf.name,
+    },
+)
+
+
+class BaseTemplateTests(TracebaseTestCase):
+
+    @classmethod
+    def setUpTestData(cls):
+        cls.t1 = BTTTreatmentTestModel.objects.create(name="T1", desc="t1")
+        cls.t2 = BTTTreatmentTestModel.objects.create(name="oddball", desc="t2")
+        cls.s1 = BTTStudyTestModel.objects.create(name="S1", desc="s1")
+        cls.s2 = BTTStudyTestModel.objects.create(name="S2", desc="s2")
+        cls.a1 = BTTAnimalTestModel.objects.create(
+            name="A1", desc="a1", treatment=cls.t1
+        )
+        cls.a1.studies.add(cls.s1)
+        cls.a2 = BTTAnimalTestModel.objects.create(
+            name="A2", desc="a2", treatment=cls.t2
+        )
+        cls.a2.studies.add(cls.s1)
+        cls.a2.studies.add(cls.s2)
+        super().setUpTestData()

--- a/DataRepo/tests/templates/models/bst/test_list_view.py
+++ b/DataRepo/tests/templates/models/bst/test_list_view.py
@@ -1,0 +1,284 @@
+from django.db.models import CharField
+from django.db.models.functions import Upper
+from django.http import HttpRequest
+from django.template.loader import render_to_string
+
+from DataRepo.tests.templates.models.bst.base_template_test import (
+    BaseTemplateTests,
+    BTTAnimalTestModel,
+    BTTStudyTestModel,
+)
+from DataRepo.views.models.bst.column.many_related_field import (
+    BSTManyRelatedColumn,
+)
+from DataRepo.views.models.bst.column.many_related_group import BSTColumnGroup
+from DataRepo.views.models.bst.list_view import BSTListView
+
+
+class StudyLV(BSTListView):
+    model = BTTStudyTestModel
+    annotations = {"description": Upper("desc", output_field=CharField())}
+    exclude = ["id", "desc"]
+
+
+class AnimalWithMultipleStudyColsLV(BSTListView):
+    model = BTTAnimalTestModel
+    column_ordering = ["name", "desc", "treatment", "studies__name", "studies__desc"]
+    exclude = ["id", "studies"]
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(
+            *args,
+            columns=[
+                BSTColumnGroup(
+                    BSTManyRelatedColumn(
+                        "studies__name", AnimalWithMultipleStudyColsLV.model
+                    ),
+                    BSTManyRelatedColumn(
+                        "studies__desc", AnimalWithMultipleStudyColsLV.model
+                    ),
+                ),
+            ],
+            **kwargs,
+        )
+
+
+class BSTListViewTests(BaseTemplateTests):
+
+    list_view_template = "models/bst/list_view.html"
+
+    def render_list_view_template(self, view: BSTListView):
+        view.object_list = view.get_queryset()[:]
+        context = view.get_context_data()
+        return render_to_string(self.list_view_template, context)
+
+    def get_massaged_template_str(self, template_str: str):
+        pos = template_str.index('<div class="container-fluid main-content">')
+        lines = template_str[pos:].splitlines()
+        non_empty_lines = [f"{line}\n" for line in lines if line.strip()]
+        return "".join(non_empty_lines)
+
+    def assert_substrings(self, expected_substrings: list, template_str: str):
+        for i, expected in enumerate(expected_substrings):
+            # assertIn has really ugly failure output.  assertTrue with msg set is better
+            self.assertTrue(
+                expected in template_str,
+                msg=f"'{expected}' not found in:\n{self.get_massaged_template_str(template_str)}",
+            )
+
+    def assert_substrings_in_order(self, expected_substrings: list, template_str: str):
+        pos = 0
+        for i, expected in enumerate(expected_substrings):
+            try:
+                pos = template_str[pos:].index(expected)
+            except ValueError:
+                if expected not in template_str:
+                    # assertIn has really ugly failure output.  assertTrue with msg set is better
+                    self.assertTrue(
+                        expected in template_str,
+                        msg=(
+                            f"Substring {i + 1} out of {len(expected_substrings)}: '{expected}' not found in the "
+                            f"expected order in:\n{self.get_massaged_template_str(template_str)}"
+                        ),
+                    )
+
+    def test_script_imports(self):
+        request = HttpRequest()
+        slv = StudyLV(request=request)
+        template_str = self.render_list_view_template(slv)
+        expected_substrings = [
+            '<script id="warnings" type="application/json">[]</script>',
+            '<script id="cookie_resets" type="application/json">[]</script>',
+            '<script src="js/bst/sorter.js"></script>',
+            '<script src="js/bst/filterers.js"></script>',
+        ]
+        self.assert_substrings(expected_substrings, template_str)
+
+    def test_warnings(self):
+        request = HttpRequest()
+        slv = StudyLV(request=request)
+        slv.warnings.append("THIS IS A WARNING")
+        slv.warnings.append("THIS IS A SECOND WARNING")
+        template_str = self.render_list_view_template(slv)
+        expected = (
+            '<script id="warnings" type="application/json">'
+            '["THIS IS A WARNING", "THIS IS A SECOND WARNING"]'
+            "</script>"
+        )
+        self.assertTrue(
+            expected in template_str,
+            msg=f"'{expected}' not found in:\n{self.get_massaged_template_str(template_str)}",
+        )
+
+    def test_cookie_resets(self):
+        request = HttpRequest()
+        slv = StudyLV(request=request)
+        slv.cookie_resets.append("test")
+        template_str = self.render_list_view_template(slv)
+        expected = (
+            '<script id="cookie_resets" type="application/json">["test"]</script>'
+        )
+        self.assertTrue(
+            expected in template_str,
+            msg=f"'{expected}' not found in:\n{self.get_massaged_template_str(template_str)}",
+        )
+
+    def test_id_title(self):
+        request = HttpRequest()
+        slv = StudyLV(request=request)
+        template_str = self.render_list_view_template(slv)
+        expected_substrings = [
+            "<h4>BTT Study Test Models</h4>",
+            'id="StudyLV"',
+        ]
+        self.assert_substrings(expected_substrings, template_str)
+
+    def test_default_table_attributes(self):
+        request = HttpRequest()
+        slv = StudyLV(request=request)
+        template_str = self.render_list_view_template(slv)
+        expected_substrings = [
+            '<table class="table table-sm table-hover table-bordered table-responsive-xl table-striped"',
+            'data-toggle="table"',
+            'data-buttons-align="left"',
+            'data-buttons-class="primary"',
+            'data-buttons="customButtonsFunction"',
+            "data-export-types=\"['csv', 'txt', 'excel']\"",
+            'data-export-data-type="all"',
+            'data-filter-control="true"',
+            'data-search="true"',
+            'data-search-align="left"',
+            'data-search-on-enter-key="true"',
+            'data-show-search-clear-button="true"',
+            'data-show-multi-sort="true"',
+            'data-show-columns="true"',
+            'data-show-columns-toggle-all="true"',
+            'data-show-fullscreen="true"',
+            'data-show-export="false">',
+        ]
+        self.assert_substrings(expected_substrings, template_str)
+        unexpected_substrings = [
+            'data-search-text=""',
+            'data-sort-name="None"',
+            'data-sort-order="asc"',
+        ]
+        for unexpected in unexpected_substrings:
+            # assertNotIn has really ugly failure output.  assertFalse with msg set is better
+            self.assertFalse(
+                unexpected in template_str,
+                msg=f"Unexpectedly found '{unexpected}' in:\n{self.get_massaged_template_str(template_str)}",
+            )
+
+    def test_search(self):
+        request = HttpRequest()
+        request.COOKIES.update(
+            {f"{StudyLV.__name__}-{StudyLV.search_cookie_name}": "test"}
+        )
+        slv = StudyLV(request=request)
+        template_str = self.render_list_view_template(slv)
+        expected = 'data-search-text="test"'
+        # assertIn has really ugly failure output.  assertTrue with msg set is better
+        self.assertTrue(
+            expected in template_str,
+            msg=f"'{expected}' not found in:\n{self.get_massaged_template_str(template_str)}",
+        )
+
+    def test_column_order(self):
+        request = HttpRequest()
+
+        slv = StudyLV(request=request)
+        template_str = self.render_list_view_template(slv)
+        expected_ordered_substrings = [
+            '<th data-field="name"',
+            '<th data-field="animals_mm_count"',
+            '<th data-field="animals"',
+            '<th data-field="description"',
+            # NOTE: The default row order is determined by the model's ordering (which is descending)
+            '<td class="table-cell">',
+            "S2",
+            "</td>",
+            '<td class="table-cell">',
+            "1",
+            "</td>",
+            '<td class="table-cell">',
+            "BTTAnimalTestModel object (2)",
+            "</td>",
+            '<td class="table-cell">',
+            "S2",
+            "</td>",
+            "</tr>",
+            "<tr>",
+            '<td class="table-cell">',
+            "S1",
+            "</td>",
+            '<td class="table-cell">',
+            "2",
+            "</td>",
+            '<td class="table-cell">',
+            'BTTAnimalTestModel object (1); <br class="cell-wrap">',
+            "BTTAnimalTestModel object (2)",
+            "</td>",
+            '<td class="table-cell">',
+            "S1",
+            "</td>",
+        ]
+        self.assert_substrings_in_order(expected_ordered_substrings, template_str)
+
+    def test_row_order(self):
+        request = HttpRequest()
+
+        # Default sort
+        slv = StudyLV(request=request)
+        template_str = self.render_list_view_template(slv)
+        expected_ordered_substrings = [
+            # NOTE: The default order is determined by the model's ordering (which is descending)
+            "S2",
+            "S1",
+        ]
+        self.assert_substrings_in_order(expected_ordered_substrings, template_str)
+
+        # Explicit descending sort
+        request.COOKIES.update(
+            {
+                f"{StudyLV.__name__}-{StudyLV.sortcol_cookie_name}": "name",
+                f"{StudyLV.__name__}-{StudyLV.asc_cookie_name}": "false",
+            }
+        )
+        slv1 = StudyLV(request=request)
+        template_str = self.render_list_view_template(slv1)
+        expected_substrings = [
+            'data-sort-name="name"',
+            'data-sort-order="desc"',
+        ]
+        self.assert_substrings(expected_substrings, template_str)
+        expected_ordered_substrings = ["S2", "S1"]
+        self.assert_substrings_in_order(expected_ordered_substrings, template_str)
+
+        # Explicit ascending sort
+        request.COOKIES.update(
+            {
+                f"{StudyLV.__name__}-{StudyLV.sortcol_cookie_name}": "name",
+                f"{StudyLV.__name__}-{StudyLV.asc_cookie_name}": "true",
+            }
+        )
+        slv2 = StudyLV(request=request)
+        template_str = self.render_list_view_template(slv2)
+        expected_substrings = [
+            'data-sort-name="name"',
+            'data-sort-order="asc"',
+        ]
+        self.assert_substrings(expected_substrings, template_str)
+        expected_ordered_substrings = ["S1", "S2"]
+        self.assert_substrings_in_order(expected_ordered_substrings, template_str)
+
+        # Default ascending sort (derived from the model's ordering?)
+        request.COOKIES = {f"{StudyLV.__name__}-{StudyLV.sortcol_cookie_name}": "name"}
+        slv3 = StudyLV(request=request)
+        template_str = self.render_list_view_template(slv3)
+        expected_substrings = [
+            'data-sort-name="name"',
+            'data-sort-order="asc"',
+        ]
+        self.assert_substrings(expected_substrings, template_str)
+        expected_ordered_substrings = ["S1", "S2"]
+        self.assert_substrings_in_order(expected_ordered_substrings, template_str)

--- a/DataRepo/tests/templates/models/bst/test_td.py
+++ b/DataRepo/tests/templates/models/bst/test_td.py
@@ -15,17 +15,13 @@ from DataRepo.views.models.bst.column.many_related_field import (
 from DataRepo.views.models.bst.column.related_field import BSTRelatedColumn
 
 
-class ValueTemplateTests(BaseTemplateTests):
+class TdTemplateTests(BaseTemplateTests):
     """Test that BST value template renders correctly."""
 
-    value_template = "models/bst/value.html"
-    value_list_template = "models/bst/value_list.html"
+    td_template = "models/bst/td.html"
 
-    def render_value_template(self, context):
-        return render_to_string(self.value_template, context)
-
-    def render_value_list_template(self, context):
-        return render_to_string(self.value_list_template, context)
+    def render_td_template(self, context):
+        return render_to_string(self.td_template, context)
 
     def test_bst_annot_column(self):
         lowtreatcol = BSTAnnotColumn(
@@ -38,8 +34,9 @@ class ValueTemplateTests(BaseTemplateTests):
             "object": rec,
         }
         # Ignoring leading/trailing whitespace characters from the template code...
-        html = self.render_value_template(context).strip()
-        self.assertEqual("t1", html)
+        html = self.render_td_template(context).strip()
+        self.assertIn('<td class="table-cell">', html)
+        self.assertIn("t1", html)
 
     def test_bst_column_field(self):
         namecol = BSTColumn("name", BTTAnimalTestModel)
@@ -49,8 +46,9 @@ class ValueTemplateTests(BaseTemplateTests):
             "object": rec,
         }
         # Ignoring leading/trailing whitespace characters from the template code...
-        html = self.render_value_template(context).strip()
-        self.assertEqual("A1", html)
+        html = self.render_td_template(context).strip()
+        self.assertIn('<td class="table-cell">', html)
+        self.assertIn("A1", html)
 
     def test_bst_column_object(self):
         namecol = BSTColumn("treatment", BTTAnimalTestModel)
@@ -60,8 +58,9 @@ class ValueTemplateTests(BaseTemplateTests):
             "object": rec,
         }
         # Ignoring leading/trailing whitespace characters from the template code...
-        html = self.render_value_template(context).strip()
-        self.assertEqual('<a href="thisisaurl">T1</a>', html)
+        html = self.render_td_template(context).strip()
+        self.assertIn('<a href="thisisaurl">T1</a>', html)
+        self.assertIn('<td class="table-cell">', html)
 
     def test_bst_related_column_field(self):
         treatdesccol = BSTRelatedColumn("treatment__desc", BTTAnimalTestModel)
@@ -71,8 +70,9 @@ class ValueTemplateTests(BaseTemplateTests):
             "object": rec,
         }
         # Ignoring leading/trailing whitespace characters from the template code...
-        html = self.render_value_template(context).strip()
-        self.assertEqual("t1", html)
+        html = self.render_td_template(context).strip()
+        self.assertIn('<td class="table-cell">', html)
+        self.assertIn("t1", html)
 
     def test_bst_related_column_object(self):
         treatcol = BSTRelatedColumn("treatment", BTTAnimalTestModel)
@@ -82,8 +82,9 @@ class ValueTemplateTests(BaseTemplateTests):
             "object": rec,
         }
         # Ignoring leading/trailing whitespace characters from the template code...
-        html = self.render_value_template(context).strip()
-        self.assertEqual('<a href="thisisaurl">T1</a>', html)
+        html = self.render_td_template(context).strip()
+        self.assertIn('<td class="table-cell">', html)
+        self.assertIn('<a href="thisisaurl">T1</a>', html)
 
     @override_settings(DEBUG=True)
     def test_bst_many_related_column_field(self):
@@ -94,16 +95,15 @@ class ValueTemplateTests(BaseTemplateTests):
             "column": studydesccol,
             "object": rec,
         }
+        self.assertEqual("models/bst/value_list.html", studydesccol.value_template)
         # Ignoring whitespace from the template code...
         html = (
-            self.render_value_list_template(context)
-            .strip()
-            .replace("\n", "")
-            .replace("  ", "")
+            self.render_td_template(context).strip().replace("\n", "").replace("  ", "")
         )
         # NOTE: The descending order here is due to the manual subrecs query and the model's ordering.
         # In BSTListView, applying the column's ordering happens via the get_user_queryset.
-        self.assertEqual('s2; <br class="cell-wrap">s1', html)
+        self.assertIn('<td class="table-cell">', html)
+        self.assertIn('s2; <br class="cell-wrap">s1', html)
 
     @override_settings(DEBUG=True)
     def test_bst_many_related_column_object(self):
@@ -114,13 +114,14 @@ class ValueTemplateTests(BaseTemplateTests):
             "column": studycol,
             "object": rec,
         }
+        self.assertEqual("models/bst/value_list.html", studycol.value_template)
         # Ignoring whitespace from the template code...
         html = (
-            self.render_value_list_template(context)
-            .strip()
-            .replace("\n", "")
-            .replace("  ", "")
+            self.render_td_template(context).strip().replace("\n", "").replace("  ", "")
         )
+        # NOTE: The descending order here is due to the manual subrecs query and the model's ordering.
+        # In BSTListView, applying the column's ordering happens via the get_user_queryset.
+        self.assertIn('<td class="table-cell">', html)
         # This avoids matching the primary key, which is not durable from test to test
         self.assertIn("BTTStudyTestModel object (", html)
         self.assertIn('); <br class="cell-wrap">BTTStudyTestModel object (', html)

--- a/DataRepo/tests/templates/models/bst/test_th.py
+++ b/DataRepo/tests/templates/models/bst/test_th.py
@@ -1,0 +1,91 @@
+from django.db.models import CharField
+from django.db.models.functions import Lower
+from django.template.loader import render_to_string
+
+from DataRepo.tests.tracebase_test_case import TracebaseTestCase
+from DataRepo.views.models.bst.column.annotation import BSTAnnotColumn
+from DataRepo.views.models.bst.column.filterer.annotation import (
+    BSTAnnotFilterer,
+)
+
+
+class ThTemplateTests(TracebaseTestCase):
+    """Test that BST th template renders correctly.
+
+    Uses BSTAnnotColumn, because the features are the same but no model is required.
+    """
+
+    th_template = "models/bst/th.html"
+
+    def render_th_template(self, column):
+        # Ignoring leading/trailing whitespace characters from the template code...
+        return render_to_string(self.th_template, {"column": column}).strip()
+
+    def test_th_basic(self):
+        col = BSTAnnotColumn("colname", Lower("name", output_field=CharField()))
+        html = self.render_th_template(col)
+        self.assertIn("<th", html)
+        self.assertIn('data-field="colname"', html)
+        self.assertIn('data-valign="top"', html)
+        self.assertIn('data-filter-control="input"', html)
+        self.assertIn('data-filter-custom-search="djangoFilterer"', html)
+        self.assertNotIn("data-filter-data", html)
+        self.assertNotIn("data-filter-default", html)
+        self.assertIn('data-sortable="true"', html)
+        self.assertIn('data-sorter="djangoSorter"', html)
+        self.assertIn('data-visible="true"', html)
+        self.assertIn("Colname", html)
+
+    def test_th_booleans(self):
+        col = BSTAnnotColumn(
+            "colname",
+            Lower("name", output_field=CharField()),
+            searchable=False,
+            sortable=False,
+            visible=False,
+        )
+        html = self.render_th_template(col)
+        self.assertNotIn("data-filter-control", html)
+        self.assertNotIn("data-filter-custom-search", html)
+        self.assertNotIn("data-filter-data", html)
+        self.assertNotIn("data-filter-default", html)
+        self.assertNotIn("data-sortable", html)
+        self.assertNotIn("data-sorter", html)
+        self.assertIn('data-visible="false"', html)
+
+    def test_th_client_filterer(self):
+        col = BSTAnnotColumn(
+            "colname",
+            Lower("name", output_field=CharField()),
+            filterer="someCustomFilterer",
+        )
+        html = self.render_th_template(col)
+        # TODO: Implement the client-mode concept just in javascript.  See #1561
+        # Then change this to test that it sets "someCustomFilterer"
+        self.assertIn('data-filter-custom-search="djangoFilterer"', html)
+
+    def test_th_input_method_select(self):
+        col = BSTAnnotColumn(
+            "colname",
+            Lower("name", output_field=CharField()),
+            filterer=BSTAnnotFilterer(
+                "colname",
+                input_method=BSTAnnotFilterer.INPUT_METHODS.SELECT,
+                choices={"1": "1", "2": "2"},
+            ),
+        )
+        html = self.render_th_template(col)
+        self.assertIn('data-filter-control="select"', html)
+        self.assertIn(
+            'data-filter-data="json:{&quot;1&quot;: &quot;1&quot;, &quot;2&quot;: &quot;2&quot;}"',
+            html,
+        )
+
+    def test_th_initial_filter(self):
+        col = BSTAnnotColumn(
+            "colname",
+            Lower("name", output_field=CharField()),
+            filterer=BSTAnnotFilterer("colname", initial="searchterm"),
+        )
+        html = self.render_th_template(col)
+        self.assertIn('data-filter-default="searchterm"', html)

--- a/DataRepo/tests/views/models/bst/column/filterer/test_annotation.py
+++ b/DataRepo/tests/views/models/bst/column/filterer/test_annotation.py
@@ -1,5 +1,4 @@
 from django.db.models import Q
-from django.templatetags.static import static
 from django.test import override_settings
 
 from DataRepo.tests.tracebase_test_case import TracebaseTestCase
@@ -20,7 +19,6 @@ class BSTAnnotFiltererTests(TracebaseTestCase):
         self.assertEqual(f.CLIENT_FILTERERS.NONE, f.filterer)
         self.assertEqual("name", f.name)
         self.assertEqual(f.SERVER_FILTERERS.CONTAINS, f._server_filterer)
-        self.assertFalse(f.client_mode)
         self.assertEqual(f.INPUT_METHODS.TEXT, f.input_method)
         self.assertIsNone(f.initial)
         self.assertIsNone(f.choices)
@@ -44,40 +42,6 @@ class BSTAnnotFiltererTests(TracebaseTestCase):
                 "name", _server_filterer=BSTAnnotFilterer.SERVER_FILTERERS.CONTAINS
             ).filterer,
         )
-
-    @TracebaseTestCase.assertNotWarns()
-    def test_script(self):
-        f = BSTAnnotFilterer(
-            "name",
-            _server_filterer=BSTAnnotFilterer.SERVER_FILTERERS.CONTAINS,
-        )
-        self.assertEqual(
-            f"<script src='{static(BSTAnnotFilterer.script_name)}'></script>",
-            f.script,
-        )
-
-    @TracebaseTestCase.assertNotWarns()
-    def test_set_client_mode(self):
-        f = BSTAnnotFilterer(
-            "name",
-            _server_filterer=BSTAnnotFilterer.SERVER_FILTERERS.CONTAINS,
-        )
-        self.assertFalse(f.client_mode)
-        f.set_client_mode()
-        self.assertTrue(f.client_mode)
-        f.set_client_mode(enabled=False)
-        self.assertFalse(f.client_mode)
-
-    @TracebaseTestCase.assertNotWarns()
-    def test_set_server_mode(self):
-        f = BSTAnnotFilterer(
-            "name",
-            _server_filterer=BSTAnnotFilterer.SERVER_FILTERERS.CONTAINS,
-        )
-        f.set_server_mode()
-        self.assertFalse(f.client_mode)
-        f.set_server_mode(enabled=False)
-        self.assertTrue(f.client_mode)
 
     @TracebaseTestCase.assertNotWarns()
     def test_init_client_filterer_contains(self):
@@ -239,4 +203,4 @@ class BSTAnnotFiltererTests(TracebaseTestCase):
         # NOTE: icontains actually works on anything.  The DB (or Django?) does a conversion.  It clearly works for
         # numeric fields and date fields, so what BSTAnnotSorter does (without knowing the field type), is it infers
         # whether to use icontains or iexact based on the input method.
-        self.assertEqual(Q(**{"name__icontains": "test"}), f.filter("test"))
+        self.assertEqual(Q(**{"name__icontains": "test"}), f.create_q_exp("test"))

--- a/DataRepo/tests/views/models/bst/column/filterer/test_field.py
+++ b/DataRepo/tests/views/models/bst/column/filterer/test_field.py
@@ -6,7 +6,6 @@ from django.db.models import (
     ManyToManyField,
     Q,
 )
-from django.templatetags.static import static
 from django.test import override_settings
 
 from DataRepo.tests.tracebase_test_case import (
@@ -51,7 +50,6 @@ class BSTFiltererTests(TracebaseTestCase):
         self.assertEqual(f.CLIENT_FILTERERS.CONTAINS, f.client_filterer)
         self.assertIsNone(f.choices)
         self.assertEqual(f.SERVER_FILTERERS.CONTAINS, f._server_filterer)
-        self.assertFalse(f.client_mode)
 
     @TracebaseTestCase.assertNotWarns()
     def test_init_integerfield(self):
@@ -60,7 +58,6 @@ class BSTFiltererTests(TracebaseTestCase):
         self.assertEqual(f.CLIENT_FILTERERS.STRICT_SINGLE, f.client_filterer)
         self.assertIsNone(f.choices)
         self.assertEqual(f.SERVER_FILTERERS.STRICT_SINGLE, f._server_filterer)
-        self.assertFalse(f.client_mode)
 
     @TracebaseTestCase.assertNotWarns()
     def test_init_choicesfield(self):
@@ -69,7 +66,6 @@ class BSTFiltererTests(TracebaseTestCase):
         self.assertEqual(f.CLIENT_FILTERERS.STRICT_SINGLE, f.client_filterer)
         self.assertDictEqual({"F": "female", "M": "male"}, f.choices)
         self.assertEqual(f.SERVER_FILTERERS.STRICT_SINGLE, f._server_filterer)
-        self.assertFalse(f.client_mode)
 
     @TracebaseTestCase.assertNotWarns()
     def test_init_choicesmanyrelatedfield(self):
@@ -78,7 +74,6 @@ class BSTFiltererTests(TracebaseTestCase):
         self.assertEqual(f.CLIENT_FILTERERS.STRICT_MULTIPLE, f.client_filterer)
         self.assertDictEqual({"F": "female", "M": "male"}, f.choices)
         self.assertEqual(f.SERVER_FILTERERS.STRICT_MULTIPLE, f._server_filterer)
-        self.assertFalse(f.client_mode)
 
     @TracebaseTestCase.assertNotWarns()
     def test_init_input_method_select_error(self):
@@ -102,7 +97,6 @@ class BSTFiltererTests(TracebaseTestCase):
         self.assertEqual(f.CLIENT_FILTERERS.STRICT_SINGLE, f.client_filterer)
         self.assertEqual({"A": "A", "B": "B"}, f.choices)
         self.assertEqual(f.SERVER_FILTERERS.STRICT_SINGLE, f._server_filterer)
-        self.assertFalse(f.client_mode)
 
     @TracebaseTestCase.assertNotWarns()
     def test_init_input_method_text(self):
@@ -115,7 +109,6 @@ class BSTFiltererTests(TracebaseTestCase):
         self.assertEqual(f.CLIENT_FILTERERS.CONTAINS, f.client_filterer)
         self.assertEqual(f.SERVER_FILTERERS.CONTAINS, f._server_filterer)
         self.assertIsNone(f.choices)
-        self.assertFalse(f.client_mode)
 
     @TracebaseTestCase.assertNotWarns()
     def test_init_client_filterer_works(self):
@@ -130,7 +123,6 @@ class BSTFiltererTests(TracebaseTestCase):
         self.assertEqual(f.CLIENT_FILTERERS.CONTAINS, f.client_filterer)
         self.assertEqual({"A": "A", "B": "B"}, f.choices)
         self.assertEqual(f.SERVER_FILTERERS.CONTAINS, f._server_filterer)
-        self.assertFalse(f.client_mode)
 
     def test_init_client_filterer_custom_warns(self):
         with self.assertWarns(DeveloperWarning) as aw:
@@ -157,7 +149,6 @@ class BSTFiltererTests(TracebaseTestCase):
         self.assertEqual("myFilterer", f.client_filterer)
         self.assertIsNone(f.choices)
         self.assertEqual(f.SERVER_FILTERERS.CONTAINS, f._server_filterer)
-        self.assertFalse(f.client_mode)
 
     @override_settings(DEBUG=False)
     @TracebaseTestCase.assertNotWarns()
@@ -200,104 +191,6 @@ class BSTFiltererTests(TracebaseTestCase):
         self.assertEqual(f.CLIENT_FILTERERS.NONE, f.client_filterer)
         self.assertIsNone(f.choices)
         self.assertEqual("istartswith", str(f._server_filterer))
-        self.assertFalse(f.client_mode)
-
-    @TracebaseTestCase.assertNotWarns()
-    def test_init_client_mode(self):
-        f = BSTFilterer(
-            BSTFStudyTestModel.name.field.name,  # pylint: disable=no-member
-            BSTFStudyTestModel,
-            client_mode=True,
-        )
-        self.assertEqual(f.INPUT_METHODS.TEXT, f.input_method)
-        self.assertEqual(f.CLIENT_FILTERERS.CONTAINS, f.client_filterer)
-        self.assertIsNone(f.choices)
-        self.assertEqual(BSTFilterer.SERVER_FILTERERS.CONTAINS, f._server_filterer)
-        self.assertTrue(f.client_mode)
-
-    @TracebaseTestCase.assertNotWarns()
-    def test_filterer_client_mode(self):
-        self.assertEqual(
-            BSTFilterer.CLIENT_FILTERERS.NONE,
-            str(
-                BSTFilterer(
-                    BSTFStudyTestModel.name.field.name,  # pylint: disable=no-member
-                    BSTFStudyTestModel,
-                )
-            ),
-        )
-
-    @TracebaseTestCase.assertNotWarns()
-    def test_filterer_server_mode(self):
-        self.assertEqual(
-            BSTFilterer.CLIENT_FILTERERS.CONTAINS,
-            str(
-                BSTFilterer(
-                    BSTFStudyTestModel.name.field.name,  # pylint: disable=no-member
-                    BSTFStudyTestModel,
-                    client_mode=True,
-                )
-            ),
-        )
-
-    @TracebaseTestCase.assertNotWarns()
-    def test_str_client_mode(self):
-        self.assertEqual(
-            BSTFilterer.CLIENT_FILTERERS.NONE,
-            str(
-                BSTFilterer(
-                    BSTFStudyTestModel.name.field.name,  # pylint: disable=no-member
-                    BSTFStudyTestModel,
-                )
-            ),
-        )
-
-    @TracebaseTestCase.assertNotWarns()
-    def test_str_server_mode(self):
-        self.assertEqual(
-            BSTFilterer.CLIENT_FILTERERS.CONTAINS,
-            str(
-                BSTFilterer(
-                    BSTFStudyTestModel.name.field.name,  # pylint: disable=no-member
-                    BSTFStudyTestModel,
-                    client_mode=True,
-                )
-            ),
-        )
-
-    @TracebaseTestCase.assertNotWarns()
-    def test_script(self):
-        f = BSTFilterer(
-            BSTFStudyTestModel.name.field.name,  # pylint: disable=no-member
-            BSTFStudyTestModel,
-        )
-        self.assertEqual(
-            f"<script src='{static(BSTFilterer.script_name)}'></script>",
-            f.script,
-        )
-
-    @TracebaseTestCase.assertNotWarns()
-    def test_set_client_mode(self):
-        f = BSTFilterer(
-            BSTFStudyTestModel.name.field.name,  # pylint: disable=no-member
-            BSTFStudyTestModel,
-        )
-        self.assertFalse(f.client_mode)
-        f.set_client_mode()
-        self.assertTrue(f.client_mode)
-        f.set_client_mode(enabled=False)
-        self.assertFalse(f.client_mode)
-
-    @TracebaseTestCase.assertNotWarns()
-    def test_set_server_mode(self):
-        f = BSTFilterer(
-            BSTFStudyTestModel.name.field.name,  # pylint: disable=no-member
-            BSTFStudyTestModel,
-        )
-        f.set_server_mode()
-        self.assertFalse(f.client_mode)
-        f.set_server_mode(enabled=False)
-        self.assertTrue(f.client_mode)
 
     @TracebaseTestCase.assertNotWarns()
     def test_filter(self):
@@ -305,4 +198,4 @@ class BSTFiltererTests(TracebaseTestCase):
             BSTFStudyTestModel.name.field.name,  # pylint: disable=no-member
             BSTFStudyTestModel,
         )
-        self.assertEqual(Q(**{"name__icontains": "test"}), f.filter("test"))
+        self.assertEqual(Q(**{"name__icontains": "test"}), f.create_q_exp("test"))

--- a/DataRepo/tests/views/models/bst/column/sorter/test_annotation.py
+++ b/DataRepo/tests/views/models/bst/column/sorter/test_annotation.py
@@ -1,6 +1,5 @@
 from django.db.models import CharField, F, IntegerField
 from django.db.models.functions import Lower, Upper
-from django.templatetags.static import static
 from django.test import override_settings
 
 from DataRepo.tests.tracebase_test_case import TracebaseTestCase
@@ -162,15 +161,6 @@ class BSTAnnotSorterTests(TracebaseTestCase):
             BSTAnnotSorter(
                 Upper("name"), client_sorter="upperSorter", client_mode=True
             ).sorter,
-        )
-
-    def test_script(self):
-        s = BSTAnnotSorter(
-            "name", _server_sorter=BSTAnnotSorter.SERVER_SORTERS.ALPHANUMERIC
-        )
-        self.assertEqual(
-            f"<script src='{static(BSTAnnotSorter.script_name)}'></script>",
-            s.script,
         )
 
     @TracebaseTestCase.assertNotWarns()

--- a/DataRepo/tests/views/models/bst/column/sorter/test_field.py
+++ b/DataRepo/tests/views/models/bst/column/sorter/test_field.py
@@ -1,6 +1,5 @@
 from django.db.models import CharField, F, IntegerField
 from django.db.models.functions import Lower, Upper
-from django.templatetags.static import static
 from django.test import override_settings
 
 from DataRepo.tests.tracebase_test_case import (
@@ -103,13 +102,6 @@ class BSTSorterTests(TracebaseTestCase):
         self.assertEqual(
             BSTSorter.CLIENT_SORTERS.NONE,
             str(BSTSorter(CharField(name="name"), BSTSTestModel)),
-        )
-
-    def test_script(self):
-        s = BSTSorter(CharField(name="name"), BSTSTestModel)
-        self.assertEqual(
-            f"<script src='{static(BSTSorter.script_name)}'></script>",
-            s.script,
         )
 
     @TracebaseTestCase.assertNotWarns()

--- a/DataRepo/tests/views/models/bst/test_base.py
+++ b/DataRepo/tests/views/models/bst/test_base.py
@@ -626,6 +626,7 @@ class BSTBaseListViewTests(TracebaseTestCase):
                     "paginator",
                     "model",
                     "view",
+                    "scripts",
                     # From ListView
                     "bstblvstudytestmodel_list",  # Same as "object_list"
                     # The remainder are from this class

--- a/DataRepo/tests/views/models/bst/test_client_interface.py
+++ b/DataRepo/tests/views/models/bst/test_client_interface.py
@@ -1,5 +1,4 @@
 from django.http import HttpRequest
-from django.templatetags.static import static
 from django.test import override_settings
 
 from DataRepo.tests.tracebase_test_case import TracebaseTestCase
@@ -22,14 +21,6 @@ class BSTClientInterfaceTests(TracebaseTestCase):
 
         m = MyBSTListView()
         self.assertEqual("MyBSTListView-", m.cookie_prefix)
-
-    @TracebaseTestCase.assertNotWarns()
-    def test_script(self):
-        c = BSTClientInterface()
-        self.assertEqual(
-            f"<script src='{static(BSTClientInterface.script_name)}'></script>",
-            c.script,
-        )
 
     @TracebaseTestCase.assertNotWarns()
     def test_get_cookie_name(self):

--- a/DataRepo/tests/views/models/bst/test_client_interface.py
+++ b/DataRepo/tests/views/models/bst/test_client_interface.py
@@ -257,6 +257,7 @@ class BSTClientInterfaceTests(TracebaseTestCase):
                     "paginator",
                     "model",
                     "view",
+                    "scripts",
                 ]
             ),
             set(context.keys()),

--- a/DataRepo/tests/views/models/bst/test_list_view.py
+++ b/DataRepo/tests/views/models/bst/test_list_view.py
@@ -713,6 +713,7 @@ class BSTListViewTests(TracebaseTestCase):
                     "paginator",
                     "model",
                     "view",
+                    "scripts",
                     # From ListView
                     "bstlvstudytestmodel_list",  # Same as "object_list"
                     # From parent class

--- a/DataRepo/views/models/bst/client_interface.py
+++ b/DataRepo/views/models/bst/client_interface.py
@@ -2,8 +2,6 @@ from typing import Dict, List, Optional, Union
 from warnings import warn
 
 from django.conf import settings
-from django.templatetags.static import static
-from django.utils.safestring import mark_safe
 from django.views.generic import ListView
 
 from DataRepo.utils.exceptions import DeveloperWarning
@@ -17,7 +15,10 @@ class BSTClientInterface(ListView):
     intended to inherit from this class).  This is not intended to be used on its own.
     """
 
-    script_name = "DataRepo/static/js/bst/base.js"
+    scripts = [
+        "DataRepo/static/js/bst/cookies.js",
+        "DataRepo/static/js/bst/list_view.js",
+    ]
 
     # Template variable names
     cookie_prefix_var_name = "cookie_prefix"
@@ -42,25 +43,16 @@ class BSTClientInterface(ListView):
 
         super().__init__(**kwargs)
 
-        self.javascripts = []
+        self.javascripts: List[str]
+        if hasattr(self, "javascripts") and isinstance(self.javascripts, list):
+            self.javascripts.insert(0, BSTClientInterface.scripts)
+        else:
+            self.javascripts = [*BSTClientInterface.scripts]
+
         self.cookie_prefix = f"{self.__class__.__name__}-"
         self.cookie_warnings = []
         self.cookie_resets = []
         self.clear_cookies = False
-
-    @property
-    def script(self) -> str:
-        """Returns an HTML script tag whose source points to self.script_name.
-
-        Example:
-            # BSTClientInterface.get_context_data
-                context["bst_object"] = self
-            # Template
-                {{ bst_object.script }}
-            # Template result (assuming settings.STATIC_URL = "static/")
-                <script src='static/js/bst/base.js'></script>
-        """
-        return mark_safe(f"<script src='{static(self.script_name)}'></script>")
 
     def get_param(self, name: str, default: Optional[str] = None) -> Optional[str]:
         """Retrieves a URL parameter.

--- a/DataRepo/views/models/bst/client_interface.py
+++ b/DataRepo/views/models/bst/client_interface.py
@@ -24,6 +24,7 @@ class BSTClientInterface(ListView):
     cookie_resets_var_name = "cookie_resets"
     clear_cookies_var_name = "clear_cookies"
     model_var_name = "model"
+    scripts_var_name = "scripts"
 
     def __init__(self, **kwargs):
         """An extension of the ListView constructor intended to initialize the javascript and cookie interface.  It
@@ -41,6 +42,7 @@ class BSTClientInterface(ListView):
 
         super().__init__(**kwargs)
 
+        self.javascripts = []
         self.cookie_prefix = f"{self.__class__.__name__}-"
         self.cookie_warnings = []
         self.cookie_resets = []
@@ -297,6 +299,8 @@ class BSTClientInterface(ListView):
                 self.cookie_prefix_var_name: self.cookie_prefix,
                 self.cookie_resets_var_name: self.cookie_resets,
                 self.clear_cookies_var_name: self.clear_cookies,
+                # A unique set of javascripts needed for the BST interface
+                self.scripts_var_name: self.javascripts,
             }
         )
 

--- a/DataRepo/views/models/bst/column/annotation.py
+++ b/DataRepo/views/models/bst/column/annotation.py
@@ -34,9 +34,8 @@ class BSTAnnotColumn(BSTBaseColumn):
     You can make the searching and sorting behavior consistent by supplying a function using the converter argument in
     the constructor, like this:
 
-        BSTColumn(
+        BSTAnnotColumn(
             "imported_timestamp_str",
-            field="imported_timestamp",
             converter=Func(
                 F("imported_timestamp"),
                 Value("YYYY-MM-DD HH:MI a.m."),
@@ -44,6 +43,8 @@ class BSTAnnotColumn(BSTBaseColumn):
                 function="to_char",
             ),
         )
+
+    See the BSTBaseColumn docstring for examples on how to customize filtering and sorting behavior.
 
     The BSTSorter and BSTFilterer provided by the base class will use the annotation field for their operations.
     """

--- a/DataRepo/views/models/bst/column/base.py
+++ b/DataRepo/views/models/bst/column/base.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
-from typing import Optional, Union
+from typing import List, Optional, Union
 from warnings import warn
 
 from DataRepo.utils.exceptions import DeveloperWarning
@@ -21,6 +21,30 @@ class BSTBaseColumn(ABC):
         BSTAnnotColumn (for an annotation attached to the root Model object)
         BSTColumnGroup (used to control the sort of delimited values in multiple BSTManyRelatedColumns from the same
             related model)
+
+    Examples:
+
+        1. Customizing filtering behavior using built-in client filterers:
+
+            BSTBaseColumn(
+                "field_name",  # An annotation name or field path
+                filterer=BSTBaseFilterer.CLIENT_FILTERERS.CONTAINS,  # See BSTBaseFilterer.CLIENT_FILTERERS
+            )
+
+        2. Customizing filtering behavior using a BSTBaseFilterer object:
+
+            BSTBaseColumn(
+                "field_name",  # An annotation name or field path
+                filterer=BSTBaseFilterer(
+                    # The first arg is usually the same as the column's field_name, but can differ.  It is essentially
+                    # the resulting column object's display_field.
+                    "filter_field_name",
+                    input_method=,
+                    choices=,
+                    client_filterer=,
+                    initial=,
+                ),
+            )
     """
 
     is_annotation: bool = False
@@ -48,9 +72,9 @@ class BSTBaseColumn(ABC):
         linked: bool = False,
         sorter: Optional[Union[str, BSTBaseSorter]] = None,
         filterer: Optional[Union[str, BSTBaseFilterer]] = None,
-        th_template: str = th_template,
-        td_template: str = td_template,
-        value_template: str = value_template,
+        th_template: Optional[str] = None,
+        td_template: Optional[str] = None,
+        value_template: Optional[str] = None,
     ):
         """Defines options used to customize bootstrap table columns.
 
@@ -101,13 +125,22 @@ class BSTBaseColumn(ABC):
         self.visible = visible
         self.exported = exported
         self.linked = linked
-        self.th_template = th_template
-        self.td_template = td_template
-        self.value_template = value_template
+        self.th_template = (
+            th_template if isinstance(th_template, str) else self.th_template
+        )
+        self.td_template = (
+            td_template if isinstance(td_template, str) else self.td_template
+        )
+        self.value_template = (
+            value_template if isinstance(value_template, str) else self.value_template
+        )
 
         # Initialized below
         self.sorter: BSTBaseSorter
         self.filterer: BSTBaseFilterer
+
+        # Collect scripts of contained classes
+        self.javascripts: List[str] = []
 
         # Modified by BSTColumnGroup
         self._in_group = False
@@ -158,7 +191,6 @@ class BSTBaseColumn(ABC):
         if self.header is None:
             self.header = self.generate_header()
 
-        # NOTE: self.name will be either a field_path or an annotation field.
         # NOTE: We set a sorter even if the field is not sortable.
         if sorter is None:
             self.sorter = self.create_sorter()
@@ -171,11 +203,16 @@ class BSTBaseColumn(ABC):
                 f"sorter must be a str or a BSTBaseSorter, not a '{type(sorter).__name__}'."
             )
 
-        # NOTE: self.name will be either a field_path or an annotation field.
+        # Collect scripts of contained classes
+        if self.sorter.script_name not in self.javascripts:
+            self.javascripts.append(self.sorter.script_name)
+
         # NOTE: We set a filterer even if the field is not searchable.
         if filterer is None:
+            # We explicitly do NOT supply the name, so that we can let the derived class's method decide it
             self.filterer = self.create_filterer()
         elif isinstance(filterer, str):
+            # We explicitly do NOT supply the name, so that we can let the derived class's method decide it
             self.filterer = self.create_filterer(client_filterer=filterer)
         elif isinstance(filterer, BSTBaseFilterer):
             self.filterer = filterer
@@ -183,6 +220,10 @@ class BSTBaseColumn(ABC):
             raise TypeError(
                 f"filterer must be a str or a BSTBaseFilterer, not a '{type(filterer).__name__}'."
             )
+
+        # Collect scripts of contained classes
+        if self.filterer.script_name not in self.javascripts:
+            self.javascripts.append(self.filterer.script_name)
 
     def __str__(self):
         return self.name

--- a/DataRepo/views/models/bst/column/field.py
+++ b/DataRepo/views/models/bst/column/field.py
@@ -62,6 +62,8 @@ class BSTColumn(BSTBaseColumn):
         context rendered value (as appears in the template) does not exactly match the database's text version of the
         value, should be converted to a simple string or number annotation that is the same as seen in the rendered
         template and in the database.  See BSTAnnotColumn.
+
+    See the BSTBaseColumn docstring for examples on how to customize filtering and sorting behavior.
     """
 
     def __init__(

--- a/DataRepo/views/models/bst/column/many_related_field.py
+++ b/DataRepo/views/models/bst/column/many_related_field.py
@@ -45,6 +45,8 @@ class BSTManyRelatedColumn(BSTRelatedColumn):
                 <a href="{{ study|get_detail_url }}">{{ study }}</a>{% if not forloop.last %}{{ studycol.delim }}<br>
                 {% endif %}
             {% endfor %}
+
+    See the BSTBaseColumn docstring for examples on how to customize filtering and sorting behavior.
     """
 
     is_many_related: bool = True

--- a/DataRepo/views/models/bst/column/related_field.py
+++ b/DataRepo/views/models/bst/column/related_field.py
@@ -41,6 +41,8 @@ class BSTRelatedColumn(BSTColumn):
 
             Data Format
             Data Type Name
+
+    See the BSTBaseColumn docstring for examples on how to customize filtering and sorting behavior.
     """
 
     is_related: bool = True

--- a/DataRepo/views/models/bst/column/sorter/base.py
+++ b/DataRepo/views/models/bst/column/sorter/base.py
@@ -7,8 +7,6 @@ from django.db import ProgrammingError
 from django.db.models import F, Field
 from django.db.models.expressions import Combinable, Expression
 from django.db.models.functions import Lower
-from django.templatetags.static import static
-from django.utils.safestring import mark_safe
 
 from DataRepo.models.utilities import (
     MultipleFields,
@@ -347,20 +345,6 @@ class BSTBaseSorter(ABC):
         else:
             client_sort_key = "UNKNOWN"
         return server_sort_key != client_sort_key
-
-    @property
-    def script(self) -> str:
-        """Returns an HTML script tag whose source points to self.script_name.
-
-        Example:
-            # In the view's get_context_data
-                context["sorter"] = BSTSorter(field=Model.name.field)  # name is a CharField
-            # Template
-                {{ sorter.script }}
-            # Template result (assuming settings.STATIC_URL = "static/")
-                <script src='static/js/bst/sorter.js'></script>
-        """
-        return mark_safe(f"<script src='{static(self.script_name)}'></script>")
 
     @classmethod
     def get_server_sorter_matching_expression(cls, expression: Combinable):

--- a/DataRepo/views/models/bst/list_view.py
+++ b/DataRepo/views/models/bst/list_view.py
@@ -371,7 +371,7 @@ class BSTListView(BSTBaseListView):
         # Add individual filters, if any are defined
         for colname, filter_term in self.filter_terms.items():
             if colname in self.columns.keys():
-                q_exp &= self.columns[colname].filterer.filter(filter_term)
+                q_exp &= self.columns[colname].filterer.create_q_exp(filter_term)
             else:
                 msg = f"Column '{colname}' filter '{filter_term}' failed.  Column not found.  Resetting filter cookie."
                 self.warnings.append(msg)
@@ -406,7 +406,7 @@ class BSTListView(BSTBaseListView):
         for column in self.columns.values():
             if column.searchable:
                 # TODO: Consider making it possible to use icontains when the input method is select (for search field)
-                q_exp |= column.filterer.filter(self.search_term)
+                q_exp |= column.filterer.create_q_exp(self.search_term)
 
         return q_exp
 

--- a/static/js/cookies.js
+++ b/static/js/cookies.js
@@ -36,28 +36,34 @@ function getCookie (name, defval) { // eslint-disable-line no-unused-vars
  * accessible on every page.
  * @param {*} name Name of the cookie, e.g. "my_cookie"
  * @param {*} val The value associated with the cookie to save.
+ * @return Cookie value.
  */
 function setCookie (name, val) { // eslint-disable-line no-unused-vars
   document.cookie = name + '=' + encodeURIComponent(val) + '; path=/'
+  return val
 }
 
 /**
  * Delete a cookie
  * @param {*} name The name of the cookie to delete
+ * @return Cookie value.
  */
 function deleteCookie (name) { // eslint-disable-line no-unused-vars
   const curval = getCookie(name)
   if (typeof curval !== 'undefined' && curval) {
     document.cookie = name + '=; path=/'
   }
+  return curval
 }
 
 /**
- * Delete a cookie
+ * Delete a list of cookies.
  * @param {*} name The name of the cookie to delete
+ * @return The number of cookies deleted.
  */
 function deleteCookies (names) { // eslint-disable-line no-unused-vars
   for (let i = 0; i < names.length; i++) {
     deleteCookie(names[i])
   }
+  return names.length
 }


### PR DESCRIPTION
## Summary Change Description

Wrote tests for the `list_view`, `th`, and `td` BST templates, updated the `value` template tests, and made a bunch of changes based on those tests.

The instigating issue was populating the column select list filters.  This was done by switching from the javascript `obj` strategy in the original prototype to using the `json` strategy, so that passing the select list content could be done via the column context variables and the logic contained in the `th` template instead of it having to be handled in the overall javascript for each listview page.

Details:

- Renamed `BSTBaseFilterer.filter` method to `create_q_exp`, for clarity.  ("filter" was too overloaded)
- Removed the script property from the `filterer` and `sorter` classes, because they all refer to the same script, and importing them for each column was needlessly redundant, so I can up with a means of gathering a unique set of scripts for import and passed them to the template.  I then added them to the `list_view` template (renamed from "`base`").
- Added a `choices_json` property to `BSTBaseFilterer`, and updated the `th` template to set `data-filter-data` using its json capability.  This removes the need to handle this via javascript and contains that logic within the column object/class.
- Removed all references to "client" mode from the `sorter`/`filterer` classes, because I realized that that too was a redundant way of handling it.  I created a `TODO` to handle the client mode inside the javascript entirely.  This will have to update the `total` variable displayed in the rows per page widget and change the logic in the client `sorter`/`filterer` methods to not hit the server when the saved "original" total is equal to or less than the original rows per page.
- Fixed the way the default templates are initialized so that a setting in the derived class will override the superclass setting.  This meant that the default for the constructor had to be `None` and they had to be set via `self` inside the constructor.  Having them set in the function prototype does not provide access to the derived class override.
- Fixed an as-yet unencountered minor bug in determining column type.
- Fixed a bad template name setting that didn't start from `/DataRepo/templates`
- Fixed `context` variables in the `th` template.
- Fleshed the `list_view` template with script imports and fixed some context variables.

## Affected Issues/Pull Requests

- Resolves #1560 (and finishes off work that should have been a part of other issues, but was neglected/overlooked)
- Merges into branch `bstlv6_templates`

## Reviewer Notes/Requests
<!-- Notes to help the reviewer or requests for specific scrutiny.
E.g. Please make sure I have accounted for all possible inputs. -->
See comments in-line.

## Checklist
<!-- If any requirements are not met, uncheck and explain.
E.g. Linting errors pre-date this PR. -->
This pull request will be merged once the following requirements are met.  The
author and/or reviewers should uncheck any unmet requirements:
<!-- Check/complete items if not applicable. -->
- Review Requirements
  - Minimum approvals: 1 <!-- Edit based on complexity. -->
  - No changes requested
  - All blocking issues resolved by reviewers
  - Specific reviewers: @__add_username_here__ <!-- Approvals required even if minimum met. -->
  - Review period: 2 days <!-- Edit based on complexity. -->
- Associated Issue/PR Requirements: <!-- Assert resolved issues/PRs are done/merged. -->
  - [x] All issue requirements are satisfied
  - [x] All PR dependencies are merged
- Basic Requirements <!-- Uncheck to indicate items you are yet to address. -->
  - [x] [Linters pass](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#linting)
  - [x] [Tests pass](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#quality-control)
  - [x] Conflicts resolved
- Overhead Requirements <!-- Requirements indirectly related to the issues. -->
  - [x] [Tests implemented/updated](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#test-implementation)
  - [ ] [Updated `CHANGELOG.md` *Unreleased* section](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/changelog.md)
