### PR TITLE
`BSTListView` 15.12: None-search, header-tweaks, count-columns, verbose-names, cookie-resets, and annotation-tooltips

### DIFF
--- a/DataRepo/static/js/bst/list_view.js
+++ b/DataRepo/static/js/bst/list_view.js
@@ -158,7 +158,6 @@ function initBST ( // eslint-disable-line no-unused-vars
       // 1. BST sort and server side sort sometimes sort differently (c.i.p. imported_timestamp)
       // 2. BST sort completely fails when the number of rows is very large
       // ...so we will always let the sort hit the server to be on the safe side.
-      console.log('Sorting by ' + orderBy + ', ' + orderDir)
       updatePage(1)
     },
     onSearch: function (searchTerm) {
@@ -178,7 +177,6 @@ function initBST ( // eslint-disable-line no-unused-vars
       }
     },
     onColumnSearch: function (columnName, searchTerm) {
-      console.log('Filtering column ' + columnName + ' with term: ' + searchTerm)
       if (!loading) {
         // NOTE: Turns out that on page load, a column search event is triggered, so we check to see if anything
         // changed before triggering a page update.

--- a/DataRepo/templates/models/bst/th.html
+++ b/DataRepo/templates/models/bst/th.html
@@ -15,6 +15,6 @@
     {% if column.hidable %}data-visible="{{ column.visible|lower }}"{% endif %}
     data-switchable="{{ column.hidable|lower }}">
     {{ column.header }}
-    {% if column.tooltip %}<sup class="bi-question-circle" title="{{ column.tooltip }}"></sup>{% endif %}
+    {% if column.tooltip %}<sup class="bi-info-circle" title="{{ column.tooltip }}"></sup>{% endif %}
 
 </th>

--- a/DataRepo/tests/models/test_utilities.py
+++ b/DataRepo/tests/models/test_utilities.py
@@ -369,8 +369,8 @@ class ModelUtilitiesTests(TracebaseTransactionTestCase):
         )
         with self.assertRaises(ProgrammingError) as ar:
             resolve_field_path(1)
-        self.assertEqual(
-            "Unexpected field_or_expression type: 'int'.",
+        self.assertIn(
+            "Unexpected field_or_expression type: 'int'",
             str(ar.exception),
         )
 

--- a/DataRepo/tests/templates/models/bst/test_th.py
+++ b/DataRepo/tests/templates/models/bst/test_th.py
@@ -35,7 +35,7 @@ class ThTemplateTests(TracebaseTestCase):
         self.assertIn('data-sorter="djangoSorter"', html)
         self.assertIn('data-visible="true"', html)
         self.assertIn("Colname", html)
-        self.assertNotIn('<sup class="bi-question-circle" title="', html)
+        self.assertNotIn('<sup class="bi-info-circle" title="', html)
 
     def test_th_booleans(self):
         col = BSTAnnotColumn(
@@ -99,5 +99,5 @@ class ThTemplateTests(TracebaseTestCase):
         )
         html = self.render_th_template(col)
         self.assertIn(
-            '<sup class="bi-question-circle" title="This is header info."></sup>', html
+            '<sup class="bi-info-circle" title="This is header info."></sup>', html
         )

--- a/DataRepo/tests/views/models/bst/column/filterer/test_base.py
+++ b/DataRepo/tests/views/models/bst/column/filterer/test_base.py
@@ -1,4 +1,4 @@
-from django.db.models import CharField
+from django.db.models import CharField, Q
 from django.test import override_settings
 
 from DataRepo.tests.tracebase_test_case import (
@@ -54,3 +54,8 @@ class BSTFiltererTests(TracebaseTestCase):
         f = FiltererTest("name", choices=get_choices_dict)
         self.assertDictEquivalent(expected, f.choices)
         self.assertEqual(BSTBaseFilterer.INPUT_METHODS.SELECT, f.input_method)
+
+    @TracebaseTestCase.assertNotWarns()
+    def test_create_q_exp(self):
+        f = FiltererTest("name")
+        self.assertEqual(Q(**{"name__isnull": True}), f.create_q_exp("None"))

--- a/DataRepo/tests/views/models/bst/column/filterer/test_field.py
+++ b/DataRepo/tests/views/models/bst/column/filterer/test_field.py
@@ -64,7 +64,7 @@ class BSTFiltererTests(TracebaseTestCase):
         f = BSTFilterer("animal__sex", BSTFSampleTestModel)
         self.assertEqual(f.INPUT_METHODS.SELECT, f.input_method)
         self.assertEqual(f.CLIENT_FILTERERS.STRICT_SINGLE, f.client_filterer)
-        self.assertDictEqual({"F": "female", "M": "male"}, f.choices)
+        self.assertDictEqual({"F": "F (female)", "M": "M (male)"}, f.choices)
         self.assertEqual(f.SERVER_FILTERERS.STRICT_SINGLE, f._server_filterer)
 
     @TracebaseTestCase.assertNotWarns()
@@ -72,7 +72,7 @@ class BSTFiltererTests(TracebaseTestCase):
         f = BSTFilterer("animals__sex", BSTFStudyTestModel)
         self.assertEqual(f.INPUT_METHODS.SELECT, f.input_method)
         self.assertEqual(f.CLIENT_FILTERERS.STRICT_MULTIPLE, f.client_filterer)
-        self.assertDictEqual({"F": "female", "M": "male"}, f.choices)
+        self.assertDictEqual({"F": "F (female)", "M": "M (male)"}, f.choices)
         self.assertEqual(f.SERVER_FILTERERS.STRICT_MULTIPLE, f._server_filterer)
 
     @TracebaseTestCase.assertNotWarns()
@@ -193,7 +193,7 @@ class BSTFiltererTests(TracebaseTestCase):
         self.assertEqual("istartswith", str(f._server_filterer))
 
     @TracebaseTestCase.assertNotWarns()
-    def test_filter(self):
+    def test_create_q_exp(self):
         f = BSTFilterer(
             BSTFStudyTestModel.name.field.name,  # pylint: disable=no-member
             BSTFStudyTestModel,

--- a/DataRepo/tests/views/models/bst/column/test_field.py
+++ b/DataRepo/tests/views/models/bst/column/test_field.py
@@ -75,7 +75,7 @@ BSTCMSRunSampleTestModel = create_test_model(
 )
 BSTCTissueTestModel = create_test_model(
     "BSTCTissueTestModel",
-    {"name": CharField(max_length=255)},
+    {"name": CharField(max_length=255, help_text="Tissue name.")},
 )
 
 
@@ -252,3 +252,7 @@ class BSTColumnTests(TracebaseTestCase):
         self.assertTrue(BSTColumn("name", BSTCAnimalTestModel).has_detail())
         # Has a unique field, but no get_absolute_url method
         self.assertFalse(BSTColumn("name", BSTCStudyTestModel).has_detail())
+
+    def test_tooltip(self):
+        c = BSTColumn("name", BSTCTissueTestModel)
+        self.assertEqual("Tissue name.", c.tooltip)

--- a/DataRepo/tests/views/models/bst/column/test_related_field.py
+++ b/DataRepo/tests/views/models/bst/column/test_related_field.py
@@ -193,8 +193,8 @@ class BSTRelatedColumnTests(TracebaseTestCase):
         self.assertFalse(c.sortable)
         self.assertEqual(
             (
-                "Test tooltip.  Search and sort is disabled for this column because the displayed values do not exist "
-                "in the database as a single field"
+                "Test tooltip.\n\nSearch and sort is disabled for this column because the displayed values do not "
+                "exist in the database as a single field"
             ),
             BSTRelatedColumn(
                 "norep",
@@ -340,4 +340,4 @@ class BSTRelatedColumnTests(TracebaseTestCase):
         # Test that every other field uses - underscored_to_title("_".join(path_tail))
         c = BSTRelatedColumn("sample__animal__sex", BSTRCMSRunSampleTestModel)
         sh = c.generate_header()
-        self.assertEqual(underscored_to_title("animal_sex"), sh)
+        self.assertEqual(underscored_to_title("sex"), sh)

--- a/DataRepo/tests/views/models/bst/test_base.py
+++ b/DataRepo/tests/views/models/bst/test_base.py
@@ -574,6 +574,8 @@ class BSTBaseListViewTests(TracebaseTestCase):
                     "treatment__desc",
                     "desc",
                     "name",
+                    "samples",
+                    "samples_mm_count",
                 ]
             ),
             set(list(alv.columns.keys())),

--- a/DataRepo/tests/views/models/bst/test_base.py
+++ b/DataRepo/tests/views/models/bst/test_base.py
@@ -59,6 +59,18 @@ BSTBLVAnimalTestModel = create_test_model(
     },
 )
 
+BSTBLVSampleTestModel = create_test_model(
+    "BSTBLVSampleTestModel",
+    {
+        "name": CharField(max_length=255, unique=True),
+        "animal": ForeignKey(
+            to="loader.BSTBLVAnimalTestModel",
+            related_name="samples",
+            on_delete=CASCADE,
+        ),
+    },
+)
+
 BSTBLVTreatmentTestModel = create_test_model(
     "BSTBLVTreatmentTestModel",
     {"name": CharField(unique=True), "desc": CharField()},
@@ -203,9 +215,7 @@ class BSTBaseListViewTests(TracebaseTestCase):
             ],
             blv.warnings,
         )
-        self.assertEqual(
-            ["StudyBLV-visible-desc", "StudyBLV-filter-stale"], blv.cookie_resets
-        )
+        self.assertEqual(["visible-desc", "filter-stale"], blv.cookie_resets)
 
     def test_init_class_attr_column_settings(self):
         """This tests that you can use the column_settings class attribute to avoid extending the constructor"""
@@ -491,7 +501,28 @@ class BSTBaseListViewTests(TracebaseTestCase):
         slv.column_settings = {}
         slv.column_ordering = []
         slv.init_column_ordering()
-        self.assertEqual(["name", "desc", "id"], slv.column_ordering)
+        self.assertNotIn("animals_mm_count", slv.column_ordering)
+
+        # Check that MR count col inserted before first MR column relation when self.column_ordering contains an MR
+        # relation that is not the first in the path
+        class SampleBLV(BSTBaseListView):
+            model = BSTBLVSampleTestModel
+            column_ordering = ["name", "animal__studies__name", "animal__studies__desc"]
+            exclude = ["id", "animal", "animal__studies"]
+
+        mlv = SampleBLV()
+        # Reset the column_ordering to isolate it
+        mlv.column_ordering = ["name", "animal__studies__name", "animal__studies__desc"]
+        mlv.init_column_ordering()
+        self.assertEqual(
+            [
+                "name",
+                "studies_mm_count",
+                "animal__studies__name",
+                "animal__studies__desc",
+            ],
+            mlv.column_ordering,
+        )
 
     @TracebaseTestCase.assertNotWarns(DeveloperWarning)
     def test_add_to_column_ordering(self):
@@ -529,18 +560,20 @@ class BSTBaseListViewTests(TracebaseTestCase):
             ]
         )
         alv.columns = {}
