### PR TITLE
`BSTListView` 18: `TracerListView` and `TracerDetailView`

### DIFF
--- a/DataRepo/models/tracer.py
+++ b/DataRepo/models/tracer.py
@@ -73,6 +73,8 @@ class Tracer(MaintainedModel, ElementLabel):
     LABELS_RIGHT_BRACKET = "]"
     LABELS_COMBO_DELIMITER = "+"
 
+    detail_name = "tracer_detail"
+
     id = models.AutoField(primary_key=True)
     name = models.CharField(
         max_length=256,
@@ -175,3 +177,11 @@ class Tracer(MaintainedModel, ElementLabel):
             f"{tracer_data['compound_name']}{cls.COMPOUND_DELIMITER}"
             f"{cls.LABELS_LEFT_BRACKET}{labels_string}{cls.LABELS_RIGHT_BRACKET}"
         )
+
+    def get_absolute_url(self):
+        """Get the URL to the detail page.
+        See: https://docs.djangoproject.com/en/5.1/ref/models/instances/#get-absolute-url
+        """
+        from django.urls import reverse
+
+        return reverse(self.detail_name, kwargs={"pk": self.pk})

--- a/DataRepo/models/utilities.py
+++ b/DataRepo/models/utilities.py
@@ -440,7 +440,6 @@ def field_path_to_field(
     if len(path) == 1:
         name = resolve_field_path(path[0])
         if hasattr(model, name):
-            # print(f"XX model {model.__name__} field: {name}")
             if ignore_reverse_related:
                 return resolve_field(getattr(model, name))
             return resolve_field(getattr(model, name), model=model)
@@ -1067,6 +1066,7 @@ def get_field_val_by_iteration(
     related_limit: int = 5,
     sort_field_path: Optional[List[str]] = None,
     asc: bool = True,
+    value_unique: bool = False,
 ):
     """User-facing interface to _get_field_val_by_iteration_helper, which returns either a tuple or list of tuples,
     where each tuple contains the value of interest, the sort value, and a unique value (e.g. primary key).
@@ -1079,13 +1079,28 @@ def get_field_val_by_iteration(
         sort_field_path (Optional[List[str]]): A path from the rec object to a sort field, that has been split by
             dunderscores.  Only relevant if the field path traverses through a many-related model.
         asc (bool) [True]: Sort is ascending.  Only relevant if the field path traverses through a many-related model.
+        value_unique (bool) [False]: For columns whose field_path passes through a many-related model, only list a
+            unique set of values.  The opposite behavior (default behavior, i.e. False) is to show all values associated
+            with a unique set of the last many-related model records in the field_path.
+            Example:
+                If the the field_path is mdla.mdlb__mdlc__mdld__name
+                where mdla is the model of rec
+                the relationships are M:M, M:M, and 1:M respectively
+                there are 5 unique mdld records
+                but 2 unique name values among them
+                When value_unique = True, this method will return 2 names
+                When value_unique = False, this method will return 5 names
     Exceptions:
         None
     Returns:
         (Any): Either a field value or a list of field values.
     """
     val = _get_field_val_by_iteration_helper(
-        rec, field_path, related_limit=related_limit, sort_field_path=sort_field_path
+        rec,
+        field_path,
+        related_limit=related_limit,
+        sort_field_path=sort_field_path,
+        value_unique=value_unique,
     )
 
     # Many-related columns should return lists
@@ -1108,6 +1123,7 @@ def _get_field_val_by_iteration_helper(
     sort_field_path: Optional[List[str]] = None,
     _sort_val: Optional[Any] = None,
     _uniq_val: Optional[Any] = None,
+    value_unique: bool = False,
 ):
     """Private recursive method that takes a record and a path and traverses the record along the path to return
     whatever value is at the end of the path.  If it traverses through a many-related model, it returns a list of
@@ -1144,7 +1160,11 @@ def _get_field_val_by_iteration_helper(
         _sort_val (Optional[Any]): Do not supply.  This holds the sort value if the field path is longer than
             the sort field path.
         _uniq_val (Optional[Any]): Do not supply.  This holds the unique value if the field path is longer than
-            the path to the last many-related model.
+            the path to the last many-related model.  Only used when value_unique is False.
+        value_unique (bool) [False]: For columns whose field_path passes through a many-related model, only list a
+            unique set of values.  The opposite behavior (default behavior, i.e. False) is to show all values associated
+            with a unique set of the last many-related model records in the field_path.  See get_field_val_by_iteration
+            for an example.
         NOTE: We don't need to know if sorting is forward or reverse.  We are only returning tuples containing the
         sort value.  The sort must be done later, by the caller.
     Exceptions:
@@ -1170,6 +1190,7 @@ def _get_field_val_by_iteration_helper(
             related_limit=related_limit,
             sort_field_path=sort_field_path,
             _sort_val=_sort_val,
+            value_unique=value_unique,
         )
     else:
         # This method handles only fields that are singly related to their immediate parent
@@ -1180,6 +1201,7 @@ def _get_field_val_by_iteration_helper(
             sort_field_path=sort_field_path,
             _sort_val=_sort_val,
             _uniq_val=_uniq_val,
+            value_unique=value_unique,
         )
 
     # A many-related field can return a single (tuple) value instead of a list if a None exists on the path before the
@@ -1217,6 +1239,7 @@ def _get_field_val_by_iteration_onerelated_helper(
     sort_field_path: Optional[List[str]] = None,
     _sort_val: Optional[Any] = None,
     _uniq_val: Optional[Any] = None,
+    value_unique: bool = False,
 ):
     """Private recursive method that takes a field_path and a record (that is 1:1 related with the first element in
     the remaining field_path) and traverses the record along the path to return whatever ORM object's field value is
@@ -1238,6 +1261,10 @@ def _get_field_val_by_iteration_onerelated_helper(
             the sort field path.
         _uniq_val (Optional[Any]): Do not supply.  This holds the unique value if the field path is longer than
             the path to the last many-related model.
+        value_unique (bool) [False]: For columns whose field_path passes through a many-related model, only list a
+            unique set of values.  The opposite behavior (default behavior, i.e. False) is to show all values associated
+            with a unique set of the last many-related model records in the field_path.  See get_field_val_by_iteration
+            for an example.
     Exceptions:
         ValueError when the sort field returns more than 1 value.
     Returns:
@@ -1274,7 +1301,11 @@ def _get_field_val_by_iteration_onerelated_helper(
         _sort_val = sort_val
 
     if len(field_path) == 1:
-        if _uniq_val is None:
+        if value_unique is True:
+            _uniq_val = val_or_rec
+            if isinstance(val_or_rec, Model):
+                _uniq_val = val_or_rec.pk
+        elif _uniq_val is None:
             _uniq_val = rec.pk
         # NOTE: Returning the value, a value to sort by, and a value that makes it unique per record (or field)
         return val_or_rec, _sort_val, _uniq_val
@@ -1290,6 +1321,7 @@ def _get_field_val_by_iteration_onerelated_helper(
         sort_field_path=next_sort_field_path,
         _sort_val=_sort_val,
         _uniq_val=_uniq_val,
+        value_unique=value_unique,
     )
 
 
@@ -1299,6 +1331,7 @@ def _get_field_val_by_iteration_manyrelated_helper(
     related_limit: int = 5,
     sort_field_path: Optional[List[str]] = None,
     _sort_val: Optional[Any] = None,
+    value_unique: bool = False,
 ):
     """Private recursive method that takes a field_path and a record (that is many:1_or_many related with the first
     element in the remaining field_path) and traverses the record along the path to return values found at the end
@@ -1325,6 +1358,10 @@ def _get_field_val_by_iteration_manyrelated_helper(
             dunderscores.  Only relevant if you know the field path to traverse through a many-related model.
         _sort_val (Optional[Any]): Do not supply.  This holds the sort value if the field path is longer than the sort
             field path.
+        value_unique (bool) [False]: For columns whose field_path passes through a many-related model, only list a
+            unique set of values.  The opposite behavior (default behavior, i.e. False) is to show all values associated
+            with a unique set of the last many-related model records in the field_path.  See get_field_val_by_iteration
+            for an example.
     Exceptions:
         ValueError when the sort field returns more than 1 value.
     Returns:
@@ -1352,6 +1389,7 @@ def _get_field_val_by_iteration_manyrelated_helper(
             # We only expect 1 value and are going to assume that the sort field was properly checked/generated to
             # not go through another many-related relationship.  Still, we specify the limit to be safe.
             related_limit=1,
+            value_unique=value_unique,
         )
         if isinstance(sort_val, list):
             raise ProgrammingError(
@@ -1380,6 +1418,7 @@ def _get_field_val_by_iteration_manyrelated_helper(
             next_sort_field_path,
             related_limit,
             _sort_val,
+            value_unique=value_unique,
         ),
         [],
     )
@@ -1438,6 +1477,7 @@ def _recursive_many_rec_iterator(
     next_sort_field_path: List[str],
     related_limit: int,
     _sort_val,
+    value_unique: bool = False,
 ):
     """Private iterator to help _get_field_val_by_iteration_many_related_helper.  It iterates through the queryset,
     retrieving the values at the end of the path using recursive calls.  This allows the caller to stop when it
@@ -1455,6 +1495,10 @@ def _recursive_many_rec_iterator(
             the field_path), that work must be done before calling this method.
         related_limit (int)
         _sort_val (Any)
+        value_unique (bool) [False]: For columns whose field_path passes through a many-related model, only list a
+            unique set of values.  The opposite behavior (default behavior, i.e. False) is to show all values associated
+            with a unique set of the last many-related model records in the field_path.  See get_field_val_by_iteration
+            for an example.
     Exceptions:
         None
     Returns:
@@ -1471,6 +1515,7 @@ def _recursive_many_rec_iterator(
             _sort_val=_sort_val,
             # At every point in the field_path that is many-related to its parent, update the unique val
             _uniq_val=mr_rec.pk,
+            value_unique=value_unique,
         )
         if isinstance(val, tuple):
             yield val
@@ -1487,6 +1532,7 @@ def get_many_related_field_val_by_subquery(
     annotations: dict = {},
     order_bys: list = [],
     distincts: list = [],
+    value_unique: bool = False,
 ) -> list:
     """
 
@@ -1502,6 +1548,10 @@ def get_many_related_field_val_by_subquery(
         distincts (List[str]) [[]]: A list of field paths.  Must match the fields contained in the order_bys list.
             This will be prepended with the field_path and appended with the primary key of the last many-related
             model foreign key in the field_path.
+        value_unique (bool) [False]: For columns whose field_path passes through a many-related model, only list a
+            unique set of values.  The opposite behavior (default behavior, i.e. False) is to show all values associated
+            with a unique set of the last many-related model records in the field_path.  See get_field_val_by_iteration
+            for an example.
     Exceptions:
         ProgrammingError
     Returns:
@@ -1536,7 +1586,8 @@ def get_many_related_field_val_by_subquery(
         ob_fields = [field_path]
         order_bys.append(field_path)
     # Append the many-related model's primary key in order to force a value for each distinct record
-    order_bys.append(f"{many_related_model_path}__pk")
+    if value_unique is False:
+        order_bys.append(f"{many_related_model_path}__pk")
     order_bys.append(f"{related_model_path}__pk")
 
     # Prepend the actual field (or fields) from the column (which may differ from the sort).  We put it first so we can
@@ -1544,15 +1595,12 @@ def get_many_related_field_val_by_subquery(
     # values_list have some quirks that prevent an intuitive usage of just flattening with the one value you want.
     # I tried many different versions of this before figuring this out.
     if is_fk:
-        distincts = (
-            [f"{related_model_path}__pk", f"{many_related_model_path}__pk"]
-            + ob_fields
-            + distincts
-        )
+        distincts = [f"{related_model_path}__pk"] + ob_fields + distincts
     else:
         distincts = ob_fields + distincts
         # Append the many-related model's primary key in order to force a value for each distinct record
         distincts.append(f"{related_model_path}__pk")
+    if value_unique is False:
         distincts.append(f"{many_related_model_path}__pk")
 
     # We re-perform (essentially) the same query that generated the table, but for one root-table record, and with

--- a/DataRepo/templates/base/sidebar.html
+++ b/DataRepo/templates/base/sidebar.html
@@ -12,6 +12,7 @@
         <a href="{% url 'archive_file_list' %}" class="list-group-item list-group-item-action bg-light">Archive Files</a>
         <a href="{% url 'compound_list' %}" class="list-group-item list-group-item-action bg-light">Compounds</a>
         <a href="{% url 'infusate_list' %}" class="list-group-item list-group-item-action bg-light">Infusates</a>
+        <a href="{% url 'tracer_list' %}" class="list-group-item list-group-item-action bg-light">Tracers</a>
         <a href="{% url 'animal_treatment_list' %}" class="list-group-item list-group-item-action bg-light">Animal<br>Treatments</a>
         <a href="{% url 'msrunsequence_list' %}" class="list-group-item list-group-item-action bg-light">MSRun<br>Sequences</a>
         <a href="{% url 'lcmethod_list' %}" class="list-group-item list-group-item-action bg-light">LC<br>Protocols</a>

--- a/DataRepo/templates/models/bst/detail_view.html
+++ b/DataRepo/templates/models/bst/detail_view.html
@@ -1,0 +1,41 @@
+{% extends "base/base.html" %}
+{% load customtags %}
+{% load static %}
+
+{% block title %}{{ table_name }}{% endblock %}
+
+{% block head_extras %}
+    <link href="{% static 'css/bst.css' %}" rel="stylesheet">
+{% endblock %}
+
+{% block content %}
+
+    <h4>{{ table_name }}</h4>
+    <br>
+    <div>
+        <table class="table table-bordered table-hover w-auto"
+            id="{{ table_id }}"
+            data-toggle="table"
+            data-buttons-align="left"
+            data-buttons-class="primary"
+            data-filter-control="false"
+            data-search="false"
+            data-show-multi-sort="false"
+            data-show-columns="false"
+            data-show-fullscreen="true"
+            data-show-export="false">
+            <tbody>
+                {% for column in columns.values %}
+                    <tr>
+                        <th class="th-inner p-3" data-field="field">
+                            {{ column.real_header }}
+                            {% if column.tooltip %}<sup class="bi-info-circle" title="{{ column.tooltip }}"></sup>{% endif %}
+                        </th>
+                        <td class="px-5">{% include column.value_template %}</td>
+                    </tr>
+                {% endfor %}
+            </tbody>
+        </table>
+    </div>
+
+{% endblock %}

--- a/DataRepo/templates/models/tracer/infusates_td.html
+++ b/DataRepo/templates/models/tracer/infusates_td.html
@@ -1,0 +1,3 @@
+<td>
+    {% include column.value_template %}
+</td>

--- a/DataRepo/templates/models/tracer/infusates_value_detail.html
+++ b/DataRepo/templates/models/tracer/infusates_value_detail.html
@@ -1,0 +1,20 @@
+{% load bsttags %}
+
+{# The nobr classes in this template are unrelated to the collapsed state.  Only the d-none classes related to "collapsed". #}
+{# It is assumed that column is a BSTManyRelatedColumn, thus get_rec_val will return a list #}
+{% with column_values=object|get_rec_val:column %}
+    {% for column_value in column_values %}
+        {% if column_value|is_model_obj and column_value|has_attr:"get_absolute_url" %}
+            {# Render model object in string context for the link's display value #}
+            <span class="table-cell-newlines {% if collapsed %}no-newlines{% else %}newlines{% endif %}"><a href="{{ column_value|get_absolute_url }}">{{ column_value.pretty_name }}</a>{% if not forloop.last %}{{ column.delim }}</span><br class="cell-wrap {% if collapsed %}d-none{% endif %}">{% else %}</span>{% endif %}
+        {% else %}
+            {% if column_value is None %}
+                <span class="text-muted">None</span>{% if not forloop.last %}{{ column.delim }}<br class="cell-wrap{% if collapsed %} d-none{% endif %}">{% endif %}
+            {% else %}
+                <span class="table-cell-newlines {% if collapsed %}no-newlines{% else %}newlines{% endif %}">{{ column_value }}{% if not forloop.last %}{{ column.delim }}</span><br class="cell-wrap{% if collapsed %} d-none{% endif %}">{% else %}</span>{% endif %}
+            {% endif %}
+        {% endif %}
+    {% empty %}
+        <span class="text-muted">None</span>
+    {% endfor %}
+{% endwith %}

--- a/DataRepo/templates/models/tracer/infusates_value_list.html
+++ b/DataRepo/templates/models/tracer/infusates_value_list.html
@@ -1,0 +1,22 @@
+{% load bsttags %}
+
+{# The nobr classes in this template are unrelated to the collapsed state.  Only the d-none classes related to "collapsed". #}
+{# It is assumed that column is a BSTManyRelatedColumn, thus get_rec_val will return a list #}
+{% with column_values=object|get_rec_val:column %}
+    <span class="nobr">
+        {% for column_value in column_values %}
+            {% if column_value|is_model_obj and column_value|has_attr:"get_absolute_url" %}
+                {# Render model object in string context for the link's display value #}
+                <span class="table-cell-newlines {% if collapsed %}no-newlines{% else %}newlines{% endif %}"><a href="{{ column_value|get_absolute_url }}">{{ column_value.pretty_short_name }}</a>{% if not forloop.last %}{{ column.delim }}</span><br class="cell-wrap {% if collapsed %}d-none{% endif %}">{% else %}</span>{% endif %}
+            {% else %}
+                {% if column_value is None %}
+                    <span class="text-muted">None</span>{% if not forloop.last %}{{ column.delim }}<br class="cell-wrap{% if collapsed %} d-none{% endif %}">{% endif %}
+                {% else %}
+                    <span class="table-cell-newlines {% if collapsed %}no-newlines{% else %}newlines{% endif %}">{{ column_value }}{% if not forloop.last %}{{ column.delim }}</span><br class="cell-wrap{% if collapsed %} d-none{% endif %}">{% else %}</span>{% endif %}
+                {% endif %}
+            {% endif %}
+        {% empty %}
+            <span class="text-muted">None</span>
+        {% endfor %}
+    </span>
+{% endwith %}

--- a/DataRepo/tests/templates/models/bst/test_list_view.py
+++ b/DataRepo/tests/templates/models/bst/test_list_view.py
@@ -12,7 +12,7 @@ from DataRepo.views.models.bst.column.many_related_field import (
     BSTManyRelatedColumn,
 )
 from DataRepo.views.models.bst.column.many_related_group import BSTColumnGroup
-from DataRepo.views.models.bst.list_view import BSTListView
+from DataRepo.views.models.bst.query import BSTListView
 
 
 class StudyLV(BSTListView):

--- a/DataRepo/tests/views/models/bst/column/test_base.py
+++ b/DataRepo/tests/views/models/bst/column/test_base.py
@@ -6,6 +6,7 @@ from DataRepo.tests.tracebase_test_case import (
     TracebaseTestCase,
     create_test_model,
 )
+from DataRepo.utils.text_utils import underscored_to_title
 from DataRepo.views.models.bst.column.base import BSTBaseColumn
 from DataRepo.views.models.bst.column.filterer.base import BSTBaseFilterer
 from DataRepo.views.models.bst.column.filterer.field import BSTFilterer
@@ -62,3 +63,7 @@ class BSTBaseColumnTests(TracebaseTestCase):
         bstbct2 = BSTBaseColumnTest("name", hidable=True, visible=False)
         self.assertTrue(bstbct2.hidable)
         self.assertFalse(bstbct2.visible)  # visible=False ignored, since not hidable
+
+    def test_generate_header(self):
+        bstbct = BSTBaseColumnTest("name")
+        self.assertEqual(underscored_to_title("name"), bstbct.generate_header())

--- a/DataRepo/tests/views/models/test_tracer.py
+++ b/DataRepo/tests/views/models/test_tracer.py
@@ -1,0 +1,40 @@
+from django.urls import reverse
+
+from DataRepo.models.tracer import Tracer
+from DataRepo.tests.views.models.base import (
+    ModelViewTests,
+    create_null_tolerance_test_class,
+)
+
+
+class TracerViewTests(ModelViewTests):
+    def test_tracer_list(self):
+        response = self.client.get(reverse("tracer_list"))
+        self.assertEqual(response.status_code, 200)
+        self.assertTemplateUsed(response, "models/bst/list_view.html")
+        self.assertTemplateUsed(response, "models/bst/th.html")
+        self.assertTemplateUsed(response, "models/bst/td.html")
+        self.assertTemplateUsed(response, "models/bst/value.html")
+        self.assertTemplateUsed(response, "models/bst/value_list.html")
+        self.assertTemplateUsed(response, "models/tracer/infusates_td.html")
+        self.assertTemplateUsed(response, "models/tracer/infusates_value_list.html")
+        self.assertEqual(len(response.context["object_list"]), 1)
+
+    def test_tracer_detail(self):
+        t1 = Tracer.objects.first()
+        response = self.client.get(reverse("tracer_detail", args=[t1.id]))
+        self.assertEqual(response.status_code, 200)
+        self.assertTemplateUsed(response, "models/bst/detail_view.html")
+        self.assertTemplateUsed(response, "models/bst/value.html")
+        self.assertTemplateUsed(response, "models/bst/value_list.html")
+        self.assertTemplateUsed(response, "models/tracer/infusates_value_detail.html")
+        self.assertEqual(t1.id, response.context["object"].id)
+
+    def test_tracer_detail_404(self):
+        t = Tracer.objects.order_by("id").last()
+        response = self.client.get(reverse("tracer_detail", args=[t.id + 1]))
+        self.assertEqual(response.status_code, 404)
+
+
+# This runs the above tests again with auto-update disabled
+TracerViewNullToleranceTests = create_null_tolerance_test_class(TracerViewTests)

--- a/DataRepo/urls.py
+++ b/DataRepo/urls.py
@@ -30,6 +30,8 @@ from .views import (
     StudyListView,
     TissueDetailView,
     TissueListView,
+    TracerDetailView,
+    TracerListView,
     home,
     search_basic,
     study_summary,
@@ -153,5 +155,11 @@ urlpatterns = [
         "infusates/<int:pk>/",
         InfusateDetailView.as_view(),
         name=InfusateDetailView.model.detail_name,
+    ),
+    path("tracers/", TracerListView.as_view(), name="tracer_list"),
+    path(
+        "tracers/<int:pk>/",
+        TracerDetailView.as_view(),
+        name=TracerDetailView.model.detail_name,
     ),
 ]

--- a/DataRepo/views/__init__.py
+++ b/DataRepo/views/__init__.py
@@ -24,6 +24,8 @@ from .models import (
     StudyListView,
     TissueDetailView,
     TissueListView,
+    TracerDetailView,
+    TracerListView,
     study_summary,
 )
 from .nav import home
@@ -61,6 +63,8 @@ __all__ = [
     "AnimalDetailView",
     "TissueListView",
     "TissueDetailView",
+    "TracerDetailView",
+    "TracerListView",
     "SampleListView",
     "SampleDetailView",
     "MSRunSampleDetailView",

--- a/DataRepo/views/models/__init__.py
+++ b/DataRepo/views/models/__init__.py
@@ -11,6 +11,7 @@ from .protocol import AnimalTreatmentListView, ProtocolDetailView
 from .sample import SampleDetailView, SampleListView
 from .study import StudyDetailView, StudyListView, study_summary
 from .tissue import TissueDetailView, TissueListView
+from .tracer import TracerDetailView, TracerListView
 
 __all__ = [
     "ArchiveFileDetailView",
@@ -30,6 +31,8 @@ __all__ = [
     "AnimalDetailView",
     "TissueListView",
     "TissueDetailView",
+    "TracerDetailView",
+    "TracerListView",
     "SampleListView",
     "SampleDetailView",
     "MSRunSampleListView",

--- a/DataRepo/views/models/animal.py
+++ b/DataRepo/views/models/animal.py
@@ -5,7 +5,7 @@ from django.views.generic import DetailView
 
 from DataRepo.models import DURATION_SECONDS_ATTRIBUTE, Animal, Researcher
 from DataRepo.utils import QuerysetToPandasDataFrame as qs2df
-from DataRepo.views.models.bst.list_view import BSTListView
+from DataRepo.views.models.bst.query import BSTListView
 
 
 class AnimalListView(BSTListView):

--- a/DataRepo/views/models/archive_file.py
+++ b/DataRepo/views/models/archive_file.py
@@ -12,7 +12,7 @@ from django.db.models.aggregates import Count, Min
 from django.views.generic import DetailView
 
 from DataRepo.models import DATETIME_FORMAT, DBSTRING_FUNCTION, ArchiveFile
-from DataRepo.views.models.bst.list_view import BSTListView, QueryMode
+from DataRepo.views.models.bst.query import BSTListView, QueryMode
 
 
 class ArchiveFileListView(BSTListView):

--- a/DataRepo/views/models/bst/column/base.py
+++ b/DataRepo/views/models/bst/column/base.py
@@ -203,6 +203,9 @@ class BSTBaseColumn(ABC):
 
         if self.header is None:
             self.header = self.generate_header()
+            self.real_header = self.generate_header(real=True)
+        else:
+            self.real_header = header
 
         # NOTE: We set a sorter even if the field is not sortable.
         if sorter is None:
@@ -289,7 +292,7 @@ class BSTBaseColumn(ABC):
                 f"Equivalence of {__class__.__name__} to {type(other).__name__} not implemented."  # type: ignore
             )
 
-    def generate_header(self):
+    def generate_header(self, **_):
         """Generate a column header from the column name."""
         return underscored_to_title(self.name)
 

--- a/DataRepo/views/models/bst/column/field.py
+++ b/DataRepo/views/models/bst/column/field.py
@@ -156,7 +156,7 @@ class BSTColumn(BSTBaseColumn):
 
         super().__init__(name, *args, **kwargs)
 
-    def generate_header(self):
+    def generate_header(self, real: bool = False, **_):
         """Generate a column header from the field_path, field.name, or the field's verbose_name.
         Overrides super().generate_header.
 
@@ -179,7 +179,7 @@ class BSTColumn(BSTBaseColumn):
                 return underscored_to_title(self.field.verbose_name)
 
         # Special case: If the name of the field is name, use the model name
-        if self.field_path == "name" and is_unique_field(self.field):
+        if real is False and self.field_path == "name" and is_unique_field(self.field):
             verbose_model_name_without_automods = self.model._meta.__dict__[
                 "verbose_name"
             ].replace(" ", "")

--- a/DataRepo/views/models/bst/column/many_related_field.py
+++ b/DataRepo/views/models/bst/column/many_related_field.py
@@ -183,9 +183,16 @@ class BSTManyRelatedColumn(BSTRelatedColumn):
         )
         if not hasattr(remote_field, "help_text"):
             if is_reverse_related_field(remote_field):
+                example = f"'{self.delim}'"
+                if self.delim == " ":
+                    example = "spaces"
+                elif self.delim == "\n":
+                    example = "new lines"
+                elif self.delim == "\t":
+                    example = "tabs"
                 new_tooltip = (
                     f"This is a reverse relationship to multiple sorted records of the '{self.related_model.__name__}' "
-                    f"model, delimited by '{self.delim}'."
+                    f"model, delimited by {example}."
                 )
                 if self.tooltip is not None:
                     new_tooltip = f"{new_tooltip}\n\n{self.tooltip}"

--- a/DataRepo/views/models/bst/column/related_field.py
+++ b/DataRepo/views/models/bst/column/related_field.py
@@ -127,7 +127,7 @@ class BSTRelatedColumn(BSTColumn):
 
                 tooltip = "" if tooltip is None else tooltip + "\n\n"
                 tooltip += (
-                    "Search and sort is disabled for this column because the displayed values do not exist in the "
+                    "Search and sort is disabled for this field because the displayed values do not exist in the "
                     "database as a single field"
                 )
 
@@ -228,7 +228,7 @@ class BSTRelatedColumn(BSTColumn):
 
         return full_rep_field
 
-    def generate_header(self):
+    def generate_header(self, **_):
         """Generate a column header from the field_path.  Overrides super().generate_header.  This only uses the field's
         name or verbose_name if the field is not a reverse relation.  The field names of reverse relations refer to the
         model that linked to it, which is "backwards".  For example, such a column header for a reverse relation off the

--- a/DataRepo/views/models/bst/column/sorter/base.py
+++ b/DataRepo/views/models/bst/column/sorter/base.py
@@ -11,6 +11,7 @@ from django.db.models.functions import Lower
 from DataRepo.models.utilities import (
     MultipleFields,
     NoFields,
+    is_key_field,
     is_number_field,
     is_string_field,
     resolve_field_path,
@@ -400,6 +401,11 @@ class BSTBaseSorter(ABC):
                 _server_sorter = cls.SERVER_SORTERS.ALPHANUMERIC
             elif type(expression) in cls.SERVER_SORTERS:
                 _server_sorter = type(expression)
+            elif is_key_field(expression.output_field):
+                _server_sorter = cls.SERVER_SORTERS.NONE
+                warn(
+                    f"Sorting of key fields such as '{type(expression.output_field).__name__}' is not yet supported."
+                )
             else:
                 _server_sorter = cls.SERVER_SORTERS.NONE
                 warn(

--- a/DataRepo/views/models/bst/query.py
+++ b/DataRepo/views/models/bst/query.py
@@ -14,7 +14,6 @@ from DataRepo.models.utilities import (
     get_many_related_field_val_by_subquery,
 )
 from DataRepo.utils.exceptions import DeveloperWarning, trace
-from DataRepo.views.models.bst.base import BSTBaseListView
 from DataRepo.views.models.bst.column.annotation import BSTAnnotColumn
 from DataRepo.views.models.bst.column.base import BSTBaseColumn
 from DataRepo.views.models.bst.column.many_related_field import (
@@ -25,6 +24,10 @@ from DataRepo.views.models.bst.column.sorter.base import BSTBaseSorter
 from DataRepo.views.models.bst.column.sorter.many_related_field import (
     BSTManyRelatedSorter,
 )
+from DataRepo.views.models.bst.column_setup import (
+    BSTBaseDetailView,
+    BSTBaseListView,
+)
 
 
 class QueryMode(Enum):
@@ -34,7 +37,346 @@ class QueryMode(Enum):
     subquery = 2
 
 
-class BSTListView(BSTBaseListView):
+class BSTQueryView:
+    """BSTBaseView is responsible for model queries.
+
+    This class represents the common components of BSTDetailView and BSTListView queries.
+
+    This base class uses the BSTBaseColumn objects configured in BSTBaseView and retrieves field values/annotations and
+    performs the searches/sorts requested by the user.
+
+    Classes derived from this class can configure the search/sort behavior and included annotations.
+
+    Class Attributes:
+        query_mode (QueryMode) [iterate] {iterate, subquery}: There are 2 query modes that can be selected based on
+            performance.
+            - *iterate* is the equivalent of traversing a dot notation field path, e.g. Sample.animal.treatment.name,
+              but it adds the ability to also traverse through many-related relationships, e.g.
+              Sample.animal.studies.name, where it returns a list of values (unique to the last many-related model
+              traversed).  It uses the field paths in the BSTBaseColumn objects configured by the superclass.
+            - *subquery* behaves the same as *iterate* except for its behavior with respect to many-related fields.  It
+              returns a list of values the same way *iterate* does, but it retrieves them by including the many-related
+              model's primary key in a distinct clause instead of traversing the field path.
+    Instance Attributes:
+        query_mode (QueryMode) [iterate] {iterate, subquery}: An override of the class attribute.
+        prefetches (List[str]): A list of related model paths to prefetch.
+        NOTE: Other class attributes are inherited, but re-declared for IDE functionality.
+    """
+
+    query_mode = QueryMode.iterate
+
+    def __init__(self, query_mode: Optional[QueryMode] = None):
+        # This assumes/requires that the self passed in has these instance attributes, which are (re-)declared here for
+        # IDEs to know they exist in the instance methods
+        self.columns: Dict[str, BSTBaseColumn]
+        self.warnings: List[str]
+
+        # Change the query mode based on the data-influenced performance
+        if isinstance(query_mode, QueryMode):
+            self.query_mode = query_mode
+        else:
+            self.query_mode = type(self).query_mode
+
+        # We can get the prefetches and annotations right away, because none of it is based on cookies.
+        self.prefetches: List[str] = self.get_prefetches()
+
+    def get_prefetches(self, along_path: Optional[str] = None):
+        """Generate a list of strings that can be provided to Django's .prefetch_related() method, to speed up database
+        interactions by reducing the number of queries necessary.
+
+        Args:
+            along_path (Optional[str]): Only include paths in or after this path.
+        Exceptions:
+            None
+        Returns:
+            prefetches (List[str]): A list of model paths.  A model path is a dunderscore-delimited series of foreign
+                keys that start from self.model.  Each model path is not contained in any other model path.
+        """
+        prefetches: List[str] = []
+        # For all related_model_paths, by descending path length (i.e. number of dunderscore-delimited foreign keys)
+        for model_path in sorted(
+            [
+                c.related_model_path
+                for c in self.columns.values()
+                if isinstance(c, BSTRelatedColumn)
+            ],
+            key=lambda p: len(p.split("__")),
+            reverse=True,
+        ):
+            contained = False
+            for prefetch in prefetches:
+                if prefetch.startswith(model_path):
+                    # Make sure that the match ends at either the end of the string or at a "__"
+                    remainder = prefetch.replace(model_path, "", 1)
+                    if remainder == "" or remainder.startswith("__"):
+                        contained = True
+                        break
+            if not contained and (
+                along_path is None
+                or model_path.startswith(along_path)
+                or along_path.startswith(model_path)
+            ):
+                prefetches.append(model_path)
+
+            # # TODO: Test to see if using Prefetch() for many-related models speeds up ArchiveFileListView
+            # if mdl is not None and column.many_related and len(mdl.split("__")) > 1:
+            #     prefetches.append(Prefetch(mdl, to_attr=column.mm_list))
+            # elif mdl is not None:
+            #     prefetches.append(mdl)
+
+        return prefetches
+
+    @classmethod
+    def get_column_val_by_iteration(cls, rec: Model, col: BSTBaseColumn):
+        """Given a model record, i.e. row-data, e.g. from a queryset, and a column, return the column value(s).
+
+        This method exists primarily to convert the column into arguments to the get_field_val_by_iteration
+        method.  get_field_val_by_iteration returns either a single value or a list of values.
+
+        Args:
+            rec (Model)
+            col (BSTBaseColumn)
+        Exceptions:
+            ProgrammingError when the value received is not a list of tuples or a tuple, as expected based on the column
+                type
+        Returns:
+            (Union[Any, List[Any]]): Column value or values (if many-related).
+        """
+        # Defaults (which do not matter if this is not a BSTManyRelatedColumn, but allow us to make a single call)
+        limit = 5
+        sort_field_path = None
+        asc = True
+        if isinstance(col, BSTManyRelatedColumn):
+            # In order for us to be able to sort the results and limit them to the TOP col.limit items, we need to get
+            # all of them.  All records should have been prefetched, so even though we are getting all, it should
+            # proceed expeditiously.  If the count annotation is absent from the rec, we go with the limit, even though
+            # that could mean we don't get fully ordered results.
+
+            # TODO: The above is apparently not true.  The mr_qs.all() in _recursive_many_rec_iterator() does perform a
+            # query, so it would likely be faster to use an order_by in _recursive_many_rec_iterator and
+            # _last_many_rec_iterator and set the related_limit here to 1 + the limit in the column object, instead of
+            # to getattr(rec, col.count_attr_name).
+            # Besides, it looks like it sorts anyway, given the model's ordering, based on the SQL output of
+            # test__last_many_rec_iterator
+
+            # We add 1 to col.limit so that we can display an ellipsis if more exist
+            limit = getattr(rec, col.count_attr_name, -1)
+            if limit == -1:
+                limit = col.limit + 1
+                if settings.DEBUG:
+                    warn(
+                        f"The count annotation for column {col} is absent.  "
+                        f"Cannot guarantee the top {col.limit} records will include the the min/max sorted records.",
+                        DeveloperWarning,
+                    )
+            if isinstance(col.sorter, BSTManyRelatedSorter):
+                sort_field_path = col.sorter.field_path.split("__")
+            else:
+                raise ProgrammingError(
+                    f"BSTManyRelatedColumn '{col.name}' does not have a BSTManyRelatedSorter"
+                )
+            asc = col.asc
+        elif isinstance(col, BSTAnnotColumn):
+            return getattr(rec, col.name)
+
+        # This method handles both singly-related and many-related column values and returns either a tuple (singly-
+        # related) or a list of tuples (many-related)
+        return get_field_val_by_iteration(
+            rec,
+            col.name.split("__"),
+            related_limit=limit,
+            sort_field_path=sort_field_path,
+            asc=asc,
+            # If a many-related column is not in a column group (i.e. there are no other columns that pass through the
+            # same many-related model), then make the displayed values unique.  Otherwise, show a value for every unique
+            # many-related model record.
+            value_unique=not col._in_group,
+        )
+
+    @classmethod
+    def get_many_related_column_val_by_subquery(
+        cls, rec: Model, col: BSTManyRelatedColumn
+    ) -> list:
+        """Method to improve performance by grabbing the annotated value first and if it is not None, does an exhaustive
+        search for all many-related values.
+
+        Args:
+            rec (Model)
+            col (BSTColumn)
+        Exceptions:
+            ProgrammingError when the supplied column's sorter is not many-related.  This is mainly to satisfy mypy.
+            TypeError when col is not a BSTManyRelatedColumn.
+        Returns:
+            (list): Sorted unique (to the many-related model) values.
+        """
+        if not isinstance(col, BSTManyRelatedColumn):
+            raise TypeError(f"Column '{col}' is not many-related.")
+
+        count_annot_name = BSTManyRelatedColumn.get_count_name(
+            col.many_related_model_path, col.model
+        )
+
+        count = getattr(rec, count_annot_name, None)
+        # It's faster to skip if we already know there are no records
+        if count is not None and count == 0:
+            return []
+
+        if not isinstance(col.sorter, BSTManyRelatedSorter):
+            raise ProgrammingError(
+                f"Column '{col}' sorter must be a BSTManyRelatedSorter, not '{type(col.sorter).__name__}'."
+            )
+
+        # Set a limit to the retrieved records (count or supplied limit: whichever is lesser and not 0 [i.e. all])
+        related_limit = col.limit + 1 if col.limit > 0 else 0
+        if isinstance(count, int) and (related_limit == 0 or count < related_limit):
+            related_limit = count
+
+        annotations = col.sorter.get_many_annotations()
+        order_bys = col.sorter.get_many_order_bys()
+        distincts = col.sorter.get_many_distinct_fields()
+
+        return get_many_related_field_val_by_subquery(
+            rec,
+            col.field_path,
+            related_limit=related_limit,
+            annotations=annotations,
+            order_bys=order_bys,
+            distincts=distincts,
+            # If a many-related column is not in a column group (i.e. there are no other columns that pass through the
+            # same many-related model), then make the displayed values unique.  Otherwise, show a value for every unique
+            # many-related model record.
+            value_unique=not col._in_group,
+        )
+
+    def apply_annotations(
+        self,
+        qs: QuerySet,
+        annotations: Dict[str, Combinable],
+    ) -> QuerySet:
+        """This method exists to be able to try and recover from an exception about a specific annotation.
+
+        Agrs:
+            qs (QuerySet)
+            annotations (Dict[str, Combinable])
+        Exceptions:
+            None
+        Returns:
+            qs (QuerySet)
+        """
+        for annot_name, expression in annotations.items():
+            try:
+                qs = qs.annotate(**{annot_name: expression})
+            except Exception as e:
+                # Attempt to recover by filling in "ERROR".  This will raise an exception if the name is the problem.
+                qs = qs.annotate(**{annot_name: Value("ERROR")})
+
+                # Account for the fact that a sort annotation does not exist as a column object, but it does reference a
+                # real column.  We will use the annotation name to detect if this is a sort annotation and if so, derive
+                # the column name.
+                if BSTBaseSorter.is_sort_annotation(annot_name):
+                    colname = BSTBaseSorter.sort_annot_name_to_col_name(annot_name)
+                else:
+                    colname = annot_name
+
+                # Disable searching and sorting.
+                self.columns[colname].searchable = False
+                self.columns[colname].sortable = False
+
+                if colname == annot_name:
+                    msg = f"The expression '{expression}' for the annotation column '{colname}' "
+                else:
+                    msg = f"The sort expression '{expression}' for column '{colname}' "
+                msg += f"has a problem: {type(e).__name__}: {e}"
+
+                if settings.DEBUG:
+                    warn(trace() + msg, DeveloperWarning)
+                self.warnings.append(msg)
+        return qs
+
+
+class BSTDetailView(BSTBaseDetailView, BSTQueryView):
+    """Generic class-based view for a Model record.  This class is responsible mainly for adding annotatiomns to a
+    record, but also for querying many-related fields.
+
+    Instance Attributes:
+        annots (Dict[str, Combinable])
+    """
+
+    def __init__(self, *args, **kwargs):
+        BSTBaseDetailView.__init__(self, *args, **kwargs)
+        BSTQueryView.__init__(self)
+
+        # We can get the annotations right away, because none of it is based on cookies.
+        self.annots: Dict[str, Combinable] = self.get_annotations()
+
+    def get_object(self, **kwargs):
+        object: Model = super().get_object(**kwargs)
+
+        # We need to create a queryset to be able to add annotations
+        qs: QuerySet = self.model.objects.filter(pk=object.pk)
+
+        if len(self.prefetches) > 0:
+            qs = qs.prefetch_related(*self.prefetches)
+
+        qs = self.apply_annotations(qs, self.annots)
+
+        if qs.count() != 1:
+            raise ProgrammingError(
+                f"The annotations of '{self.model.__name__}' record '{object}' resulted in multiple ({qs.count()}) "
+                "objects.  This occurs when an annotation uses a many-related field without an aggregation function.  "
+                f"The annotations are: {self.annots}.  Please find the annotation returning multiple values and apply "
+                "an aggregate function."
+            )
+
+        object = qs.get()
+
+        # If there are any many-related or annotated columns
+        if any(
+            isinstance(c, (BSTManyRelatedColumn, BSTAnnotColumn))
+            for c in self.columns.values()
+        ):
+
+            # For each column object (order doesn't matter)
+            for column in self.columns.values():
+
+                # If this is a many-related column
+                if isinstance(column, BSTManyRelatedColumn):
+
+                    if self.query_mode == QueryMode.subquery:
+                        subrecs = self.get_many_related_column_val_by_subquery(
+                            object, column
+                        )
+                    elif self.query_mode == QueryMode.iterate:
+                        subrecs = self.get_column_val_by_iteration(object, column)
+                    else:
+                        raise NotImplementedError(
+                            f"QueryMode {self.query_mode} not implemented."
+                        )
+
+                    column.set_list_attr(object, subrecs)
+
+                elif isinstance(column, BSTAnnotColumn) and column.is_fk:
+
+                    # See if there are any foreign key annotations
+                    model_obj: Model = column.get_model_object(
+                        getattr(object, column.name)
+                    )
+
+                    if model_obj is not None:
+                        setattr(object, column.name, model_obj)
+
+        return object
+
+    def get_annotations(self) -> Dict[str, Combinable]:
+        """An override of the superclass method."""
+        annotations: Dict[str, Combinable] = {}
+        for column in self.columns.values():
+            if isinstance(column, BSTAnnotColumn):
+                annotations[column.name] = column.converter
+        return annotations
+
+
+class BSTListView(BSTBaseListView, BSTQueryView):
     """Generic class-based view for a Model record list to make pages load faster, using server-side behavior for
     pagination.  This class (which inherits the client interface, Django ListView, and the auto-setup functionality of
     BSTBaseListView) is responsible for executing queries and serving up the results.  It uses the instance variables
@@ -74,19 +416,9 @@ class BSTListView(BSTBaseListView):
             }
     """
 
-    query_mode = QueryMode.iterate
-
-    def __init__(self, *args, query_mode: Optional[QueryMode] = None, **kwargs):
-        super().__init__(*args, **kwargs)
-
-        # Change the query mode based on the data-influenced performance
-        if isinstance(query_mode, QueryMode):
-            self.query_mode = query_mode
-        else:
-            self.query_mode = type(self).query_mode
-
-        # We can get the prefetches right away, because none of that is based on cookies.
-        self.prefetches: List[str] = self.get_prefetches()
+    def __init__(self, *args, query_mode=None, **kwargs):
+        BSTBaseListView.__init__(self, *args, **kwargs)
+        BSTQueryView.__init__(self, query_mode=query_mode)
 
         # The filters and annotations are initially empty.  Will be set in get()
         self.filters = Q()
@@ -311,7 +643,7 @@ class BSTListView(BSTBaseListView):
 
                         column.set_list_attr(rec, subrecs)
 
-                    elif isinstance(column, BSTAnnotColumn):
+                    elif isinstance(column, BSTAnnotColumn) and column.is_fk:
 
                         # See if there are any foreign key annotations
                         model_obj: Model = column.get_model_object(
@@ -323,92 +655,8 @@ class BSTListView(BSTBaseListView):
 
         return paginator, page, object_list, is_paginated
 
-    def set_many_related_records_list(
-        self, rec: Model, column: BSTManyRelatedColumn, subrecs: List[Model]
-    ):
-        """Adds a list of many-related records as an attribute of the root model record.  Also truncates the list down
-        to the size indicated in the column's settings (it's limit attribute) and "appends" an element with an ellipsis
-        (if there are more records not shown).
-
-        NOTE: The count of the total many-related records is already added to the records of the queryset, because it is
-        added by get_user_queryset() as an annotation.
-
-        Args:
-            rec (Model): A record from self.model.
-            column (BSTManyRelatedColumn): A column object that describes the many-related metadata.
-            subrecs (List[Model]): A list of Model field values (or Model objects) from a model that is many-related
-                with self.model.
-        Exceptions:
-            ProgrammingError when there is an attribute name collision
-        Returns:
-            None
-        """
-        if len(subrecs) >= (column.limit + 1):
-            n = column.limit + 1
-            limited_subrecs = subrecs[0:n]
-            if hasattr(rec, column.count_attr_name):
-                count = getattr(rec, column.count_attr_name)
-                limited_subrecs[-1] = column.more_msg.format(count - column.limit)
-            else:
-                # The derived class must've eliminated the {colname}_mm_count column, so we cannot tell them how many
-                # there are left to display.
-                limited_subrecs[-1] = column.more_unknown_msg
-        else:
-            limited_subrecs = subrecs
-
-        if hasattr(rec, column.list_attr_name):
-            raise ProgrammingError(
-                f"Attribute '{column.list_attr_name}' already exists on '{self.model.__name__}' object."
-            )
-
-        setattr(rec, column.list_attr_name, limited_subrecs)
-
-    def get_prefetches(self, along_path: Optional[str] = None):
-        """Generate a list of strings that can be provided to Django's .prefetch_related() method, to speed up database
-        interactions by reducing the number of queries necessary.
-
-        Args:
-            along_path (Optional[str]): Only include paths in or after this path.
-        Exceptions:
-            None
-        Returns:
-            prefetches (List[str]): A list of model paths.  A model path is a dunderscore-delimited series of foreign
-                keys that start from self.model.  Each model path is not contained in any other model path.
-        """
-        prefetches: List[str] = []
-        # For all related_model_paths, by descending path length (i.e. number of dunderscore-delimited foreign keys)
-        for model_path in sorted(
-            [
-                c.related_model_path
-                for c in self.columns.values()
-                if isinstance(c, BSTRelatedColumn)
-            ],
-            key=lambda p: len(p.split("__")),
-            reverse=True,
-        ):
-            contained = False
-            for prefetch in prefetches:
-                if prefetch.startswith(model_path):
-                    # Make sure that the match ends at either the end of the string or at a "__"
-                    remainder = prefetch.replace(model_path, "", 1)
-                    if remainder == "" or remainder.startswith("__"):
-                        contained = True
-                        break
-            if not contained and (
-                along_path is None
-                or model_path.startswith(along_path)
-                or along_path.startswith(model_path)
-            ):
-                prefetches.append(model_path)
-
-            # # TODO: Test to see if using Prefetch() for many-related models speeds up ArchiveFileListView
-            # if mdl is not None and column.many_related and len(mdl.split("__")) > 1:
-            #     prefetches.append(Prefetch(mdl, to_attr=column.mm_list))
-            # elif mdl is not None:
-            #     prefetches.append(mdl)
-
-        return prefetches
-
+    # TODO: Figure out a way to move this to BSTQueryView without it having to know about the client interface elements
+    # like cookeis and filter_terms.
     def get_filters(self) -> Q:
         """Returns a Q expression for every filtered and searchable column using self.filter_terms and self.search_term.
 
