### PR TITLE
`BSTListView` 15.2: Fixed a header naming issue with reverse relations

### DIFF
--- a/DataRepo/tests/views/models/bst/column/test_field.py
+++ b/DataRepo/tests/views/models/bst/column/test_field.py
@@ -84,12 +84,12 @@ class BSTColumnTests(TracebaseTestCase):
     def test_init_field_path_required(self):
         # Test ValueError - "field_path is required"
         with self.assertRaises(ValueError) as ar:
-            BSTColumn(None, model=BSTCStudyTestModel)
+            BSTColumn(None, BSTCStudyTestModel)
         self.assertIn("field_path is required", str(ar.exception))
 
     def test_init_suggest_annot(self):
         with self.assertRaises(AttributeError) as ar:
-            BSTColumn("annot", model=BSTCStudyTestModel)
+            BSTColumn("annot", BSTCStudyTestModel)
         self.assertIn("('annot') is not an attribute", str(ar.exception))
         self.assertIn("BSTAnnotColumn", str(ar.exception))
 
@@ -97,17 +97,17 @@ class BSTColumnTests(TracebaseTestCase):
         # Test self.name == self.field_path
         mdl = BSTCStudyTestModel
         fld = "name"
-        c = BSTColumn(fld, model=mdl)
+        c = BSTColumn(fld, mdl)
         self.assertEqual(fld, c.name)
-        # Test if sorter is None - self.sorter = BSTSorter(self.field_path, model=self.model)
-        self.assertEqual(BSTSorter(fld, model=mdl), c.sorter)
-        # Test if filterer is None - self.filterer = BSTFilterer(model=self.model, field_path=self.field_path)
-        self.assertEqual(BSTFilterer(field_path=fld, model=mdl), c.filterer)
+        # Test if sorter is None - self.sorter = BSTSorter(self.field_path, self.model)
+        self.assertEqual(BSTSorter(fld, mdl), c.sorter)
+        # Test if filterer is None - self.filterer = BSTFilterer(self.model, self.field_path)
+        self.assertEqual(BSTFilterer(fld, mdl), c.filterer)
 
     def test_init_no_many_related(self):
         # Test if is_many_related and not self.is_many_related and not self.is_annotation - ValueError
         with self.assertRaises(ValueError) as ar:
