### PR TITLE
`BSTListView` 15.6: Fixed sort of annotation columns

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -136,9 +136,14 @@ dmypy.json
 .pyre/
 archive
 
-# Robs custom ignores - I use the following file that I haven't made into an "app" yet
-DataRepo/management/commands/list_tests.py
+# Node linters
 node_modules
 package-lock.json
 package.json
 *.patch
+
+# Scratch files
+scratch.*
+
+# Robs custom ignores - I use the following file that I haven't made into an "app" yet
+DataRepo/management/commands/list_tests.py

--- a/DataRepo/templatetags/bsttags.py
+++ b/DataRepo/templatetags/bsttags.py
@@ -59,21 +59,33 @@ def get_rec_val(rec: Model, column: BSTBaseColumn) -> Any:
         (Any): a field value or a list of field values (if the column is from a field in a many-related model)
     """
     if isinstance(column, BSTManyRelatedColumn):
-        default: list = []
+        list_default: list = []
         try:
             vals = getattr(rec, column.list_attr_name)
         except AttributeError as ae:
             if settings.DEBUG:
                 warn(
                     f"Attribute '{column.list_attr_name}' not found in '{type(rec).__name__}' record: '{rec}'.\n"
-                    f"Returning default '{default}'.\n"
+                    f"Returning default '{list_default}'.\n"
                     f"Original error: {type(ae).__name__}: {str(ae)}",
                     category=DeveloperWarning,
                     stacklevel=0,
                 )
-            vals = default
+            vals = list_default
         return vals
-    return get_field_val_by_iteration(rec, column.name.split("__"))
+
+    default = "ERROR"
+    try:
+        val = get_field_val_by_iteration(rec, column.name.split("__"))
+    except AttributeError as ae:
+        warning = (
+            f"A problem was encountered while processing {type(column).__name__} '{column}':\n"
+            f"Exception: {type(ae).__name__}: {ae}"
+        )
+        warn(warning, DeveloperWarning)
+        val = default
+
+    return val
 
 
 @register.filter

--- a/DataRepo/tests/views/models/bst/column/sorter/test_base.py
+++ b/DataRepo/tests/views/models/bst/column/sorter/test_base.py
@@ -1,0 +1,46 @@
+from django.db.models import Value
+from django.test import override_settings
+
+from DataRepo.tests.tracebase_test_case import TracebaseTestCase
+from DataRepo.views.models.bst.column.sorter.base import BSTBaseSorter
+
+
+class TestAnnotSorter(BSTBaseSorter):
+    is_annotation = True
+
+
+class TestFieldSorter(BSTBaseSorter):
+    pass
+
+
+@override_settings(DEBUG=True)
+class BSTBaseSorterTests(TracebaseTestCase):
+    def test_init_annot_name(self):
+        self.assertEqual(
+            "whatever" + BSTBaseSorter.sort_annot_suffix,
+            TestAnnotSorter("whatever", Value(1)).annot_name,
+        )
+        self.assertEqual(
+            "whatever" + BSTBaseSorter.sort_annot_suffix,
+            TestFieldSorter("whatever", Value(1)).annot_name,
+        )
+
+    def test_is_sort_annotation(self):
+        self.assertTrue(
+            BSTBaseSorter.is_sort_annotation(
+                "whatever" + BSTBaseSorter.sort_annot_suffix
+            )
+        )
+        self.assertFalse(BSTBaseSorter.is_sort_annotation("whatever"))
+
+    def test_sort_annot_name_to_col_name(self):
+        self.assertEqual(
+            "whatever",
+            BSTBaseSorter.sort_annot_name_to_col_name(
+                "whatever" + BSTBaseSorter.sort_annot_suffix
+            ),
+        )
+        self.assertEqual(
+            "whatever",
+            BSTBaseSorter.sort_annot_name_to_col_name("whatever"),
+        )

--- a/DataRepo/tests/views/models/bst/column/test_annotation.py
+++ b/DataRepo/tests/views/models/bst/column/test_annotation.py
@@ -17,35 +17,32 @@ from DataRepo.views.models.bst.column.sorter.field import BSTSorter
 class BSTAnnotColumnTests(TracebaseTestCase):
 
     def test_init_sorter_filterer_defaults(self):
-        # Test if self.is_annotation is None - return underscored_to_title(self.name)
         ann = "meaning_of_life"
         c = BSTAnnotColumn(ann, Value(42))
         self.assertEqual(BSTAnnotSorter, type(c.sorter))
         self.assertEqual(BSTAnnotFilterer, type(c.filterer))
 
     def test_init_sorter_filterer_str(self):
-        # Test if self.is_annotation is None - return underscored_to_title(self.name)
         ann = "meaning_of_life"
         c = BSTAnnotColumn(ann, Value(42), sorter="mySorter", filterer="myFilterer")
         self.assertEqual(BSTAnnotSorter, type(c.sorter))
         self.assertEqual(BSTAnnotFilterer, type(c.filterer))
 
     def test_init_sorter_invalid(self):
-        # Test if self.is_annotation is None - return underscored_to_title(self.name)
         ann = "meaning_of_life"
-        sorter = BSTSorter("name", BSTCStudyTestModel)
+        sorter = BSTSorter("name", BSTCStudyTestModel, name=ann)
+        # Testing to make sure that BSTSorter, as a type, is caught as wrong.  Must be a BSTAnnotSorter.
         with self.assertRaises(TypeError):
             BSTAnnotColumn(ann, Value(42), sorter=sorter)
 
     def test_init_filterer_invalid(self):
-        # Test if self.is_annotation is None - return underscored_to_title(self.name)
         ann = "meaning_of_life"
         filterer = BSTFilterer("name", BSTCStudyTestModel)
+        # Testing to make sure that BSTFilterer, as a type, is caught as wrong.  Must be a BSTAnnotFilterer.
         with self.assertRaises(TypeError):
             BSTAnnotColumn(ann, Value(42), filterer=filterer)
 
     def test_generate_header_annotation(self):
-        # Test if self.is_annotation is None - return underscored_to_title(self.name)
         ann = "meaning_of_life"
         c = BSTAnnotColumn(ann, Value(42))
         an = c.generate_header()

--- a/DataRepo/tests/views/models/bst/column/test_field.py
+++ b/DataRepo/tests/views/models/bst/column/test_field.py
@@ -170,7 +170,7 @@ class BSTColumnTests(TracebaseTestCase):
         with self.assertRaises(TypeError) as ar:
             BSTColumn(fld, mdl, sorter=1)
         self.assertIn(
-            "sorter must be a str or a BSTBaseSorter, not a 'int'", str(ar.exception)
+            "sorter must be a str or a BSTSorter, not a 'int'", str(ar.exception)
         )
 
     def test_init_filterer_wrong_type(self):
@@ -180,7 +180,7 @@ class BSTColumnTests(TracebaseTestCase):
         with self.assertRaises(TypeError) as ar:
             BSTColumn(fld, mdl, filterer=1)
         self.assertIn(
-            "filterer must be a str or a BSTBaseFilterer, not a 'int'",
+            "filterer must be a str or a BSTFilterer, not a 'int'",
             str(ar.exception),
         )
 


### PR DESCRIPTION
## Summary Change Description

Fixed sorting on annotation columns.

The sorting of annotation columns was being performed by creating an annotation of an annotation and creating an order-by clause of the name of that double-annotation.  Django was trying to resolve the field in the F() in the order-by expression, but since it contained the name of an annotation, it was failing.  The solution was to create an annotation that is based on the underlying field instead of on the annotation field.

Details:

- Added the ability to convert an annotation name to the column's name in order to be able to disable search/sort on the column that encountered the problem.
- Moved the sort annotations to the "after filter" annotations set.  They were mistakenly being added to the *before* filtering set.
- Added class methods to the BSTBaseSorter class:
  - is_sort_annotation
  - sort_annot_name_to_col_name
- Created a class attribute in BSTBaseSorter: sort_annot_suffix
- Fixed a type issue in BSTBaseSorter
- Added type checking to BSTBaseColumn on the sorter and filterer, if the user supplied an object.
- Changed the declaration of BSTBaseColumn's create_sorter method to remove the keyword are that wasn't needed in the annotation derived class.
- Updates to BSTAnnotColumn:
  - Fixed an issue in create_sorter by supplying self.converter as the expression and set the name and _server_sorter arguments if not in kwargs.  This was the crux of the fix.
  - Removed unnecessary code from the constructor because the base class was doing the same exact thing.
- Added a try/catch to get_rec_val in bsttags.py that falls back to setting "ERROR" as the value as well as issue a warning to the log.  This was useful in debugging the issue and mitigates future errors relating to bad columns.
- Added scratch.* to the gitignore and organized miscellaneous entries into better commented categories.

## Affected Issues/Pull Requests

- Partially addresses #1585
  - Specifically, this PR fixes this issue in [this comment](https://github.com/Princeton-LSI-ResearchComputing/tracebase/issues/1585#issuecomment-2968130096):
    - Sorting on count columns complains that the annotation doesn't exist.
- Merges into branch `bstlv15_sample_list5_catch_reset`

## Reviewer Notes/Requests
<!-- Notes to help the reviewer or requests for specific scrutiny.
E.g. Please make sure I have accounted for all possible inputs. -->
See comments in-line.

## Checklist
<!-- If any requirements are not met, uncheck and explain.
E.g. Linting errors pre-date this PR. -->
This pull request will be merged once the following requirements are met.  The
author and/or reviewers should uncheck any unmet requirements:
<!-- Check/complete items if not applicable. -->
- Review Requirements
  - Minimum approvals: 1 <!-- Edit based on complexity. -->
  - No changes requested
  - All blocking issues resolved by reviewers
  - Specific reviewers: @__add_username_here__ <!-- Approvals required even if minimum met. -->
  - Review period: 2 days <!-- Edit based on complexity. -->
- Associated Issue/PR Requirements: <!-- Assert resolved issues/PRs are done/merged. -->
  - [x] All issue requirements are satisfied
  - [x] All PR dependencies are merged
- Basic Requirements <!-- Uncheck to indicate items you are yet to address. -->
  - [x] [Linters pass](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#linting)
  - [x] [Tests pass](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#quality-control)
  - [x] Conflicts resolved
- Overhead Requirements <!-- Requirements indirectly related to the issues. -->
  - [x] [Tests implemented/updated](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#test-implementation)
  - [ ] [Updated `CHANGELOG.md` *Unreleased* section](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/changelog.md)