-        # Re-init the column_settings for study_count, because the forst pass would have removed the name:
+        # NOTE: This was changed to remove references to studies_mm_count because the way the count columns are added
+        # was changed in a way that allows the derived class to supply settings for the count columns, so the count
+        # column key in the settings does not exist.  It is left clear for custom settings to be supplied.
         alv.init_columns()
         self.assertEqual(
             set(
                 [
+                    "studies_mm_count",
                     "studies__name",
                     "studies__desc",
                     "treatment",
                     "treatment__desc",
                     "desc",
                     "name",
-                    "studies_mm_count",
                 ]
             ),
             set(list(alv.columns.keys())),
@@ -579,8 +612,11 @@ class BSTBaseListViewTests(TracebaseTestCase):
         )
         alv.column_settings["study_count"] = {"converter": Count("studies")}
         alv.init_column("study_count")
-        self.assertEqual(
-            BSTAnnotColumn("study_count", Count("studies")), alv.columns["study_count"]
+        self.assertEquivalent(
+            BSTAnnotColumn(
+                "study_count", Count("studies"), model=BSTBLVAnimalTestModel
+            ),
+            alv.columns["study_count"],
         )
 
     @TracebaseTestCase.assertNotWarns()
@@ -664,6 +700,106 @@ class BSTBaseListViewTests(TracebaseTestCase):
                 ),
             },
             slv.column_settings,
