### PR TITLE
`BSTListView` 15.10: Added a way to init `column_settings` as a class attribute

### DIFF
--- a/DataRepo/models/utilities.py
+++ b/DataRepo/models/utilities.py
@@ -148,7 +148,8 @@ def resolve_field(
 
 
 def resolve_field_path(
-    field_or_expression: Union[str, Combinable, DeferredAttribute, Field]
+    field_or_expression: Union[str, Combinable, DeferredAttribute, Field],
+    _level=0,
 ) -> str:
     """Takes a representation of a field, e.g. from Model._meta.ordering, which can have transform functions applied
     (like Lower('field_name')) and returns the field path.
@@ -171,6 +172,7 @@ def resolve_field_path(
     Args:
         field_or_expression (Union[str, Combinable]): A str (e.g. a field path), Combinable (e.g. an F, Transform [like
             Lower("name")], Expression, etc object), or a Model Field.
+        _level (int): Recursion level, used to determine whether to raise an exception or return ""
     Exceptions:
         ValueError when the field_or_expression contains multiple field paths.
     Returns
@@ -187,28 +189,34 @@ def resolve_field_path(
     elif isinstance(field_or_expression, DeferredAttribute):
         return field_or_expression.field.name
     elif isinstance(field_or_expression, Expression):
-        field_reps = field_or_expression.get_source_expressions()
+        field_reps = [
+            f if isinstance(f, str) else resolve_field_path(f, _level=_level + 1)
+            for f in field_or_expression.get_source_expressions()
+        ]
+        # Filter out empty strings, which indicate no fields found
+        field_reps = [f for f in field_reps if f != ""]
 
         if len(field_reps) == 0:
-            raise NoFields("No field name in field representation.")
+            if _level > 0:
+                # Return an empty string (to stay type-consistent) to indicate no fields detected in the expression(s)
+                return ""
+            else:
+                # If we're back to the original caller and there are still no expressions, raise an exception.
+                raise NoFields("No field name in field representation.")
         elif len(field_reps) > 1:
             raise MultipleFields(
-                f"Multiple field names in field representation {[f.name for f in field_reps]}."
+                f"Multiple field names in field representation {field_reps}."
             )
-
-        if isinstance(field_reps[0], Expression):
-            return resolve_field_path(field_reps[0])
-        elif isinstance(field_reps[0], F):
-            return resolve_field_path(field_reps[0].name)
-        else:
-            raise ProgrammingError(
-                f"Unexpected field_or_expression type: '{type(field_or_expression).__name__}'."
-            )
+        else:  # Assumes field_reps[0] is a str based on the above code
+            # Strings need processing too, in case this comes from an order-by expression with a leading dash (for
+            # reversing the order)
+            return resolve_field_path(field_reps[0], _level=_level + 1)
     elif isinstance(field_or_expression, F):
         return field_or_expression.name
     else:
         raise ProgrammingError(
-            f"Unexpected field_or_expression type: '{type(field_or_expression).__name__}'."
+            f"Unexpected field_or_expression type: '{type(field_or_expression).__name__}' for expression: "
+            f"{field_or_expression}."
         )
 
 
@@ -1000,11 +1008,6 @@ def get_field_val_by_iteration(
             for tpl in sorted(val, key=lambda t: t[1], reverse=not asc)
         ]
 
-    if not isinstance(val, tuple) or len(val) != 3:
-        raise ProgrammingError(
-            f"3-member tuple not returned from _get_field_val_by_iteration_helper '{type(val).__name__}': {val}."
-        )
-
     # Convert empty strings in the tuple's return value to None
     return val[0] if not isinstance(val[0], str) or val[0] != "" else None
 
@@ -1058,12 +1061,27 @@ def _get_field_val_by_iteration_helper(
         (Union[List[Tuple[Any, Any, Any]]], Tuple[Any, Any, Any]): A list of 3-membered tuples or a 3-membered
             tuple.  Each tuple contains the value, a sort value, and a unique value.
     """
-    if len(field_path) == 0 or rec is None:
-        return None
+    if len(field_path) == 0:
+        raise ProgrammingError("A non-zero length field_path is required")
+
+    if rec is None:
+        if is_many_related_to_root(field_path, type(rec)):
+            return []
+        else:
+            return None, None, None
 
     if is_many_related_to_parent(field_path[0], type(rec)):
         # This method handles only fields that are many-related to their immediate parent
-        return _get_field_val_by_iteration_manyrelated_helper(
+        retval = _get_field_val_by_iteration_manyrelated_helper(
+            rec,
+            field_path,
+            related_limit=related_limit,
+            sort_field_path=sort_field_path,
+            _sort_val=_sort_val,
+        )
+    else:
+        # This method handles only fields that are singly related to their immediate parent
+        retval = _get_field_val_by_iteration_onerelated_helper(
             rec,
             field_path,
             related_limit=related_limit,
@@ -1071,14 +1089,32 @@ def _get_field_val_by_iteration_helper(
             _sort_val=_sort_val,
         )
 
-    # This method handles only fields that are singly related to their immediate parent
-    return _get_field_val_by_iteration_onerelated_helper(
-        rec,
-        field_path,
-        related_limit=related_limit,
-        sort_field_path=sort_field_path,
-        _sort_val=_sort_val,
-    )
+    # A many-related field can return a single (tuple) value instead of a list if a None exists on the path before the
+    # first many-related model is encountered.  E.g. animal__infusate__tracer_links__tracer is many-related to Sample,
+    # thus we expect a list, but if the animal has no infusate, a tuple would be returned because we haven't gotten to
+    # the many-related relationship with tracer_links yet.  The following catches that and performs type checking.
+    # NOTE: hasattr assumes that if the model doesn't have the first field, then it is an annotation and is by
+    # definition, not many-related
+    if hasattr(type(rec), field_path[0]) and is_many_related_to_root(
+        field_path, type(rec)
+    ):
+        if (
+            isinstance(retval, tuple) and (len(retval) != 3 or retval[0] is not None)
+        ) and not isinstance(retval, list):
+            raise ProgrammingError(
+                f"Expected a list, but got '{type(retval).__name__}': '{retval}' when looking for many-related field "
+                f"'{'__'.join(field_path)}' in a '{type(rec).__name__}' record: '{rec}'."
+            )
+        if isinstance(retval, tuple):
+            return []
+    else:
+        if not isinstance(retval, tuple) or len(retval) != 3:
+            raise ProgrammingError(
+                f"Expected a 3-member tuple, but got '{type(retval).__name__}': '{retval}' when looking for one-"
+                f"related field '{'__'.join(field_path)}' in a '{type(rec).__name__}' record: '{rec}'."
+            )
+
+    return retval
 
 
 def _get_field_val_by_iteration_onerelated_helper(
@@ -1147,6 +1183,10 @@ def _get_field_val_by_iteration_onerelated_helper(
             uniq_val = val_or_rec.pk
         # NOTE: Returning the value, a value to sort by, and a value that makes it unique per record (or field)
         return val_or_rec, _sort_val, uniq_val
+
+    # The foreign key is None and iterating deeper would cause an exception, so return a None tuple
+    if val_or_rec is None:
+        return None, None, None
 
     return _get_field_val_by_iteration_helper(
         val_or_rec,

--- a/DataRepo/static/js/bst/list_view.js
+++ b/DataRepo/static/js/bst/list_view.js
@@ -11,6 +11,7 @@ var djangoLimit = djangoLimitDefault // eslint-disable-line no-var
 var djangoPerPage = djangoLimitDefault // eslint-disable-line no-var
 var djangoRawTotal = 0 // eslint-disable-line no-var
 var djangoTotal = djangoRawTotal // eslint-disable-line no-var
+var columnNames = [] // eslint-disable-line no-var
 
 var sortCookieName = 'sort' // eslint-disable-line no-var, no-unused-vars
 var ascCookieName = 'asc' // eslint-disable-line no-var, no-unused-vars
@@ -23,9 +24,13 @@ var pageCookieName = 'page' // eslint-disable-line no-var
 /**
  * This function exists solely for testing purposes
  */
-function initGlobalDefaults () { // eslint-disable-line no-unused-vars
+function initGlobalDefaults (customDjangoTableID, columnNames) { // eslint-disable-line no-unused-vars
   globalThis.djangoCurrentURL = window.location.href.split('?')[0]
-  globalThis.djangoTableID = 'bstlistviewtable'
+  if (typeof customDjangoTableID === 'undefined') {
+    globalThis.djangoTableID = 'bstlistviewtable'
+  } else {
+    globalThis.djangoTableID = customDjangoTableID
+  }
   globalThis.jqTableID = '#' + djangoTableID
   globalThis.djangoLimitDefault = 15
   globalThis.djangoLimit = djangoLimitDefault
@@ -40,6 +45,11 @@ function initGlobalDefaults () { // eslint-disable-line no-unused-vars
   globalThis.visibleCookieName = 'visible'
   globalThis.limitCookieName = 'limit'
   globalThis.pageCookieName = 'page'
+  if (typeof columnNames === 'undefined') {
+    globalThis.columnNames = []
+  } else {
+    globalThis.columnNames = columnNames
+  }
 }
 
 /**
@@ -53,6 +63,7 @@ function initGlobalDefaults () { // eslint-disable-line no-unused-vars
  * @param {*} total The total number of results/rows given the current searc/filter.
  * @param {*} rawTotal The total unfiltered number of results.
  * @param {*} currentURL The current URL of the page.
+ * @param {*} columnNames Ordered list of column names (the data-field attribute of the th tags).
  * @param {*} warnings A list of warnings from django.
  * @param {*} cookieResets A list of cookie names to reset from django.  (Not the whole cookie name, just the last bit, e.g. 'sortcol'.)
  * @param {*} clearCookies A boolean represented as a string, e.g. 'false'.
@@ -74,6 +85,7 @@ function initBST ( // eslint-disable-line no-unused-vars
   total,
   rawTotal,
   currentURL,
+  columnNames,
   warnings,
   cookieResets,
   clearCookies,
@@ -101,6 +113,13 @@ function initBST ( // eslint-disable-line no-unused-vars
   globalThis.visibleCookieName = visibleCookieName
   globalThis.limitCookieName = limitCookieName
   globalThis.pageCookieName = pageCookieName
+
+  // Clear whatever might already be in the global columnNames array
+  globalThis.columnNames = []
+  // Add the supplied columnNames
+  for (let i = 0; i < columnNames.length; i++) {
+    globalThis.columnNames.push(columnNames[i])
+  }
 
   // Initialize the cookies (basically just the prefix)
   initViewCookies(cookiePrefix) // eslint-disable-line no-undef
@@ -139,7 +158,6 @@ function initBST ( // eslint-disable-line no-unused-vars
       // 1. BST sort and server side sort sometimes sort differently (c.i.p. imported_timestamp)
       // 2. BST sort completely fails when the number of rows is very large
       // ...so we will always let the sort hit the server to be on the safe side.
-      console.log('Sorting by ' + orderBy + ', ' + orderDir)
       updatePage(1)
     },
     onSearch: function (searchTerm) {
@@ -159,7 +177,6 @@ function initBST ( // eslint-disable-line no-unused-vars
       }
     },
     onColumnSearch: function (columnName, searchTerm) {
-      console.log('Filtering column ' + columnName + ' with term: ' + searchTerm)
       if (!loading) {
         // NOTE: Turns out that on page load, a column search event is triggered, so we check to see if anything
         // changed before triggering a page update.
@@ -209,21 +226,6 @@ function displayWarnings (warningsArray) {
     }
     alert(warningText) // eslint-disable-line no-undef
   }
-}
-
-/**
- * Retrieves a list of column names (obtained from the data-field attribute of every th element).
- * Bootstrap table provides alternate methods of retrieving the fields, but they are not in order and are limited to
- * only either the visible or hidden ones.
- * @returns Column names.
- */
-function getColumnNames () {
-  const columnNames = []
-  const headerCells = document.querySelectorAll(`${jqTableID} th`)
-  for (let i = 0; i < headerCells.length; i++) {
-    columnNames.push(headerCells[i].dataset.field)
-  }
-  return columnNames
 }
 
 /**
@@ -349,7 +351,6 @@ function parseBool (boolval, def) {
  * @returns Nothing.
  */
 function updateVisible (visible, columnName) {
-  const columnNames = getColumnNames()
   if (typeof columnName !== 'undefined' && columnName) {
     if (columnNames.includes(columnName)) {
       setViewColumnCookie(columnName, visibleCookieName, visible) // eslint-disable-line no-undef
@@ -358,15 +359,22 @@ function updateVisible (visible, columnName) {
       alert('Error: Unable to save your column visibility selection') // eslint-disable-line no-undef
     } else {
       console.error(
-        "Column '" + columnName.toString() + "' not found.  The second argument must match a th data-field attribute.  " +
-        'Current data-fields: [' + columnNames.toString() + ']'
+        "Column '" + columnName.toString() + "' not found.  The second argument must match a th data-field " +
+        'attribute.  Current data-fields: [' + columnNames.toString() + ']'
       )
       alert('Error: Unable to save your column visibility selection') // eslint-disable-line no-undef
     }
   } else {
-    // When a columnName is not provided, set all columns' visibility
-    for (let i = 0; i < columnNames.length; i++) {
-      setViewColumnCookie(columnNames[i], visibleCookieName, visible) // eslint-disable-line no-undef
+    if (visible) {
+      $(jqTableID).bootstrapTable('getVisibleColumns').map(function (col) { // eslint-disable-line no-undef
+        setViewColumnCookie(col.field, visibleCookieName, visible) // eslint-disable-line no-undef
+        return col.field
+      })
+    } else {
+      $(jqTableID).bootstrapTable('getHiddenColumns').map(function (col) { // eslint-disable-line no-undef
+        setViewColumnCookie(col.field, visibleCookieName, visible) // eslint-disable-line no-undef
+        return col.field
+      })
     }
   }
 }

--- a/DataRepo/templates/models/bst/scripts.html
+++ b/DataRepo/templates/models/bst/scripts.html
@@ -1,6 +1,8 @@
 {% load static %}
+{% load bsttags %}
 
 {# Variables needed for the scripts #}
+{{ columns|keys|json_script:"orderedColumnNames" }}
 {{ warnings|json_script:"warnings" }}
 {{ cookie_resets|json_script:"cookieResets" }}
 
@@ -10,6 +12,9 @@
 
 {# Script initialization #}
 <script>
+    // columnNames: An ordered list of column names from django.
+    const columnNamesElem = document.getElementById("orderedColumnNames");
+    const orderedColumnNames = JSON.parse(columnNamesElem.textContent);
     // warnings: A list of warnings from django.
     const warningsElem = document.getElementById("warnings");
     const warnings = JSON.parse(warningsElem.textContent);
@@ -35,6 +40,7 @@
             to create a proper concrete view for BSTListView in the tests, with a url and everything.
             {% endcomment %}
             {% comment %} '{% url request.resolver_match.url_name %}', {% endcomment %}
+            orderedColumnNames,
             warnings,
             cookieResets,
             '{{ clear_cookies }}',

--- a/DataRepo/templates/models/bst/th.html
+++ b/DataRepo/templates/models/bst/th.html
@@ -12,8 +12,9 @@
     data-sorter="{{ column.sorter }}"{% endif %}
 
     data-valign="top"
-    data-visible="{{ column.visible|lower }}">
+    {% if column.hidable %}data-visible="{{ column.visible|lower }}"{% endif %}
+    data-switchable="{{ column.hidable|lower }}">
     {{ column.header }}
-    {% if column.tooltip %}<sup class="bi-question-circle" title="{{ column.tooltip }}"></sup>{% endif %}
+    {% if column.tooltip %}<sup class="bi-info-circle" title="{{ column.tooltip }}"></sup>{% endif %}
 
 </th>

--- a/DataRepo/templatetags/bsttags.py
+++ b/DataRepo/templatetags/bsttags.py
@@ -6,7 +6,7 @@ from django.conf import settings
 from django.db.models import Model
 
 from DataRepo.models.utilities import get_field_val_by_iteration
-from DataRepo.utils.exceptions import DeveloperWarning
+from DataRepo.utils.exceptions import DeveloperWarning, trace
 from DataRepo.views.models.bst.column.base import BSTBaseColumn
 from DataRepo.views.models.bst.column.many_related_field import (
     BSTManyRelatedColumn,
@@ -78,11 +78,12 @@ def get_rec_val(rec: Model, column: BSTBaseColumn) -> Any:
     try:
         val = get_field_val_by_iteration(rec, column.name.split("__"))
     except AttributeError as ae:
-        warning = (
-            f"A problem was encountered while processing {type(column).__name__} '{column}':\n"
-            f"Exception: {type(ae).__name__}: {ae}"
-        )
-        warn(warning, DeveloperWarning)
+        if settings.DEBUG:
+            warning = (
+                f"A problem was encountered while processing {type(column).__name__} '{column}':\n"
+                f"Exception:\n{trace(ae)}\n{type(ae).__name__}: {ae}"
+            )
+            warn(warning, DeveloperWarning)
         val = default
 
     return val
@@ -95,3 +96,9 @@ def get_absolute_url(model_object: Model):
     if url is not None and url != "":
         return url
     return None
+
+
+@register.filter
+def keys(dct: dict):
+    """Return ordered dict keys as a list"""
+    return list(dct.keys()) if isinstance(dct, dict) else []

--- a/DataRepo/tests/templates/models/bst/test_th.py
+++ b/DataRepo/tests/templates/models/bst/test_th.py
@@ -35,7 +35,7 @@ class ThTemplateTests(TracebaseTestCase):
         self.assertIn('data-sorter="djangoSorter"', html)
         self.assertIn('data-visible="true"', html)
         self.assertIn("Colname", html)
-        self.assertNotIn('<sup class="bi-question-circle" title="', html)
+        self.assertNotIn('<sup class="bi-info-circle" title="', html)
 
     def test_th_booleans(self):
         col = BSTAnnotColumn(
@@ -99,5 +99,5 @@ class ThTemplateTests(TracebaseTestCase):
         )
         html = self.render_th_template(col)
         self.assertIn(
-            '<sup class="bi-question-circle" title="This is header info."></sup>', html
+            '<sup class="bi-info-circle" title="This is header info."></sup>', html
         )

--- a/DataRepo/tests/templatetags/test_bsttags.py
+++ b/DataRepo/tests/templatetags/test_bsttags.py
@@ -8,6 +8,7 @@ from DataRepo.templatetags.bsttags import (
     get_rec_val,
     has_attr,
     is_model_obj,
+    keys,
 )
 from DataRepo.tests.tracebase_test_case import (
     TracebaseTestCase,
@@ -79,8 +80,13 @@ class BSTListViewTagsTests(TracebaseTestCase):
             "problem was encountered while processing BSTAnnotColumn 'badname'",
             str(aw.warnings[0].message),
         )
-        self.assertIn("Exception: AttributeError", str(aw.warnings[0].message))
+        self.assertIn("Exception:", str(aw.warnings[0].message))
+        self.assertIn("AttributeError", str(aw.warnings[0].message))
         self.assertIn(
             "'BSTLVStudy' object has no attribute 'badname'",
             str(aw.warnings[0].message),
         )
+
+    @TracebaseTestCase.assertNotWarns()
+    def test_keys(self):
+        self.assertEqual(["a", "b"], keys({"a": 1, "b": 2}))

--- a/DataRepo/tests/tracebase_test_case.py
+++ b/DataRepo/tests/tracebase_test_case.py
@@ -155,34 +155,17 @@ def test_case_class_factory(base_class: Type[T]) -> Type[T]:
                 return
             primitives = (bool, str, int, float, type(None))
             if isinstance(o1, primitives):
-                try:
-                    self.assertEqual(o1, o2, **kwargs)
-                except AssertionError as ae:
-                    if _path is None:
-                        raise ae
-                    raise AssertionError(
-                        f"Object path: {_path} difference: {ae}"
-                    ).with_traceback(ae.__traceback__)
+                self.assertEqual(o1, o2, **kwargs, msg=f"Object path: {_path}")
             elif type(o1).__name__ == "function":
-                try:
-                    self.assertEqual(o1, o2, **kwargs)
-                except AssertionError as ae:
-                    if _path is None:
-                        raise ae
-                    raise AssertionError(
-                        f"Object path: {_path} difference: {ae}"
-                    ).with_traceback(ae.__traceback__)
+                self.assertEqual(o1, o2, **kwargs, msg=f"Object path: {_path}")
             else:
-                self.assertIsInstance(o2, type(o1), **kwargs)
+                self.assertIsInstance(
+                    o2, type(o1), **kwargs, msg=f"Object path: {_path}"
+                )
                 if isinstance(o1, (list, tuple)) and isinstance(o2, (list, tuple)):
-                    try:
-                        self.assertEqual(len(o1), len(o2), **kwargs)
-                    except AssertionError as ae:
-                        if _path is None:
-                            raise ae
-                        raise AssertionError(
-                            f"Object path: {_path} difference: {ae}"
-                        ).with_traceback(ae.__traceback__)
+                    self.assertEqual(
+                        len(o1), len(o2), **kwargs, msg=f"Object path: {_path}"
+                    )
                     for i in range(len(o1)):
                         self.assertEquivalent(
                             o1[i],

--- a/DataRepo/tests/views/models/bst/column/filterer/test_base.py
+++ b/DataRepo/tests/views/models/bst/column/filterer/test_base.py
@@ -1,4 +1,4 @@
-from django.db.models import CharField
+from django.db.models import CharField, Q
 from django.test import override_settings
 
 from DataRepo.tests.tracebase_test_case import (
@@ -54,3 +54,8 @@ class BSTFiltererTests(TracebaseTestCase):
         f = FiltererTest("name", choices=get_choices_dict)
         self.assertDictEquivalent(expected, f.choices)
         self.assertEqual(BSTBaseFilterer.INPUT_METHODS.SELECT, f.input_method)
+
+    @TracebaseTestCase.assertNotWarns()
+    def test_create_q_exp(self):
+        f = FiltererTest("name")
+        self.assertEqual(Q(**{"name__isnull": True}), f.create_q_exp("None"))

--- a/DataRepo/tests/views/models/bst/column/filterer/test_base.py
+++ b/DataRepo/tests/views/models/bst/column/filterer/test_base.py
@@ -1,0 +1,56 @@
+from django.db.models import CharField
+from django.test import override_settings
+
+from DataRepo.tests.tracebase_test_case import (
+    TracebaseTestCase,
+    create_test_model,
+)
+from DataRepo.views.models.bst.column.filterer.base import BSTBaseFilterer
+
+BSTBFStudyTestModel = create_test_model(
+    "BSTBFStudyTestModel",
+    {"name": CharField(max_length=255)},
+)
+
+
+class FiltererTest(BSTBaseFilterer):
+    pass
+
+
+@override_settings(DEBUG=True)
+class BSTFiltererTests(TracebaseTestCase):
+
+    @TracebaseTestCase.assertNotWarns()
+    def test_init_choices_callable_list(self):
+        expected = {}
+        for n in range(4):
+            name = f"name{n}"
+            BSTBFStudyTestModel.objects.create(name=name)
+            expected[name] = name
+
+        def get_choices_list():
+            return list(BSTBFStudyTestModel.objects.values_list("name", flat=True))
+
+        f = FiltererTest("name", choices=get_choices_list)
+        self.assertDictEquivalent(expected, f.choices)
+        self.assertEqual(BSTBaseFilterer.INPUT_METHODS.SELECT, f.input_method)
+
+    @TracebaseTestCase.assertNotWarns()
+    def test_init_choices_callable_dict(self):
+        expected = {}
+        for n in range(4):
+            name = f"name{n}"
+            BSTBFStudyTestModel.objects.create(name=name)
+            expected[name] = name
+
+        def get_choices_dict():
+            return dict(
+                (n, n)
+                for n in list(
+                    BSTBFStudyTestModel.objects.values_list("name", flat=True)
+                )
+            )
+
+        f = FiltererTest("name", choices=get_choices_dict)
+        self.assertDictEquivalent(expected, f.choices)
+        self.assertEqual(BSTBaseFilterer.INPUT_METHODS.SELECT, f.input_method)

--- a/DataRepo/tests/views/models/bst/column/filterer/test_field.py
+++ b/DataRepo/tests/views/models/bst/column/filterer/test_field.py
@@ -64,7 +64,7 @@ class BSTFiltererTests(TracebaseTestCase):
         f = BSTFilterer("animal__sex", BSTFSampleTestModel)
         self.assertEqual(f.INPUT_METHODS.SELECT, f.input_method)
         self.assertEqual(f.CLIENT_FILTERERS.STRICT_SINGLE, f.client_filterer)
-        self.assertDictEqual({"F": "female", "M": "male"}, f.choices)
+        self.assertDictEqual({"F": "F (female)", "M": "M (male)"}, f.choices)
         self.assertEqual(f.SERVER_FILTERERS.STRICT_SINGLE, f._server_filterer)
 
     @TracebaseTestCase.assertNotWarns()
@@ -72,7 +72,7 @@ class BSTFiltererTests(TracebaseTestCase):
         f = BSTFilterer("animals__sex", BSTFStudyTestModel)
         self.assertEqual(f.INPUT_METHODS.SELECT, f.input_method)
         self.assertEqual(f.CLIENT_FILTERERS.STRICT_MULTIPLE, f.client_filterer)
-        self.assertDictEqual({"F": "female", "M": "male"}, f.choices)
+        self.assertDictEqual({"F": "F (female)", "M": "M (male)"}, f.choices)
         self.assertEqual(f.SERVER_FILTERERS.STRICT_MULTIPLE, f._server_filterer)
 
     @TracebaseTestCase.assertNotWarns()
@@ -193,7 +193,7 @@ class BSTFiltererTests(TracebaseTestCase):
         self.assertEqual("istartswith", str(f._server_filterer))
 
     @TracebaseTestCase.assertNotWarns()
-    def test_filter(self):
+    def test_create_q_exp(self):
         f = BSTFilterer(
             BSTFStudyTestModel.name.field.name,  # pylint: disable=no-member
             BSTFStudyTestModel,

--- a/DataRepo/tests/views/models/bst/column/test_base.py
+++ b/DataRepo/tests/views/models/bst/column/test_base.py
@@ -1,3 +1,5 @@
+from typing import Optional
+
 from django.db.models import CharField
 
 from DataRepo.tests.tracebase_test_case import (
@@ -5,6 +7,9 @@ from DataRepo.tests.tracebase_test_case import (
     create_test_model,
 )
 from DataRepo.views.models.bst.column.base import BSTBaseColumn
+from DataRepo.views.models.bst.column.filterer.base import BSTBaseFilterer
+from DataRepo.views.models.bst.column.filterer.field import BSTFilterer
+from DataRepo.views.models.bst.column.sorter.field import BSTSorter
 
 BSTBCStudyTestModel = create_test_model(
     "BSTBCStudyTestModel",
@@ -17,7 +22,34 @@ BSTBCAnimalTestModel = create_test_model(
 )
 
 
+class BSTBaseColumnTest(BSTBaseColumn):
+    def create_sorter(self, **kwargs):
+        # This test class only supports BSTBCStudyTestModel.name
+        return BSTSorter("name", BSTBCStudyTestModel, **kwargs)
+
+    def create_filterer(self, field: Optional[str] = None, **kwargs) -> BSTFilterer:
+        return BSTFilterer("name", BSTBCStudyTestModel, **kwargs)
+
+
 class BSTBaseColumnTests(TracebaseTestCase):
     def test_has_detail(self):
         self.assertTrue(BSTBaseColumn.has_detail(BSTBCAnimalTestModel))
         self.assertFalse(BSTBaseColumn.has_detail(BSTBCStudyTestModel))
+
+    def test_init_filter_dict_callable(self):
+        """This tests that a BSTBaseColumn constructor can set the filterer to a dict containing a callable for its
+        choices argument."""
+        expected = {}
+        for n in range(4):
+            name = f"name{n}"
+            BSTBCStudyTestModel.objects.create(name=name)
+            expected[name] = name
+
+        def get_choices():
+            return list(BSTBCStudyTestModel.objects.values_list("name", flat=True))
+
+        bstbct = BSTBaseColumnTest("name", filterer={"choices": get_choices})
+        self.assertDictEquivalent(expected, bstbct.filterer.choices)
+        self.assertEqual(
+            BSTBaseFilterer.INPUT_METHODS.SELECT, bstbct.filterer.input_method
+        )

--- a/DataRepo/tests/views/models/bst/column/test_base.py
+++ b/DataRepo/tests/views/models/bst/column/test_base.py
@@ -53,3 +53,12 @@ class BSTBaseColumnTests(TracebaseTestCase):
         self.assertEqual(
             BSTBaseFilterer.INPUT_METHODS.SELECT, bstbct.filterer.input_method
         )
+
+    def test_init_hidable(self):
+        bstbct1 = BSTBaseColumnTest("name", hidable=False, visible=False)
+        self.assertFalse(bstbct1.hidable)
+        self.assertTrue(bstbct1.visible)  # visible=False ignored, since not hidable
+
+        bstbct2 = BSTBaseColumnTest("name", hidable=True, visible=False)
+        self.assertTrue(bstbct2.hidable)
+        self.assertFalse(bstbct2.visible)  # visible=False ignored, since not hidable

--- a/DataRepo/tests/views/models/bst/column/test_field.py
+++ b/DataRepo/tests/views/models/bst/column/test_field.py
@@ -75,7 +75,7 @@ BSTCMSRunSampleTestModel = create_test_model(
 )
 BSTCTissueTestModel = create_test_model(
     "BSTCTissueTestModel",
-    {"name": CharField(max_length=255)},
+    {"name": CharField(max_length=255, help_text="Tissue name.")},
 )
 
 
@@ -252,3 +252,7 @@ class BSTColumnTests(TracebaseTestCase):
         self.assertTrue(BSTColumn("name", BSTCAnimalTestModel).has_detail())
         # Has a unique field, but no get_absolute_url method
         self.assertFalse(BSTColumn("name", BSTCStudyTestModel).has_detail())
+
+    def test_tooltip(self):
+        c = BSTColumn("name", BSTCTissueTestModel)
+        self.assertEqual("Tissue name.", c.tooltip)

--- a/DataRepo/tests/views/models/bst/column/test_related_field.py
+++ b/DataRepo/tests/views/models/bst/column/test_related_field.py
@@ -193,8 +193,8 @@ class BSTRelatedColumnTests(TracebaseTestCase):
         self.assertFalse(c.sortable)
         self.assertEqual(
             (
-                "Test tooltip.  Search and sort is disabled for this column because the displayed values do not exist "
-                "in the database as a single field"
+                "Test tooltip.\n\nSearch and sort is disabled for this column because the displayed values do not "
+                "exist in the database as a single field"
             ),
             BSTRelatedColumn(
                 "norep",
@@ -340,4 +340,4 @@ class BSTRelatedColumnTests(TracebaseTestCase):
         # Test that every other field uses - underscored_to_title("_".join(path_tail))
         c = BSTRelatedColumn("sample__animal__sex", BSTRCMSRunSampleTestModel)
         sh = c.generate_header()
-        self.assertEqual(underscored_to_title("animal_sex"), sh)
+        self.assertEqual(underscored_to_title("sex"), sh)

--- a/DataRepo/tests/views/models/bst/test_base.py
+++ b/DataRepo/tests/views/models/bst/test_base.py
@@ -204,6 +204,28 @@ class BSTBaseListViewTests(TracebaseTestCase):
             ["StudyBLV-visible-desc", "StudyBLV-filter-stale"], blv.cookie_resets
         )
 
+    def test_init_class_attr_column_settings(self):
+        """This tests that you can use the column_settings class attribute to avoid extending the constructor"""
+
+        class StudyBLVcs(BSTBaseListView):
+            model = BSTBLVStudyTestModel
+            column_settings = {"name": {"filterer": {"choices": ["1", "2"]}}}
+
+        sblvcs = StudyBLVcs()
+        self.assertIn("name", sblvcs.column_settings.keys())
+        self.assertEqual(
+            ["1", "2"], sblvcs.column_settings["name"]["filterer"]["choices"]
+        )
+        self.assertEquivalent(
+            BSTColumn(
+                "name",
+                BSTBLVStudyTestModel,
+                filterer=BSTFilterer("name", BSTBLVStudyTestModel, choices=["1", "2"]),
+                linked=True,
+            ),
+            sblvcs.columns["name"],
+        )
+
     def test_init_column_settings_list_supplied_for_columns(self):
         blv = BSTBaseListView()
 

--- a/DataRepo/tests/views/models/bst/test_client_interface.py
+++ b/DataRepo/tests/views/models/bst/test_client_interface.py
@@ -118,19 +118,23 @@ class BSTClientInterfaceTests(TracebaseTestCase):
         self.assertEqual(
             str(aw.warnings[0].message), c.warnings[0] + "  'BSTClientInterface-cname'"
         )
-        self.assertEqual(f"BSTClientInterface-{view_cookie_name}", c.cookie_resets[0])
+        self.assertEqual(view_cookie_name, c.cookie_resets[0])
 
         # second occurrence does not warn
         val = c.get_boolean_cookie(view_cookie_name, default=True)
         self.assertTrue(val)
         # The rest has not changed...
-        self.assertEqual(1, len(c.warnings))
+        self.assertEqual(
+            1,
+            len(c.warnings),
+            msg=f"Cookie: {view_cookie_name} Resets: {c.cookie_resets} Warnings: {c.warnings}",
+        )
         # The warning message gives the full cookie name, which the user does not need to know.
         self.assertEqual(
             str(aw.warnings[0].message), c.warnings[0] + "  'BSTClientInterface-cname'"
         )
         self.assertEqual(1, len(c.cookie_resets))
-        self.assertEqual(f"BSTClientInterface-{view_cookie_name}", c.cookie_resets[0])
+        self.assertEqual(view_cookie_name, c.cookie_resets[0])
 
     @TracebaseTestCase.assertNotWarns()
     def test_get_column_cookie_name(self):
@@ -197,8 +201,8 @@ class BSTClientInterfaceTests(TracebaseTestCase):
         self.assertEqual(2, len(aw.warnings))
         self.assertEqual(2, len(c.warnings))
         self.assertEqual(2, len(c.cookie_resets))
-        self.assertIn("BSTClientInterface-filter-column1", c.cookie_resets)
-        self.assertIn("BSTClientInterface-filter-column2", c.cookie_resets)
+        self.assertIn("filter-column1", c.cookie_resets)
+        self.assertIn("filter-column2", c.cookie_resets)
 
     @TracebaseTestCase.assertNotWarns()
     def test_get_column_cookie(self):
@@ -256,7 +260,7 @@ class BSTClientInterfaceTests(TracebaseTestCase):
         bci.reset_column_cookies(["name", "desc"], "visible")
         # Only deletes the ones that are "set" (and empty string is eval'ed as None)
         self.assertEqual(
-            ["BSTClientInterface-visible-name", "BSTClientInterface-visible-desc"],
+            ["visible-name", "visible-desc"],
             bci.cookie_resets,
         )
 
@@ -279,7 +283,7 @@ class BSTClientInterfaceTests(TracebaseTestCase):
         bci.init_interface()
         bci.reset_cookie("sortcol")
         # Only deletes the ones that are "set" (and empty string is eval'ed as None)
-        self.assertEqual(["BSTClientInterface-sortcol"], bci.cookie_resets)
+        self.assertEqual(["sortcol"], bci.cookie_resets)
 
     def test_model_title_plural(self):
         self.assertEqual("BCI Study Test Models", StudyBCI.model_title_plural)
@@ -306,7 +310,7 @@ class BSTClientInterfaceTests(TracebaseTestCase):
         slv.init_interface()
         slv.reset_filter_cookies()
         # Only deletes the ones that are "set" (and empty string is eval'ed as None)
-        self.assertEqual(["StudyBCI-filter-desc"], slv.cookie_resets)
+        self.assertEqual(["filter-desc"], slv.cookie_resets)
 
     @TracebaseTestCase.assertNotWarns()
     def test_reset_search_cookie(self):
@@ -326,7 +330,7 @@ class BSTClientInterfaceTests(TracebaseTestCase):
         slv = StudyBCI(request=request)
         slv.init_interface()
         slv.reset_search_cookie()
-        self.assertEqual(["StudyBCI-search"], slv.cookie_resets)
+        self.assertEqual(["search"], slv.cookie_resets)
 
     @TracebaseTestCase.assertNotWarns()
     def test_get_context_data(self):

--- a/DataRepo/tests/views/models/bst/test_list_view.py
+++ b/DataRepo/tests/views/models/bst/test_list_view.py
@@ -365,12 +365,14 @@ class BSTListViewTests(TracebaseTestCase):
         alv = AnimalWithMultipleStudyColsLV(request=request)
         alv.init_interface()
         self.assertEqual(
-            "(OR: ('name__icontains', 'test1'), "
-            "('desc__icontains', 'test1'), "
-            "('treatment__name__icontains', 'test1'), "
-            "('studies__name__icontains', 'test1'), "
-            "('studies__desc__icontains', 'test1'), "
-            "('studies_mm_count__iexact', 'test1'))",
+            (
+                "(OR: ('name__icontains', 'test1'), "
+                "('desc__icontains', 'test1'), "
+                "('treatment__name__icontains', 'test1'), "
+                "('studies_mm_count__iexact', 'test1'), "
+                "('studies__name__icontains', 'test1'), "
+                "('studies__desc__icontains', 'test1'))"
+            ),
             str(alv.search()),
         )
 
@@ -508,9 +510,7 @@ class BSTListViewTests(TracebaseTestCase):
             BSTLVStudyTestModel.objects.all(),
             fqs,
         )
-        self.assertEqual(
-            [f"StudyLV-{StudyLV.filter_cookie_name}-desc"], slv.cookie_resets
-        )
+        self.assertEqual([f"{StudyLV.filter_cookie_name}-desc"], slv.cookie_resets)
 
     @TracebaseTestCase.assertNotWarns()
     def test_paginate_queryset(self):

--- a/DataRepo/views/models/bst/base.py
+++ b/DataRepo/views/models/bst/base.py
@@ -134,12 +134,12 @@ class BSTBaseListView(BSTClientInterface):
         super().__init__(**kwargs)
 
         # Copy what's in the class attribute to start
-        self.column_settings = deepcopy(self.__class__.column_settings)
+        self.column_settings = deepcopy(type(self).column_settings)
         # Initialize column settings
         self.init_column_settings(columns)
 
         # Initialize column order
-        self.column_ordering: List[str] = self.__class__.column_ordering.copy()
+        self.column_ordering: List[str] = type(self).column_ordering.copy()
         self.init_column_ordering()
 
         # Initialize columns (NOTE: This could add a Details BSTAnnotColumn)
@@ -597,7 +597,7 @@ class BSTBaseListView(BSTClientInterface):
         """
         if self.column_ordering is None:
             # Initialize if None
-            self.column_ordering = self.__class__.column_ordering.copy()
+            self.column_ordering = type(self).column_ordering.copy()
         else:
             # Remove excludes
             self.column_ordering = [

--- a/DataRepo/views/models/bst/base.py
+++ b/DataRepo/views/models/bst/base.py
@@ -10,6 +10,7 @@ from django.db.models.aggregates import Count
 from django.db.models.expressions import Combinable
 
 from DataRepo.models.utilities import (
+    field_path_to_model_path,
     is_many_related_to_root,
     is_related,
     model_path_to_model,
@@ -133,6 +134,10 @@ class BSTBaseListView(BSTClientInterface):
         """
         super().__init__(**kwargs)
 
+        # This is to be able to insert automatically generated count columns before the first column that displays many-
+        # related values from the model the count column counts.  col name -> many-related model path.
+        self.count_cols: Dict[str, str] = {}
+
         # Copy what's in the class attribute to start
         self.column_settings = deepcopy(type(self).column_settings)
         # Initialize column settings
@@ -158,7 +163,9 @@ class BSTBaseListView(BSTClientInterface):
                 self.ordered = True
             else:
                 raise ProgrammingError(
-                    "Invalid return from select_representative_field"
+                    "Invalid return from select_representative_field when looking for a representative for model "
+                    f"'{self.model.__name__}' using the column subset {self.column_ordering}.  "
+                    f"Got a '{type(sort_field).__name__}' instead of a str."
                 )
         elif len(self.columns.keys()) > 0:
             # Arbitrary column - does not matter without a model
@@ -170,7 +177,8 @@ class BSTBaseListView(BSTClientInterface):
         self.add_check_groups()
 
     def init_interface(self):
-        """An extension of the BSTClientInterface init_interface method, used here to set the sort_col.
+        """An extension of the BSTClientInterface init_interface method, used here to set the sort_col, and check and
+        set the filter_terms and visibles that are a part of the user-controlled interface.
 
         Call this method after setting the class's request object in the get method, but before calling super().get().
 
@@ -216,6 +224,32 @@ class BSTBaseListView(BSTClientInterface):
         # Delete any bad filter term so that it doesn't come up in BSTListView when creating a Q expression
         for colname in bad_filter_entries:
             del self.filter_terms[colname]
+
+        # Set initial filter terms
+        bad_visibles_entries = []
+        for colname, visible in self.visibles.items():
+            if colname not in self.columns.keys():
+                bad_visibles_entries.append(colname)
+                self.reset_column_cookie(colname, self.visible_cookie_name)
+                warning = (
+                    f"Invalid '{self.visible_cookie_name}' column encountered: '{colname}'.  "
+                    "Resetting visible cookie."
+                )
+                self.warnings.append(warning)
+                if settings.DEBUG:
+                    warn(
+                        warning
+                        + f"  '{self.get_column_cookie_name(colname, self.visible_cookie_name)}'",
+                        DeveloperWarning,
+                    )
+            elif self.columns[colname].hidable:
+                self.columns[colname].visible = visible
+            else:
+                self.columns[colname].visible = True
+
+        # Delete any bad visible value
+        for colname in bad_visibles_entries:
+            del self.visibles[colname]
 
     def init_column_settings(
         self,
@@ -273,11 +307,21 @@ class BSTBaseListView(BSTClientInterface):
         # NOTE: This could get overridden by what's in columns
         for annot_name, annot_expression in self.annotations.items():
             if annot_name in self.column_settings.keys():
-                raise ProgrammingError(
-                    f"The annotation column '{annot_name}' has been defined twice: once in "
-                    f"{type(self).__name__}.column_settings and once in {type(self).__name__}.annotations."
-                )
-            self.column_settings[annot_name] = {"converter": annot_expression}
+                if isinstance(
+                    self.column_settings[annot_name], (BSTBaseColumn, BSTColumnGroup)
+                ) or (
+                    isinstance(self.column_settings[annot_name], dict)
+                    and "converter" in self.column_settings[annot_name].keys()  # type: ignore[union-attr]
+                ):
+                    raise ProgrammingError(
+                        f"The annotation column '{annot_name}' has been defined twice: once in "
+                        f"{type(self).__name__}.column_settings and once in {type(self).__name__}.annotations."
+                    )
+                # self.column_settings[annot_name] must be a dict (without a converter key) or an exception would have
+                # been raised above
+                self.column_settings[annot_name]["converter"] = annot_expression  # type: ignore[index]
+            else:
+                self.column_settings[annot_name] = {"converter": annot_expression}
 
         if isinstance(columns, list):
             # CASE 1: A list was supplied, potentially containing:
@@ -353,7 +397,8 @@ class BSTBaseListView(BSTClientInterface):
                 value of the "name" key, or in the case of a str, the value of the str).
         Exceptions:
             TypeError when a colobj type is not supported.
-            ValueError when a name does not match the colkey or when duplicate conflicting settings encountered.
+            ValueError when a name does not match the colkey.
+            ProgrammingError when duplicate conflicting settings encountered.
         Returns:
             None
         """
@@ -385,8 +430,8 @@ class BSTBaseListView(BSTClientInterface):
             if isinstance(colobj, str):
                 if settings.DEBUG:
                     warn(
-                        f"Ignoring duplicate column setting (with just the column name) for column {colkey}.  Silence "
-                        "this warning by removing the duplicate setting."
+                        f"Ignoring duplicate column setting (with just the column name) for column '{colkey}'.  "
+                        "Silence this warning by removing the duplicate setting."
                     )
             elif isinstance(colobj, dict):
                 if isinstance(self.column_settings[colkey], str):
@@ -395,7 +440,7 @@ class BSTBaseListView(BSTClientInterface):
                     if settings.DEBUG:
                         warn(
                             "Overwriting duplicate column settings (with just the column name) with the supplied dict "
-                            f"for column {colkey}.  Silence this warning by removing the duplicate setting."
+                            f"for column '{colkey}'.  Silence this warning by removing the duplicate setting."
                         )
                 if isinstance(self.column_settings[colkey], dict):
                     # If the settings are a supplied annotation and the only key in the settings is the converter
@@ -408,7 +453,7 @@ class BSTBaseListView(BSTClientInterface):
                         self.column_settings[colkey].keys()  # type: ignore[union-attr]
                     ) == ["converter"]:
                         if "converter" in colobj.keys():
-                            raise ValueError(
+                            raise ProgrammingError(
                                 f"Multiple BSTAnnotColumn converters defined.  "
                                 f"Class default: '{self.annotations[colkey]}'.  "
                                 f"Supplied via the constructor: '{colobj['converter']}'."
@@ -422,17 +467,22 @@ class BSTBaseListView(BSTClientInterface):
                         # attribute "update"  [union-attr]
                         self.column_settings[colkey].update(colobj)  # type: ignore[union-attr]
                     else:
-                        raise ValueError(
-                            f"Multiple column settings dicts defined for column {colkey}."
+                        raise ProgrammingError(
+                            f"Multiple column settings dicts defined for column '{colkey}'."
                         )
                 else:
-                    raise ValueError(
-                        f"Multiple column settings defined for column {colkey}.  A "
+                    raise ProgrammingError(
+                        f"Multiple column settings defined for column '{colkey}'.  A "
                         f"'{type(self.column_settings[colkey]).__name__}' and 'dict' were supplied."
                     )
+            elif colkey in self.annotations.keys():
+                raise ProgrammingError(
+                    f"Multiple column settings defined for annotation column '{colkey}'.  A "
+                    f"'{type(self.column_settings[colkey]).__name__}' and '{type(colobj).__name__}' were supplied."
+                )
             else:
-                raise ValueError(
-                    f"Multiple column settings defined for column {colkey}.  A "
+                raise ProgrammingError(
+                    f"Multiple column settings defined for column '{colkey}'.  A "
                     f"'{type(self.column_settings[colkey]).__name__}' and '{type(colobj).__name__}' were supplied."
                 )
         else:
@@ -460,6 +510,9 @@ class BSTBaseListView(BSTClientInterface):
         """Adds an automatically generated count column to complement each many-related column (if that column is not
         excluded).
 
+        NOTE: This intentionally does not use the related model's verbose_name because the name of the foreign key can
+        provide context.
+
         NOTE: The count added here is distinct and results may not be what you might expect.  For example:
         Animal.last_serum_sample links to Sample using ForeignKey.  You might think this is a 1:1 relationship, but that
         is wrong.  When gathering many-related fields for the Sample model, "Animal.last_serum_sample's related name is
@@ -476,38 +529,101 @@ class BSTBaseListView(BSTClientInterface):
         Returns:
             None
         """
-        mmfields = [
-            f
-            for f in self.model._meta.get_fields()
-            if is_many_related_to_root(f.name, self.model)
+        all_colnames = []
+        if self.column_ordering is not None:
+            # self.column_ordering hasn't been set yet, but a derived class may have set it and may not have set any
+            # custom settings for it, so we must check it
+            all_colnames = self.column_ordering.copy()
+        for colname, colobj in self.column_settings.items():
+            if (
+                not isinstance(colobj, (BSTAnnotColumn, BSTColumnGroup))
+                and colname not in all_colnames
+                and colname not in self.exclude
+            ):
+                all_colnames.append(colname)
+        mm_colnames = []
+        # column_ordering may be empty, as it may not have been initialized yet, but a derived class may have populated
+        # its class attribute.
+        mm_colnames = [
+            cname
+            for cname in all_colnames
+            if (
+                cname not in self.annotations
+                and (
+                    cname not in self.column_settings
+                    or not isinstance(self.column_settings[cname], BSTAnnotColumn)
+                )
+                # self.count_cols is first set below, but we check it here in case this is being called by other
+                # code outside this class.
+                and cname not in self.count_cols.keys()
+                # This is to filter out dict column_settings (that were added above) for annotation columns
+                and hasattr(self.model, cname.split("__")[0])
+                and is_many_related_to_root(cname, self.model)
+            )
         ]
-        for fld in mmfields:
-            count_annot_name = BSTManyRelatedColumn.get_count_name(fld.name, self.model)
+        mm_colnames.extend(
+            [
+                fld.name
+                for fld in self.model._meta.get_fields()
+                if (
+                    fld.name not in self.exclude
+                    and fld.name not in mm_colnames
+                    and is_many_related_to_root(fld.name, self.model)
+                )
+            ]
+        )
+        for colname in mm_colnames:
+            mr_model_path = field_path_to_model_path(
+                self.model, colname, many_related=True
+            )
+            count_annot_name = BSTManyRelatedColumn.get_count_name(
+                mr_model_path, self.model
+            )
 
             if (
-                (
-                    fld.name not in self.exclude
-                    or self.many_related_columns_exist(fld.name)
-                )
-                and count_annot_name not in self.exclude
-                and count_annot_name not in self.column_settings.keys()
+                colname not in self.exclude or self.many_related_columns_exist(colname)
+            ) and (
+                count_annot_name not in self.column_settings.keys()
+                or isinstance(self.column_settings[count_annot_name], dict)
             ):
-                self.column_settings[count_annot_name] = BSTAnnotColumn(
-                    count_annot_name,
-                    Count(fld.name, output_field=IntegerField(), distinct=True),
-                    header=(
+                # Track created columns to insert them before the related columns in the column_ordering
+                if count_annot_name not in self.column_ordering:
+                    self.count_cols[count_annot_name] = mr_model_path
+
+                # Allow the derived class to have added custom settings for the count column
+                kwargs = {
+                    "header": (
                         underscored_to_title(
-                            BSTManyRelatedColumn.get_attr_stub(fld.name, self.model)
+                            BSTManyRelatedColumn.get_attr_stub(
+                                mr_model_path, self.model
+                            )
                         )
                         + " Count"
                     ),
-                    filterer="strictFilterer",
-                    sorter="numericSorter",
+                    "filterer": "strictFilterer",
+                    "sorter": "numericSorter",
+                }
+                if count_annot_name in self.column_settings.keys():
+                    kwargs.update(self.column_settings[count_annot_name])
+
+                # Allow the user to supply a custom count converter
+                if "converter" in kwargs.keys():
+                    converter = kwargs.pop("converter")
+                else:
+                    converter = Count(
+                        mr_model_path, output_field=IntegerField(), distinct=True
+                    )
+
+                self.column_settings[count_annot_name] = BSTAnnotColumn(
+                    count_annot_name,
+                    converter,
+                    **kwargs,
                 )
 
     def many_related_columns_exist(self, mr_model_path: str):
         """Checks if a supplied many-related model path is the parent of any field among the column_settings keys or
-        column_ordering field paths.
+        column_ordering field paths.  The purpose of this check is because the foreign key itself may have been
+        excluded, but other fields from that many-related model are *included*.  This catches that case.
 
         Assumptions:
             1. mr_model_path ends in a foreign key field
@@ -604,24 +720,16 @@ class BSTBaseListView(BSTClientInterface):
                 f for f in self.column_ordering if f not in self.exclude
             ]
 
-        # Supporting the model being None to mimmick Django's ListView
+        # Add the default columns (Supporting the model being None to mimmick Django's ListView)
         if self.model is not None:
-            # Add the defaults
-
-            for fld, many_related in sorted(
+            # Sorting many-related to the end
+            for fld, _ in sorted(
                 [
                     (f, is_many_related_to_root(f.name, self.model))
                     for f in self.model._meta.get_fields()
                 ],
                 key=lambda tpl: tpl[1] is True,
             ):
-                if many_related is True:
-                    # Add an automatically generated count column to complement many-related columns
-                    count_annot_name = BSTManyRelatedColumn.get_count_name(
-                        fld.name, self.model
-                    )
-                    if fld.name not in self.exclude:
-                        self.add_to_column_ordering(count_annot_name, _warn=False)
                 self.add_to_column_ordering(fld.name, _warn=False)
 
         # Add from the annotations
@@ -630,10 +738,33 @@ class BSTBaseListView(BSTClientInterface):
 
         # Add from the settings dict
         for colname, obj in self.column_settings.items():
-            self.add_to_column_ordering(colname)
+            # The automatically generated count columns will be inserted before the first related column
+            if colname not in self.count_cols.keys():
+                self.add_to_column_ordering(colname)
+            # Recursively add columns contained in a group
             if isinstance(obj, BSTColumnGroup):
-                for col in obj.columns:
+                for col in obj.columns:  # pylint: disable=no-member
                     self.add_to_column_ordering(col.name)
+
+        # Insert the automatically generated count columns immediately before the column whose values it counts
+        # NOTE: This assumes that this does not include excluded columns or count columns that were manually added.
+        for count_colname, mr_model_path in self.count_cols.items():
+            # Get the indexes of every column that comes from the many-related model
+            start_indexes = [
+                self.column_ordering.index(colname)
+                for colname in self.column_ordering
+                if colname.startswith(mr_model_path)
+            ]
+            if len(start_indexes) == 0:
+                # If the related model path and the count column itself are not excluded.  Append the count column.
+                if (
+                    mr_model_path not in self.exclude
+                    and count_colname not in self.exclude
+                ):
+                    self.add_to_column_ordering(count_colname)
+            else:
+                # Insert the count column at the occurrence of the first related column
+                self.column_ordering.insert(start_indexes[0], count_colname)
 
     def add_to_column_ordering(self, colname: str, _warn=True):
         """This takes a column name and adds it to self.column_ordering if it is not among the excludes and hasn't
@@ -676,10 +807,10 @@ class BSTBaseListView(BSTClientInterface):
 
             # See if the derived class specified a linked column (to the row's details page)
             if colname not in self.groups.keys() and self.columns[colname].linked:
-                details_link_exists = True
                 # Only make the first linked column the representative (if there are multiple)
                 if not details_link_exists:
                     self.representative_column = self.columns[colname]
+                details_link_exists = True
 
         # If no representative exists and the model has a detail page, automatically set a representative
         if not details_link_exists and BSTBaseColumn.has_detail(self.model):
@@ -696,8 +827,14 @@ class BSTBaseListView(BSTClientInterface):
                 self.columns[rep_colname].linked = True
                 self.representative_column = self.columns[rep_colname]
 
+        # The representative column is either the first linked column or the first column
+        # Allowing no model is purely for testing, since this isn't an abstract base class
+        if self.representative_column is None and self.model is not None:
+            self.representative_column = list(self.columns.values())[0]
+
     def init_column(self, colname: str):
-        """Takes a column name, creates a derived instance of the BSTBaseColumn class, and adds it to self.columns.
+        """Takes a column name and sets or creates a derived instance of the BSTBaseColumn class, adding it to
+        self.columns.
 
         Assumptions:
             1. The legnth of the colname string is greater than 0.
@@ -737,9 +874,23 @@ class BSTBaseListView(BSTClientInterface):
             else:
                 self.columns[colname] = BSTColumn(colname, self.model, **kwargs)
 
-        elif colname is not None and "converter" in kwargs.keys():
+        elif (
+            colname is not None
+            and "converter" in kwargs.keys()
+            or colname in self.annotations.keys()
+        ):
 
-            converter = kwargs.pop("converter")
+            if colname in self.annotations.keys() and "converter" not in kwargs.keys():
+                converter = self.annotations[colname]
+            else:
+                # This assumes that the converter in annotations is the same, as conflicts are caught earlier
+                converter = kwargs.pop("converter")
+
+            # Adding the model enables BSTAnnotColumn to add a tooltip to the header if a single field_path extracted
+            # from the converter is a model field
+            if "model" not in kwargs.keys() or kwargs["model"] is None:
+                kwargs["model"] = self.model
+
             self.columns[colname] = BSTAnnotColumn(colname, converter, **kwargs)
 
         elif len(kwargs.keys()) > 0 and not hasattr(self.model, first_field):
@@ -864,7 +1015,11 @@ class BSTBaseListView(BSTClientInterface):
             subset=relative_subset,
         )
         # This assumes that there are not duplicate columns
-        representative = orig_subset_lookup[str(relative_representative)]
+        representative = (
+            orig_subset_lookup[str(relative_representative)]
+            if relative_representative is not None
+            else None
+        )
 
         return representative
 

--- a/DataRepo/views/models/bst/client_interface.py
+++ b/DataRepo/views/models/bst/client_interface.py
@@ -345,14 +345,14 @@ class BSTClientInterface(ListView):
         elif boolstr.lower().startswith("f"):
             return False
 
-        cookie_name = self.get_cookie_name(name)
-        if cookie_name not in self.cookie_resets:
-            self.cookie_resets.append(cookie_name)
+        if name not in self.cookie_resets:
+            self.cookie_resets.append(name)
             warning = (
                 f"Invalid '{name}' value encountered: '{boolstr}'.  Resetting cookie."
             )
             self.warnings.append(warning)
             if settings.DEBUG:
+                cookie_name = self.get_cookie_name(name)
                 warn(warning + f"  '{cookie_name}'", DeveloperWarning)
 
         return default
@@ -415,9 +415,9 @@ class BSTClientInterface(ListView):
             elif boolstr.lower().startswith("f"):
                 bools_dict[colname] = False
             else:
-                cookie_name = self.get_column_cookie_name(colname, name)
-                if cookie_name not in self.cookie_resets:
-                    self.cookie_resets.append(cookie_name)
+                view_cookie_name = f"{name}-{colname}"
+                if view_cookie_name not in self.cookie_resets:
+                    self.cookie_resets.append(view_cookie_name)
                     # TODO: Change the column name to the header
                     warning = (
                         f"Invalid '{name}' cookie value encountered for column '{colname}': '{boolstr}'.  "
@@ -425,6 +425,7 @@ class BSTClientInterface(ListView):
                     )
                     self.warnings.append(warning)
                     if settings.DEBUG:
+                        cookie_name = self.get_column_cookie_name(colname, name)
                         warn(warning + f"  '{cookie_name}'", DeveloperWarning)
         return bools_dict
 
@@ -466,7 +467,7 @@ class BSTClientInterface(ListView):
             )
         cookie_name = self.get_column_cookie_name(str(column), name)
         if cookie_name not in self.cookie_resets:
-            self.cookie_resets.append(cookie_name)
+            self.cookie_resets.append(f"{name}-{column}")
 
     def reset_column_cookies(self, columns: List[Union[str, BSTBaseColumn]], name: str):
         """Adds cookies to the cookie_resets list.
@@ -499,7 +500,7 @@ class BSTClientInterface(ListView):
         cookie_name = self.get_cookie_name(name)
         if cookie_name not in self.cookie_resets:
             delete_cookie(self.request, cookie_name)
-            self.cookie_resets.append(cookie_name)
+            self.cookie_resets.append(name)
 
     def reset_all_cookies(self):
         """Sets clear_cookies to True and removes all cookies from the request object.

--- a/DataRepo/views/models/bst/column/base.py
+++ b/DataRepo/views/models/bst/column/base.py
@@ -74,8 +74,8 @@ class BSTBaseColumn(ABC):
         visible: bool = True,
         exported: bool = True,
         linked: bool = False,
-        sorter: Optional[Union[str, BSTBaseSorter]] = None,
-        filterer: Optional[Union[str, BSTBaseFilterer]] = None,
+        sorter: Optional[Union[str, BSTBaseSorter, dict]] = None,
+        filterer: Optional[Union[str, BSTBaseFilterer, dict]] = None,
         th_template: Optional[str] = None,
         td_template: Optional[str] = None,
         value_template: Optional[str] = None,
@@ -104,10 +104,14 @@ class BSTBaseColumn(ABC):
                 record the row represents.
                 NOTE: The model must have a "get_absolute_url" method.  Checked in the template.
 
-            sorter (Optional[Union[str, BSTBaseSorter]]) [auto]: If the value is a str, must be in
-                BSTBaseSorter.CLIENT_SORTERS.  Default will be based on the name and the sorter (if it is a str).
-            filterer (Optional[Union[str, BSTBaseFilterer]]) [auto]: If the value is a str, must be in
+            sorter (Optional[Union[str, BSTBaseSorter, dict]]) [auto]: If the value is a str, must be in
+                BSTBaseSorter.CLIENT_SORTERS.  Default will be based on the name and the sorter (if it is a str).  If
+                the value is a dict, that dict will be supplied as the kwargs in the constructor call of a
+                BSTBaseSorter.
+            filterer (Optional[Union[str, BSTBaseFilterer, dict]]) [auto]: If the value is a str, must be in
                 BSTBaseFilterer.CLIENT_FILTERERS.  Default will be based on the name and the filterer (if it is a str).
+                If the value is a dict, that dict will be supplied as the kwargs in the constructor call of a
+                BSTBaseFilterer.
 
             th_template (str) ["models/bst/th.html"]: Template path to an html file used to render the th
                 element for the column header.  This must handle the initial sort field, search term, and filter term.
@@ -202,6 +206,8 @@ class BSTBaseColumn(ABC):
             self.sorter = self.create_sorter()
         elif isinstance(sorter, str):
             self.sorter = self.create_sorter(client_sorter=sorter)
+        elif isinstance(sorter, dict):
+            self.sorter = self.create_sorter(**sorter)
         elif isinstance(sorter, BSTBaseSorter):
             # Make sure that the sorter's name matches the column name
             if sorter.name != self.name:
@@ -229,6 +235,9 @@ class BSTBaseColumn(ABC):
         elif isinstance(filterer, str):
             # We explicitly do NOT supply the name, so that we can let the derived class's method decide it
             self.filterer = self.create_filterer(client_filterer=filterer)
+        elif isinstance(filterer, dict):
+            # We explicitly do NOT supply the name, so that we can let the derived class's method decide it
+            self.filterer = self.create_filterer(**filterer)
         elif isinstance(filterer, BSTBaseFilterer):
             if not isinstance(filterer, type(self.create_filterer())):
                 raise TypeError(

--- a/DataRepo/views/models/bst/column/base.py
+++ b/DataRepo/views/models/bst/column/base.py
@@ -71,6 +71,7 @@ class BSTBaseColumn(ABC):
         tooltip: Optional[str] = None,
         searchable: Optional[bool] = None,
         sortable: Optional[bool] = None,
+        hidable: bool = True,
         visible: bool = True,
         exported: bool = True,
         linked: bool = False,
@@ -98,6 +99,7 @@ class BSTBaseColumn(ABC):
                 default is based on whether the column is a foreign key or not, because Django turns keys into model
                 objects that do not render the actual numeric key value, so what the user sees would not behave as
                 expected when sorted.
+            hidable (bool) [True]: Controls whether a column's visible state can be made False.
             visible (bool) [True]: Controls whether a column is initially visible.
             exported (bool) [True]: Adds to BST's exportOptions' ignoreColumn attribute if False.
             linked (bool) [False]: Whether or not the value in the column should link to a detail page for the model
@@ -132,7 +134,8 @@ class BSTBaseColumn(ABC):
         self.tooltip = tooltip
         self.searchable = searchable
         self.sortable = sortable
-        self.visible = visible
+        self.hidable = hidable
+        self.visible = visible if hidable else True
         self.exported = exported
         self.linked = linked
         self.th_template = (

--- a/DataRepo/views/models/bst/column/field.py
+++ b/DataRepo/views/models/bst/column/field.py
@@ -94,6 +94,7 @@ class BSTColumn(BSTBaseColumn):
 
         # Get some superclass instance members we need for checks
         linked = kwargs.get("linked")
+        tooltip = kwargs.get("tooltip")
 
         # Set the name for the superclass based on field_path
         name = self.field_path
@@ -137,6 +138,12 @@ class BSTColumn(BSTBaseColumn):
         self.field = field_path_to_field(self.model, self.field_path)
         if not hasattr(self, "is_fk") or getattr(self, "is_fk", None) is None:
             self.is_fk = is_key_field(self.field)
+
+        if self.field.help_text is not None and self.field.help_text != "":
+            new_tooltip = self.field.help_text
+            if tooltip is not None:
+                new_tooltip += "\n\n" + tooltip
+            kwargs.update({"tooltip": new_tooltip})
 
         super().__init__(name, *args, **kwargs)
 

--- a/DataRepo/views/models/bst/column/filterer/base.py
+++ b/DataRepo/views/models/bst/column/filterer/base.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import json
 from abc import ABC, abstractmethod
 from functools import reduce
-from typing import Dict, List, NamedTuple, Optional, Union
+from typing import Callable, Dict, List, NamedTuple, Optional, Union
 from warnings import warn
 
 from django.conf import settings
@@ -165,7 +165,7 @@ class BSTBaseFilterer(ABC):
         self,
         name: str,
         input_method: Optional[str] = None,
-        choices: Optional[Union[Dict[str, str], List[str]]] = None,
+        choices: Optional[Union[Dict[str, str], List[str], Callable]] = None,
         client_filterer: Optional[str] = None,
         _server_filterer: Optional[Union[ServerLookup, str]] = None,
         initial: Optional[str] = None,
@@ -189,8 +189,9 @@ class BSTBaseFilterer(ABC):
                 'field__icontains="term"').  Default is based on client_filterer.
                 NOTE: The lookup behavior should match the client_filterer behavior.
                 See https://docs.djangoproject.com/en/5.1/topics/db/queries/#field-lookups.
-            choices (Optional[Union[Dict[str, str], List[str]]]): Values to populate a select list, if input_method is
-                "select".
+            choices (Optional[Union[Dict[str, str], List[str], Callable]]): Values to populate a select list, if
+                input_method is "select".  If a function name is provided, the function must not take any arguments.  It
+                must return either a list or dict of strings.
                 NOTE: Supplying this value will automatically set the input_method to "select".
                 TODO: choices could be used for auto-complete in the text input method.
             initial (Optional[str]): Initial filter search term.
@@ -210,9 +211,19 @@ class BSTBaseFilterer(ABC):
 
         tmp_server_filterer = self._process_server_filterer(_server_filterer)
 
-        if choices is None or len(choices) == 0:
+        if choices is not None and not isinstance(choices, (dict, list)):
+            if callable(choices):
+                choices = choices()
+            else:
+                raise TypeError(
+                    f"choices must be a 'Dict[str, str]', 'List[str]', or 'Callable', not '{type(choices).__name__}'."
+                )
+
+        if choices is None or (isinstance(choices, (list, dict)) and len(choices) == 0):
             self.choices = None
-        elif not isinstance(choices, dict):  # list (by process of elimination)
+        elif isinstance(choices, dict):
+            self.choices = choices
+        elif isinstance(choices, list):
             # choices is populated, but not a dict, so here, we convert it...
 
             # NOTE: This filters for a unique case-insensitive sorted dict, and arbitrarily uses the first case
@@ -237,7 +248,10 @@ class BSTBaseFilterer(ABC):
                 )
             )
         else:
-            self.choices = choices
+            # Assuming that choices was originally a callable.
+            raise TypeError(
+                f"The return of choices() must be a 'Dict[str, str]' or 'List[str]' not '{type(choices).__name__}'."
+            )
 
         if self.input_method is None:
             if choices is None:

--- a/DataRepo/views/models/bst/column/filterer/field.py
+++ b/DataRepo/views/models/bst/column/filterer/field.py
@@ -104,7 +104,15 @@ class BSTFilterer(BSTBaseFilterer):
             and self.field.choices is not None
             and len(self.field.choices) > 0
         ):
-            choices = dict(self.field.choices)
+            choices = dict(
+                (
+                    (k, v)
+                    if str(k).lower().replace(" ", "")
+                    == str(v).lower().replace(" ", "")
+                    else (k, f"{k} ({v})")
+                )
+                for k, v in self.field.choices
+            )
 
         if client_filterer is None:
             if _server_filterer is not None:

--- a/DataRepo/views/models/bst/column/filterer/field.py
+++ b/DataRepo/views/models/bst/column/filterer/field.py
@@ -38,8 +38,10 @@ class BSTFilterer(BSTBaseFilterer):
                 order to automatically select a client_filterer and input_method (if model is provided - if model is not
                 provided, it is assumed to be an annotation).
             model (Optional[Model]): The root model that the field starts from.  Ignored unless field is provided.
-                Used to change the default client_filterer when the input_method ends up being "select" but the field is
-                a many-related field.
+                Used for 2 purposes:
+                    1. to change the default client_filterer when the input_method ends up being "select" but the field
+                       is a many-related field.  (See Explanation below.)
+                    2. to populate a select list if distinct_choices is True.
                 Explanation: Many-related fields are displayed as delimited values, but the client filterer javascript
                 code is unaware of that, so the default of strict (full match) filtering will not match any delimited
                 values.  Many to many relations can be changed without the source model, but one to many related fields
@@ -55,6 +57,12 @@ class BSTFilterer(BSTBaseFilterer):
         """
 
         self.field_path = field_path
+        # TODO: Make model an optional keyword argument and:
+        # 1. Raise an exception if not set and distinct_choices is True
+        # 2. Create a BSTManyRelatedFilterer that autoimatically sets the client filterer to contains (thereby no longer
+        #    needing model to determine if the field is many-related).  Maybe name it as BSTDelimitedFilterer?
+        # OR OPTIONALLY: Change the model argument to a QuerySet argument and move it into the BSTBaseFilterer class so
+        #                that it can work on annotations as well.
         self.model = model
         self.distinct_choices = distinct_choices
 
@@ -74,11 +82,11 @@ class BSTFilterer(BSTBaseFilterer):
             else:
                 raise ae
 
-        if choices is not None and len(choices) > 0 and distinct_choices:
+        if choices is not None and distinct_choices:
             raise ValueError(
                 f"choices {choices} and distinct_choices '{distinct_choices}' are mutually exclusive."
             )
-        elif (choices is None or len(choices) == 0) and distinct_choices:
+        elif choices is None and distinct_choices:
             # If field_path is a foreign key, the way to construct the query is by getting all of the related model's
             # ordering fields, to avoid errors
             distinct_fields = get_distinct_fields(self.model, self.field_path)
@@ -91,14 +99,12 @@ class BSTFilterer(BSTBaseFilterer):
                 # The displayed and searchable values will be how the related model's objects render in string context
                 choices[str(val)] = str(val)
         elif (
-            (choices is None or len(choices) == 0)
+            choices is None
             and hasattr(self.field, "choices")
             and self.field.choices is not None
             and len(self.field.choices) > 0
         ):
             choices = dict(self.field.choices)
-        elif choices is not None and len(choices) == 0:
-            choices = None
 
         if client_filterer is None:
             if _server_filterer is not None:
@@ -156,12 +162,12 @@ class BSTFilterer(BSTBaseFilterer):
         Returns:
             (str): A value from self.CLIENT_FILTERERS
         """
-        select_list = (
+        has_select_list = (
             self.distinct_choices
             or choices is not None
             or (self.field.choices is not None and len(self.field.choices) > 0)
         )
-        if select_list:
+        if has_select_list:
             return (
                 self.CLIENT_FILTERERS.STRICT_MULTIPLE
                 if self.many_related

--- a/DataRepo/views/models/bst/column/related_field.py
+++ b/DataRepo/views/models/bst/column/related_field.py
@@ -123,7 +123,7 @@ class BSTRelatedColumn(BSTColumn):
                         "display_field_path could not be determined.  Supply display_field_path to allow search/sort."
                     )
 
-                tooltip = "" if tooltip is None else tooltip + "  "
+                tooltip = "" if tooltip is None else tooltip + "\n\n"
                 tooltip += (
                     "Search and sort is disabled for this column because the displayed values do not exist in the "
                     "database as a single field"
@@ -220,19 +220,23 @@ class BSTRelatedColumn(BSTColumn):
             None
         """
         # Grab as many of the last 2 items from the field_path as is present
-        path_tail = self.field_path.split("__")[-2:]
+        path = self.field_path.split("__")
 
         # If the length is greater than 1, the last element is "name", and the field is unique, use the name of the
         # foreign key to this model's field only.
-        if (
-            len(path_tail) == 2
-            and path_tail[1] == "name"
-            and is_unique_field(self.field)
-        ):
-            return underscored_to_title(path_tail[0])
+        if len(path) > 1 and path[-1] == "name" and is_unique_field(self.field):
+            return underscored_to_title(path[-2])
+
+        # If the field has a verbose name different from name (because it's automatically filled in with name), use it
+        if self.field.name != self.field.verbose_name:
+            if any(c.isupper() for c in self.field.verbose_name):
+                # If the field has a verbose name with caps, use it as-is
+                return self.field.verbose_name
+            else:
+                return underscored_to_title(self.field.verbose_name)
 
         # Otherwise, use the last 2 elements of the path
-        return underscored_to_title("_".join(path_tail))
+        return underscored_to_title(path[-1])
 
     def create_sorter(
         self, field: Optional[Union[Combinable, Field, str]] = None, **kwargs

--- a/DataRepo/views/models/bst/list_view.py
+++ b/DataRepo/views/models/bst/list_view.py
@@ -59,6 +59,19 @@ class BSTListView(BSTBaseListView):
                 # All of the other model fields are auto-added
                 columns = {"field1": {"visible": False}}
                 super().__init__(columns)
+
+        # Customize the fields without extending the constructor
+        class SampleList(BSTBaseListView):
+            model = Sample
+            column_ordering = ["name", "tissue", "animal", "time_collected", "handler"]
+            exclude = ["id", "msrun_samples"]
+            column_settings = {
+                # You only need to include columns and their options when you want something other than the default
+                "handler": {
+                    "header": "Researcher",
+                    filterer: {"choices": get_researchers}  # BSTBaseFilterer.__init__'s choices arg takes a callable
+                }
+            }
     """
 
     QueryModes = ["iterate", "subquery"]


### PR DESCRIPTION
## Summary Change Description

Added the ability to set column_settings in a class attribute and supply kwargs for the sorter and filterer constructors via the BSTBaseListView constructor's sorter and filterer arguments.

Details:

- Added an example to the docstrings for classes `BSTListView` and `BSTBaseListView`
- Made the `BSTBaseFilterer` constructor's `choices` option take a callable so that DB queries wouldn't happen at the class attribute level when setting the drop-down list content.
- `BSTFilterer`
  - Renamed `select_list` to `has_select_list` for clarity.
  - Removed calls to `len()` on `choices` because of the type change.  This means that it no longer detects empty `choices` when handling `distinct_choices`.  `choices` must be `None` or populated.
  - Added a `TODO` comment to make `model` an optional keyword argument and create a derived class for the many-related case.
- `BSTBaseListView`: replaced references to `self.__class__` with `type(self)`, which is a best practice.
- Improved the `assertEquivalent` method in the `TracebaseTestCase` to supply the `_path` in the msg keyword argument.

## Affected Issues/Pull Requests

- Partially addresses #1585
- Merges into branch `bstlv15_sample_list9_replink`

## Reviewer Notes/Requests
<!-- Notes to help the reviewer or requests for specific scrutiny.
E.g. Please make sure I have accounted for all possible inputs. -->
See comments in-line.

## Checklist
<!-- If any requirements are not met, uncheck and explain.
E.g. Linting errors pre-date this PR. -->
This pull request will be merged once the following requirements are met.  The
author and/or reviewers should uncheck any unmet requirements:
<!-- Check/complete items if not applicable. -->
- Review Requirements
  - Minimum approvals: 1 <!-- Edit based on complexity. -->
  - No changes requested
  - All blocking issues resolved by reviewers
  - Specific reviewers: @__add_username_here__ <!-- Approvals required even if minimum met. -->
  - Review period: 2 days <!-- Edit based on complexity. -->
- Associated Issue/PR Requirements: <!-- Assert resolved issues/PRs are done/merged. -->
  - [x] All issue requirements are satisfied
  - [x] All PR dependencies are merged
- Basic Requirements <!-- Uncheck to indicate items you are yet to address. -->
  - [x] [Linters pass](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#linting)
  - [x] [Tests pass](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#quality-control)
  - [x] Conflicts resolved
- Overhead Requirements <!-- Requirements indirectly related to the issues. -->
  - [x] [Tests implemented/updated](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#test-implementation)
  - [ ] [Updated `CHANGELOG.md` *Unreleased* section](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/changelog.md)
