### PR TITLE
Fixed exceptions from skipped `mzXML` rows that should not happen

### DIFF
--- a/DataRepo/tests/loaders/test_msruns_loader.py
+++ b/DataRepo/tests/loaders/test_msruns_loader.py
@@ -1895,7 +1895,7 @@ class MSRunsLoaderTests(TracebaseTestCase):
         self.assertFalse(msrl.aggregated_errors_object.exceptions[0].is_error)
         self.assertFalse(msrl.aggregated_errors_object.exceptions[0].is_fatal)
 
-    def test_check_mzxml_files(self):
+    def test_check_mzxml_files_buffers_exc_for_every_unmatched_file(self):
         """This test ensures that every unmatched mzXML gets its own exception."""
         mrl = MSRunsLoader(
             df=pd.DataFrame.from_dict({}),
@@ -1922,6 +1922,56 @@ class MSRunsLoaderTests(TracebaseTestCase):
         self.assertEqual("unknown_blank.mzXML", aes.exceptions[2].mzxml_file)
         self.assertIsInstance(aes.exceptions[3], UnmatchedBlankMzXML)
         self.assertEqual("scan2/unknown_blank.mzXML", aes.exceptions[3].mzxml_file)
+
+    def test_check_mzxml_files_does_not_error_when_skipped(self):
+        """Test that there is no error about sample 'some_unknown_sample' not existing."""
+        # Create an MSRunsLoader object named mrl
+        # Set its mrl.df to a dataframe with skipped lines and an mzXML file whose name (some_unknown_sample.mzXML) does
+        # not match any sample
+        # Set mrl.mzxml_files to ["some_unknown_sample.mzXML"]
+        msruns_loader_instance = MSRunsLoader(
+            df=pd.DataFrame.from_dict(
+                {
+                    MSRunsLoader.DataHeaders.SAMPLENAME: [
+                        "s1",
+                        "s2",
+                        "some_unknown_sample",
+                    ],
+                    MSRunsLoader.DataHeaders.SAMPLEHEADER: [
+                        "s1_pos",
+                        None,
+                        "some_unknown_sample",
+                    ],
+                    MSRunsLoader.DataHeaders.MZXMLNAME: [
+                        None,
+                        "s2_pos.mzXML",
+                        "some_unknown_sample.mzXML",
+                    ],
+                    MSRunsLoader.DataHeaders.ANNOTNAME: [
+                        None,
+                        None,
+                        None,
+                    ],
+                    MSRunsLoader.DataHeaders.SEQNAME: [
+                        None,
+                        None,
+                        None,
+                    ],
+                    MSRunsLoader.DataHeaders.SKIP: [
+                        "skip",
+                        "skip",
+                        "skip",
+                    ],
+                }
+            ),
+            file="DataRepo/data/tests/same_name_mzxmls/mzxml_study_doc_same_seq.xlsx",  # Peak Annotation Dtls not used
+            mzxml_files=["some_unknown_sample.mzXML"],
+            debug=True,
+        )
+        msruns_loader_instance.check_mzxml_files()
+        self.assertEqual(
+            0, len(msruns_loader_instance.aggregated_errors_object.exceptions)
+        )
 
 
 class MSRunsLoaderArchiveTests(TracebaseArchiveTestCase):


### PR DESCRIPTION
## What

- Resolves [GREATS-69](https://princeton-university.atlassian.net/browse/GREATS-69)
- Resolves #1665

From [GREATS-69](https://princeton-university.atlassian.net/browse/GREATS-69) suggested change:

> This is a simple fix.  Check the skip value at the top of the iterrows loop in `check_mzxml_files` and continue if True.
>
> There is a second cause of this issue as well.  Calls to `get_sample_by_name` were raising errors when the `mzXML` files were iterated because not all skipped files were included in the `explicitly_skipped_mzxmls` variable.  It was only getting a representative file for multiple files that all match the same sample name.  So populate `explicitly_skipped_mzxmls` with all same-named file paths and continue in the loop when `os.path.samefile` is True

Note that `os.path.samefile` was changed to use normalized path comparisons so that there cannot be an exception from a skipped row due to the file not existing.

Also note that the population of `explicitly_skipped_mzxmls` was handled separately in the prior PR.

## Why

From [GREATS-69](https://princeton-university.atlassian.net/browse/GREATS-69) description:

> Errors are arising on `Peak Annotation Details` rows that are marked as skipped.  (Note: Keep in mind that we want to load every `mzXML` file in the archive so that data is not lost, despite the skip).
> `mzXML` file checks are raising exceptions even when they are associated with skip rows

## How

From the git log:

> Added a skip of any mzXML file whose path matches any skipped row in the Peak Annotation Details sheet.
> 
> Details:
> 
> - MSRunsLoader.check_mzxml_files
>   - Added tracking of skipped mzXML files in variable 'explicitly_skipped_mzxmls'
>   - Skipped any checks of mzXML files whose paths match the 'explicitly_skipped_mzxmls'
> - Tests
>   - Renamed test test_check_mzxml_files to test_check_mzxml_files_buffers_exc_for_every_unmatched_file in order to have a second test of that method.
>   - Added test test_check_mzxml_files_does_not_error_when_skipped

## Tests

- CI tests pass
- CI linting passes

From #1665:

> Test that there is no error about sample some_unknown_sample not existing.
> 
> 1. Create an MSRunsLoader object named mrl
> 2. Set its mrl.df to a dataframe with skipped lines and an mzXML file whose name (some_unknown_sample.mzXML) does not match any sample
> 3. Set mrl.mzxml_files to ["some_unknown_sample.mzXML"]
> 4. Call mrl.check_mzxml_files()
> 5. Assert that mrl.aggregated_errors_object does not contain any errors

## Security Concerns
<!--
Call out any **security implications**:
- Data handling (PII/PHI/credentials)
- Authentication/authorization changes
- Dependencies or third-party libraries introduced
- Potential attack surface increase
Mitigations or safeguards applied.
-->


## Others
<!--
Anything else reviewers should know:
- Performance implications
- Backward compatibility / migration needs
- Documentation or release notes updates
- Known limitations or follow-ups
-->