@@ -442,6 +690,8 @@ class BSTListView(BSTBaseListView):
 
         return q_exp
 
+    # TODO: Figure out a way to move this to BSTQueryView without it having to know about the client interface elements
+    # like cookeis and search_term.
     def search(self) -> Q:
         """Returns a Q expression for every searchable column using self.search_term.
 
@@ -462,13 +712,18 @@ class BSTListView(BSTBaseListView):
 
         for column in self.columns.values():
             if column.searchable:
-                # TODO: Consider making it possible to use icontains when the input method is select (for search field)
+                # TODO: Consider making it possible to use icontains when the input method is select (for a particular
+                # search field)
                 q_exp |= column.filterer.create_q_exp(self.search_term)
 
         return q_exp
 
+    # TODO: Figure out a way to move this to BSTQueryView without it having to know about the client interface aspects
+    # like pre- and post- filter annotations.
     def get_annotations(self) -> Tuple[Dict[str, Combinable], Dict[str, Combinable]]:
-        """Generate 2 dicts of annotations that can each be provided to Django's .annotate() method.  The dicts are for
+        """An override of the superclass method.
+
+        Generate 2 dicts of annotations that can each be provided to Django's .annotate() method.  The dicts are for
         before and after the call to .filter(), separated due to performance issues related to certain annotations'
         interactions with the WHERE clause.  If an annotation is not used in a filter, it is entered into the
         after-dict.
@@ -503,49 +758,8 @@ class BSTListView(BSTBaseListView):
 
         return annotations_before_filter, annotations_after_filter
 
-    def apply_annotations(
-        self, qs: QuerySet, annotations: Dict[str, Combinable]
-    ) -> QuerySet:
-        """This method exists to be able to try and recover from an exception about a specific annotation.
-
-        Agrs:
-            qs (QuerySet)
-            annotations (Dict[str, Combinable])
-        Exceptions:
-            None
-        Returns:
-            qs (QuerySet)
-        """
-        for annot_name, expression in annotations.items():
-            try:
-                qs = qs.annotate(**{annot_name: expression})
-            except Exception as e:
-                # Attempt to recover by filling in "ERROR".  This will raise an exception if the name is the problem.
-                qs = qs.annotate(**{annot_name: Value("ERROR")})
-
-                # Account for the fact that a sort annotation does not exist as a column object, but it does reference a
-                # real column.  We will use the annotation name to detect if this is a sort annotation and if so, derive
-                # the column name.
-                if BSTBaseSorter.is_sort_annotation(annot_name):
-                    colname = BSTBaseSorter.sort_annot_name_to_col_name(annot_name)
-                else:
-                    colname = annot_name
-
-                # Disable searching and sorting.
-                self.columns[colname].searchable = False
-                self.columns[colname].sortable = False
-
-                if colname == annot_name:
-                    msg = f"The expression '{expression}' for the annotation column '{colname}' "
-                else:
-                    msg = f"The sort expression '{expression}' for column '{colname}' "
-                msg += f"has a problem: {type(e).__name__}: {e}"
-
-                if settings.DEBUG:
-                    warn(trace() + msg, DeveloperWarning)
-                self.warnings.append(msg)
-        return qs
-
+    # TODO: Figure out a way to move this to BSTQueryView without it having to know about the client interface elements
+    # like cookeis and filters.
     def apply_filters(self, qs: QuerySet) -> QuerySet:
         """This method exists to be able to try and recover from an exception about a Q expression.
 