+        )
+
+        # Set self.column_ordering containing a MR relation that is not the first in the path and
+        # check that count col is added to the settings, even if the FK field is excluded
+        class SampleBLV(BSTBaseListView):
+            model = BSTBLVSampleTestModel
+            column_ordering = ["name", "animal__studies__name", "animal__studies__desc"]
+            exclude = ["id", "animal__studies"]
+
+        mlv = SampleBLV()
+        mlv.add_default_many_related_column_settings()
+        self.assertDictEquivalent(
+            {
+                "studies_mm_count": BSTAnnotColumn(
+                    "studies_mm_count",
+                    Count(
+                        "animal__studies", output_field=IntegerField(), distinct=True
+                    ),
+                    header="Studies Count",
+                    filterer="strictFilterer",
+                    sorter="numericSorter",
+                ),
+            },
+            mlv.column_settings,
+        )
+
+        # Check that having count col manually entered as dict into column_settings class attribute without a setting
+        # for converter still auto-creates count col in column_settings, preserving those settings, e.g. visible=False
+        class CustomSampleBLV(BSTBaseListView):
+            model = BSTBLVSampleTestModel
+            column_ordering = ["name", "animal__studies__name", "animal__studies__desc"]
+            exclude = ["id", "animal__studies"]
+            column_settings = {"studies_mm_count": {"visible": False}}
+
+        clv = CustomSampleBLV()
+        clv.add_default_many_related_column_settings()
+        self.assertDictEquivalent(
+            {
+                "studies_mm_count": BSTAnnotColumn(
+                    "studies_mm_count",
+                    Count(
+                        "animal__studies", output_field=IntegerField(), distinct=True
+                    ),
+                    header="Studies Count",
+                    filterer="strictFilterer",
+                    sorter="numericSorter",
+                    visible=False,
+                ),
+            },
+            clv.column_settings,
+        )
+
+        # Test that a dict for an annot col in the annotations class attribute creates a BSTAnnotColumn in
+        # self.columns[colname] using that converter
+        class SampleWithAnnotBLV(BSTBaseListView):
+            model = BSTBLVSampleTestModel
+            column_ordering = ["name", "animal__studies__name", "animal__studies__desc"]
+            exclude = ["id", "animal__studies"]
+            # Custom count annotation (could be anything, but arbitrarily using Value, just to have something different
+            # and confirm it is used)
+            annotations = {"studies_mm_count": Value(5)}
+
+        clv = SampleWithAnnotBLV()
+        clv.add_default_many_related_column_settings()
+        self.assertDictEquivalent(
+            {
+                "studies_mm_count": BSTAnnotColumn(
+                    "studies_mm_count",
+                    Value(5),
+                    header="Studies Count",
+                    filterer="strictFilterer",
+                    sorter="numericSorter",
+                ),
+            },
+            clv.column_settings,
+        )
+
+        # Test that a dict for an annot col with a converter in the column_settings class attribute creates a
+        # BSTAnnotColumn in self.columns[colname] using that converter (same as above, only different attribute)
+        class SampleWithAnnotSettingBLV(BSTBaseListView):
+            model = BSTBLVSampleTestModel
+            column_ordering = ["name", "animal__studies__name", "animal__studies__desc"]
+            exclude = ["id", "animal__studies"]
+            # Custom count annotation (could be anything, but arbitrarily using Value, just to have something different
+            # and confirm it is used)
+            column_settings = {"studies_mm_count": {"converter": Value(5)}}
+
+        clv = SampleWithAnnotSettingBLV()
+        clv.add_default_many_related_column_settings()
+        self.assertDictEquivalent(
+            {
+                "studies_mm_count": BSTAnnotColumn(
+                    "studies_mm_count",
+                    Value(5),
+                    header="Studies Count",
+                    filterer="strictFilterer",
+                    sorter="numericSorter",
+                ),
+            },
+            clv.column_settings,
         )
 
     def test_many_related_columns_exist(self):

