### PR TITLE
`BSTListView` 15.8: Removed duplicate paginator, explained disabled search/sort, and made count column counts distinct

### DIFF
--- a/DataRepo/templates/models/bst/th.html
+++ b/DataRepo/templates/models/bst/th.html
@@ -14,5 +14,6 @@
     data-valign="top"
     data-visible="{{ column.visible|lower }}">
     {{ column.header }}
+    {% if column.tooltip %}<sup class="bi-question-circle" title="{{ column.tooltip }}"></sup>{% endif %}
 
 </th>

--- a/DataRepo/tests/templates/models/bst/test_th.py
+++ b/DataRepo/tests/templates/models/bst/test_th.py
@@ -35,6 +35,7 @@ class ThTemplateTests(TracebaseTestCase):
         self.assertIn('data-sorter="djangoSorter"', html)
         self.assertIn('data-visible="true"', html)
         self.assertIn("Colname", html)
+        self.assertNotIn('<sup class="bi-question-circle" title="', html)
 
     def test_th_booleans(self):
         col = BSTAnnotColumn(
@@ -89,3 +90,14 @@ class ThTemplateTests(TracebaseTestCase):
         )
         html = self.render_th_template(col)
         self.assertIn('data-filter-default="searchterm"', html)
+
+    def test_th_tooltip(self):
+        col = BSTAnnotColumn(
+            "colname",
+            Lower("name", output_field=CharField()),
+            tooltip="This is header info.",
+        )
+        html = self.render_th_template(col)
+        self.assertIn(
+            '<sup class="bi-question-circle" title="This is header info."></sup>', html
+        )

--- a/DataRepo/tests/views/models/bst/column/test_field.py
+++ b/DataRepo/tests/views/models/bst/column/test_field.py
@@ -187,9 +187,6 @@ class BSTColumnTests(TracebaseTestCase):
     def test_init_is_fk(self):
         self.assertTrue(BSTColumn("animal", BSTCSampleTestModel).is_fk)
         self.assertFalse(BSTColumn("name", BSTCSampleTestModel).is_fk)
-        # TODO: Put this test in the tests for BSTRelatedColumn
-        # self.assertTrue(BSTColumn("animal__studies", BSTCSampleTestModel).is_fk)
-        # self.assertFalse(BSTColumn("animal__studies__name", BSTCSampleTestModel).is_fk)
 
     def test_eq(self):
         # Test __eq__ works when other val is string

--- a/DataRepo/tests/views/models/bst/column/test_many_related_field.py
+++ b/DataRepo/tests/views/models/bst/column/test_many_related_field.py
@@ -259,3 +259,11 @@ class BSTManyRelatedColumnTests(TracebaseTestCase):
         c = BSTManyRelatedColumn("msrun_samples__name", BSTMRCSampleTestModel)
         sh = c.generate_header()
         self.assertEqual(underscored_to_title("msrun_samples"), sh)
+
+    def test_init_is_fk(self):
+        self.assertTrue(
+            BSTManyRelatedColumn("animal__studies", BSTMRCSampleTestModel).is_fk
+        )
+        self.assertFalse(
+            BSTManyRelatedColumn("animal__studies__name", BSTMRCSampleTestModel).is_fk
+        )

--- a/DataRepo/tests/views/models/bst/column/test_related_field.py
+++ b/DataRepo/tests/views/models/bst/column/test_related_field.py
@@ -155,6 +155,54 @@ class BSTRelatedColumnTests(TracebaseTestCase):
         self.assertTrue(c.sortable)
         self.assertTrue(c.searchable)
 