@@ -575,115 +789,3 @@ class BSTListView(BSTBaseListView):
             self.reset_filter_cookies()
 
         return qs
-
-    def get_column_val_by_iteration(self, rec: Model, col: BSTBaseColumn):
-        """Given a model record, i.e. row-data, e.g. from a queryset, and a column, return the column value(s).
-
-        This method exists primarily to convert the column into arguments to the get_field_val_by_iteration
-        method.  get_field_val_by_iteration returns either a single value or a list of values.
-
-        Args:
-            rec (Model)
-            col (BSTBaseColumn)
-        Exceptions:
-            ProgrammingError when the value received is not a list of tuples or a tuple, as expected based on the column
-                type
-        Returns:
-            (Union[Any, List[Any]]): Column value or values (if many-related).
-        """
-        # Defaults (which do not matter if this is not a BSTManyRelatedColumn, but allow us to make a single call)
-        limit = 5
-        sort_field_path = None
-        asc = True
-        if isinstance(col, BSTManyRelatedColumn):
-            # In order for us to be able to sort the results and limit them to the TOP col.limit items, we need to get
-            # all of them.  All records should have been prefetched, so even though we are getting all, it should
-            # proceed expeditiously.  If the count annotation is absent from the rec, we go with the limit, even though
-            # that could mean we don't get fully ordered results.
-
-            # TODO: The above is apparently not true.  The mr_qs.all() in _recursive_many_rec_iterator() does perform a
-            # query, so it would likely be faster to use an order_by in _recursive_many_rec_iterator and
-            # _last_many_rec_iterator and set the related_limit here to 1 + the limit in the column object, instead of
-            # to getattr(rec, col.count_attr_name).
-            # Besides, it looks like it sorts anyway, given the model's ordering, based on the SQL output of
-            # test__last_many_rec_iterator
-
-            # We add 1 to col.limit so that we can display an ellipsis if more exist
-            limit = getattr(rec, col.count_attr_name, -1)
-            if limit == -1:
-                limit = col.limit + 1
-                if settings.DEBUG:
-                    warn(
-                        f"The count annotation for column {col} is absent.  "
-                        f"Cannot guarantee the top {col.limit} records will include the the min/max sorted records.",
-                        DeveloperWarning,
-                    )
-            if isinstance(col.sorter, BSTManyRelatedSorter):
-                sort_field_path = col.sorter.field_path.split("__")
-            else:
-                raise ProgrammingError(
-                    f"BSTManyRelatedColumn '{col.name}' does not have a BSTManyRelatedSorter"
-                )
-            asc = col.asc
-        elif isinstance(col, BSTAnnotColumn):
-            return getattr(rec, col.name)
-
-        # This method handles both singly-related and many-related column values and returns either a tuple (singly-
-        # related) or a list of tuples (many-related)
-        return get_field_val_by_iteration(
-            rec,
-            col.name.split("__"),
-            related_limit=limit,
-            sort_field_path=sort_field_path,
-            asc=asc,
-        )
-
-    def get_many_related_column_val_by_subquery(
-        self, rec: Model, col: BSTManyRelatedColumn
-    ) -> list:
-        """Method to improve performance by grabbing the annotated value first and if it is not None, does an exhaustive
-        search for all many-related values.
-
-        Args:
-            rec (Model)
-            col (BSTColumn)
-        Exceptions:
-            ProgrammingError when the supplied column's sorter is not many-related.  This is mainly to satisfy mypy.
-            TypeError when col is not a BSTManyRelatedColumn.
-        Returns:
-            (list): Sorted unique (to the many-related model) values.
-        """
-        if not isinstance(col, BSTManyRelatedColumn):
-            raise TypeError(f"Column '{col}' is not many-related.")
-
-        count_annot_name = BSTManyRelatedColumn.get_count_name(
-            col.many_related_model_path, self.model
-        )
-
-        count = getattr(rec, count_annot_name, None)
-        # It's faster to skip if we already know there are no records
-        if count is not None and count == 0:
-            return []
-
-        if not isinstance(col.sorter, BSTManyRelatedSorter):
-            raise ProgrammingError(
-                f"Column '{col}' sorter must be a BSTManyRelatedSorter, not '{type(col.sorter).__name__}'."
-            )
-
-        # Set a limit to the retrieved records (count or supplied limit: whichever is lesser and not 0 [i.e. all])
-        related_limit = col.limit + 1 if col.limit > 0 else 0
-        if isinstance(count, int) and (related_limit == 0 or count < related_limit):
-            related_limit = count
-
-        annotations = col.sorter.get_many_annotations()
-        order_bys = col.sorter.get_many_order_bys()
-        distincts = col.sorter.get_many_distinct_fields()
-
-        return get_many_related_field_val_by_subquery(
-            rec,
-            col.field_path,
-            related_limit=related_limit,
-            annotations=annotations,
-            order_bys=order_bys,
-            distincts=distincts,
-        )