--- a/DataRepo/tests/views/models/bst/test_client_interface.py
+++ b/DataRepo/tests/views/models/bst/test_client_interface.py
@@ -118,19 +118,23 @@ class BSTClientInterfaceTests(TracebaseTestCase):
         self.assertEqual(
             str(aw.warnings[0].message), c.warnings[0] + "  'BSTClientInterface-cname'"
         )
-        self.assertEqual(f"BSTClientInterface-{view_cookie_name}", c.cookie_resets[0])
+        self.assertEqual(view_cookie_name, c.cookie_resets[0])
 
         # second occurrence does not warn
         val = c.get_boolean_cookie(view_cookie_name, default=True)
         self.assertTrue(val)
         # The rest has not changed...
-        self.assertEqual(1, len(c.warnings))
+        self.assertEqual(
+            1,
+            len(c.warnings),
+            msg=f"Cookie: {view_cookie_name} Resets: {c.cookie_resets} Warnings: {c.warnings}",
+        )
         # The warning message gives the full cookie name, which the user does not need to know.
         self.assertEqual(
             str(aw.warnings[0].message), c.warnings[0] + "  'BSTClientInterface-cname'"
         )
         self.assertEqual(1, len(c.cookie_resets))
-        self.assertEqual(f"BSTClientInterface-{view_cookie_name}", c.cookie_resets[0])
+        self.assertEqual(view_cookie_name, c.cookie_resets[0])
 
     @TracebaseTestCase.assertNotWarns()
     def test_get_column_cookie_name(self):
