### PR TITLE
Build Cache Script (a download speed issue)

### DIFF
--- a/DataRepo/management/commands/build_cached_fields.py
+++ b/DataRepo/management/commands/build_cached_fields.py
@@ -1,0 +1,87 @@
+from argparse import RawTextHelpFormatter
+
+from django.core.management import BaseCommand
+
+from DataRepo.models.hier_cached_model import (
+    HierCachedModel,
+    caching_retrievals,
+    caching_updates,
+    delete_all_caches,
+    disable_caching_retrievals,
+    disable_caching_updates,
+    enable_caching_retrievals,
+    enable_caching_updates,
+    get_cached_method_names,
+)
+
+# This builds a string to use in the help text when the user supplied -h
+nlt = "\n  "
+nltt = "\n    "
+funcs_str = nlt.join(
+    [f"{k}\n    {nltt.join(v)}" for k, v in get_cached_method_names().items()]
+)
+
+
+class Command(BaseCommand):
+    help = (
+        "Builds missing cached values for all model fields with the following cached_functions:\n"
+        f"{nlt}{funcs_str}"
+    )
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "--models",
+            required=False,
+            default=[],
+            nargs="*",
+            help="Only update cached fields of these models.",
+        )
+        parser.add_argument(
+            "--functions",
+            required=False,
+            default=[],
+            nargs="*",
+            help="Only update cached fields whose update functions exactly match any of these function names.",
+        )
+        parser.add_argument(
+            "--clear",
+            action="store_true",
+            default=False,
+            help="Clear existing cached values first.",
+        )
+
+    def handle(self, *args, **options):
+        save_retrievals = caching_retrievals
+        save_updates = caching_updates
+        if not caching_retrievals:
+            enable_caching_retrievals()
+        if not caching_updates:
+            enable_caching_updates()
+
+        if options["clear"]:
+            delete_all_caches()
+
+        try:
+            HierCachedModel.build_cached_fields(
+                model_names=options["models"],
+                func_names=options["functions"],
+            )
+        except Exception as e:
+            if not save_updates:
+                disable_caching_updates()
+            if not save_retrievals:
+                disable_caching_retrievals()
+            raise e
+
+        if not save_updates:
+            disable_caching_updates()
+        if not save_retrievals:
+            disable_caching_retrievals()
+
+    def create_parser(self, *args, **kwargs):
+        """This extends the superclass method to allow multi-line help text.
+        See: https://stackoverflow.com/a/35470682
+        """
+        parser = super().create_parser(*args, **kwargs)
+        parser.formatter_class = RawTextHelpFormatter
+        return parser


### PR DESCRIPTION
## Summary Change Description

This doesn't solve the download speed issue, but it is a significant factor.  I will update the `nplcadmindocs` to include running this after a load.

This involved adding a class method to `HierCachedModel`: `build_cached_fields`.

Note the usage output:
```
$ python manage.py build_cached_fields -h
usage: manage.py build_cached_fields [-h] [--version] [-v {0,1,2,3}] [--settings SETTINGS] [--pythonpath PYTHONPATH] [--traceback] [--no-color] [--force-color] [--skip-checks] [--models [MODELS ...]] [--functions [FUNCTIONS ...]] [--clear]

Builds missing cached values for all model fields with the following cached_functions:

  Animal
    tracers
    last_serum_tracer_peak_groups
    tracer_links
  AnimalLabel
    tracers
    last_serum_tracer_label_peak_groups
    serum_tracers_enrichment_fraction
  FCirc
    last_peak_group_in_animal
    last_peak_group_in_sample
    peak_groups
    serum_validity
    rate_disappearance_intact_per_gram
    rate_appearance_intact_per_gram
    rate_disappearance_intact_per_animal
    rate_appearance_intact_per_animal
    rate_disappearance_average_per_gram
    rate_appearance_average_per_gram
    rate_disappearance_average_per_animal
    rate_appearance_average_per_animal
  Infusate
    tracer_labeled_elements
  PeakGroup
    peak_labeled_elements
    tracer_labeled_elements
    possible_isotope_observations
  PeakGroupLabel
    enrichment_fraction
    enrichment_abundance
    normalized_labeling
    tracer
    tracer_label_count
    tracer_concentration
    get_peak_group_label_tracer_info
    is_tracer_label_compound_group
    from_serum_sample
    can_compute_tracer_label_rates
    can_compute_body_weight_intact_tracer_label_rates
    can_compute_body_weight_average_tracer_label_rates
    can_compute_intact_tracer_label_rates
    can_compute_average_tracer_label_rates
    rate_disappearance_intact_per_gram
    rate_appearance_intact_per_gram
    rate_disappearance_intact_per_animal
    rate_appearance_intact_per_animal
    rate_disappearance_average_per_gram
    rate_appearance_average_per_gram
    rate_disappearance_average_per_animal
    rate_appearance_average_per_animal
  Sample
    last_tracer_peak_groups

optional arguments:
  -h, --help            show this help message and exit
  --version             Show program's version number and exit.
  -v {0,1,2,3}, --verbosity {0,1,2,3}
                        Verbosity level; 0=minimal output, 1=normal output, 2=verbose output, 3=very verbose output
  --settings SETTINGS   The Python path to a settings module, e.g. "myproject.settings.main". If this isn't provided, the DJANGO_SETTINGS_MODULE environment variable will be used.
  --pythonpath PYTHONPATH
                        A directory to add to the Python path, e.g. "/home/djangoprojects/myproject".
  --traceback           Raise on CommandError exceptions.
  --no-color            Don't colorize the command output.
  --force-color         Force colorization of the command output.
  --skip-checks         Skip system checks.
  --models [MODELS ...]
                        Only update cached fields of these models.
  --functions [FUNCTIONS ...]
                        Only update cached fields whose update functions exactly match any of these function names.
  --clear               Clear existing cached values first.
```

## Affected Issues/Pull Requests

- Partially addresses: #617
- Partially addresses: #1492

## Reviewer Notes/Requests

As a side-note, I also experimented with changing the tsv template strategy with a direct iterator strategy (not included in this PR, because I ruled it out as a significant factor in the overall speed), but just to give you an idea, this is the call to the iterator method I tried:

<img width="1836" height="938" alt="template_speed_test_code" src="https://github.com/user-attachments/assets/29f3c478-8f57-4448-b889-a780822ffc92" />

## Checklist
<!-- If any requirements are not met, uncheck and explain.
E.g. Linting errors pre-date this PR. -->
This pull request will be merged once the following requirements are met.  The
author and/or reviewers should uncheck any unmet requirements:
<!-- Check/complete items if not applicable. -->
- Review Requirements
  - Minimum approvals: 1 <!-- Edit based on complexity. -->
  - No changes requested
  - All blocking issues resolved by reviewers
  - Specific reviewers: @__add_username_here__ <!-- Approvals required even if minimum met. -->
  - Review period: 2 days <!-- Edit based on complexity. -->
- Associated Issue/PR Requirements: <!-- Assert resolved issues/PRs are done/merged. -->
  - [x] All issue requirements are satisfied
  - [x] All PR dependencies are merged
- Basic Requirements <!-- Uncheck to indicate items you are yet to address. -->
  - [x] [Linters pass](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#linting)
  - [x] [Tests pass](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#quality-control)
  - [x] Conflicts resolved
- Overhead Requirements <!-- Requirements indirectly related to the issues. -->
  - [x] [Tests implemented/updated](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#test-implementation)
  - [ ] [Updated `CHANGELOG.md` *Unreleased* section](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/changelog.md)
