### PR TITLE
Fixed inaccurate/difficult `mzXML` Colocation exceptions

### DIFF
--- a/DataRepo/loaders/msruns_loader.py
+++ b/DataRepo/loaders/msruns_loader.py
@@ -1991,6 +1991,8 @@ class MSRunsLoader(TableLoader):
 
         msrun_sequence = None
         msrun_sequence_names = []
+        nearest_annot_dir: str
+        nearest_annot_dir_assigned = False
 
         if mzxml_filename is None:
             mzxml_filename = mzxml_name
@@ -1999,16 +2001,30 @@ class MSRunsLoader(TableLoader):
         if os.path.isabs(mzxml_dir):
             mzxml_dir = os.path.relpath(mzxml_dir, start=self.mzxml_dir)
 
-        # Build the msrun_sequence_names list containing unique sequence names of peak annotation files found along the
-        # path to the mzXML
-        for annot_dir in self.annotdir_to_seq_dict.keys():
+        # Build the msrun_sequence_names list containing unique sequence names of peak annotation files found nearest to
+        # the mzXML file (along its path) (by iterating over the paths of the peak annotation files from longest to
+        # shortest)
+        for annot_dir in sorted(
+            self.annotdir_to_seq_dict.keys(),
+            key=lambda p: len(str(p).split(os.sep)),
+            reverse=True,
+        ):
             common_dir = os.path.commonpath([mzxml_dir, annot_dir])
             norm_common_dir = os.path.normpath(common_dir)
             norm_annot_dir = os.path.normpath(annot_dir)
             if norm_annot_dir == norm_common_dir:
-                for seqname in self.annotdir_to_seq_dict[annot_dir]:
-                    if seqname not in msrun_sequence_names:
-                        msrun_sequence_names.append(seqname)
+                # We want the sequence associated with the peak annotation file that is the closest to the mzXML.
+                if nearest_annot_dir_assigned is False:
+                    nearest_annot_dir = annot_dir
+                    nearest_annot_dir_assigned = True
+                if nearest_annot_dir == annot_dir:
+                    for seqname in self.annotdir_to_seq_dict[annot_dir]:
+                        # If the current annot_dir (which corresponds to a peak annotation file with a default sequence)
+                        # matches the nearest_annot_dir (which is the closest dir to the mzXML in question), and its
+                        # assigned default sequence hasn't already been added to the list of sequence names associated
+                        # with this directory
+                        if seqname not in msrun_sequence_names:
+                            msrun_sequence_names.append(seqname)
 
         # If none are found
         if len(msrun_sequence_names) == 0:
@@ -2059,6 +2075,7 @@ class MSRunsLoader(TableLoader):
             self.aggregated_errors_object.buffer_exception(
                 MzxmlColocatedWithMultipleAnnot(
                     msrun_sequence_names,
+                    nearest_annot_dir,
                     file=os.path.join(mzxml_dir, mzxml_filename),
                     suggestion=suggestion,
                 ),


### PR DESCRIPTION

## What

- Resolves [GREATS-71](https://princeton-university.atlassian.net/browse/GREATS-71)
- Resolves #1667

From the suggested change in [GREATS-71](https://princeton-university.atlassian.net/browse/GREATS-71):

> This issue was complicated by a data issue where multiple peak annotation files along the path were incorrectly annotated as belonging to different sequences, which is why the directory paths were needed.
> Track the annot dirs in `get_msrun_sequence_from_dir` and supply them to a new option in `MzxmlColocatedWithMultipleAnnot`

### Acceptance Criteria

- Meets the requirements listed in #1667:

> NOTE: MzxmlColocatedWithMultipleAnnot exceptions can happen when multiple peak annotation files (along an mzXML file's path, even if they are in different directories) are annotated as being from different sequences, so it's confusing when you get a "multiple colocated" peak annotation file error, when the files are not "colocated".
> 
> Keep in mind that this script (and in the get_msrun_sequence_from_dir method in particular), we are trying to get a default sequence to assign for a directory of mzXML files, meaning that this is not about a peak annotation file containing data from mzXML's derived from other sequences (for which there is a different mechanism to identify those sequences). We don't know what samples are in which peak annotation file, and a peak annotation file can be generated from mzXML files from ANY sequence and from a mix of directories. The file could have even been duplicated and renamed. The mechanism for handling that in a flexible way is by adding the specific sequence directly to the Peak Annotation Details sheet. We don't have to figure that out right here. All we need is a default. Code later will try and match the mzXML with sample headers. So for the purposes of this method, if only one peak annotation file is in the directory, we should assign the directory's sequence by the closest peak annotation file's default sequence.
> 
> - `1.` An `MzxmlColocatedWithMultipleAnnot` exception must only be buffered when peak annotation files with different annotated default sequences are in the same directory.
> - `1.1.` If there are multiple directories along the `mzXML` file's path that contain peak annotation files, only use the one that is closest to the `mzXML` file.
> - `2.` An `MzxmlColocatedWithMultipleAnnot` exception must include the offending directories containing peak annotation files from different sequences
> - `3.` Multiple `MzxmlColocatedWithMultipleAnnot` exceptions should be summarized
> - `4.` Multiple `MzxmlNotColocatedWithAnnot` exceptions should be summarized

- [CI Linters pass](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#linting)
- [CI Tests pass](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#quality-control)
- [Tests implemented/updated](https://github.com/Princeton-LSI-ResearchComputing/tracebase/blob/main/CONTRIBUTING.md#test-implementation)

## Why

From the description in [GREATS-71](https://princeton-university.atlassian.net/browse/GREATS-71):

> `MzxmlColocatedWithMultipleAnnot` are inaccurate and difficult to debug

## How

Corrected, summarized, and better explained the `mzXML`/peak-annotation-file colocated exceptions about ambiguous or missing sequence assignments.

Details:

- `MSRunsLoader.get_msrun_sequence_from_dir`
  - Sorted the `annotdir_to_seq_dict` dict based on decreasing peak annotation file path length in order to get the directory closest to the mzXML file whose sequence is being determined.
  - Identified the peak annotation file's directory location closest to the mzXML file and only added it's default sequence to the list of sequence names to assign to the mzXML (`msrun_sequence_names`)
  - Supplied the nearest peak annotation file directory to the `MzxmlColocatedWithMultipleAnnot` exception to include in its message
- `DataRepo.utils.exceptions`
  - `MzxmlColocatedWithMultipleAnnot`
    - Clarified the exception message.
    - Included the directory of the peak annotation files with differing default sequences
    - Added argument to the constructor: `matching_annot_dir`
  - `MzxmlColocatedWithMultipleAnnot` and `MzxmlNotColocatedWithAnnot`
    - Added instance attributes
    - Made them inherit from `SummarizableError` and set their `SummarizerExceptionClass` class attribute
  - Created summary exceptions `MzxmlNotColocatedWithAnnots` `MzxmlColocatedWithMultipleAnnots`
- `DataRepo.tests.utils.test_exceptions.ExceptionTests`
  - Added tests:
    - `test_MzxmlNotColocatedWithAnnots`
    - `test_MzxmlColocatedWithMultipleAnnots`
  - Updated `test_MzxmlColocatedWithMultipleAnnot` for the added exception constructor argument
- Added test `MSRunsLoaderTests.test_get_msrun_sequence_from_dir_last_annot`

## Tests

- A couple of existing tests will likely need to be fixed, but this is roughly the test that should be added:
```
    def test_get_msrun_sequence_from_dir_last_annot(self):
        msrl = MSRunsLoader()
        msrl.annotdir_to_seq_dict = {
            "path/to": [
                "Rob, polar-HILIC-25-min, QE, 1972-11-24",
                "Zoe, polar-HILIC-25-min, QE, 1985-4-18",
            ],
            "path/to/scan2": [
                "Rob, polar-HILIC-25-min, QE, 1972-11-24",
            ],
        }
        seq = msrl.get_msrun_sequence_from_dir(
            "sample.mzXML",
            "path/to/scan2",
            None,
        )
        self.assertEqual(self.seq, seq)
        self.assertEqual(0, len(msrl.aggregated_errors_object.exceptions))
```
- A pair of tests for `MzxmlNotColocatedWithAnnot` and `MzxmlColocatedWithMultipleAnnot` should be edited in DataRepo.tests.utils.test_exceptions
- A pair of tests should be added for `MzxmlNotColocatedWithAnnots` and `MzxmlColocatedWithMultipleAnnots`

## Security Concerns

None

## Others

None