--- a/DataRepo/views/models/sample.py
+++ b/DataRepo/views/models/sample.py
@@ -9,7 +9,7 @@ from DataRepo.models import (
     Researcher,
     Sample,
 )
-from DataRepo.views.models.bst.list_view import BSTListView
+from DataRepo.views.models.bst.query import BSTListView
 
 
 class SampleListView(BSTListView):

--- a/DataRepo/views/models/tracer.py
+++ b/DataRepo/views/models/tracer.py
@@ -1,0 +1,30 @@
+from DataRepo.models import Tracer
+from DataRepo.views.models.bst.query import BSTDetailView, BSTListView
+
+
+class TracerDetailView(BSTDetailView):
+    model = Tracer
+    exclude = ["id", "fcircs", "infusate_links"]
+    column_settings = {
+        "infusates": {
+            "td_template": "models/tracer/infusates_td.html",
+            "value_template": "models/tracer/infusates_value_detail.html",
+            "delim": "\n",
+            "limit": 25,
+        },
+        "label_combo": {"filterer": {"distinct_choices": True}},
+    }
+
+
+class TracerListView(BSTListView):
+    model = Tracer
+    exclude = ["id", "fcircs", "infusate_links"]
+    column_settings = {
+        "infusates": {
+            "td_template": "models/tracer/infusates_td.html",
+            "value_template": "models/tracer/infusates_value_list.html",
+            "delim": "\n",
+            "visible": False,
+        },
+        "label_combo": {"filterer": {"distinct_choices": True}},
+    }