-            BSTColumn("studies__name", model=BSTCAnimalTestModel)
+            BSTColumn("studies__name", BSTCAnimalTestModel)
         self.assertIn("must not be many-related", str(ar.exception))
         self.assertIn(
             "use BSTManyRelatedColumn to create a delimited-value column",
@@ -117,7 +117,7 @@ class BSTColumnTests(TracebaseTestCase):
     def test_init_donot_link_related(self):
         # Test if self.link and "__" in self.field_path - ValueError
         with self.assertRaises(ValueError) as ar:
-            BSTColumn("animal__body_weight", model=BSTCSampleTestModel, linked=True)
+            BSTColumn("animal__body_weight", BSTCSampleTestModel, linked=True)
         self.assertIn(
             "'linked' must not be true when 'field_path' 'animal__body_weight' passes through a related model",
             str(ar.exception),
@@ -126,27 +126,27 @@ class BSTColumnTests(TracebaseTestCase):
     def test_init_link_needs_get_abs_url(self):
         # Test if self.link and no get_absolute_url - ValueError
         with self.assertRaises(ValueError) as ar:
-            BSTColumn("name", model=BSTCStudyTestModel, linked=True)
+            BSTColumn("name", BSTCStudyTestModel, linked=True)
         self.assertIn(
             "'linked' must not be true when model 'BSTCStudyTestModel' does not have a 'get_absolute_url'",
             str(ar.exception),
         )
         # No error = successful test:
-        BSTColumn("body_weight", model=BSTCAnimalTestModel, linked=True)
+        BSTColumn("body_weight", BSTCAnimalTestModel, linked=True)
 
     def test_init_sorter_filterer_str(self):
-        # Test if sorter is None - self.sorter = BSTSorter(self.field_path, model=self.model)
-        # Test if filterer is None - self.filterer = BSTFilterer(model=self.model, field_path=self.field_path)
+        # Test if sorter is None - self.sorter = BSTSorter(self.field_path, self.model)
+        # Test if filterer is None - self.filterer = BSTFilterer(self.model, self.field_path)
         mdl = BSTCStudyTestModel
         fld = "name"
         my_sorter = "mySorter"
         my_filterer = "myFilterer"
-        c = BSTColumn(fld, model=mdl, sorter=my_sorter, filterer=my_filterer)
+        c = BSTColumn(fld, mdl, sorter=my_sorter, filterer=my_filterer)
         self.assertEqual(
-            str(BSTSorter(fld, model=mdl, client_sorter=my_sorter)), str(c.sorter)
+            str(BSTSorter(fld, mdl, client_sorter=my_sorter)), str(c.sorter)
         )
         self.assertEqual(
-            str(BSTFilterer(field_path=fld, model=mdl, client_filterer=my_filterer)),
+            str(BSTFilterer(fld, mdl, client_filterer=my_filterer)),
             str(c.filterer),
         )
 
@@ -157,9 +157,9 @@ class BSTColumnTests(TracebaseTestCase):
         fld = "name"
         my_sorter = "mySorter"
         my_filterer = "myFilterer"
-        bsts = BSTSorter(fld, model=mdl, client_sorter=my_sorter)
-        bstf = BSTFilterer(field_path=fld, model=mdl, client_filterer=my_filterer)
-        c = BSTColumn(fld, model=mdl, sorter=bsts, filterer=bstf)
+        bsts = BSTSorter(fld, mdl, client_sorter=my_sorter)
+        bstf = BSTFilterer(fld, mdl, client_filterer=my_filterer)
+        c = BSTColumn(fld, mdl, sorter=bsts, filterer=bstf)
         self.assertEqual(bsts, c.sorter)
         self.assertEqual(bstf, c.filterer)
 
@@ -168,7 +168,7 @@ class BSTColumnTests(TracebaseTestCase):
         mdl = BSTCStudyTestModel
         fld = "name"
         with self.assertRaises(TypeError) as ar:
-            BSTColumn(fld, model=mdl, sorter=1)
+            BSTColumn(fld, mdl, sorter=1)
         self.assertIn(
             "sorter must be a str or a BSTBaseSorter, not a 'int'", str(ar.exception)
         )
@@ -178,26 +178,26 @@ class BSTColumnTests(TracebaseTestCase):
         mdl = BSTCStudyTestModel
         fld = "name"
         with self.assertRaises(TypeError) as ar:
-            BSTColumn(fld, model=mdl, filterer=1)
+            BSTColumn(fld, mdl, filterer=1)
         self.assertIn(
             "filterer must be a str or a BSTBaseFilterer, not a 'int'",
             str(ar.exception),
         )
 
     def test_init_is_fk(self):
-        self.assertTrue(BSTColumn("animal", model=BSTCSampleTestModel).is_fk)
-        self.assertFalse(BSTColumn("name", model=BSTCSampleTestModel).is_fk)
+        self.assertTrue(BSTColumn("animal", BSTCSampleTestModel).is_fk)
+        self.assertFalse(BSTColumn("name", BSTCSampleTestModel).is_fk)
         # TODO: Put this test in the tests for BSTRelatedColumn
-        # self.assertTrue(BSTColumn("animal__studies", model=BSTCSampleTestModel).is_fk)
-        # self.assertFalse(BSTColumn("animal__studies__name", model=BSTCSampleTestModel).is_fk)
+        # self.assertTrue(BSTColumn("animal__studies", BSTCSampleTestModel).is_fk)
+        # self.assertFalse(BSTColumn("animal__studies__name", BSTCSampleTestModel).is_fk)
 
     def test_eq(self):
         # Test __eq__ works when other val is string
         sexfldp = "sex"
         bwfldp = "body_weight"
-        sexcol = BSTColumn(sexfldp, model=BSTCAnimalTestModel)
-        sexcol2 = BSTColumn(sexfldp, model=BSTCAnimalTestModel)
-        bwcol = BSTColumn(bwfldp, model=BSTCAnimalTestModel)
+        sexcol = BSTColumn(sexfldp, BSTCAnimalTestModel)
+        sexcol2 = BSTColumn(sexfldp, BSTCAnimalTestModel)
+        bwcol = BSTColumn(bwfldp, BSTCAnimalTestModel)
         self.assertTrue(sexcol == sexfldp)
         self.assertFalse(sexcol == bwfldp)
         self.assertTrue(bwcol == bwfldp)
@@ -206,7 +206,7 @@ class BSTColumnTests(TracebaseTestCase):
 
     def test_generate_header_field_verbose_name(self):
         # Test if field has verbose name with caps - return field.verbose_name
-        c = BSTColumn("body_weight", model=BSTCAnimalTestModel)
+        c = BSTColumn("body_weight", BSTCAnimalTestModel)
         bwh = c.generate_header()
         self.assertEqual(
             BSTCAnimalTestModel.body_weight.field.verbose_name,  # pylint: disable=no-member
@@ -216,13 +216,13 @@ class BSTColumnTests(TracebaseTestCase):
 
     def test_generate_header_field_name_to_model_name(self):
         # Test if self.field_path == "name" and is_unique_field(field) - Use the model's name
-        c = BSTColumn("name", model=BSTCSampleTestModel)
+        c = BSTColumn("name", BSTCSampleTestModel)
         sh = c.generate_header()
         self.assertEqual(camel_to_title("BSTCSampleTestModel"), sh)
 
     def test_generate_header_field_name_to_model_cap_verbose_name(self):
         # Test caps model verbose_name used as-is
-        c = BSTColumn("name", model=BSTCStudyTestModel)
+        c = BSTColumn("name", BSTCStudyTestModel)
         sh = c.generate_header()
         self.assertEqual(
             BSTCStudyTestModel._meta.__dict__[  # pylint: disable=no-member
@@ -233,7 +233,7 @@ class BSTColumnTests(TracebaseTestCase):
 
     def test_generate_header_field_name_to_model_diff_verbose_name(self):
         # Test diff model verbose_name used as-is
-        c = BSTColumn("name", model=BSTCAnimalTestModel)
+        c = BSTColumn("name", BSTCAnimalTestModel)
         ah = c.generate_header()
         self.assertEqual(
             underscored_to_title(
@@ -246,18 +246,6 @@ class BSTColumnTests(TracebaseTestCase):
 
     def test_generate_header_field_name_not_unique_not_changed_to_model_name(self):
         # Test diff model verbose_name used as-is
-        c = BSTColumn("name", model=BSTCTissueTestModel)
+        c = BSTColumn("name", BSTCTissueTestModel)
         th = c.generate_header()
         self.assertEqual(underscored_to_title("name"), th)
-
-    def test_generate_header_related_model_name_field_to_fkey_name(self):
-        # Test when related model unique field, uses foreign key name when field is "name"
-        c = BSTColumn("animal__name", model=BSTCSampleTestModel)
-        ah = c.generate_header()
-        self.assertEqual(underscored_to_title("animal"), ah)
-
-    def test_generate_header_related_model_uses_last_fkey(self):
-        # Test that every other field uses - underscored_to_title("_".join(path_tail))
-        c = BSTColumn("sample__animal__sex", model=BSTCMSRunSampleTestModel)
-        sh = c.generate_header()
-        self.assertEqual(underscored_to_title("animal_sex"), sh)

--- a/DataRepo/tests/views/models/bst/column/test_many_related_field.py
+++ b/DataRepo/tests/views/models/bst/column/test_many_related_field.py
@@ -16,6 +16,7 @@ from DataRepo.tests.tracebase_test_case import (
     create_test_model,
 )
 from DataRepo.utils.exceptions import DeveloperWarning
+from DataRepo.utils.text_utils import underscored_to_title
 from DataRepo.views.models.bst.column.many_related_field import (
     BSTManyRelatedColumn,
 )
@@ -252,3 +253,9 @@ class BSTManyRelatedColumnTests(TracebaseTestCase):
                 "samples__animal__body_weight", BSTMRCTissueTestModel
             ),
         )
+
+    def test_generate_header_reverse_related_model_uses_last_fkey(self):
+        # Test that reverse relations use the related_name
+        c = BSTManyRelatedColumn("msrun_samples__name", BSTMRCSampleTestModel)
+        sh = c.generate_header()
+        self.assertEqual(underscored_to_title("msrun_samples"), sh)

--- a/DataRepo/tests/views/models/bst/column/test_related_field.py
+++ b/DataRepo/tests/views/models/bst/column/test_related_field.py
@@ -13,6 +13,7 @@ from DataRepo.tests.tracebase_test_case import (
     create_test_model,
 )
 from DataRepo.utils.exceptions import DeveloperWarning
+from DataRepo.utils.text_utils import underscored_to_title
 from DataRepo.views.models.bst.column.related_field import BSTRelatedColumn
 
 BSTRCStudyTestModel = create_test_model(
@@ -29,7 +30,7 @@ BSTRCStudyTestModel = create_test_model(
 BSTRCAnimalTestModel = create_test_model(
     "BSTRCAnimalTestModel",
     {
-        "name": CharField(max_length=255),
+        "name": CharField(max_length=255, unique=True),
         "sex": CharField(choices=[("F", "female"), ("M", "male")]),
         "body_weight": FloatField(verbose_name="Weight (g)"),
         "studies": ManyToManyField(
@@ -280,3 +281,15 @@ class BSTRelatedColumnTests(TracebaseTestCase):
         self.assertIn(
             "Supply display_field_path to allow search/sort", str(ar.exception)
         )
+
+    def test_generate_header_related_model_name_field_to_fkey_name(self):
+        # Test when related model unique field, uses foreign key name when field is "name"
+        c = BSTRelatedColumn("animal__name", BSTRCSampleTestModel)
+        ah = c.generate_header()
+        self.assertEqual(underscored_to_title("animal"), ah)
+
+    def test_generate_header_related_model_uses_last_fkey(self):
+        # Test that every other field uses - underscored_to_title("_".join(path_tail))
+        c = BSTRelatedColumn("sample__animal__sex", BSTRCMSRunSampleTestModel)
+        sh = c.generate_header()
+        self.assertEqual(underscored_to_title("animal_sex"), sh)

--- a/DataRepo/views/models/bst/column/field.py
+++ b/DataRepo/views/models/bst/column/field.py
@@ -141,8 +141,11 @@ class BSTColumn(BSTBaseColumn):
         super().__init__(name, *args, **kwargs)
 
     def generate_header(self):
-        """Generate a column header from the field_path, model name, or column name.
+        """Generate a column header from the field_path, field.name, or the field's verbose_name.
+        Overrides super().generate_header.
 
+        Assumptions:
+            1. self.field_path contains no dunderscores.  I.e. this is a field directly on self.model.
         Args:
             None
         Exceptions:
@@ -150,7 +153,7 @@ class BSTColumn(BSTBaseColumn):
         Returns:
             None
         """
-        # If the field has a verbose name different from name, use it
+        # If the field has a verbose name different from name (because it's automatically filled in with name), use it
         if self.field.name != self.field.verbose_name:
             if any(c.isupper() for c in self.field.verbose_name):
                 # If the field has a verbose name with caps, use it as-is
@@ -180,19 +183,8 @@ class BSTColumn(BSTBaseColumn):
                 # Use the model name
                 return camel_to_title(self.model.__name__)
 
-        # Grab as many of the last 2 items from the field_path as is present
-        path_tail = self.field_path.split("__")[-2:]
-
-        # If the length is 2, the last element is "name", and the field is unique, use the related model name
-        if (
-            len(path_tail) == 2
-            and path_tail[1] == "name"
-            and is_unique_field(self.field)
-        ):
-            return underscored_to_title(path_tail[0])
-
-        # Default is to use the last 2 elements of the path
-        return underscored_to_title("_".join(path_tail))
+        # Default is to use the field name, as saved in the field_path.  Assumed to not be dunderscored.
+        return underscored_to_title(self.field_path)
 
     def create_sorter(
         self, field: Optional[Union[Combinable, Field, str]] = None, **kwargs


### PR DESCRIPTION
## Summary Change Description

Fixed an issue where the headers for reverse related fields were being derived from the related model's field name instead of from the foreign key name (which provides context).

Details:

- Added override method BSTRelatedColumn.generate_header.
- Removed related model logic from BSTColumn.generate_header.
- Fixed constructor arguments given as keyword arguments in test_field.py.
- Added `unique=True` to the temp Animal model in test_related_field.py in order to test generated headfers of reverse relations.

Examples from the Sample List page:

- Header for reverse related field `Animal.last_serum_sample` (whose `related_name` is `animals`) was getting a generated header of `Last Serum Sample` and now is `Animals`
  - Note: `animals` is a bad related name, but that is a separate issue from this work.  It is bad for a couple reasons: 1. It is a 1:1 relationship, so should not be plural.  2. It provides no context from the `Sample` perspective that differentiates it from its other reverse relation to `animals` directly.
  - Also note: This (default-added) column contributes no meaningful information from the context of a sample (list).  That is also a separate issue, for which I intend to exclude the column from the sample list page.
- Header for reverse related field `FCirc.serum_sample` (whose `related_name` is `fcircs`) was getting a generated header of `Serum Sample`and now is `Fcircs`
  - Note: This (default-added) column is not intended to be added to the Sample List page.  Excluding it is a separate issue.

## Affected Issues/Pull Requests

- Partially addresses #1585
  - Specifically, this fixes the following issues documented in [this comment](https://github.com/Princeton-LSI-ResearchComputing/tracebase/issues/1585#issuecomment-2968130096).  This defines the entire scope of this PR:
    - Reverse relation headers should be based on the related name, not the field name in the related model:
      - `Last Serum Sample` (`animals`)
      - `Serum Sample` (`fcircs`)
- Merges into branch `bstlv15_sample_list`

## Reviewer Notes/Requests
<!-- Notes to help the reviewer or requests for specific scrutiny.
E.g. Please make sure I have accounted for all possible inputs. -->
See comments in-line.

## Checklist
<!-- If any requirements are not met, uncheck and explain.
E.g. Linting errors pre-date this PR. -->
This pull request will be merged once the following requirements are met.  The
author and/or reviewers should uncheck any unmet requirements:
<!-- Check/complete items if not applicable. -->
- Review Requirements
  - Minimum approvals: 1 <!-- Edit based on complexity. -->
  - No changes requested
  - All blocking issues resolved by reviewers
  - Specific reviewers: @__add_username_here__ <!-- Approvals required even if minimum met. -->
  - Review period: 2 days <!-- Edit based on complexity. -->
- Associated Issue/PR Requirements: <!-- Assert resolved issues/PRs are done/merged. -->
  - [x] All issue requirements are satisfied
  - [x] All PR dependencies are merged
- Basic Requirements <!-- Uncheck to indicate items you are yet to address. -->
  - [x] [Linters pass](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#linting)
  - [x] [Tests pass](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#quality-control)
  - [x] Conflicts resolved
- Overhead Requirements <!-- Requirements indirectly related to the issues. -->
  - [x] [Tests implemented/updated](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#test-implementation)
  - [ ] [Updated `CHANGELOG.md` *Unreleased* section](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/changelog.md)
