### PR TITLE
`BSTListView` 15.3: Fixed cookie init strategy

### DIFF
--- a/DataRepo/templates/models/bst/scripts.html
+++ b/DataRepo/templates/models/bst/scripts.html
@@ -31,6 +31,14 @@
             warnings,
             cookieResets,
             '{{ clear_cookies }}',
+            // Cookie (and URL parameter) names for the javascript to use
+            '{{ sort_cookie_name }}',
+            '{{ asc_cookie_name }}',
+            '{{ search_cookie_name }}',
+            '{{ filter_cookie_name }}',
+            '{{ visible_cookie_name }}',
+            '{{ limit_cookie_name }}',
+            '{{ page_cookie_name }}',
         )
     });
 </script>

--- a/DataRepo/tests/static/js/bst/test_list_view.js
+++ b/DataRepo/tests/static/js/bst/test_list_view.js
@@ -363,18 +363,25 @@ QUnit.test('initBST', function (assert) {
 
   // First call - this satisfies most of the tests
   initBST(
-    10, // limit,
-    15, // limitDefault,
-    'TTID', // tableID,
-    'PFX-', // cookiePrefix,
-    2, // pageNumber,
-    10, // perPage,
-    100, // total,
-    120, // rawTotal,
-    window.location.href.split('?')[0], // currentURL,
-    ['WX'], // warnings,
-    ['TC'], // cookieResets,
-    'false' // clearCookies,
+    10, // limit
+    15, // limitDefault
+    'TTID', // tableID
+    'PFX-', // cookiePrefix
+    2, // pageNumber
+    10, // perPage
+    100, // total
+    120, // rawTotal
+    window.location.href.split('?')[0], // currentURL
+    ['WX'], // warnings
+    ['TC'], // cookieResets
+    'false', // clearCookies
+    'sortcol', // sort cookie name
+    'asc', // asc cookie name
+    'search', // search cookie name
+    'filter', // filter cookie name
+    'visible', // visible cookie name
+    'limit', // limit cookie name
+    'page' // page cookie name
   )
 
   // NOTE: No need to test that cookiePrefix is set.  If it is not, none of the cookie tests would work.
@@ -397,18 +404,25 @@ QUnit.test('initBST', function (assert) {
   // Second call - this satisfies the tests for the limit being 0 and the clearCookies test
   setViewCookie('TC', 'xx')
   initBST(
-    0, // limit,
-    15, // limitDefault,
-    'TTID', // tableID,
-    'PFX-', // cookiePrefix,
-    2, // pageNumber,
-    10, // perPage,
-    100, // total,
-    120, // rawTotal,
-    window.location.href.split('?')[0], // currentURL,
-    [], // warnings,
-    [], // cookieResets,
-    'true' // clearCookies,
+    0, // limit
+    15, // limitDefault
+    'TTID', // tableID
+    'PFX-', // cookiePrefix
+    2, // pageNumber
+    10, // perPage
+    100, // total
+    120, // rawTotal
+    window.location.href.split('?')[0], // currentURL
+    [], // warnings
+    [], // cookieResets
+    'true', // clearCookies
+    'sortcol', // sort cookie name
+    'asc', // asc cookie name
+    'search', // search cookie name
+    'filter', // filter cookie name
+    'visible', // visible cookie name
+    'limit', // limit cookie name
+    'page' // page cookie name
   )
   // A limit of 0 is allowed when there is no URL parameter override and it's not coming from a cookie.
   assert.equal(getViewCookie('limit'), '0')
@@ -421,19 +435,26 @@ QUnit.test('initBST', function (assert) {
   // out.
   setViewCookie('limit', '0')
   initBST(
-    10, // limit,
-    15, // limitDefault,
+    10, // limit
+    15, // limitDefault
     // The rest of the parameters don't matter for this test, but they are required.
-    'TTID', // tableID,
-    'PFX-', // cookiePrefix,
-    2, // pageNumber,
-    10, // perPage,
-    100, // total,
-    120, // rawTotal,
-    window.location.href.split('?')[0], // currentURL,
-    [], // warnings,
-    [], // cookieResets,
-    'false' // clearCookies,
+    'TTID', // tableID
+    'PFX-', // cookiePrefix
+    2, // pageNumber
+    10, // perPage
+    100, // total
+    120, // rawTotal
+    window.location.href.split('?')[0], // currentURL
+    [], // warnings
+    [], // cookieResets
+    'false', // clearCookies,
+    'sortcol', // sort cookie name
+    'asc', // asc cookie name
+    'search', // search cookie name
+    'filter', // filter cookie name
+    'visible', // visible cookie name
+    'limit', // limit cookie name
+    'page' // page cookie name
   )
   // A limit of 0 is allowed when there is no URL parameter override.
   assert.equal(getViewCookie('limit'), '15')

--- a/DataRepo/tests/templates/models/bst/test_list_view.py
+++ b/DataRepo/tests/templates/models/bst/test_list_view.py
@@ -85,6 +85,7 @@ class BSTListViewTests(BaseTemplateTests):
     def test_script_imports(self):
         request = HttpRequest()
         slv = StudyLV(request=request)
+        slv.init_interface()
         template_str = self.render_list_view_template(slv)
         expected_substrings = [
             '<script id="warnings" type="application/json">[]</script>',
@@ -97,6 +98,7 @@ class BSTListViewTests(BaseTemplateTests):
     def test_warnings(self):
         request = HttpRequest()
         slv = StudyLV(request=request)
+        slv.init_interface()
         slv.warnings.append("THIS IS A WARNING")
         slv.warnings.append("THIS IS A SECOND WARNING")
         template_str = self.render_list_view_template(slv)
@@ -113,6 +115,7 @@ class BSTListViewTests(BaseTemplateTests):
     def test_cookie_resets(self):
         request = HttpRequest()
         slv = StudyLV(request=request)
+        slv.init_interface()
         slv.cookie_resets.append("test")
         template_str = self.render_list_view_template(slv)
         expected = '<script id="cookieResets" type="application/json">["test"]</script>'
@@ -124,6 +127,7 @@ class BSTListViewTests(BaseTemplateTests):
     def test_id_title(self):
         request = HttpRequest()
         slv = StudyLV(request=request)
+        slv.init_interface()
         template_str = self.render_list_view_template(slv)
         expected_substrings = [
             "<h4>BTT Study Test Models</h4>",
@@ -134,6 +138,7 @@ class BSTListViewTests(BaseTemplateTests):
     def test_default_table_attributes(self):
         request = HttpRequest()
         slv = StudyLV(request=request)
+        slv.init_interface()
         template_str = self.render_list_view_template(slv)
         expected_substrings = [
             '<table class="table table-sm table-hover table-bordered table-responsive-xl table-striped"',
@@ -173,6 +178,7 @@ class BSTListViewTests(BaseTemplateTests):
             {f"{StudyLV.__name__}-{StudyLV.search_cookie_name}": "test"}
         )
         slv = StudyLV(request=request)
+        slv.init_interface()
         template_str = self.render_list_view_template(slv)
         expected = 'data-search-text="test"'
         # assertIn has really ugly failure output.  assertTrue with msg set is better
@@ -185,6 +191,7 @@ class BSTListViewTests(BaseTemplateTests):
         request = HttpRequest()
 
         slv = StudyLV(request=request)
+        slv.init_interface()
         template_str = self.render_list_view_template(slv)
         expected_ordered_substrings = [
             '<th data-field="name"',
@@ -227,6 +234,7 @@ class BSTListViewTests(BaseTemplateTests):
 
         # Default sort
         slv = StudyLV(request=request)
+        slv.init_interface()
         template_str = self.render_list_view_template(slv)
         expected_ordered_substrings = [
             # NOTE: The default order is determined by the model's ordering (which is descending)
@@ -243,6 +251,7 @@ class BSTListViewTests(BaseTemplateTests):
             }
         )
         slv1 = StudyLV(request=request)
+        slv1.init_interface()
         template_str = self.render_list_view_template(slv1)
         expected_substrings = [
             'data-sort-name="name"',
@@ -260,6 +269,7 @@ class BSTListViewTests(BaseTemplateTests):
             }
         )
         slv2 = StudyLV(request=request)
+        slv2.init_interface()
         template_str = self.render_list_view_template(slv2)
         expected_substrings = [
             'data-sort-name="name"',
@@ -272,6 +282,7 @@ class BSTListViewTests(BaseTemplateTests):
         # Default ascending sort (derived from the model's ordering?)
         request.COOKIES = {f"{StudyLV.__name__}-{StudyLV.sortcol_cookie_name}": "name"}
         slv3 = StudyLV(request=request)
+        slv3.init_interface()
         template_str = self.render_list_view_template(slv3)
         expected_substrings = [
             'data-sort-name="name"',
@@ -284,6 +295,7 @@ class BSTListViewTests(BaseTemplateTests):
     def test_paginator_added(self):
         request = HttpRequest()
         slv1 = StudyLV(request=request)
+        slv1.init_interface()
         template_str = self.get_massaged_template_str(
             self.render_list_view_template(slv1)
         )

--- a/DataRepo/tests/tracebase_test_case.py
+++ b/DataRepo/tests/tracebase_test_case.py
@@ -136,7 +136,7 @@ def test_case_class_factory(base_class: Type[T]) -> Type[T]:
             self.assertEqual(
                 set([k for k in d1.keys() if k not in ignores]),
                 set([k for k in d2.keys() if k not in ignores]),
-                msg="keys differ",
+                msg=f"Object path: {_path} difference: keys differ",
             )
             for key, v1 in d1.items():
                 if key in ignores:


### PR DESCRIPTION
## Summary Change Description

See the Affected Issues section for the issues that this PR addresses.  Review of this PR is limited to satisfying those specific issues.

The strategy I'd used to initialize cookies in the constructor worked for tests, but when there's a real view, Django is the one calling the view constructor, and it doesn't supply the request object..

I had been lead astray by some example code online and in Django documentation that showed the request object being supplied to a view's constructor, which I'd assumed is how the django view constructors are called.  Doing so works, but apparently when a `GET` request comes in, the constructor is not supplied the request.  The first place that's available is in the `get` method.  I tried initially to simply move code into `get` method extensions, but that wasn't good enough, because the django superclass's `get` method calls `get_queryset`, so I could not hierarchically handle all of the cookie operations in the right order before `get_queryset` was called.  The way I solved it is annoyingly less encapsulated than before, but at least it's all contained in the BST superclasses and should not be an issue that derived classes have to deal with.

What is more annoying was that I'd brought this up in the Django forum and I was told that how I was doing it wasn't the way they usually do it, but that it _should_ work, and only served to "organize" the code.  I'll probably head into that form after I submit this PR and report back about the roadblock this encountered.

Details:

- Added init_interface methods to BSTClientInterface, BSTBaseListView, and BSTListView that handle all of the cookie initializations formerly handled in the constructors (because the request object isn't passed from Django.
- Extended BSTListView.get to call init_interface.
- Added cookie name variables to the context and initBST javascript call.
- Minor change to cookie reset warning message.
- A default sort column is always selected now.
- Constructors now initialize default values before the cookie values are available.
- Filter terms are now processed in BSTBaseListView to set column.filterer.initial values so that user filter terms are preserved in the filter boxes.
- Bad filter column names are now removed from the filter_terms instance member in BSTBaseListView so that the Q expression generation in BSTListView doesn't encounter it.
- The scripts.html template was updated to add the cookie names to the initBST call.
- All hard-coded cookie name references were replaced with variables in list_view.js (also included the page and limit URL parameters).

## Affected Issues/Pull Requests

- Partially addresses #1585
  - Specifically, this PR addresses these issues in [this comment](https://github.com/Princeton-LSI-ResearchComputing/tracebase/issues/1585#issuecomment-2968130096):
    - None of the cookies are working (sorting doesn't sort, filtering doesn't filter, searching doesn't search)
    - Entering a limit param to the URL doesn't change the rows per page
- Merges into branch `bstlv15_sample_list2_revrel`

## Reviewer Notes/Requests

![qunitcookienamefix](https://github.com/user-attachments/assets/eb1ccdb4-1651-4698-822e-74408aa331bd)

## Checklist
<!-- If any requirements are not met, uncheck and explain.
E.g. Linting errors pre-date this PR. -->
This pull request will be merged once the following requirements are met.  The
author and/or reviewers should uncheck any unmet requirements:
<!-- Check/complete items if not applicable. -->
- Review Requirements
  - Minimum approvals: 1 <!-- Edit based on complexity. -->
  - No changes requested
  - All blocking issues resolved by reviewers
  - Specific reviewers: @__add_username_here__ <!-- Approvals required even if minimum met. -->
  - Review period: 2 days <!-- Edit based on complexity. -->
- Associated Issue/PR Requirements: <!-- Assert resolved issues/PRs are done/merged. -->
  - [x] All issue requirements are satisfied
  - [x] All PR dependencies are merged
- Basic Requirements <!-- Uncheck to indicate items you are yet to address. -->
  - [x] [Linters pass](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#linting)
  - [x] [Tests pass](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#quality-control)
  - [x] Conflicts resolved
- Overhead Requirements <!-- Requirements indirectly related to the issues. -->
  - [x] [Tests implemented/updated](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#test-implementation)
  - [ ] [Updated `CHANGELOG.md` *Unreleased* section](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/changelog.md)
