### PR TITLE
Added sample name as searchable in the FCirc advanced search format

### DIFF
--- a/DataRepo/formats/fluxcirc_dataformat.py
+++ b/DataRepo/formats/fluxcirc_dataformat.py
@@ -26,7 +26,7 @@ class FluxCircFormat(Format):
             },
             "fields": {
                 "element": {
-                    "displayname": "Peak Group Labeled Element",
+                    "displayname": "Labeled Element",
                     "searchable": True,
                     "displayed": True,
                     "type": "enumeration",
@@ -266,10 +266,14 @@ class FluxCircFormat(Format):
                     "displayname": "(Internal) Sample Index",
                     "searchable": True,
                     "displayed": False,  # Used in link
-                    # "handoff": "",
-                    # Using in link will expose the internal index field in the search form because there's no
-                    # searchable unique field for handoff
+                    "handoff": "name",  # This is the field that will be loaded in the search form
                     "type": "number",
+                },
+                "name": {
+                    "displayname": "Serum Sample",
+                    "searchable": True,
+                    "displayed": True,
+                    "type": "string",
                 },
                 "time_collected": {
                     "displayname": "Time Collected (since infusion)",


### PR DESCRIPTION
## Summary Change Description

While working on the documentation, I wanted to contextualize Lance's `FCirc` barplot example, because the data he linked points to the public site, but the data in the analysis is on the internal production site.  I.e. that data is not there and you get a 404.  So in trying to whittle down an example, I noticed an omission in the advanced search.  The serum sample was displayed in a column, but was not searchable, so I added it as searchable in the `FCirc` format.

Also edited the labeled element name in the advanced search's `field` select list to be more succinct.  It's clear that this is a `PeakGroup` label.  Besides, the distinction is with a tracer label, which is observable in the tracer name.

## Affected Issues/Pull Requests

- Resolves no documented issue
- Merges into branch `main`

## Reviewer Notes/Requests
<!-- Notes to help the reviewer or requests for specific scrutiny.
E.g. Please make sure I have accounted for all possible inputs. -->
See comments in-line.

## Checklist
<!-- If any requirements are not met, uncheck and explain.
E.g. Linting errors pre-date this PR. -->
This pull request will be merged once the following requirements are met.  The
author and/or reviewers should uncheck any unmet requirements:
<!-- Check/complete items if not applicable. -->
- Review Requirements
  - Minimum approvals: 1 <!-- Edit based on complexity. -->
  - No changes requested
  - All blocking issues resolved by reviewers
  - Specific reviewers: @__add_username_here__ <!-- Approvals required even if minimum met. -->
  - Review period: 2 days <!-- Edit based on complexity. -->
- Associated Issue/PR Requirements: <!-- Assert resolved issues/PRs are done/merged. -->
  - [x] All issue requirements are satisfied
  - [x] All PR dependencies are merged
- Basic Requirements <!-- Uncheck to indicate items you are yet to address. -->
  - [x] [Linters pass](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#linting)
  - [x] [Tests pass](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#quality-control)
  - [x] Conflicts resolved
- Overhead Requirements <!-- Requirements indirectly related to the issues. -->
  - [x] [Tests implemented/updated](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#test-implementation)
  - [ ] [Updated `CHANGELOG.md` *Unreleased* section](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/changelog.md)