@@ -197,8 +201,8 @@ class BSTClientInterfaceTests(TracebaseTestCase):
         self.assertEqual(2, len(aw.warnings))
         self.assertEqual(2, len(c.warnings))
         self.assertEqual(2, len(c.cookie_resets))
-        self.assertIn("BSTClientInterface-filter-column1", c.cookie_resets)
-        self.assertIn("BSTClientInterface-filter-column2", c.cookie_resets)
+        self.assertIn("filter-column1", c.cookie_resets)
+        self.assertIn("filter-column2", c.cookie_resets)
 
     @TracebaseTestCase.assertNotWarns()
     def test_get_column_cookie(self):
@@ -256,7 +260,7 @@ class BSTClientInterfaceTests(TracebaseTestCase):
         bci.reset_column_cookies(["name", "desc"], "visible")
         # Only deletes the ones that are "set" (and empty string is eval'ed as None)
         self.assertEqual(
-            ["BSTClientInterface-visible-name", "BSTClientInterface-visible-desc"],
+            ["visible-name", "visible-desc"],
             bci.cookie_resets,
         )
 
@@ -279,7 +283,7 @@ class BSTClientInterfaceTests(TracebaseTestCase):
         bci.init_interface()
         bci.reset_cookie("sortcol")
         # Only deletes the ones that are "set" (and empty string is eval'ed as None)
-        self.assertEqual(["BSTClientInterface-sortcol"], bci.cookie_resets)
+        self.assertEqual(["sortcol"], bci.cookie_resets)
 
     def test_model_title_plural(self):
         self.assertEqual("BCI Study Test Models", StudyBCI.model_title_plural)
@@ -306,7 +310,7 @@ class BSTClientInterfaceTests(TracebaseTestCase):
         slv.init_interface()
         slv.reset_filter_cookies()
         # Only deletes the ones that are "set" (and empty string is eval'ed as None)
-        self.assertEqual(["StudyBCI-filter-desc"], slv.cookie_resets)
+        self.assertEqual(["filter-desc"], slv.cookie_resets)
 
     @TracebaseTestCase.assertNotWarns()
     def test_reset_search_cookie(self):
@@ -326,7 +330,7 @@ class BSTClientInterfaceTests(TracebaseTestCase):
         slv = StudyBCI(request=request)
         slv.init_interface()
         slv.reset_search_cookie()
-        self.assertEqual(["StudyBCI-search"], slv.cookie_resets)
+        self.assertEqual(["search"], slv.cookie_resets)
 
     @TracebaseTestCase.assertNotWarns()
     def test_get_context_data(self):

