### PR TITLE
Made `TableLoader.check_for_inconsistencies` account for populated DB record fields not represented in the `rec_dict`

### DIFF
--- a/DataRepo/tests/loaders/base/test_table_loader.py
+++ b/DataRepo/tests/loaders/base/test_table_loader.py
@@ -363,8 +363,7 @@ class TableLoaderTests(TracebaseTestCase):
         erec2.full_clean()
 
         # Send a simulated IntegrityError to handle_load_db_errors
-        # TODO: I added `"opt_val": None` to work around a minor bug I will fix in a separate PR.
-        newrecdict = {"name": "a", "file": 1, "opt_val": None}
+        newrecdict = {"name": "a", "file": 1}
         tl.handle_load_db_errors(
             IntegrityError("duplicate key value violates unique constraint"),
             self.test_ucc_model_class,
@@ -382,7 +381,12 @@ class TableLoaderTests(TracebaseTestCase):
             ),
         )
         self.assertIsInstance(
-            tl.aggregated_errors_object.exceptions[0], ConflictingValueError
+            tl.aggregated_errors_object.exceptions[0],
+            ConflictingValueError,
+            msg=(
+                "Expected 1 ConflictingValueError, got: "
+                f"{[type(e).__name__ for e in tl.aggregated_errors_object.exceptions]}"
+            ),
         )
 
         # Ensure that the record that handle_load_db_errors identified is the correct one (it had to have used the
@@ -461,7 +465,13 @@ class TableLoaderTests(TracebaseTestCase):
         # where Excel or pandas autodetected a type (inaccurately)
         recdict["uf1"] = 2
         errfound = tl.check_for_inconsistencies(rec, recdict)
-        self.assertFalse(errfound)
+        self.assertFalse(
+            errfound,
+            msg=(
+                "Expected 0 exceptions, got: "
+                f"{[type(e).__name__ + ': ' + str(e) for e in tl.aggregated_errors_object.exceptions]}"
+            ),
+        )
         # No error when the field is mapped to a column and the column's type is recorded
         self.assertEqual(0, len(tl.aggregated_errors_object.exceptions))
 

--- a/DataRepo/tests/loaders/test_samples_loader.py
+++ b/DataRepo/tests/loaders/test_samples_loader.py
@@ -168,7 +168,14 @@ class SamplesLoaderTests(TracebaseTestCase):
         with self.assertRaises(RollbackException):
             sl.get_or_create_sample(row, self.anml1, self.tiss1)
 
-        self.assertEqual(4, len(sl.aggregated_errors_object.exceptions))
+        self.assertEqual(
+            4,
+            len(sl.aggregated_errors_object.exceptions),
+            msg=(
+                f"Expected 4 exceptions, got {len(sl.aggregated_errors_object.exceptions)}: "
+                f"{[type(e).__name__ + ': ' + str(e) for e in sl.aggregated_errors_object.exceptions]}"
+            ),
+        )
 
         self.assertIsInstance(sl.aggregated_errors_object.exceptions[0], NewResearcher)
         self.assertIn(


### PR DESCRIPTION
## How

Made `TableLoader.check_for_inconsistencies` account for populated DB record fields not represented in the `rec_dict`.

- Edited test_check_for_inconsistencies_case3 to provide debug info when my initial test run failed that test
- Edited test_get_or_create_sample_date_time_and_unique_error to provide debug info about fields that were not in the infile columns, like Sample.is_serum_sample.
- Compared to my initial attempt at this change in the previous PR, I added a check that the DB field is in FieldToDataHeaderKey to ensure that the reported differences are ones that a researcher can do something about.

## What

- Resolves no documented GitHub issue
- Resolves [GREATS-79](https://princeton-university.atlassian.net/browse/GREATS-89?atlOrigin=eyJpIjoiZjYzMzliNWY0NjM1NGM1NDgzOWQ5ODc2MDE0NThhNzQiLCJwIjoiaiJ9)
- Merges into branch `dev/3_1_7_table_loader_unique_constraint_condition`

## Reviewer Notes/Requests

This was a minor bug found during the work on the previous PR.  I initially had included it in the previous PR, but decided to split it up.

## Checklist
<!-- If any requirements are not met, uncheck and explain.
E.g. Linting errors pre-date this PR. -->
This pull request will be merged once the following requirements are met.  The
author and/or reviewers should uncheck any unmet requirements:
<!-- Check/complete items if not applicable. -->
- Review Requirements
  - Minimum approvals: 1 <!-- Edit based on complexity. -->
  - No changes requested
  - All blocking issues resolved by reviewers
  - Specific reviewers: @__add_username_here__ <!-- Approvals required even if minimum met. -->
  - Review period: 2 days <!-- Edit based on complexity. -->
- Associated Issue/PR Requirements: <!-- Assert resolved issues/PRs are done/merged. -->
  - [x] All issue requirements are satisfied
  - [x] All PR dependencies are merged
- Basic Requirements <!-- Uncheck to indicate items you are yet to address. -->
  - [x] [Linters pass](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#linting)
  - [x] [Tests pass](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#quality-control)
  - [x] Conflicts resolved
- Overhead Requirements <!-- Requirements indirectly related to the issues. -->
  - [x] [Tests implemented/updated](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#test-implementation)