+    def test_no_representative(self):
+        """This tests that when a related model has no representative field, it is automatically not searchable or
+        sortable, and a tooltip is set"""
+        BSTRCNoRepTestModel = create_test_model(  # noqa: F841
+            "BSTRCNoRepTestModel",
+            {
+                # No unique field, i.e. no representative for display when a related model creates a column for the
+                # foreign key to this model
+                "value1": CharField(max_length=255),
+                "value2": CharField(max_length=255),
+            },
+        )
+        BSTRCMainTestModel = create_test_model(
+            "BSTRCMainTestModel",
+            {
+                "name": CharField(max_length=255, unique=True),
+                "norep": ForeignKey(
+                    to="loader.BSTRCNoRepTestModel",
+                    related_name="parent",
+                    on_delete=CASCADE,
+                ),
+            },
+        )
+        c = BSTRelatedColumn(
+            "norep",
+            BSTRCMainTestModel,
+        )
+        self.assertEqual(
+            (
+                "Search and sort is disabled for this column because the displayed values do not exist in the database "
+                "as a single field"
+            ),
+            c.tooltip,
+        )
+        self.assertFalse(c.searchable)
+        self.assertFalse(c.sortable)
+        self.assertEqual(
+            (
+                "Test tooltip.  Search and sort is disabled for this column because the displayed values do not exist "
+                "in the database as a single field"
+            ),
+            BSTRelatedColumn(
+                "norep",
+                BSTRCMainTestModel,
+                tooltip="Test tooltip.",
+            ).tooltip,
+        )
+
     @TracebaseTestCase.assertNotWarns()
     def test_init_display_field_nonfk(self):
         c = BSTRelatedColumn("sample__characteristic", BSTRCMSRunSampleTestModel)
@@ -293,3 +341,9 @@ class BSTRelatedColumnTests(TracebaseTestCase):
         c = BSTRelatedColumn("sample__animal__sex", BSTRCMSRunSampleTestModel)
         sh = c.generate_header()
         self.assertEqual(underscored_to_title("animal_sex"), sh)
+
+    def test_init_is_fk(self):
+        self.assertTrue(BSTRelatedColumn("animal__studies", BSTRCSampleTestModel).is_fk)
+        self.assertFalse(
+            BSTRelatedColumn("animal__studies__name", BSTRCSampleTestModel).is_fk
+        )

--- a/DataRepo/tests/views/models/bst/column/test_related_field.py
+++ b/DataRepo/tests/views/models/bst/column/test_related_field.py
@@ -341,9 +341,3 @@ class BSTRelatedColumnTests(TracebaseTestCase):
         c = BSTRelatedColumn("sample__animal__sex", BSTRCMSRunSampleTestModel)
         sh = c.generate_header()
         self.assertEqual(underscored_to_title("animal_sex"), sh)
-
-    def test_init_is_fk(self):
-        self.assertTrue(BSTRelatedColumn("animal__studies", BSTRCSampleTestModel).is_fk)
-        self.assertFalse(
-            BSTRelatedColumn("animal__studies__name", BSTRCSampleTestModel).is_fk
-        )