--- a/DataRepo/tests/views/models/bst/test_list_view.py
+++ b/DataRepo/tests/views/models/bst/test_list_view.py
@@ -365,12 +365,14 @@ class BSTListViewTests(TracebaseTestCase):
         alv = AnimalWithMultipleStudyColsLV(request=request)
         alv.init_interface()
         self.assertEqual(
-            "(OR: ('name__icontains', 'test1'), "
-            "('desc__icontains', 'test1'), "
-            "('treatment__name__icontains', 'test1'), "
-            "('studies__name__icontains', 'test1'), "
-            "('studies__desc__icontains', 'test1'), "
-            "('studies_mm_count__iexact', 'test1'))",
+            (
+                "(OR: ('name__icontains', 'test1'), "
+                "('desc__icontains', 'test1'), "
+                "('treatment__name__icontains', 'test1'), "
+                "('studies_mm_count__iexact', 'test1'), "
+                "('studies__name__icontains', 'test1'), "
+                "('studies__desc__icontains', 'test1'))"
+            ),
             str(alv.search()),
         )
 
@@ -508,9 +510,7 @@ class BSTListViewTests(TracebaseTestCase):
             BSTLVStudyTestModel.objects.all(),
             fqs,
         )
-        self.assertEqual(
-            [f"StudyLV-{StudyLV.filter_cookie_name}-desc"], slv.cookie_resets
-        )
+        self.assertEqual([f"{StudyLV.filter_cookie_name}-desc"], slv.cookie_resets)
 
     @TracebaseTestCase.assertNotWarns()
     def test_paginate_queryset(self):

--- a/DataRepo/views/models/bst/client_interface.py
+++ b/DataRepo/views/models/bst/client_interface.py
@@ -345,14 +345,14 @@ class BSTClientInterface(ListView):
         elif boolstr.lower().startswith("f"):
             return False
 
-        cookie_name = self.get_cookie_name(name)
-        if cookie_name not in self.cookie_resets:
-            self.cookie_resets.append(cookie_name)
+        if name not in self.cookie_resets:
+            self.cookie_resets.append(name)
             warning = (
                 f"Invalid '{name}' value encountered: '{boolstr}'.  Resetting cookie."
             )
             self.warnings.append(warning)
             if settings.DEBUG:
+                cookie_name = self.get_cookie_name(name)
                 warn(warning + f"  '{cookie_name}'", DeveloperWarning)
 
         return default
@@ -415,9 +415,9 @@ class BSTClientInterface(ListView):
             elif boolstr.lower().startswith("f"):
                 bools_dict[colname] = False
             else:
-                cookie_name = self.get_column_cookie_name(colname, name)
-                if cookie_name not in self.cookie_resets:
-                    self.cookie_resets.append(cookie_name)
+                view_cookie_name = f"{name}-{colname}"
+                if view_cookie_name not in self.cookie_resets:
+                    self.cookie_resets.append(view_cookie_name)
                     # TODO: Change the column name to the header
                     warning = (
                         f"Invalid '{name}' cookie value encountered for column '{colname}': '{boolstr}'.  "
@@ -425,6 +425,7 @@ class BSTClientInterface(ListView):
                     )
                     self.warnings.append(warning)
                     if settings.DEBUG:
+                        cookie_name = self.get_column_cookie_name(colname, name)
                         warn(warning + f"  '{cookie_name}'", DeveloperWarning)
         return bools_dict
 
@@ -466,7 +467,7 @@ class BSTClientInterface(ListView):
             )
         cookie_name = self.get_column_cookie_name(str(column), name)
         if cookie_name not in self.cookie_resets:
-            self.cookie_resets.append(cookie_name)
+            self.cookie_resets.append(f"{name}-{column}")
 
     def reset_column_cookies(self, columns: List[Union[str, BSTBaseColumn]], name: str):
         """Adds cookies to the cookie_resets list.
@@ -499,7 +500,7 @@ class BSTClientInterface(ListView):
         cookie_name = self.get_cookie_name(name)
         if cookie_name not in self.cookie_resets:
             delete_cookie(self.request, cookie_name)
-            self.cookie_resets.append(cookie_name)
+            self.cookie_resets.append(name)
 
     def reset_all_cookies(self):
         """Sets clear_cookies to True and removes all cookies from the request object.