### PR DESCRIPTION
## Summary Change Description

This PR reconfigures the BST Inheritance Hierarchy to be able to re-use it for a DetailView.

I have depicted the change using d2lang:

This is the old hierarchy:

![BSTInheritanceHierarchy-old](https://github.com/user-attachments/assets/e12510e5-09c6-4a4d-9a0f-69ec0f957799)

```
# Old BST Hierarchy

direction: up

ListView: {
  shape: class
}

BSTClientInterface: {
  shape: class
  "Responsible for server/client communication"
}

BSTBaseListView: {
  shape: class
  "Responsible for column setup"
}

BSTListView: {
  shape: class
  "Responsible for queries"
}

BSTClientInterface -> ListView: {
  target-arrowhead.shape: triangle
  target-arrowhead.style.filled: false
}
BSTBaseListView -> BSTClientInterface: {
  target-arrowhead.shape: triangle
  target-arrowhead.style.filled: false
}
BSTListView -> BSTBaseListView: {
  target-arrowhead.shape: triangle
  target-arrowhead.style.filled: false
}
```

Each point in that hierarchy was split into a *list* version and a *detail* version.  Common functionality between the 2 at each level went into a common superclass by using multiple inheritance.  Each of those levels is depicted here separately:

![BSTClientInterface-new](https://github.com/user-attachments/assets/969106e4-6783-46c8-aec4-49ec213093bf)

```
# New BSTClientInterface

direction: up

DetailView: {
  shape: class
}

BSTClientInterface: {
  shape: class
  "Responsible for server/client"
}

BSTDetailViewClient: {
  shape: class
  "Responsible for server/client"
  "communication for detail pages"
}

BSTDetailViewClient -> BSTClientInterface: {
  target-arrowhead.shape: triangle
  target-arrowhead.style.filled: false
}
BSTDetailViewClient -> DetailView: {
  target-arrowhead.shape: triangle
  target-arrowhead.style.filled: false
}

ListView: {
  shape: class
}

BSTListViewClient: {
  shape: class
  "Responsible for server/client"
  "communication for list pages"
}

BSTListViewClient -> BSTClientInterface: {
  target-arrowhead.shape: triangle
  target-arrowhead.style.filled: false
}
BSTListViewClient -> ListView: {
  target-arrowhead.shape: triangle
  target-arrowhead.style.filled: false
}
```

![BSTBaseListView-new](https://github.com/user-attachments/assets/466bdc14-9598-4354-83a4-93926132ee67)

```
# New BSTBaseListView (& BSTBaseDetailView)

direction: up

BSTListViewClient: {
  shape: class
  "Responsible for server/client"
  "communication for list pages"
}

BSTDetailViewClient: {
  shape: class
  "Responsible for server/client"
  "communication for detail pages"
}

BSTBaseView: {
  shape: class
  "Responsible for setup Model data"
}

BSTBaseListView: {
  shape: class
  "Responsible for column setup"
}

BSTBaseDetailView: {
  shape: class
  "Responsible for row setup"
}

BSTBaseDetailView -> BSTDetailViewClient: {
  target-arrowhead.shape: triangle
  target-arrowhead.style.filled: false
}
BSTBaseDetailView -> BSTBaseView: {
  target-arrowhead.shape: triangle
  target-arrowhead.style.filled: false
}
BSTBaseListView -> BSTListViewClient: {
  target-arrowhead.shape: triangle
  target-arrowhead.style.filled: false
}
BSTBaseListView -> BSTBaseView: {
  target-arrowhead.shape: triangle
  target-arrowhead.style.filled: false
}
```

![BSTListView-new](https://github.com/user-attachments/assets/73a0186b-d6af-41bc-af39-da0d7ee86c7e)

```
# New BSTListView (& BSTDetailView)

direction: up

BSTBaseListView: {
  shape: class
  "Responsible for column setup"
}

BSTBaseDetailView: {
  shape: class
  "Responsible for row setup"
}

BSTQueryView: {
  shape: class
  "Responsible for queries"
}

BSTDetailView: {
  shape: class
  "Responsible for detail queries"
}

BSTListView: {
  shape: class
  "Responsible for list queries"
}

BSTDetailView -> BSTBaseDetailView: {
  target-arrowhead.shape: triangle
  target-arrowhead.style.filled: false
}
BSTListView -> BSTBaseListView: {
  target-arrowhead.shape: triangle
  target-arrowhead.style.filled: false
}
BSTListView -> BSTQueryView: {
  target-arrowhead.shape: triangle
  target-arrowhead.style.filled: false
}
BSTDetailView -> BSTQueryView: {
  target-arrowhead.shape: triangle
  target-arrowhead.style.filled: false
}
```

Details:

- Renames:
  - DataRepo.views.models.bst.list_view -> DataRepo.views.models.bst.query
  - DataRepo.views.models.bst.base -> DataRepo.views.models.bst.column_setup
  - BSTClientInterface -> BSTListViewClient
- Added classes:
  - BSTClientInterface (repurposed old name)
  - BSTDetailViewClient
  - BSTBaseView
  - BSTBaseDetailView
  - BSTQueryView
  - BSTDetailView
- BSTBaseSorter
  - Added the ability to recognize key fields
- BSTManyRelatedColumn
  - Added the ability to describe white space delimiters in the tooltip (for the newline infusates delimiter).
- BSTColumn
  - Fixed header generation to select the correct field when faced with a reverse relation descriptor.
- BSTBaseColumn
  - Added a real_header instance attribute for use in the detail view.
- BSTAnnotColumn
  - Added is_fk instance attribute to be able to know when to convert a foreign key ID to an object.
- Added a link to the tracer list to the sidebar.
- `DataRepo/models/utilities.py`
  - Added the ability to make the field value unique in many-related model fields (instead of the pk) using a `value_unique` argument to the various query methods.
- `Tracer`
  - Added `get_absolute_url` and `detail_name`
- `BSTQueryView`
  - Passed `not column._in_group` to the `value_unique` argument in the utility query methods so that if a many-related column has no neighboring columns from the same many-related model, the displayed values are just the unique ones.  This affected the "Sample Owner" column in the animal list view.
- The overall hierarchy change essentially changed this:
  - ListView <- BSTClientInterface <- BSTBaseListView <- BSTListView
  - To this:
    - ListView <- BSTListViewClient <- BSTBaseListView <- BSTListView
    - DetailView <- BSTDetailViewClient <- BSTBaseDetailView <- BSTDetailView
  - But also, common functionality/data was put in new superclasses by way of multiple inheritance, so the above classes also inherit from:
    - BSTClientInterface <- BSTListViewClient/BSTDetailViewClient
    - BSTBaseView <- BSTBaseListView/BSTBaseDetailView
    - BSTQueryView <- BSTListView/BSTDetailView

## Affected Issues/Pull Requests

- Resolves #1590
- Merges into branch `bstlv17_archive_file_list`

## Reviewer Notes/Requests
<!-- Notes to help the reviewer or requests for specific scrutiny.
E.g. Please make sure I have accounted for all possible inputs. -->
See comments in-line.

## Checklist
<!-- If any requirements are not met, uncheck and explain.
E.g. Linting errors pre-date this PR. -->
This pull request will be merged once the following requirements are met.  The
author and/or reviewers should uncheck any unmet requirements:
<!-- Check/complete items if not applicable. -->
- Review Requirements
  - Minimum approvals: 1 <!-- Edit based on complexity. -->
  - No changes requested
  - All blocking issues resolved by reviewers
  - Specific reviewers: @__add_username_here__ <!-- Approvals required even if minimum met. -->
  - Review period: 2 days <!-- Edit based on complexity. -->
- Associated Issue/PR Requirements: <!-- Assert resolved issues/PRs are done/merged. -->
  - [x] All issue requirements are satisfied
  - [x] All PR dependencies are merged
- Basic Requirements <!-- Uncheck to indicate items you are yet to address. -->
  - [x] [Linters pass](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#linting)
  - [x] [Tests pass](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#quality-control)
  - [x] Conflicts resolved
- Overhead Requirements <!-- Requirements indirectly related to the issues. -->
  - [x] [Tests implemented/updated](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#test-implementation)
  - [ ] [Updated `CHANGELOG.md` *Unreleased* section](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/changelog.md)