--- a/DataRepo/tests/views/models/bst/test_base.py
+++ b/DataRepo/tests/views/models/bst/test_base.py
@@ -135,7 +135,7 @@ class BSTBaseListViewTests(TracebaseTestCase):
             {
                 "animals_mm_count": BSTAnnotColumn(
                     "animals_mm_count",
-                    Count("animals", output_field=IntegerField()),
+                    Count("animals", output_field=IntegerField(), distinct=True),
                     header="Animals Count",
                     filterer="strictFilterer",
                     sorter="numericSorter",
@@ -157,7 +157,7 @@ class BSTBaseListViewTests(TracebaseTestCase):
                 ),
                 "animals_mm_count": BSTAnnotColumn(
                     "animals_mm_count",
-                    Count("animals", output_field=IntegerField()),
+                    Count("animals", output_field=IntegerField(), distinct=True),
                     header="Animals Count",
                     filterer="strictFilterer",
                     sorter="numericSorter",
@@ -462,7 +462,7 @@ class BSTBaseListViewTests(TracebaseTestCase):
         self.assertEquivalent(
             BSTAnnotColumn(
                 "studies_mm_count",
-                Count("studies", output_field=IntegerField()),
+                Count("studies", output_field=IntegerField(), distinct=True),
                 header="Studies Count",
                 filterer="strictFilterer",
                 sorter="numericSorter",
@@ -558,7 +558,7 @@ class BSTBaseListViewTests(TracebaseTestCase):
             {
                 "animals_mm_count": BSTAnnotColumn(
                     "animals_mm_count",
-                    Count("animals", output_field=IntegerField()),
+                    Count("animals", output_field=IntegerField(), distinct=True),
                     header="Animals Count",
                     filterer="strictFilterer",
                     sorter="numericSorter",
@@ -636,7 +636,7 @@ class BSTBaseListViewTests(TracebaseTestCase):
                 "desc": BSTColumn("desc", BSTBLVStudyTestModel),
                 "animals_mm_count": BSTAnnotColumn(
                     "animals_mm_count",
-                    Count("animals", output_field=IntegerField()),
+                    Count("animals", output_field=IntegerField(), distinct=True),
                     header="Animals Count",
                     filterer="strictFilterer",
                 ),

--- a/DataRepo/tests/views/models/bst/test_client_interface.py
+++ b/DataRepo/tests/views/models/bst/test_client_interface.py
@@ -369,6 +369,9 @@ class BSTClientInterfaceTests(TracebaseTestCase):
             ),
             set(context.keys()),
         )
+        # Not a standard Paginator.  Having is_paginated=None prevents the base.html template from rendering the vanilla
+        # paginator under the SizedPaginator
+        self.assertIsNone(context["is_paginated"])
         self.assertEqual("BSTClientInterface-", context["cookie_prefix"])
         self.assertFalse(context["clear_cookies"])
         self.assertEqual([], context["cookie_resets"])

--- a/DataRepo/tests/views/models/bst/test_list_view.py
+++ b/DataRepo/tests/views/models/bst/test_list_view.py
@@ -138,7 +138,9 @@ class BSTListViewTests(TracebaseTestCase):
             {
                 "name_bstrowsort": Lower("name"),
                 "description": Upper("desc", output_field=CharField()),
-                "animals_mm_count": Count("animals", output_field=IntegerField()),
+                "animals_mm_count": Count(
+                    "animals", output_field=IntegerField(), distinct=True
+                ),
             },
             slv.postfilter_annots,
         )
@@ -157,7 +159,9 @@ class BSTListViewTests(TracebaseTestCase):
         self.assertEqual(q, slv.filters)
         self.assertDictEquivalent(
             {
-                "animals_mm_count": Count("animals", output_field=IntegerField()),
+                "animals_mm_count": Count(
+                    "animals", output_field=IntegerField(), distinct=True
+                ),
                 "description": Upper("desc", output_field=CharField()),
             },
             slv.prefilter_annots,
@@ -178,7 +182,9 @@ class BSTListViewTests(TracebaseTestCase):
         self.assertDictEquivalent(
             {
                 "name_bstrowsort": Lower("name"),
-                "animals_mm_count": Count("animals", output_field=IntegerField()),
+                "animals_mm_count": Count(
+                    "animals", output_field=IntegerField(), distinct=True
+                ),
                 "description": Upper("desc", output_field=CharField()),
             },
             slv.postfilter_annots,
@@ -199,9 +205,11 @@ class BSTListViewTests(TracebaseTestCase):
         self.assertDictEquivalent({}, slv.prefilter_annots)
         self.assertDictEquivalent(
             {
-                "name_bstrowsort": Lower("name"),
-                "animals_mm_count": Count("animals", output_field=IntegerField()),
                 "description": Upper("desc", output_field=CharField()),
+                "name_bstrowsort": Lower("name"),
+                "animals_mm_count": Count(
+                    "animals", output_field=IntegerField(), distinct=True
+                ),
             },
             slv.postfilter_annots,
         )
@@ -374,7 +382,9 @@ class BSTListViewTests(TracebaseTestCase):
         self.assertDictEquivalent(
             {
                 "name_bstrowsort": Lower("name"),
-                "animals_mm_count": Count("animals", output_field=IntegerField()),
+                "animals_mm_count": Count(
+                    "animals", output_field=IntegerField(), distinct=True
+                ),
                 "description": Upper("desc", output_field=CharField()),
             },
             after,
@@ -389,7 +399,9 @@ class BSTListViewTests(TracebaseTestCase):
         before, after = alv2.get_annotations()
         self.assertDictEquivalent(
             {
-                "animals_mm_count": Count("animals", output_field=IntegerField()),
+                "animals_mm_count": Count(
+                    "animals", output_field=IntegerField(), distinct=True
+                ),
                 "description": Upper("desc", output_field=CharField()),
             },
             before,
@@ -408,7 +420,9 @@ class BSTListViewTests(TracebaseTestCase):
         self.assertDictEquivalent(
             {
                 "name_bstrowsort": Lower("name"),
-                "animals_mm_count": Count("animals", output_field=IntegerField()),
+                "animals_mm_count": Count(
+                    "animals", output_field=IntegerField(), distinct=True
+                ),
             },
             after,
         )
@@ -422,7 +436,9 @@ class BSTListViewTests(TracebaseTestCase):
         self.assertDictEquivalent(
             {
                 "name_bstrowsort": Lower("name"),
-                "animals_mm_count": Count("animals", output_field=IntegerField()),
+                "animals_mm_count": Count(
+                    "animals", output_field=IntegerField(), distinct=True
+                ),
                 "description": Upper("desc", output_field=CharField()),
             },
             after,
@@ -437,9 +453,11 @@ class BSTListViewTests(TracebaseTestCase):
         self.assertDictEquivalent(
             {
                 "animals_mm_count_bstrowsort": Count(
-                    "animals", output_field=IntegerField()
+                    "animals", output_field=IntegerField(), distinct=True
                 ),
-                "animals_mm_count": Count("animals", output_field=IntegerField()),
+                "animals_mm_count": Count(
+                    "animals", output_field=IntegerField(), distinct=True
+                ),
                 "description": Upper("desc", output_field=CharField()),
             },
             after,

--- a/DataRepo/views/models/bst/client_interface.py
+++ b/DataRepo/views/models/bst/client_interface.py
@@ -592,6 +592,8 @@ class BSTClientInterface(ListView):
                 "asc_cookie_name": self.asc_cookie_name,
                 "limit_cookie_name": self.limit_cookie_name,
                 "page_cookie_name": self.page_var_name,
+                # Override Django's is_paginated to not trigger the base.html template from adding vanilla pagination
+                "is_paginated": None,
             }
         )
 

--- a/DataRepo/views/models/bst/column/base.py
+++ b/DataRepo/views/models/bst/column/base.py
@@ -67,6 +67,7 @@ class BSTBaseColumn(ABC):
         self,
         name: str,
         header: Optional[str] = None,
+        tooltip: Optional[str] = None,
         searchable: Optional[bool] = None,
         sortable: Optional[bool] = None,
         visible: bool = True,
@@ -85,6 +86,7 @@ class BSTBaseColumn(ABC):
                 and filtering operations.
             header (Optional[str]) [auto]: The column header to display in the template.  Will be automatically
                 generated using the title case conversion of the last (2, if present) dunderscore-delimited name values.
+            tooltip (Optional[str]): A tooltip to display on hover over the column header.
 
             searchable (Optional[bool]) [auto]: Whether or not a column is searchable.  This affects whether the column
                 is searched as a part of the table's search box and whether the column filter input will be enabled.
@@ -122,6 +124,7 @@ class BSTBaseColumn(ABC):
 
         self.name = name
         self.header = header
+        self.tooltip = tooltip
         self.searchable = searchable
         self.sortable = sortable
         self.visible = visible

--- a/DataRepo/views/models/bst/column/related_field.py
+++ b/DataRepo/views/models/bst/column/related_field.py
@@ -69,6 +69,7 @@ class BSTRelatedColumn(BSTColumn):
             None
         """
         self.display_field_path = display_field_path
+        tooltip = kwargs.get("tooltip")
 
         # Get some superclass instance members we need for checks
         field_path: str = cast(str, args[0])
@@ -122,6 +123,12 @@ class BSTRelatedColumn(BSTColumn):
                         "display_field_path could not be determined.  Supply display_field_path to allow search/sort."
                     )
 
+                tooltip = "" if tooltip is None else tooltip + "  "
+                tooltip += (
+                    "Search and sort is disabled for this column because the displayed values do not exist in the "
+                    "database as a single field"
+                )
+
                 # Fall back to the actual foreign key as the display field.  This will end up rendering related objects
                 # in string context, which is what is not searchable/sortable.
                 self.display_field_path = field_path
@@ -130,6 +137,7 @@ class BSTRelatedColumn(BSTColumn):
                     {
                         "searchable": False,
                         "sortable": False,
+                        "tooltip": tooltip,
                     }
                 )
         elif not self.display_field_path.startswith(field_path):


### PR DESCRIPTION
## Summary Change Description

Fixed the redundant paginator, added a tooltip for headers with no search/sort, and made count columns distinct.

Details:

- A tooltip is created when a foreign key column to a model with no representative to explain why search/sort is not enabled.
- Set is_paginated to None so that the vanilla paginator isn't rendered under the SizedPaginator.
- Made automatically added count columns use distinct=True.

## Affected Issues/Pull Requests

- Partially addresses #1585
  - Specifically, the following issues in [this comment](https://github.com/Princeton-LSI-ResearchComputing/tracebase/issues/1585#issuecomment-2968130096) were addressed:
    - The paginator from the base template is redundantly displaying (e.g. "Page 1 of 179. next" at the bottom of the page)
    - Add a tooltip to make it clear that the reason there is no filter is because it's a foreign key field where no representative could be chosen. E.g. the FCircs and Msrun Samples columns.
    - Figure out why the Animals Count for the Animal.last_serum_sample reverse relation on the 20220818_M1_mix1_T150 sample row is 9 instead of 1.
    - These issues were dismissed as invalid during this work:
      - ~Do not pluralize the count column names.~ **There's no active pluralization being done. It's occurring because that's the name of the field.**
      - ~There should not exist a Count column for a 1:1 related reverse link (e.g. the Animals Count column for Animal.last_serum_sample).~ **It's not 1:1.**
      - ~Figure out how to prevent the Animals Count column from being automatically created for the Animal.last_serum_sample reverse relation.~ **It's a valid reverse relation.**
- Merges into branch `bstlv15_sample_list7_totalrpp`

## Reviewer Notes/Requests
<!-- Notes to help the reviewer or requests for specific scrutiny.
E.g. Please make sure I have accounted for all possible inputs. -->
See comments in-line.

## Checklist
<!-- If any requirements are not met, uncheck and explain.
E.g. Linting errors pre-date this PR. -->
This pull request will be merged once the following requirements are met.  The
author and/or reviewers should uncheck any unmet requirements:
<!-- Check/complete items if not applicable. -->
- Review Requirements
  - Minimum approvals: 1 <!-- Edit based on complexity. -->
  - No changes requested
  - All blocking issues resolved by reviewers
  - Specific reviewers: @__add_username_here__ <!-- Approvals required even if minimum met. -->
  - Review period: 2 days <!-- Edit based on complexity. -->
- Associated Issue/PR Requirements: <!-- Assert resolved issues/PRs are done/merged. -->
  - [x] All issue requirements are satisfied
  - [x] All PR dependencies are merged
- Basic Requirements <!-- Uncheck to indicate items you are yet to address. -->
  - [x] [Linters pass](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#linting)
  - [x] [Tests pass](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#quality-control)
  - [x] Conflicts resolved
- Overhead Requirements <!-- Requirements indirectly related to the issues. -->
  - [x] [Tests implemented/updated](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#test-implementation)
  - [ ] [Updated `CHANGELOG.md` *Unreleased* section](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/changelog.md)