--- a/DataRepo/views/models/bst/column/field.py
+++ b/DataRepo/views/models/bst/column/field.py
@@ -94,6 +94,7 @@ class BSTColumn(BSTBaseColumn):
 
         # Get some superclass instance members we need for checks
         linked = kwargs.get("linked")
+        tooltip = kwargs.get("tooltip")
 
         # Set the name for the superclass based on field_path
         name = self.field_path
@@ -137,6 +138,12 @@ class BSTColumn(BSTBaseColumn):
         self.field = field_path_to_field(self.model, self.field_path)
         if not hasattr(self, "is_fk") or getattr(self, "is_fk", None) is None:
             self.is_fk = is_key_field(self.field)
+
+        if self.field.help_text is not None and self.field.help_text != "":
+            new_tooltip = self.field.help_text
+            if tooltip is not None:
+                new_tooltip += "\n\n" + tooltip
+            kwargs.update({"tooltip": new_tooltip})
 
         super().__init__(name, *args, **kwargs)
 

--- a/DataRepo/views/models/bst/column/filterer/field.py
+++ b/DataRepo/views/models/bst/column/filterer/field.py
@@ -104,7 +104,15 @@ class BSTFilterer(BSTBaseFilterer):
             and self.field.choices is not None
             and len(self.field.choices) > 0
         ):
-            choices = dict(self.field.choices)
+            choices = dict(
+                (
+                    (k, v)
+                    if str(k).lower().replace(" ", "")
+                    == str(v).lower().replace(" ", "")
+                    else (k, f"{k} ({v})")
+                )
+                for k, v in self.field.choices
+            )
 
         if client_filterer is None:
             if _server_filterer is not None:

--- a/DataRepo/views/models/bst/column/related_field.py
+++ b/DataRepo/views/models/bst/column/related_field.py
@@ -220,19 +220,23 @@ class BSTRelatedColumn(BSTColumn):
             None
         """
         # Grab as many of the last 2 items from the field_path as is present
-        path_tail = self.field_path.split("__")[-2:]
+        path = self.field_path.split("__")
 
         # If the length is greater than 1, the last element is "name", and the field is unique, use the name of the
         # foreign key to this model's field only.
-        if (
-            len(path_tail) == 2
-            and path_tail[1] == "name"
-            and is_unique_field(self.field)
-        ):
-            return underscored_to_title(path_tail[0])
+        if len(path) > 1 and path[-1] == "name" and is_unique_field(self.field):
+            return underscored_to_title(path[-2])
+
+        # If the field has a verbose name different from name (because it's automatically filled in with name), use it
+        if self.field.name != self.field.verbose_name:
+            if any(c.isupper() for c in self.field.verbose_name):
+                # If the field has a verbose name with caps, use it as-is
+                return self.field.verbose_name
+            else:
+                return underscored_to_title(self.field.verbose_name)
 
         # Otherwise, use the last 2 elements of the path
-        return underscored_to_title("_".join(path_tail))
+        return underscored_to_title(path[-1])
 
     def create_sorter(
         self, field: Optional[Union[Combinable, Field, str]] = None, **kwargs

--- a/DataRepo/views/models/bst/column/related_field.py
+++ b/DataRepo/views/models/bst/column/related_field.py
@@ -123,7 +123,7 @@ class BSTRelatedColumn(BSTColumn):
                         "display_field_path could not be determined.  Supply display_field_path to allow search/sort."
                     )
 
-                tooltip = "" if tooltip is None else tooltip + "  "
+                tooltip = "" if tooltip is None else tooltip + "\n\n"
                 tooltip += (
                     "Search and sort is disabled for this column because the displayed values do not exist in the "
                     "database as a single field"


### PR DESCRIPTION
## Summary Change Description

This is the last PR before I push updates to the `SampleListView` class.  It's the "final push", so there's a bit more in here size-wise than previous PRs.

Added the ability to search for "None", removed the related model name from headers, fixed the auto-addition of count columns, fixed the usage of field verbose names, fixed cookie resets, and added a tooltip to all non-count columns that have a single field associated with them.

Details:

- `BSTRelatedColumn`
  - Removed the parent model from header construction.
- `BSTFilterer`
  - Modified choices dict values to include the key if the key and value differ.
- `BSTBaseFilterer`
  - Added a special case when `term` == "None" to create an `isnull` filter.
- `BSTColumn`
  - Added a `tooltip` to include `self.field.help_text`.
- `BSTAnnotColumn`
  - Added an optional `model` keyword argument.
  - If `model` is not `None`, added a call to `resolve_field_path` on the supplied `converter`, and if there was a non-`None` return, the `tooltip` is updated with the field's `help_text`.
- `BSTClientInterface`
  - Fixed the cookie names to **not** include the prefix, as the prefix is accounted for in the javascript code.  This is how it was intended to work, originally, which was why it wasn't working to delete the user's browser cookies.
- `BSTBaseListView`
  - Changed the way the automatic count columns are handled to allow derived classes to change only the default settings in `column_settings` that they want to change.  This involved the following edits:
    - Added instance member `count_cols` to track auto-added count columns.
    - Improved exception and warning outputs for debugging purposes.
    - Modified `add_default_many_related_column_settings` to
      - Not overwrite existing count column settings.
        - If a BSTAnnotColumn object exists, the creating is skipped entirely.
        - Otherwise, it creates the default `kwargs` and updates that dict with whatever the derived class supplied.
    - Modified `init_column_ordering` to: - Not create count columns
  - Addressed the count columns not being auto-added with the following changes:
    - Renamed `mmfields` to `mm_colnames` for clarity.
    - Modified `add_default_many_related_column_settings` to
      - Check `column_ordering`, which is set by the derived class, instead of how it previously only came in as a constructor argument.
  - Addressed the count column positions by modifying `init_column_ordering` to
    - Not add count columns based on `BSTColumnGroup` creation
    - Insert the count column name based on the first position of many-related columns (or append if none exist, but it was not excluded).
  - Addressed the addition of field tooltips on annotation columns by adding the class's model to the creation of `BSTAnnotColumn` objects.
- Changed the bootstrap icon for the tooltips from a circled question mark to a circled "i", since it is not more informational that an attempt to resolve confusion.
- Removed console debug prints from the javascript.
- Improved `resolve_field_path` to be able to handle deeper expressions and to filter out multiple expressions that do not contain field paths.  Recursion was cleaned up too.

## Affected Issues/Pull Requests

- Partially addresses #1585
- Merges into branch `bstlv15_sample_list11_columns`

## Reviewer Notes/Requests
<!-- Notes to help the reviewer or requests for specific scrutiny.
E.g. Please make sure I have accounted for all possible inputs. -->
See comments in-line.

## Checklist
<!-- If any requirements are not met, uncheck and explain.
E.g. Linting errors pre-date this PR. -->
This pull request will be merged once the following requirements are met.  The
author and/or reviewers should uncheck any unmet requirements:
<!-- Check/complete items if not applicable. -->
- Review Requirements
  - Minimum approvals: 1 <!-- Edit based on complexity. -->
  - No changes requested
  - All blocking issues resolved by reviewers
  - Specific reviewers: @__add_username_here__ <!-- Approvals required even if minimum met. -->
  - Review period: 2 days <!-- Edit based on complexity. -->
- Associated Issue/PR Requirements: <!-- Assert resolved issues/PRs are done/merged. -->
  - [x] All issue requirements are satisfied
  - [x] All PR dependencies are merged
- Basic Requirements <!-- Uncheck to indicate items you are yet to address. -->
  - [x] [Linters pass](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#linting)
  - [x] [Tests pass](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#quality-control)
  - [x] Conflicts resolved
- Overhead Requirements <!-- Requirements indirectly related to the issues. -->
  - [x] [Tests implemented/updated](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#test-implementation)
  - [ ] [Updated `CHANGELOG.md` *Unreleased* section](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/changelog.md)
