### PR TITLE
`BSTListView` 15.11: Fixed column visibility, representative fields, null foreign keys, and setting conflicts

### DIFF
--- a/DataRepo/static/js/bst/list_view.js
+++ b/DataRepo/static/js/bst/list_view.js
@@ -11,6 +11,7 @@ var djangoLimit = djangoLimitDefault // eslint-disable-line no-var
 var djangoPerPage = djangoLimitDefault // eslint-disable-line no-var
 var djangoRawTotal = 0 // eslint-disable-line no-var
 var djangoTotal = djangoRawTotal // eslint-disable-line no-var
+var columnNames = [] // eslint-disable-line no-var
 
 var sortCookieName = 'sort' // eslint-disable-line no-var, no-unused-vars
 var ascCookieName = 'asc' // eslint-disable-line no-var, no-unused-vars
@@ -23,9 +24,13 @@ var pageCookieName = 'page' // eslint-disable-line no-var
 /**
  * This function exists solely for testing purposes
  */
-function initGlobalDefaults () { // eslint-disable-line no-unused-vars
+function initGlobalDefaults (customDjangoTableID, columnNames) { // eslint-disable-line no-unused-vars
   globalThis.djangoCurrentURL = window.location.href.split('?')[0]
-  globalThis.djangoTableID = 'bstlistviewtable'
+  if (typeof customDjangoTableID === 'undefined') {
+    globalThis.djangoTableID = 'bstlistviewtable'
+  } else {
+    globalThis.djangoTableID = customDjangoTableID
+  }
   globalThis.jqTableID = '#' + djangoTableID
   globalThis.djangoLimitDefault = 15
   globalThis.djangoLimit = djangoLimitDefault
@@ -40,6 +45,11 @@ function initGlobalDefaults () { // eslint-disable-line no-unused-vars
   globalThis.visibleCookieName = 'visible'
   globalThis.limitCookieName = 'limit'
   globalThis.pageCookieName = 'page'
+  if (typeof columnNames === 'undefined') {
+    globalThis.columnNames = []
+  } else {
+    globalThis.columnNames = columnNames
+  }
 }
 
 /**
@@ -53,6 +63,7 @@ function initGlobalDefaults () { // eslint-disable-line no-unused-vars
  * @param {*} total The total number of results/rows given the current searc/filter.
  * @param {*} rawTotal The total unfiltered number of results.
  * @param {*} currentURL The current URL of the page.
+ * @param {*} columnNames Ordered list of column names (the data-field attribute of the th tags).
  * @param {*} warnings A list of warnings from django.
  * @param {*} cookieResets A list of cookie names to reset from django.  (Not the whole cookie name, just the last bit, e.g. 'sortcol'.)
  * @param {*} clearCookies A boolean represented as a string, e.g. 'false'.
@@ -74,6 +85,7 @@ function initBST ( // eslint-disable-line no-unused-vars
   total,
   rawTotal,
   currentURL,
+  columnNames,
   warnings,
   cookieResets,
   clearCookies,
@@ -101,6 +113,13 @@ function initBST ( // eslint-disable-line no-unused-vars
   globalThis.visibleCookieName = visibleCookieName
   globalThis.limitCookieName = limitCookieName
   globalThis.pageCookieName = pageCookieName
+
+  // Clear whatever might already be in the global columnNames array
+  globalThis.columnNames = []
+  // Add the supplied columnNames
+  for (let i = 0; i < columnNames.length; i++) {
+    globalThis.columnNames.push(columnNames[i])
+  }
 
   // Initialize the cookies (basically just the prefix)
   initViewCookies(cookiePrefix) // eslint-disable-line no-undef
@@ -209,21 +228,6 @@ function displayWarnings (warningsArray) {
     }
     alert(warningText) // eslint-disable-line no-undef
   }
-}
-
-/**
- * Retrieves a list of column names (obtained from the data-field attribute of every th element).
- * Bootstrap table provides alternate methods of retrieving the fields, but they are not in order and are limited to
- * only either the visible or hidden ones.
- * @returns Column names.
- */
-function getColumnNames () {
-  const columnNames = []
-  const headerCells = document.querySelectorAll(`${jqTableID} th`)
-  for (let i = 0; i < headerCells.length; i++) {
-    columnNames.push(headerCells[i].dataset.field)
-  }
-  return columnNames
 }
 
 /**
@@ -349,7 +353,6 @@ function parseBool (boolval, def) {
  * @returns Nothing.
  */
 function updateVisible (visible, columnName) {
-  const columnNames = getColumnNames()
   if (typeof columnName !== 'undefined' && columnName) {
     if (columnNames.includes(columnName)) {
       setViewColumnCookie(columnName, visibleCookieName, visible) // eslint-disable-line no-undef
@@ -358,15 +361,22 @@ function updateVisible (visible, columnName) {
       alert('Error: Unable to save your column visibility selection') // eslint-disable-line no-undef
     } else {
       console.error(
-        "Column '" + columnName.toString() + "' not found.  The second argument must match a th data-field attribute.  " +
-        'Current data-fields: [' + columnNames.toString() + ']'
+        "Column '" + columnName.toString() + "' not found.  The second argument must match a th data-field " +
+        'attribute.  Current data-fields: [' + columnNames.toString() + ']'
       )
       alert('Error: Unable to save your column visibility selection') // eslint-disable-line no-undef
     }
   } else {
-    // When a columnName is not provided, set all columns' visibility
-    for (let i = 0; i < columnNames.length; i++) {
-      setViewColumnCookie(columnNames[i], visibleCookieName, visible) // eslint-disable-line no-undef
+    if (visible) {
+      $(jqTableID).bootstrapTable('getVisibleColumns').map(function (col) { // eslint-disable-line no-undef
+        setViewColumnCookie(col.field, visibleCookieName, visible) // eslint-disable-line no-undef
+        return col.field
+      })
+    } else {
+      $(jqTableID).bootstrapTable('getHiddenColumns').map(function (col) { // eslint-disable-line no-undef
+        setViewColumnCookie(col.field, visibleCookieName, visible) // eslint-disable-line no-undef
+        return col.field
+      })
     }
   }
 }

--- a/DataRepo/static/js/bst/list_view.js
+++ b/DataRepo/static/js/bst/list_view.js
@@ -158,7 +158,6 @@ function initBST ( // eslint-disable-line no-unused-vars
       // 1. BST sort and server side sort sometimes sort differently (c.i.p. imported_timestamp)
       // 2. BST sort completely fails when the number of rows is very large
       // ...so we will always let the sort hit the server to be on the safe side.
-      console.log('Sorting by ' + orderBy + ', ' + orderDir)
       updatePage(1)
     },
     onSearch: function (searchTerm) {
@@ -178,7 +177,6 @@ function initBST ( // eslint-disable-line no-unused-vars
       }
     },
     onColumnSearch: function (columnName, searchTerm) {
-      console.log('Filtering column ' + columnName + ' with term: ' + searchTerm)
       if (!loading) {
         // NOTE: Turns out that on page load, a column search event is triggered, so we check to see if anything
         // changed before triggering a page update.

--- a/DataRepo/templates/models/bst/scripts.html
+++ b/DataRepo/templates/models/bst/scripts.html
@@ -1,6 +1,8 @@
 {% load static %}
+{% load bsttags %}
 
 {# Variables needed for the scripts #}
+{{ columns|keys|json_script:"orderedColumnNames" }}
 {{ warnings|json_script:"warnings" }}
 {{ cookie_resets|json_script:"cookieResets" }}
 
@@ -10,6 +12,9 @@
 
 {# Script initialization #}
 <script>
+    // columnNames: An ordered list of column names from django.
+    const columnNamesElem = document.getElementById("orderedColumnNames");
+    const orderedColumnNames = JSON.parse(columnNamesElem.textContent);
     // warnings: A list of warnings from django.
     const warningsElem = document.getElementById("warnings");
     const warnings = JSON.parse(warningsElem.textContent);
@@ -35,6 +40,7 @@
             to create a proper concrete view for BSTListView in the tests, with a url and everything.
             {% endcomment %}
             {% comment %} '{% url request.resolver_match.url_name %}', {% endcomment %}
+            orderedColumnNames,
             warnings,
             cookieResets,
             '{{ clear_cookies }}',

--- a/DataRepo/templates/models/bst/th.html
+++ b/DataRepo/templates/models/bst/th.html
@@ -12,7 +12,8 @@
     data-sorter="{{ column.sorter }}"{% endif %}
 
     data-valign="top"
-    data-visible="{{ column.visible|lower }}">
+    {% if column.hidable %}data-visible="{{ column.visible|lower }}"{% endif %}
+    data-switchable="{{ column.hidable|lower }}">
     {{ column.header }}
     {% if column.tooltip %}<sup class="bi-question-circle" title="{{ column.tooltip }}"></sup>{% endif %}
 

--- a/DataRepo/templates/models/bst/th.html
+++ b/DataRepo/templates/models/bst/th.html
@@ -15,6 +15,6 @@
     {% if column.hidable %}data-visible="{{ column.visible|lower }}"{% endif %}
     data-switchable="{{ column.hidable|lower }}">
     {{ column.header }}
-    {% if column.tooltip %}<sup class="bi-question-circle" title="{{ column.tooltip }}"></sup>{% endif %}
+    {% if column.tooltip %}<sup class="bi-info-circle" title="{{ column.tooltip }}"></sup>{% endif %}
 
 </th>

--- a/DataRepo/templatetags/bsttags.py
+++ b/DataRepo/templatetags/bsttags.py
@@ -6,7 +6,7 @@ from django.conf import settings
 from django.db.models import Model
 
 from DataRepo.models.utilities import get_field_val_by_iteration
-from DataRepo.utils.exceptions import DeveloperWarning
+from DataRepo.utils.exceptions import DeveloperWarning, trace
 from DataRepo.views.models.bst.column.base import BSTBaseColumn
 from DataRepo.views.models.bst.column.many_related_field import (
     BSTManyRelatedColumn,
@@ -78,11 +78,12 @@ def get_rec_val(rec: Model, column: BSTBaseColumn) -> Any:
     try:
         val = get_field_val_by_iteration(rec, column.name.split("__"))
     except AttributeError as ae:
-        warning = (
-            f"A problem was encountered while processing {type(column).__name__} '{column}':\n"
-            f"Exception: {type(ae).__name__}: {ae}"
-        )
-        warn(warning, DeveloperWarning)
+        if settings.DEBUG:
+            warning = (
+                f"A problem was encountered while processing {type(column).__name__} '{column}':\n"
+                f"Exception:\n{trace(ae)}\n{type(ae).__name__}: {ae}"
+            )
+            warn(warning, DeveloperWarning)
         val = default
 
     return val
@@ -95,3 +96,9 @@ def get_absolute_url(model_object: Model):
     if url is not None and url != "":
         return url
     return None
+
+
+@register.filter
+def keys(dct: dict):
+    """Return ordered dict keys as a list"""
+    return list(dct.keys()) if isinstance(dct, dict) else []

--- a/DataRepo/tests/models/test_utilities.py
+++ b/DataRepo/tests/models/test_utilities.py
@@ -10,11 +10,12 @@ from django.db.models import (
     Field,
     FloatField,
     ForeignKey,
+    Func,
     ManyToManyField,
     Min,
     Value,
 )
-from django.db.models.functions import Concat, Lower, Upper
+from django.db.models.functions import Concat, Extract, Lower, Upper
 from django.db.models.query_utils import DeferredAttribute
 from django.forms import ValidationError, model_to_dict
 from django.test import override_settings
@@ -368,9 +369,32 @@ class ModelUtilitiesTests(TracebaseTransactionTestCase):
         )
         with self.assertRaises(ProgrammingError) as ar:
             resolve_field_path(1)
-        self.assertEqual(
-            "Unexpected field_or_expression type: 'int'.",
+        self.assertIn(
+            "Unexpected field_or_expression type: 'int'",
             str(ar.exception),
+        )
+
+        # Test deeper field_path expression and filtering out expressions without field_paths
+        self.assertEqual(
+            "time_collected",
+            resolve_field_path(
+                Extract(
+                    F("time_collected"),
+                    "epoch",
+                )
+                / Value(60),
+            ),
+        )
+        self.assertEqual(
+            "date",
+            resolve_field_path(
+                Func(
+                    F("date"),
+                    Value("YYYY-MM-DD"),
+                    output_field=CharField(),
+                    function="to_char",
+                ),
+            ),
         )
 
     def test_get_distinct_fields_nonkeyfield(self):

--- a/DataRepo/tests/models/test_utilities.py
+++ b/DataRepo/tests/models/test_utilities.py
@@ -456,6 +456,23 @@ MUQStudyTestModel = create_test_model(
     },
 )
 
+MUQInfusateTestModel = create_test_model(
+    "MUQInfusateTestModel",
+    {"name": CharField(max_length=255, unique=True)},
+)
+
+MUQTracerTestModel = create_test_model(
+    "MUQTracerTestModel",
+    {
+        "name": CharField(max_length=255, unique=True),
+        "infusate": ForeignKey(
+            to="loader.MUQInfusateTestModel",
+            related_name="tracers",
+            on_delete=CASCADE,
+        ),
+    },
+)
+
 MUQAnimalTestModel = create_test_model(
     "MUQAnimalTestModel",
     {
@@ -467,6 +484,12 @@ MUQAnimalTestModel = create_test_model(
         "treatment": ForeignKey(
             to="loader.MUQTreatmentTestModel",
             related_name="animals",
+            on_delete=CASCADE,
+        ),
+        "infusate": ForeignKey(
+            to="loader.MUQInfusateTestModel",
+            null=True,
+            related_name="infused_animals",
             on_delete=CASCADE,
         ),
     },
@@ -505,7 +528,7 @@ class ModelUtilityQueryTests(TracebaseTestCase):
         super().setUpTestData()
 
     @TracebaseTestCase.assertNotWarns()
-    def test_get_field_val_by_iteration(self):
+    def test_get_field_val_by_iteration_helper_basic(self):
         with self.assertNumQueries(0):
             # NOTE: Not sure yet why this performs no queries
             val, sval, id = _get_field_val_by_iteration_helper(
@@ -529,12 +552,31 @@ class ModelUtilityQueryTests(TracebaseTestCase):
             )
         expected1 = set([self.s2, self.s1])
         expected2 = set(["s1", "s2"])
-        vals1 = set([v[0] for v in vals])
-        vals2 = set([v[1] for v in vals])
-        vals3 = set([v[2] for v in vals])
+        self.assertIsInstance(vals, list)
+        self.assertIsInstance(vals[0], tuple)
+        self.assertIsInstance(vals[1], tuple)
+        self.assertEqual(2, len(vals))
+        # Tests above assures that the unsubscriptable-object errors from pylint are false positives
+        vals1 = set([v[0] for v in vals])  # pylint: disable=unsubscriptable-object
+        vals2 = set([v[1] for v in vals])  # pylint: disable=unsubscriptable-object
+        vals3 = set([v[2] for v in vals])  # pylint: disable=unsubscriptable-object
         self.assertEqual(expected1, vals1)
         self.assertEqual(expected2, vals2)
         self.assertTrue(all(isinstance(v3, int) for v3 in vals3))
+
+    @TracebaseTestCase.assertNotWarns()
+    def test_get_field_val_by_iteration_helper_manycheck(self):
+        """This test ensures that an empty list instead of None is returned when the field path doesn't make it to the
+        many-related portion of the path before hitting a None value.  E.g. Animal's field path:
+        infusate__tracers__name should return an empty list instead of None when no animal has an infusate.
+        """
+        vals = _get_field_val_by_iteration_helper(
+            self.a2,
+            ["infusate", "tracers", "name"],
+            related_limit=2,
+            sort_field_path=["name"],
+        )
+        self.assertEqual([], vals)
 
     @TracebaseTestCase.assertNotWarns()
     def test__get_field_val_by_iteration_onerelated_helper(self):

--- a/DataRepo/tests/static/js/bst/test_list_view.js
+++ b/DataRepo/tests/static/js/bst/test_list_view.js
@@ -402,7 +402,6 @@ QUnit.test('updateVisible', function (assert) {
   assert.equal(errors.length, 0)
   assert.equal(getViewColumnCookie('firstcol', 'visible'), 'true')
   assert.equal(getViewColumnCookie('testfield', 'visible'), 'false')
-  console.warn($('#bstlistviewtable').bootstrapTable('getVisibleColumns'))
   $('#bstlistviewtable').bootstrapTable('showAllColumns')
   updateVisible(true)
   assert.equal(alerts.length, 0)

--- a/DataRepo/tests/static/js/bst/test_list_view.js
+++ b/DataRepo/tests/static/js/bst/test_list_view.js
@@ -128,6 +128,56 @@ function createTestTable () {
   return fixture
 }
 
+function createTestTable2 (tableID, columnNames) {
+  // This is defined in tests.html and cleaned automatically by QUnit
+  const fixture = document.querySelector('#qunit-fixture')
+
+  // Create a table with a td containing 'table-cell' and a br containing 'cell-wrap'
+  const table = document.createElement('table')
+  // This is the default ID defined in DataRepo/static/js/bst/list_view.js
+  table.id = tableID
+  // This makes sure that there's always at least 1 column visible
+  table.setAttribute('data-show-columns', 'true')
+
+  // Create a thead row
+  const tr1 = document.createElement('tr')
+  for (let i = 0; i < columnNames.length; i++) {
+    const th = document.createElement('th')
+    th.setAttribute('data-field', columnNames[i])
+    tr1.appendChild(th)
+  }
+
+  // Create a tbody row
+  const tr = document.createElement('tr')
+  for (let i = 0; i < columnNames.length; i++) {
+    const td = document.createElement('td')
+    td.classList.add('table-cell')
+    td.classList.add('nobr')
+    td.id = 'test2'
+    const textOne = document.createTextNode('First line ')
+    const br = document.createElement('br')
+    br.classList.add('cell-wrap')
+    br.classList.add('d-none')
+    br.id = 'test3'
+    const textTwo = document.createTextNode('Second line')
+    td.appendChild(textOne)
+    td.appendChild(br)
+    td.appendChild(textTwo)
+    tr.appendChild(td)
+  }
+
+  const thead = document.createElement('thead')
+  const tbody = document.createElement('tbody')
+  thead.appendChild(tr1)
+  tbody.appendChild(tr)
+
+  table.appendChild(thead)
+  table.appendChild(tbody)
+  fixture.append(table)
+
+  return fixture
+}
+
 function assertCollapsed (assert, fixture, collapsed) {
   if (typeof collapsed === 'undefined') {
     // Test initial state is collapsed
@@ -287,13 +337,6 @@ QUnit.test('displayWarnings', function (assert) {
   assert.true(alerts[0].includes('Warning2.'))
 })
 
-QUnit.test('getColumnNames', function (assert) {
-  createTestTable()
-  const result = getColumnNames()
-  // 'testfield' is the data-field attribute of the single 'th' element added to the table in createTestTable
-  assert.deepEqual(result, ['testfield'])
-})
-
 QUnit.test('updateVisible', function (assert) {
   // Override the alert and error functions to capture messages for testing
   // See: https://stackoverflow.com/a/41369753
@@ -307,38 +350,65 @@ QUnit.test('updateVisible', function (assert) {
   initViewCookies('testcookieprefix')
 
   // Test before table is created to assert the error about no th data-field attributes
-  updateVisible('false', 'anyname')
+  updateVisible(false, 'anyname')
   assert.equal(errors.length, 1)
   assert.equal(errors[0], 'No th data-field attributes found.')
   assert.equal(alerts.length, 1)
   assert.equal(alerts[0], 'Error: Unable to save your column visibility selection')
 
   // Create the table
-  createTestTable()
+  const tid = 'bstlistviewtable'
+  const testColumnNames = ['firstcol', 'testfield']
+  createTestTable2(tid, testColumnNames)
+  // Init bootstrap so that the getVisibleColumns and getHiddenColumns functions will work
+  $('#bstlistviewtable').bootstrapTable()
+  // Set the columnNames
+  initGlobalDefaults(tid, testColumnNames)
 
   // Empty the arrays for the next test
   alerts.splice(0, alerts.length)
   errors.splice(0, errors.length)
 
-  updateVisible('false', 'testfield')
+  updateVisible(false, 'testfield')
   assert.equal(alerts.length, 0)
   assert.equal(errors.length, 0)
   assert.equal(getViewColumnCookie('testfield', 'visible'), 'false')
-  updateVisible('true', 'testfield')
+  updateVisible(true, 'testfield')
   assert.equal(alerts.length, 0)
   assert.equal(errors.length, 0)
   assert.equal(getViewColumnCookie('testfield', 'visible'), 'true')
 
   // Now test for an invalid column
-  updateVisible('false', 'wrongname')
+  updateVisible(false, 'wrongname')
   assert.equal(errors.length, 1)
   assert.equal(
     errors[0],
     "Column 'wrongname' not found.  The second argument must match a th data-field attribute.  " +
-    'Current data-fields: [testfield]'
+    'Current data-fields: [firstcol,testfield]'
   )
   assert.equal(alerts.length, 1)
   assert.equal(alerts[0], 'Error: Unable to save your column visibility selection')
+
+  // Now test setting all column visibility (BST sets all but the first column as hidden)
+  // Empty the arrays for the next test
+  alerts.splice(0, alerts.length)
+  errors.splice(0, errors.length)
+
+  // We need to trigger bootstrap to hide all columns so that getVisibleColumns returns the one that BST arbitrarily
+  // decided should not be hidden (the first one, based on 'data-show-columns'='true')
+  $('#bstlistviewtable').bootstrapTable('hideAllColumns')
+  updateVisible(false)
+  assert.equal(alerts.length, 0)
+  assert.equal(errors.length, 0)
+  assert.equal(getViewColumnCookie('firstcol', 'visible'), 'true')
+  assert.equal(getViewColumnCookie('testfield', 'visible'), 'false')
+  console.warn($('#bstlistviewtable').bootstrapTable('getVisibleColumns'))
+  $('#bstlistviewtable').bootstrapTable('showAllColumns')
+  updateVisible(true)
+  assert.equal(alerts.length, 0)
+  assert.equal(errors.length, 0)
+  assert.equal(getViewColumnCookie('firstcol', 'visible'), 'true')
+  assert.equal(getViewColumnCookie('testfield', 'visible'), 'true')
 
   // Restore the original functions
   window.alert = alertBackup
@@ -372,6 +442,7 @@ QUnit.test('initBST', function (assert) {
     100, // total
     120, // rawTotal
     window.location.href.split('?')[0], // currentURL
+    ['col1'], // columnNames
     ['WX'], // warnings
     ['TC'], // cookieResets
     'false', // clearCookies
@@ -388,6 +459,10 @@ QUnit.test('initBST', function (assert) {
 
   // Test that cookieResets deletes specific cookies
   assert.equal(getViewCookie('TC'), '')
+
+  // Test that the columnNames global is set
+  assert.equal(1, columnNames.length)
+  assert.equal('col1', columnNames[0])
 
   // Test that cookies are set
   assert.equal(getViewCookie('limit'), '10')
@@ -413,6 +488,7 @@ QUnit.test('initBST', function (assert) {
     100, // total
     120, // rawTotal
     window.location.href.split('?')[0], // currentURL
+    ['col1'], // columnNames
     [], // warnings
     [], // cookieResets
     'true', // clearCookies
@@ -445,6 +521,7 @@ QUnit.test('initBST', function (assert) {
     100, // total
     120, // rawTotal
     window.location.href.split('?')[0], // currentURL
+    ['col1'], // columnNames
     [], // warnings
     [], // cookieResets
     'false', // clearCookies,

--- a/DataRepo/tests/templates/models/bst/test_th.py
+++ b/DataRepo/tests/templates/models/bst/test_th.py
@@ -35,7 +35,7 @@ class ThTemplateTests(TracebaseTestCase):
         self.assertIn('data-sorter="djangoSorter"', html)
         self.assertIn('data-visible="true"', html)
         self.assertIn("Colname", html)
-        self.assertNotIn('<sup class="bi-question-circle" title="', html)
+        self.assertNotIn('<sup class="bi-info-circle" title="', html)
 
     def test_th_booleans(self):
         col = BSTAnnotColumn(
@@ -99,5 +99,5 @@ class ThTemplateTests(TracebaseTestCase):
         )
         html = self.render_th_template(col)
         self.assertIn(
-            '<sup class="bi-question-circle" title="This is header info."></sup>', html
+            '<sup class="bi-info-circle" title="This is header info."></sup>', html
         )

--- a/DataRepo/tests/templatetags/test_bsttags.py
+++ b/DataRepo/tests/templatetags/test_bsttags.py
@@ -80,7 +80,8 @@ class BSTListViewTagsTests(TracebaseTestCase):
             "problem was encountered while processing BSTAnnotColumn 'badname'",
             str(aw.warnings[0].message),
         )
-        self.assertIn("Exception: AttributeError", str(aw.warnings[0].message))
+        self.assertIn("Exception:", str(aw.warnings[0].message))
+        self.assertIn("AttributeError", str(aw.warnings[0].message))
         self.assertIn(
             "'BSTLVStudy' object has no attribute 'badname'",
             str(aw.warnings[0].message),

--- a/DataRepo/tests/templatetags/test_bsttags.py
+++ b/DataRepo/tests/templatetags/test_bsttags.py
@@ -8,6 +8,7 @@ from DataRepo.templatetags.bsttags import (
     get_rec_val,
     has_attr,
     is_model_obj,
+    keys,
 )
 from DataRepo.tests.tracebase_test_case import (
     TracebaseTestCase,
@@ -84,3 +85,7 @@ class BSTListViewTagsTests(TracebaseTestCase):
             "'BSTLVStudy' object has no attribute 'badname'",
             str(aw.warnings[0].message),
         )
+
+    @TracebaseTestCase.assertNotWarns()
+    def test_keys(self):
+        self.assertEqual(["a", "b"], keys({"a": 1, "b": 2}))

--- a/DataRepo/tests/views/models/bst/column/filterer/test_base.py
+++ b/DataRepo/tests/views/models/bst/column/filterer/test_base.py
@@ -1,4 +1,4 @@
-from django.db.models import CharField
+from django.db.models import CharField, Q
 from django.test import override_settings
 
 from DataRepo.tests.tracebase_test_case import (
@@ -54,3 +54,8 @@ class BSTFiltererTests(TracebaseTestCase):
         f = FiltererTest("name", choices=get_choices_dict)
         self.assertDictEquivalent(expected, f.choices)
         self.assertEqual(BSTBaseFilterer.INPUT_METHODS.SELECT, f.input_method)
+
+    @TracebaseTestCase.assertNotWarns()
+    def test_create_q_exp(self):
+        f = FiltererTest("name")
+        self.assertEqual(Q(**{"name__isnull": True}), f.create_q_exp("None"))

--- a/DataRepo/tests/views/models/bst/column/filterer/test_field.py
+++ b/DataRepo/tests/views/models/bst/column/filterer/test_field.py
@@ -64,7 +64,7 @@ class BSTFiltererTests(TracebaseTestCase):
         f = BSTFilterer("animal__sex", BSTFSampleTestModel)
         self.assertEqual(f.INPUT_METHODS.SELECT, f.input_method)
         self.assertEqual(f.CLIENT_FILTERERS.STRICT_SINGLE, f.client_filterer)
-        self.assertDictEqual({"F": "female", "M": "male"}, f.choices)
+        self.assertDictEqual({"F": "F (female)", "M": "M (male)"}, f.choices)
         self.assertEqual(f.SERVER_FILTERERS.STRICT_SINGLE, f._server_filterer)
 
     @TracebaseTestCase.assertNotWarns()
@@ -72,7 +72,7 @@ class BSTFiltererTests(TracebaseTestCase):
         f = BSTFilterer("animals__sex", BSTFStudyTestModel)
         self.assertEqual(f.INPUT_METHODS.SELECT, f.input_method)
         self.assertEqual(f.CLIENT_FILTERERS.STRICT_MULTIPLE, f.client_filterer)
-        self.assertDictEqual({"F": "female", "M": "male"}, f.choices)
+        self.assertDictEqual({"F": "F (female)", "M": "M (male)"}, f.choices)
         self.assertEqual(f.SERVER_FILTERERS.STRICT_MULTIPLE, f._server_filterer)
 
     @TracebaseTestCase.assertNotWarns()
@@ -193,7 +193,7 @@ class BSTFiltererTests(TracebaseTestCase):
         self.assertEqual("istartswith", str(f._server_filterer))
 
     @TracebaseTestCase.assertNotWarns()
-    def test_filter(self):
+    def test_create_q_exp(self):
         f = BSTFilterer(
             BSTFStudyTestModel.name.field.name,  # pylint: disable=no-member
             BSTFStudyTestModel,

--- a/DataRepo/tests/views/models/bst/column/test_base.py
+++ b/DataRepo/tests/views/models/bst/column/test_base.py
@@ -53,3 +53,12 @@ class BSTBaseColumnTests(TracebaseTestCase):
         self.assertEqual(
             BSTBaseFilterer.INPUT_METHODS.SELECT, bstbct.filterer.input_method
         )
+
+    def test_init_hidable(self):
+        bstbct1 = BSTBaseColumnTest("name", hidable=False, visible=False)
+        self.assertFalse(bstbct1.hidable)
+        self.assertTrue(bstbct1.visible)  # visible=False ignored, since not hidable
+
+        bstbct2 = BSTBaseColumnTest("name", hidable=True, visible=False)
+        self.assertTrue(bstbct2.hidable)
+        self.assertFalse(bstbct2.visible)  # visible=False ignored, since not hidable

--- a/DataRepo/tests/views/models/bst/column/test_field.py
+++ b/DataRepo/tests/views/models/bst/column/test_field.py
@@ -75,7 +75,7 @@ BSTCMSRunSampleTestModel = create_test_model(
 )
 BSTCTissueTestModel = create_test_model(
     "BSTCTissueTestModel",
-    {"name": CharField(max_length=255)},
+    {"name": CharField(max_length=255, help_text="Tissue name.")},
 )
 
 
@@ -252,3 +252,7 @@ class BSTColumnTests(TracebaseTestCase):
         self.assertTrue(BSTColumn("name", BSTCAnimalTestModel).has_detail())
         # Has a unique field, but no get_absolute_url method
         self.assertFalse(BSTColumn("name", BSTCStudyTestModel).has_detail())
+
+    def test_tooltip(self):
+        c = BSTColumn("name", BSTCTissueTestModel)
+        self.assertEqual("Tissue name.", c.tooltip)

--- a/DataRepo/tests/views/models/bst/column/test_related_field.py
+++ b/DataRepo/tests/views/models/bst/column/test_related_field.py
@@ -193,8 +193,8 @@ class BSTRelatedColumnTests(TracebaseTestCase):
         self.assertFalse(c.sortable)
         self.assertEqual(
             (
-                "Test tooltip.  Search and sort is disabled for this column because the displayed values do not exist "
-                "in the database as a single field"
+                "Test tooltip.\n\nSearch and sort is disabled for this column because the displayed values do not "
+                "exist in the database as a single field"
             ),
             BSTRelatedColumn(
                 "norep",
@@ -340,4 +340,4 @@ class BSTRelatedColumnTests(TracebaseTestCase):
         # Test that every other field uses - underscored_to_title("_".join(path_tail))
         c = BSTRelatedColumn("sample__animal__sex", BSTRCMSRunSampleTestModel)
         sh = c.generate_header()
-        self.assertEqual(underscored_to_title("animal_sex"), sh)
+        self.assertEqual(underscored_to_title("sex"), sh)

--- a/DataRepo/tests/views/models/bst/test_client_interface.py
+++ b/DataRepo/tests/views/models/bst/test_client_interface.py
@@ -118,19 +118,23 @@ class BSTClientInterfaceTests(TracebaseTestCase):
         self.assertEqual(
             str(aw.warnings[0].message), c.warnings[0] + "  'BSTClientInterface-cname'"
         )
-        self.assertEqual(f"BSTClientInterface-{view_cookie_name}", c.cookie_resets[0])
+        self.assertEqual(view_cookie_name, c.cookie_resets[0])
 
         # second occurrence does not warn
         val = c.get_boolean_cookie(view_cookie_name, default=True)
         self.assertTrue(val)
         # The rest has not changed...
-        self.assertEqual(1, len(c.warnings))
+        self.assertEqual(
+            1,
+            len(c.warnings),
+            msg=f"Cookie: {view_cookie_name} Resets: {c.cookie_resets} Warnings: {c.warnings}",
+        )
         # The warning message gives the full cookie name, which the user does not need to know.
         self.assertEqual(
             str(aw.warnings[0].message), c.warnings[0] + "  'BSTClientInterface-cname'"
         )
         self.assertEqual(1, len(c.cookie_resets))
-        self.assertEqual(f"BSTClientInterface-{view_cookie_name}", c.cookie_resets[0])
+        self.assertEqual(view_cookie_name, c.cookie_resets[0])
 
     @TracebaseTestCase.assertNotWarns()
     def test_get_column_cookie_name(self):
@@ -197,8 +201,8 @@ class BSTClientInterfaceTests(TracebaseTestCase):
         self.assertEqual(2, len(aw.warnings))
         self.assertEqual(2, len(c.warnings))
         self.assertEqual(2, len(c.cookie_resets))
-        self.assertIn("BSTClientInterface-filter-column1", c.cookie_resets)
-        self.assertIn("BSTClientInterface-filter-column2", c.cookie_resets)
+        self.assertIn("filter-column1", c.cookie_resets)
+        self.assertIn("filter-column2", c.cookie_resets)
 
     @TracebaseTestCase.assertNotWarns()
     def test_get_column_cookie(self):
@@ -256,7 +260,7 @@ class BSTClientInterfaceTests(TracebaseTestCase):
         bci.reset_column_cookies(["name", "desc"], "visible")
         # Only deletes the ones that are "set" (and empty string is eval'ed as None)
         self.assertEqual(
-            ["BSTClientInterface-visible-name", "BSTClientInterface-visible-desc"],
+            ["visible-name", "visible-desc"],
             bci.cookie_resets,
         )
 
@@ -279,7 +283,7 @@ class BSTClientInterfaceTests(TracebaseTestCase):
         bci.init_interface()
         bci.reset_cookie("sortcol")
         # Only deletes the ones that are "set" (and empty string is eval'ed as None)
-        self.assertEqual(["BSTClientInterface-sortcol"], bci.cookie_resets)
+        self.assertEqual(["sortcol"], bci.cookie_resets)
 
     def test_model_title_plural(self):
         self.assertEqual("BCI Study Test Models", StudyBCI.model_title_plural)
@@ -306,7 +310,7 @@ class BSTClientInterfaceTests(TracebaseTestCase):
         slv.init_interface()
         slv.reset_filter_cookies()
         # Only deletes the ones that are "set" (and empty string is eval'ed as None)
-        self.assertEqual(["StudyBCI-filter-desc"], slv.cookie_resets)
+        self.assertEqual(["filter-desc"], slv.cookie_resets)
 
     @TracebaseTestCase.assertNotWarns()
     def test_reset_search_cookie(self):
@@ -326,7 +330,7 @@ class BSTClientInterfaceTests(TracebaseTestCase):
         slv = StudyBCI(request=request)
         slv.init_interface()
         slv.reset_search_cookie()
-        self.assertEqual(["StudyBCI-search"], slv.cookie_resets)
+        self.assertEqual(["search"], slv.cookie_resets)
 
     @TracebaseTestCase.assertNotWarns()
     def test_get_context_data(self):

--- a/DataRepo/tests/views/models/bst/test_list_view.py
+++ b/DataRepo/tests/views/models/bst/test_list_view.py
@@ -365,12 +365,14 @@ class BSTListViewTests(TracebaseTestCase):
         alv = AnimalWithMultipleStudyColsLV(request=request)
         alv.init_interface()
         self.assertEqual(
-            "(OR: ('name__icontains', 'test1'), "
-            "('desc__icontains', 'test1'), "
-            "('treatment__name__icontains', 'test1'), "
-            "('studies__name__icontains', 'test1'), "
-            "('studies__desc__icontains', 'test1'), "
-            "('studies_mm_count__iexact', 'test1'))",
+            (
+                "(OR: ('name__icontains', 'test1'), "
+                "('desc__icontains', 'test1'), "
+                "('treatment__name__icontains', 'test1'), "
+                "('studies_mm_count__iexact', 'test1'), "
+                "('studies__name__icontains', 'test1'), "
+                "('studies__desc__icontains', 'test1'))"
+            ),
             str(alv.search()),
         )
 
@@ -508,9 +510,7 @@ class BSTListViewTests(TracebaseTestCase):
             BSTLVStudyTestModel.objects.all(),
             fqs,
         )
-        self.assertEqual(
-            [f"StudyLV-{StudyLV.filter_cookie_name}-desc"], slv.cookie_resets
-        )
+        self.assertEqual([f"{StudyLV.filter_cookie_name}-desc"], slv.cookie_resets)
 
     @TracebaseTestCase.assertNotWarns()
     def test_paginate_queryset(self):

--- a/DataRepo/views/models/bst/base.py
+++ b/DataRepo/views/models/bst/base.py
@@ -675,7 +675,7 @@ class BSTBaseListView(BSTClientInterface):
         for colname, obj in self.column_settings.items():
             self.add_to_column_ordering(colname)
             if isinstance(obj, BSTColumnGroup):
-                for col in obj.columns:
+                for col in obj.columns:  # pylint: disable=no-member
                     self.add_to_column_ordering(col.name)
 
     def add_to_column_ordering(self, colname: str, _warn=True):

--- a/DataRepo/views/models/bst/client_interface.py
+++ b/DataRepo/views/models/bst/client_interface.py
@@ -345,14 +345,14 @@ class BSTClientInterface(ListView):
         elif boolstr.lower().startswith("f"):
             return False
 
-        cookie_name = self.get_cookie_name(name)
-        if cookie_name not in self.cookie_resets:
-            self.cookie_resets.append(cookie_name)
+        if name not in self.cookie_resets:
+            self.cookie_resets.append(name)
             warning = (
                 f"Invalid '{name}' value encountered: '{boolstr}'.  Resetting cookie."
             )
             self.warnings.append(warning)
             if settings.DEBUG:
+                cookie_name = self.get_cookie_name(name)
                 warn(warning + f"  '{cookie_name}'", DeveloperWarning)
 
         return default
@@ -415,9 +415,9 @@ class BSTClientInterface(ListView):
             elif boolstr.lower().startswith("f"):
                 bools_dict[colname] = False
             else:
-                cookie_name = self.get_column_cookie_name(colname, name)
-                if cookie_name not in self.cookie_resets:
-                    self.cookie_resets.append(cookie_name)
+                view_cookie_name = f"{name}-{colname}"
+                if view_cookie_name not in self.cookie_resets:
+                    self.cookie_resets.append(view_cookie_name)
                     # TODO: Change the column name to the header
                     warning = (
                         f"Invalid '{name}' cookie value encountered for column '{colname}': '{boolstr}'.  "
@@ -425,6 +425,7 @@ class BSTClientInterface(ListView):
                     )
                     self.warnings.append(warning)
                     if settings.DEBUG:
+                        cookie_name = self.get_column_cookie_name(colname, name)
                         warn(warning + f"  '{cookie_name}'", DeveloperWarning)
         return bools_dict
 
@@ -466,7 +467,7 @@ class BSTClientInterface(ListView):
             )
         cookie_name = self.get_column_cookie_name(str(column), name)
         if cookie_name not in self.cookie_resets:
-            self.cookie_resets.append(cookie_name)
+            self.cookie_resets.append(f"{name}-{column}")
 
     def reset_column_cookies(self, columns: List[Union[str, BSTBaseColumn]], name: str):
         """Adds cookies to the cookie_resets list.
@@ -499,7 +500,7 @@ class BSTClientInterface(ListView):
         cookie_name = self.get_cookie_name(name)
         if cookie_name not in self.cookie_resets:
             delete_cookie(self.request, cookie_name)
-            self.cookie_resets.append(cookie_name)
+            self.cookie_resets.append(name)
 
     def reset_all_cookies(self):
         """Sets clear_cookies to True and removes all cookies from the request object.

--- a/DataRepo/views/models/bst/column/base.py
+++ b/DataRepo/views/models/bst/column/base.py
@@ -71,6 +71,7 @@ class BSTBaseColumn(ABC):
         tooltip: Optional[str] = None,
         searchable: Optional[bool] = None,
         sortable: Optional[bool] = None,
+        hidable: bool = True,
         visible: bool = True,
         exported: bool = True,
         linked: bool = False,
@@ -98,6 +99,7 @@ class BSTBaseColumn(ABC):
                 default is based on whether the column is a foreign key or not, because Django turns keys into model
                 objects that do not render the actual numeric key value, so what the user sees would not behave as
                 expected when sorted.
+            hidable (bool) [True]: Controls whether a column's visible state can be made False.
             visible (bool) [True]: Controls whether a column is initially visible.
             exported (bool) [True]: Adds to BST's exportOptions' ignoreColumn attribute if False.
             linked (bool) [False]: Whether or not the value in the column should link to a detail page for the model
@@ -132,7 +134,8 @@ class BSTBaseColumn(ABC):
         self.tooltip = tooltip
         self.searchable = searchable
         self.sortable = sortable
-        self.visible = visible
+        self.hidable = hidable
+        self.visible = visible if hidable else True
         self.exported = exported
         self.linked = linked
         self.th_template = (

--- a/DataRepo/views/models/bst/column/field.py
+++ b/DataRepo/views/models/bst/column/field.py
@@ -94,6 +94,7 @@ class BSTColumn(BSTBaseColumn):
 
         # Get some superclass instance members we need for checks
         linked = kwargs.get("linked")
+        tooltip = kwargs.get("tooltip")
 
         # Set the name for the superclass based on field_path
         name = self.field_path
@@ -137,6 +138,12 @@ class BSTColumn(BSTBaseColumn):
         self.field = field_path_to_field(self.model, self.field_path)
         if not hasattr(self, "is_fk") or getattr(self, "is_fk", None) is None:
             self.is_fk = is_key_field(self.field)
+
+        if self.field.help_text is not None and self.field.help_text != "":
+            new_tooltip = self.field.help_text
+            if tooltip is not None:
+                new_tooltip += "\n\n" + tooltip
+            kwargs.update({"tooltip": new_tooltip})
 
         super().__init__(name, *args, **kwargs)
 

--- a/DataRepo/views/models/bst/column/filterer/field.py
+++ b/DataRepo/views/models/bst/column/filterer/field.py
@@ -104,7 +104,15 @@ class BSTFilterer(BSTBaseFilterer):
             and self.field.choices is not None
             and len(self.field.choices) > 0
         ):
-            choices = dict(self.field.choices)
+            choices = dict(
+                (
+                    (k, v)
+                    if str(k).lower().replace(" ", "")
+                    == str(v).lower().replace(" ", "")
+                    else (k, f"{k} ({v})")
+                )
+                for k, v in self.field.choices
+            )
 
         if client_filterer is None:
             if _server_filterer is not None:

--- a/DataRepo/views/models/bst/column/related_field.py
+++ b/DataRepo/views/models/bst/column/related_field.py
@@ -123,7 +123,7 @@ class BSTRelatedColumn(BSTColumn):
                         "display_field_path could not be determined.  Supply display_field_path to allow search/sort."
                     )
 
-                tooltip = "" if tooltip is None else tooltip + "  "
+                tooltip = "" if tooltip is None else tooltip + "\n\n"
                 tooltip += (
                     "Search and sort is disabled for this column because the displayed values do not exist in the "
                     "database as a single field"
@@ -220,19 +220,23 @@ class BSTRelatedColumn(BSTColumn):
             None
         """
         # Grab as many of the last 2 items from the field_path as is present
-        path_tail = self.field_path.split("__")[-2:]
+        path = self.field_path.split("__")
 
         # If the length is greater than 1, the last element is "name", and the field is unique, use the name of the
         # foreign key to this model's field only.
-        if (
-            len(path_tail) == 2
-            and path_tail[1] == "name"
-            and is_unique_field(self.field)
-        ):
-            return underscored_to_title(path_tail[0])
+        if len(path) > 1 and path[-1] == "name" and is_unique_field(self.field):
+            return underscored_to_title(path[-2])
+
+        # If the field has a verbose name different from name (because it's automatically filled in with name), use it
+        if self.field.name != self.field.verbose_name:
+            if any(c.isupper() for c in self.field.verbose_name):
+                # If the field has a verbose name with caps, use it as-is
+                return self.field.verbose_name
+            else:
+                return underscored_to_title(self.field.verbose_name)
 
         # Otherwise, use the last 2 elements of the path
-        return underscored_to_title("_".join(path_tail))
+        return underscored_to_title(path[-1])
 
     def create_sorter(
         self, field: Optional[Union[Combinable, Field, str]] = None, **kwargs


### PR DESCRIPTION
## Summary Change Description

I started fleshing the `SampleListView` class with custom columns and ran into some more minor bugs.

Fixed column visibility cookies and exceptions regarding representative fields, null foreign keys, and setting conflicts.

Details:

- `BSTBaseColumn`
  - Added instance attribute `hidable` to `BSTBaseColumn`.
- `BSTBaseListView`
  - `init_interface`
    - Added a set for `column.visible` from the cookies in `init_interface`.
    - Deleted bad visible cookies.
  - `init_column_settings`
    - Only raise `ProgrammingError` when the annotation conflict is specifically with "converter".  This allows derived classes to tweak the settings of an annotation column.
  - `init_column_setting`
    - Added a check for conflicting annotations (with column objects).
  - `init_column_setting`
    - Changed `ValueError`s to `ProgrammingError`s when there are multiple conflicting column settings.
  - `init_columns`
    - Fixed the setting of `representative_column`, and added a case to select an arbitrary representative even when an existing column wasn't linked.
  - `_get_group_representative`
    - Accounted for the relative_representative being `None`.
- `bsttags.py`
  - Added function `keys` to return an ordered list of column names to be able to supply those names to the javascript.
  - Added a trace to the warning from `get_rec_val` and made it only come out in DEBUG mode.
- `th.html`
  - Added the `data-switchable` attribute to the `th` tag for the column `hidable` attribute and made `data-visible` be conditional based on that value.
- `scripts.html`
  - Added a load of the `bsttags`.
  - Added an `orderedColumnNames` javascript variable set by `columns` using the new `keys` tag, and supplied it to `initBST`.
- `utilities.py`
  - Fixed a bug I discovered in the case where a one-related foreign key is `None` before a many-related foreign key is encountered, causing a `tuple` to be returned instead of the expected `list`.
    - `_get_field_val_by_iteration_helper`
      - When `rec` is `None`, returned `None, None, None` instead of just `None` when the path is one-related.  And returned an empty list when many-related.
      - Added a check on the obtained value for the `None` case to return the right type based on whether the field path is one or many-related.
    - `_get_field_val_by_iteration_onerelated_helper` - Returned a `None` `tuple` when `val_or_rec` is `None`.

## Affected Issues/Pull Requests

- Partially addresses #1585
  - Specifically, the following issues in [this comment](https://github.com/Princeton-LSI-ResearchComputing/tracebase/issues/1585#issuecomment-2989476636) are addressed:
    - Exception `representative = orig_subset_lookup[str(relative_representative)]` key was `None`
    - Sorting by `tracer` `concentration` raised an exception
    - `visible` state isn't being remembered. The `getColumnNames` method is only grabbing `visible` column.
    - Got an error that annotation was defined in `column_settings` and `annotations`.
- Merges into branch `bstlv15_sample_list10_settings_attr_choices_func`

## Reviewer Notes/Requests

![qunit_colnames](https://github.com/user-attachments/assets/557d23e9-4fc7-401f-bf01-06f4aae7719b)

## Checklist
<!-- If any requirements are not met, uncheck and explain.
E.g. Linting errors pre-date this PR. -->
This pull request will be merged once the following requirements are met.  The
author and/or reviewers should uncheck any unmet requirements:
<!-- Check/complete items if not applicable. -->
- Review Requirements
  - Minimum approvals: 1 <!-- Edit based on complexity. -->
  - No changes requested
  - All blocking issues resolved by reviewers
  - Specific reviewers: @__add_username_here__ <!-- Approvals required even if minimum met. -->
  - Review period: 2 days <!-- Edit based on complexity. -->
- Associated Issue/PR Requirements: <!-- Assert resolved issues/PRs are done/merged. -->
  - [x] All issue requirements are satisfied
  - [x] All PR dependencies are merged
- Basic Requirements <!-- Uncheck to indicate items you are yet to address. -->
  - [x] [Linters pass](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#linting)
  - [x] [Tests pass](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#quality-control)
  - [x] Conflicts resolved
- Overhead Requirements <!-- Requirements indirectly related to the issues. -->
  - [x] [Tests implemented/updated](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#test-implementation)
  - [ ] [Updated `CHANGELOG.md` *Unreleased* section](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/changelog.md)
