### PR TITLE
[POC Prototype] New Exported ListView Prototype (with Design notes) based on Prototype

### DIFF
--- a/DataRepo/templates/models/bst/download_metadata_header.txt
+++ b/DataRepo/templates/models/bst/download_metadata_header.txt
@@ -2,7 +2,7 @@
 # Time: {{ timestamp }}
 # Rows: {{ total }}
 # Global Search Term: {% if search %}'{{ search }}'{% else %}None{% endif %}
-# Column Filters: {% for column in columns %}{% if column.filterable and column.filterer.initial %}
-#   {{ column }}: '{{ column.filterer.initial }}'{% empty %}None{% endfor %}
+# Column Filters: {% for column, filter in export_filters.items %}
+#   {{ column }}: '{{ filter }}'{% empty %}None{% endfor %}
 # Sort: {{ sortcol }}, {% if asc %}ascending{% else %}descending{% endif %}
 

--- a/DataRepo/templates/models/bst/download_metadata_header.txt
+++ b/DataRepo/templates/models/bst/download_metadata_header.txt
@@ -1,0 +1,8 @@
+# {{ table_name }}
+# Time: {{ timestamp }}
+# Rows: {{ total }}
+# Global Search Term: {% if search %}'{{ search }}'{% else %}None{% endif %}
+# Column Filters: {% for column in columns %}{% if column.filterable and column.filterer.initial %}
+#   {{ column }}: '{{ column.filterer.initial }}'{% empty %}None{% endfor %}
+# Sort: {{ sortcol }}, {% if asc %}ascending{% else %}descending{% endif %}
+

--- a/DataRepo/templates/models/bst/list_view.html
+++ b/DataRepo/templates/models/bst/list_view.html
@@ -37,8 +37,8 @@
             data-buttons-align="left"
             data-buttons-class="primary"
             data-buttons="customButtonsFunction"
-            data-export-types="['csv', 'txt', 'excel']"
-            data-export-data-type="all"
+            {% comment %} {% if export_types %}data-export-types="{{ export_types }}"
+            data-export-data-type="all"{% endif %} {% endcomment %}
             data-filter-control="true"
             data-search="true"
             data-search-align="left"

--- a/DataRepo/templates/models/bst/scripts.html
+++ b/DataRepo/templates/models/bst/scripts.html
@@ -5,6 +5,15 @@
 {{ columns|keys|json_script:"orderedColumnNames" }}
 {{ warnings|json_script:"warnings" }}
 {{ cookie_resets|json_script:"cookieResets" }}
+{% if export_enabled %}
+    {{ export_types|json_script:"exportTypes" }}
+    {{ not_exported|json_script:"notExported" }}
+    {% if export_data %}
+        <span class="d-none" id="export_filename">{{ export_filename }}</span>
+        <span class="d-none" id="{{ export_filetype_var_name }}">{{ file_type }}</span>
+        <pre class="d-none" id="{{ export_data_var_name }}">{{ export_data }}</pre>
+    {% endif %}
+{% endif %}
 
 {# The script imports #}
 {% for script in scripts %}<script src="{% static script %}"></script>
@@ -52,6 +61,13 @@
             '{{ visible_cookie_name }}',
             '{{ limit_cookie_name }}',
             '{{ page_cookie_name }}',
+            '{{ export_enabled }}',
+            '{{ export_data_var_name }}',
+            '{{ export_filename }}',
+            '{{ file_type }}',
+            'exportTypes',
+            '{{ export_param_name }}',
+            'notExported',
         )
     });
 </script>

--- a/DataRepo/views/models/animal.py
+++ b/DataRepo/views/models/animal.py
@@ -5,10 +5,10 @@ from django.views.generic import DetailView
 
 from DataRepo.models import DURATION_SECONDS_ATTRIBUTE, Animal, Researcher
 from DataRepo.utils import QuerysetToPandasDataFrame as qs2df
-from DataRepo.views.models.bst.query import BSTListView
+from DataRepo.views.models.bst.export import BSTExportedListView
 
 
-class AnimalListView(BSTListView):
+class AnimalListView(BSTExportedListView):
     model = Animal
     column_ordering = [
         "name",

--- a/DataRepo/views/models/archive_file.py
+++ b/DataRepo/views/models/archive_file.py
@@ -12,10 +12,11 @@ from django.db.models.aggregates import Count, Min
 from django.views.generic import DetailView
 
 from DataRepo.models import DATETIME_FORMAT, DBSTRING_FUNCTION, ArchiveFile
-from DataRepo.views.models.bst.query import BSTListView, QueryMode
+from DataRepo.views.models.bst.query import QueryMode
+from DataRepo.views.models.bst.export import BSTExportedListView
 
 
-class ArchiveFileListView(BSTListView):
+class ArchiveFileListView(BSTExportedListView):
     model = ArchiveFile
 
     # The subquery strategy is multiple orders of magnitude faster for this model, given the multiple M:M relationships
@@ -51,12 +52,14 @@ class ArchiveFileListView(BSTListView):
             "header": "Peak Groups",
             "searchable": False,
             "sortable": False,
+            "exported": False,
             "value_template": "models/archive_file/peak_groups_link_value.html",
         },
         "peak_data_link": {
             "header": "Peak Data",
             "searchable": False,
             "sortable": False,
+            "exported": False,
             "value_template": "models/archive_file/peak_data_link_value.html",
         },
     }

--- a/DataRepo/views/models/bst/client_interface.py
+++ b/DataRepo/views/models/bst/client_interface.py
@@ -32,7 +32,7 @@ class BSTClientInterface:
         warnings_var_name (str) ["warnings"]
         above_var_name (str) ["above_template"]
         below_var_name (str) ["below_template"]
-        title (Optional[str]): The page title
+        title (Optional[str]) [self.model_title_plural]: The page title. For overriding in the derived class.
         above_template (Optional[str]): Path to a template to include above the table.
         below_template (Optional[str]): Path to a template to include below the table.
     Instance Attributes:

--- a/DataRepo/views/models/bst/column/base.py
+++ b/DataRepo/views/models/bst/column/base.py
@@ -116,7 +116,7 @@ class BSTBaseColumn(ABC):
                 expected when sorted.
             hidable (bool) [True]: Controls whether a column's visible state can be made False.
             visible (bool) [True]: Controls whether a column is initially visible.
-            exported (bool) [True]: Adds to BST's exportOptions' ignoreColumn attribute if False.
+            exported (bool) [True]: Controls whether a column is included in an exported download or not.
             linked (bool) [False]: Whether or not the value in the column should link to a detail page for the model
                 record the row represents.
                 NOTE: The model must have a "get_absolute_url" method.  Checked in the template.

--- a/DataRepo/views/models/bst/export.py
+++ b/DataRepo/views/models/bst/export.py
@@ -1,0 +1,275 @@
+import base64
+from typing import List
+from datetime import datetime
+from io import BytesIO, StringIO
+import pandas as pd
+import csv
+import _csv
+
+from django.db.models import Model
+from django.template import loader
+
+from DataRepo.views.models.bst.column.base import BSTBaseColumn
+from DataRepo.views.models.bst.column.many_related_field import BSTManyRelatedColumn
+from DataRepo.views.models.bst.query import BSTListView, QueryMode
+
+
+class BSTExportedListView(BSTListView):
+    download_header_template_name = "models/bst/download_metadata_header.txt"
+    download_header_template = (
+        loader.get_template(download_header_template_name)
+        if download_header_template_name is not None
+        else None
+    )
+
+    header_time_format = "%Y-%m-%d %H:%M:%S"
+    filename_time_format = "%Y.%m.%d.%H.%M.%S"
+
+    excel_format = "Excel"
+    tsv_format = "TSV"
+    csv_format = "CSV"
+    export_formats = {
+        tsv_format: {"type": "text", "extension": "tsv"},
+        csv_format: {"type": "text", "extension": "csv"},
+        excel_format: {"type": "excel", "extension": "xlsx"},
+    }
+
+    # URL Parameter names
+    export_param_name = "export"
+
+    # Context variable names
+    export_formats_var_name = "export_formats"
+    timestamp_var_name = "timestamp"
+    export_format_var_name = "export_format"
+    export_type_var_name = "export_type"
+    export_data_var_name = "export_data"
+    export_filename_var_name = "export_filename"
+
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+        now = datetime.now()
+        self.fileheader_timestamp = now.strftime(self.header_time_format)
+        self.filename_timestamp = now.strftime(self.filename_time_format)
+
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data()
+
+        export_data, export_filename = self.get_export_data()
+        context.update(
+            {
+                self.export_data_var_name: export_data,
+                self.export_filename_var_name: export_filename,
+                self.export_format_var_name: self.export_format,
+            }
+        )
+        return context
+
+    def init_interface(self):
+        super().init_interface()
+
+        export_format = self.get_param(self.export_param_name)
+        if export_format is not None:
+            if export_format not in self.export_formats.keys():
+                warning = (
+                    f"Invalid export type encountered: '{export_format}'.  "
+                    f"Must be one of {list(self.export_formats.keys())}.  "
+                    "Aborting download."
+                )
+                self.warnings.append(warning)
+            else:
+                self.export_format = export_format
+
+    def get_export_data(self):
+        """Turns the queryset into a base64 encoded string and a filename.
+
+        Args:
+            format (str) {excel, csv, tsv}
+        Exceptions:
+            NotImplementedError when the format is unrecognized.
+        Returns:
+            export_data (str): Base64 encoded string.
+            (str): The filename
+        """
+        file_extension = self.export_formats[self.export_format]["extension"]
+        file_type = self.export_formats[self.export_format]["type"]
+        if self.export_format == self.excel_format:
+            byte_stream = BytesIO()
+            self.get_excel_streamer(byte_stream)
+            export_data = base64.b64encode(byte_stream.read()).decode("utf-8")
+        else:
+            buffer = StringIO()
+            if self.export_format == self.csv_format:
+                # This fills the buffer
+                self.get_text_streamer(buffer, delim=",")
+                # This consumes the buffer
+                export_data = base64.b64encode(buffer.getvalue().encode('utf-8')).decode("utf-8")
+                # export_data = base64.b64encode(buffer.getvalue().encode('utf-8')).decode("utf-8")
+            elif self.export_format == self.tsv_format:
+                # This fills the buffer
+                self.get_text_streamer(buffer, delim="\t")
+                # This consumes the buffer
+                export_data = base64.b64encode(buffer.getvalue().encode('utf-8')).decode("utf-8")
+                # export_data = base64.b64encode(buffer.getvalue().encode('utf-8')).decode("utf-8")
+            else:
+                raise NotImplementedError(f"Export format {self.export_format} not supported.")
+
+        return export_data, f"{type(self.model).__name__}.{self.filename_timestamp}.{file_extension}"
+
+    def get_excel_streamer(self, byte_stream: BytesIO):
+        """Returns an xlsxwriter for an excel file created from the self.dfs_dict.
+
+        The created writer will output to the supplied stream_obj.
+
+        Args:
+            stream_obj (BytesIO)
+        Exceptions:
+            None
+        Returns:
+            xlsx_writer (xlsxwriter)
+        """
+        xlsx_writer = pd.ExcelWriter(  # pylint: disable=abstract-class-instantiated
+            byte_stream, engine="xlsxwriter"
+        )
+
+        header_context = self.get_header_context()
+        sheet = self.model_title_plural
+        columns = self.row_headers()
+
+        xlsx_writer.book.set_properties(
+            {
+                "title": sheet,
+                "author": "Robert Leach",
+                "company": "Princeton University",
+                "comments": self.download_header_template.render(header_context),
+            }
+        )
+
+        # Build the dict by iterating over the row lists
+        qs_dict_by_index = dict((i, []) for i in range(len(columns)))
+        for row in self.rows_iterator(headers=False):
+            for i, val in enumerate(row):
+                qs_dict_by_index[i].append(str(val))
+
+        export_dict = {}
+        # Now convert the indexes to the headers
+        for i, col in enumerate(columns):
+            export_dict[col] = qs_dict_by_index[i]
+
+        # Create a dataframe and add it as an excel object to an xlsx_writer sheet
+        pd.DataFrame.from_dict(export_dict).to_excel(
+            excel_writer=xlsx_writer,
+            sheet_name=sheet,
+            columns=columns,
+            index=False,
+        )
+        xlsx_writer.sheets[sheet].autofit()
+
+        xlsx_writer.close()
+        # Rewind the buffer so that when it is read(), you won't get an error about opening a zero-length file in Excel
+        byte_stream.seek(0)
+
+        return byte_stream
+
+    def get_text_streamer(self, buffer: StringIO, delim: str = "\t"):
+        """Fills a supplied buffer with string-cast delimited values from the rows_iterator using a csv writer.
+
+        Args:
+            buffer (StringIO)
+            delim (str) [\t]: Column delimiter
+        Exceptions:
+            None
+        Returns:
+            buffer (StringIO)
+        """
+        writer: "_csv._writer" = csv.writer(buffer, delimiter=delim)
+
+        # Commented metadata header containing download date and info
+        buffer.write(self.download_header_template.render(self.get_header_context()))
+
+        for row in self.rows_iterator():
+            writer.writerow([str(c) for c in row])
+
+        return buffer
+
+    def get_header_context(self):
+        """Returns a context dict with metadata about the queryset used in the header template.
+
+        Args:
+            None
+        Exceptions:
+            None
+        Returns:
+            (dict)
+        """
+        return {
+            self.title_var_name: (
+                self.model_title_plural if self.title is None else self.title
+            ),
+            self.timestamp_var_name: self.fileheader_timestamp,
+            self.total_var_name: self.total,
+            self.search_cookie_name: self.search_term,
+            self.columns_var_name: self.columns,
+            self.sortcol_cookie_name: self.sort_col,
+            self.asc_cookie_name: self.asc,
+        }
+
+    def row_headers(self):
+        return [col.header for col in self.columns.values() if col.exported]
+
+    def rows_iterator(self, headers=True):
+        """Takes a queryset of records and returns a list of lists of column data.  Note that delimited many-related
+        values are converted to strings, but everything else in the returned list of lists is the original type.
+
+        Args:
+            headers (bool): Whether to include the header row.
+        Exceptions:
+            None
+        Returns:
+            (List[list])
+        """
+        if headers:
+            yield self.row_headers()
+        rec: Model
+        for rec in self.get_queryset():
+            yield self.rec_to_row(rec)
+
+    def rec_to_row(self, rec: Model) -> List[str]:
+        """Takes a Model record and returns a list of values for a file.
+
+        Args:
+            rec (Model)
+        Exceptions:
+            None
+        Returns:
+            (List[str])
+        """
+        return [
+            self.get_column_val(rec, col)
+            for col in self.columns.values()
+            if col.exported
+        ]
+
+    def get_column_val(self, rec: Model, col: BSTBaseColumn):
+        """Given a model record, i.e. row-data, e.g. from a queryset, and a column, return the column value.
+
+        NOTE: While this supports many-related columns, it is more efficient to call get_many_related_rec_val directly.
+
+        Args:
+            rec (Model)
+            col (BSTBaseColumn)
+        Exceptions:
+            ValueError when the BSTColumn is not labeled as many-related.
+        Returns:
+            (str): Column value or values (if many-related).
+        """
+        if isinstance(col, BSTManyRelatedColumn) and self.query_mode == QueryMode.subquery:
+            return col.delim.join(
+                [str(val) for val in self.get_many_related_column_val_by_subquery(rec, col)]
+            )
+        else:
+            if self.query_mode == QueryMode.iterate:
+                return str(self.get_column_val_by_iteration(rec, col))
+            elif self.query_mode != QueryMode.subquery:
+                raise NotImplementedError(f"QueryMode {self.query_mode} not implemented.")
+            else:
+                raise NotImplementedError(f"QueryMode {self.query_mode} not implemented for {type(col).__name__}.")

--- a/DataRepo/views/models/compound.py
+++ b/DataRepo/views/models/compound.py
@@ -2,10 +2,10 @@ from django.views.generic import DetailView
 
 from DataRepo.models import Compound, PeakGroup
 from DataRepo.utils import QuerysetToPandasDataFrame as qs2df
-from DataRepo.views.models.bst.query import BSTListView
+from DataRepo.views.models.bst.export import BSTExportedListView
 
 
-class CompoundListView(BSTListView):
+class CompoundListView(BSTExportedListView):
     model = Compound
     exclude = ["id", "peak_groups", "tracers"]
     column_ordering = [

--- a/DataRepo/views/models/infusate.py
+++ b/DataRepo/views/models/infusate.py
@@ -2,7 +2,7 @@ from django.views.generic import DetailView
 
 from DataRepo.models import Infusate
 from DataRepo.utils import QuerysetToPandasDataFrame as qs2df
-from DataRepo.views.models.bst.query import BSTListView
+from DataRepo.views.models.bst.export import BSTExportedListView
 
 
 class InfusateDetailView(DetailView):
@@ -26,7 +26,7 @@ class InfusateDetailView(DetailView):
         return context
 
 
-class InfusateListView(BSTListView):
+class InfusateListView(BSTExportedListView):
     model = Infusate
     exclude = ["id", "animals", "tracers", "tracer_links"]
     column_ordering = [

--- a/DataRepo/views/models/lcmethod.py
+++ b/DataRepo/views/models/lcmethod.py
@@ -3,10 +3,10 @@ from django.db.models.functions import Extract
 from django.views.generic import DetailView
 
 from DataRepo.models import DURATION_SECONDS_ATTRIBUTE, LCMethod
-from DataRepo.views.models.bst.query import BSTListView
+from DataRepo.views.models.bst.export import BSTExportedListView
 
 
-class LCMethodListView(BSTListView):
+class LCMethodListView(BSTExportedListView):
     model = LCMethod
     exclude = ["id", "msrunsequence", "run_length"]
     column_ordering = [

--- a/DataRepo/views/models/msrun_sample.py
+++ b/DataRepo/views/models/msrun_sample.py
@@ -1,7 +1,7 @@
 from django.views.generic import DetailView
 
 from DataRepo.models import MSRunSample
-from DataRepo.views.models.bst.query import BSTListView
+from DataRepo.views.models.bst.export import BSTExportedListView
 
 
 class MSRunSampleDetailView(DetailView):
@@ -10,7 +10,7 @@ class MSRunSampleDetailView(DetailView):
     context_object_name = "msrun_sample"
 
 
-class MSRunSampleListView(BSTListView):
+class MSRunSampleListView(BSTExportedListView):
     model = MSRunSample
     exclude = ["id", "peak_groups"]
     column_ordering = [

--- a/DataRepo/views/models/msrun_sequence.py
+++ b/DataRepo/views/models/msrun_sequence.py
@@ -3,7 +3,7 @@ from django.views.generic import DetailView
 
 from DataRepo.models import DATE_FORMAT, DBSTRING_FUNCTION, MSRunSequence
 from DataRepo.models.researcher import Researcher
-from DataRepo.views.models.bst.query import BSTListView
+from DataRepo.views.models.bst.export import BSTExportedListView
 
 
 class MSRunSequenceDetailView(DetailView):
@@ -12,7 +12,7 @@ class MSRunSequenceDetailView(DetailView):
     context_object_name = "sequence"
 
 
-class MSRunSequenceListView(BSTListView):
+class MSRunSequenceListView(BSTExportedListView):
     model = MSRunSequence
     exclude = ["id", "date", "msrun_samples"]
     column_ordering = [

--- a/DataRepo/views/models/peakdata.py
+++ b/DataRepo/views/models/peakdata.py
@@ -1,8 +1,9 @@
 from DataRepo.models import PeakData
-from DataRepo.views.models.bst.query import BSTDetailView, BSTListView
+from DataRepo.views.models.bst.query import BSTDetailView
+from DataRepo.views.models.bst.export import BSTExportedListView
 
 
-class PeakDataListView(BSTListView):
+class PeakDataListView(BSTExportedListView):
     model = PeakData
     paginate_by = 200
     column_settings = {

--- a/DataRepo/views/models/peakgroup.py
+++ b/DataRepo/views/models/peakgroup.py
@@ -1,10 +1,10 @@
 from django.views.generic import DetailView
 
 from DataRepo.models import PeakGroup
-from DataRepo.views.models.bst.query import BSTListView
+from DataRepo.views.models.bst.export import BSTExportedListView
 
 
-class PeakGroupListView(BSTListView):
+class PeakGroupListView(BSTExportedListView):
     model = PeakGroup
     exclude = ["id", "peak_data", "msrun_sample"]
     column_settings = {

--- a/DataRepo/views/models/protocol.py
+++ b/DataRepo/views/models/protocol.py
@@ -3,10 +3,10 @@ from django.views.generic import DetailView
 
 from DataRepo.models import Protocol
 from DataRepo.utils import QuerysetToPandasDataFrame as qs2df
-from DataRepo.views.models.bst.query import BSTListView
+from DataRepo.views.models.bst.export import BSTExportedListView
 
 
-class AnimalTreatmentListView(BSTListView):
+class AnimalTreatmentListView(BSTExportedListView):
     model = Protocol
     exclude = ["id", "category", "animals"]
     column_ordering = ["name", "description", "animals_mm_count"]

--- a/DataRepo/views/models/sample.py
+++ b/DataRepo/views/models/sample.py
@@ -9,10 +9,10 @@ from DataRepo.models import (
     Researcher,
     Sample,
 )
-from DataRepo.views.models.bst.query import BSTListView
+from DataRepo.views.models.bst.export import BSTExportedListView
 
 
-class SampleListView(BSTListView):
+class SampleListView(BSTExportedListView):
     model = Sample
 
     # Column order

--- a/DataRepo/views/models/study.py
+++ b/DataRepo/views/models/study.py
@@ -5,10 +5,10 @@ from django.views.generic import DetailView
 
 from DataRepo.models import Researcher, Study
 from DataRepo.utils import QuerysetToPandasDataFrame as qs2df
-from DataRepo.views.models.bst.query import BSTListView
+from DataRepo.views.models.bst.export import BSTExportedListView
 
 
-class StudyListView(BSTListView):
+class StudyListView(BSTExportedListView):
     model = Study
     below_template = "models/study/below_table.html"
     exclude = ["id", "animals"]

--- a/DataRepo/views/models/tissue.py
+++ b/DataRepo/views/models/tissue.py
@@ -1,10 +1,10 @@
 from django.views.generic import DetailView
 
 from DataRepo.models import Tissue
-from DataRepo.views.models.bst.query import BSTListView
+from DataRepo.views.models.bst.export import BSTExportedListView
 
 
-class TissueListView(BSTListView):
+class TissueListView(BSTExportedListView):
     model = Tissue
     exclude = ["id", "samples"]
     column_ordering = ["name", "description", "samples_mm_count"]

--- a/DataRepo/views/models/tracer.py
+++ b/DataRepo/views/models/tracer.py
@@ -1,5 +1,6 @@
 from DataRepo.models import Tracer
-from DataRepo.views.models.bst.query import BSTDetailView, BSTListView
+from DataRepo.views.models.bst.query import BSTDetailView
+from DataRepo.views.models.bst.export import BSTExportedListView
 
 
 class TracerDetailView(BSTDetailView):
@@ -16,7 +17,7 @@ class TracerDetailView(BSTDetailView):
     }
 
 
-class TracerListView(BSTListView):
+class TracerListView(BSTExportedListView):
     model = Tracer
     exclude = ["id", "fcircs", "infusate_links"]
     column_settings = {

--- a/static/js/bst/cookies.js
+++ b/static/js/bst/cookies.js
@@ -3,10 +3,8 @@ var cookieViewPrefix = null // eslint-disable-line no-var
 // To use this code, static/js/cookies.js must be imported.
 
 /**
- * Gets a cookie specific to this view/page.
- * @param {*} name Cookie name.
- * @param {*} defval Default if cookie not found.
- * @returns Cookie value.
+ * Initialize this package.
+ * @param {*} cookieViewPrefix Cookie prefix for the view.
  */
 function initViewCookies (cookieViewPrefix) { // eslint-disable-line no-unused-vars
   globalThis.cookieViewPrefix = cookieViewPrefix

--- a/static/js/bst/exporter.js
+++ b/static/js/bst/exporter.js
@@ -1,0 +1,121 @@
+var exportTypes = [] // eslint-disable-line no-var
+var exportDataElemName = 'export_data' // eslint-disable-line no-var
+var exportTypeElemName = 'export_type' // eslint-disable-line no-var
+var exportFunc = 'exportAllPages' // eslint-disable-line no-var
+var notExported = [] // eslint-disable-line no-var
+
+// To use this code, static/js/cookies.js must be imported.
+
+/**
+ * Initializes this package.
+ * @param {*} exportTypes A list of export type strings to present in the export button's contextual menu.
+ */
+function initExporter (
+  exportTypesElemName,
+  exportDataElemName,
+  exportFileName,
+  exportFileType,
+  djangoTableID,
+  exportFunc,
+  notExportedElemName
+) {
+  console.log(exportTypesElemName)
+  const exportTypesElem = document.getElementById(exportTypesElemName);
+  const exportTypes = JSON.parse(exportTypesElem.textContent);
+  const notExportedElem = document.getElementById(notExportedElemName);
+  const notExported = JSON.parse(notExportedElem.textContent);
+
+  globalThis.exportTypes = exportTypes
+  globalThis.exportFunc = exportFunc
+
+  if (typeof exportDataElemName !== 'undefined' && exportDataElemName) {
+    globalThis.exportDataElemName = exportDataElemName
+  }
+
+  const exportDataElem = document.getElementById(exportDataElemName);
+
+  // If there is download data, trigger the download
+  if (typeof exportDataElem !== 'undefined' && exportDataElem) {
+    browserDownloadBase64( // eslint-disable-line no-undef
+      exportFileName,
+      exportDataElem.innerHTML,
+      exportFileType
+    );
+  }
+
+  checkBuiltinExport(djangoTableID);
+
+  var exportObject = {
+    exportSelectHtml: generateExportSelect(exportTypes),
+    exportFallbackFunc: exportOnePage,
+    notExported: notExported
+  }
+
+  return exportObject
+}
+
+/**
+ * Takes the export options defined in the bootstrap table and generates a drop-down list that calls the custom
+ * exportAllPages function when clicked.
+ * @param {*} exportTypes A list of export type strings to present in the export button's contextual menu.
+ * @returns html
+ */
+function generateExportSelect (exportTypes) {
+  let html = `              <div class="btn-group">
+                    <button type="button"
+                            class="btn btn-primary dropdown-toggle"
+                            data-bs-toggle="dropdown"
+                            aria-expanded="false">
+                        <i class="bi bi-download"></i>
+                    </button>
+                    <ul class="dropdown-menu">\n`
+  for (let i=0; i < exportTypes.length; i++) {
+    let val = exportTypes[i];
+    html += `                        <li><a class="dropdown-item" onclick="${exportFunc}('${val}')">${val}</a></li>\n`;
+  }
+  html += `                    </ul>
+              </div>\n`;
+  return html
+}
+
+/**
+ * Validates the BST export settings.  With this server-side pagination, the bootstrap table's data-show-export
+ * attribute must be false.
+ */
+function checkBuiltinExport () {
+  let tableElem = document.getElementById(djangoTableID);
+  if (tableElem.hasAttribute('data-show-export') && $('#' + djangoTableID).data("show-export"))
+    alert(
+      "ERROR: Bootstrap Table's builtin data-show-export must be false to support server-side data.  Otherwise, only 1 "
+      + 'page of data will be exported.'
+    );
+}
+
+/**
+ * Fallback export behavior.  If the custom export dropdown button is eliminated, this kicks in to tell the user how to
+ * download all results.  If the user decides they want all results, they are instructed to select all rows per page and
+ * an error is thrown to stop bootstrap from doing an export of 1 page of data.
+ */
+function exportOnePage (page, limit, total) {
+  if (typeof limit === 'undefined' || !limit) {
+    limit = 1
+  }
+  if (typeof total === 'undefined' || !total) {
+    total = 2
+  }
+  if (typeof page === 'undefined' || !page) {
+    page = 'unknown'
+  }
+  if (limit !== 0 && limit < total) {
+    if (
+      confirm(
+          "Download 1 page?\n\nTo retrieve all data, cancel and select 'ALL' from the rows per page select list "
+          + "below and try again."
+      )
+    ) {
+      console.log("Downloading page " + page.toString() + ".");
+    } else {
+      throw new Error("Canceling download");
+    }
+  }
+}


### PR DESCRIPTION
# ListView export feature design

I am basing the design of the export feature for the list views on the old prototype (branch `bst10_messy_bstlv_prototype`).  Yesterday, I copied over the old prototype code that governs the export feature and made minimal updates to make it work with the current main's implementation of the new list views (which were themselves formally designed and implemented, representing dramatic improvements compared to the original rapid prototype).  In this PR, I will comment on each code change to indicate how I would like to formalize/change the design.

See Jira issue [GREATS-93](https://princeton-university.atlassian.net/browse/GREATS-93), under-which subtasks will be created.

This PR is only for background notes on the design.  It is not for review.  The formal design (for review) is located in my confluence space: [ListView Export Feature - General Requirements and Design](https://princeton-university.atlassian.net/wiki/x/EgDoGw).

## Requirements

The requirements (a.k.a. "Acceptance Criteria") are pre-existing in these issues:

- [BSTExportedListView #1558](https://github.com/Princeton-LSI-ResearchComputing/tracebase/issues/1558)
  - `1.` Individual columns can be configured by the developer to be exported or not exported.
  - `2.` A list view's data can be exported via a button in the toolbar
  - `3.` Every export will include data from all pages.
  - `4.` Data exported will include all exported columns (visible or hidden by the user) 
  - `5.` Data exported will include only the filtered rows currently displayed
  - `6.` Data formats will include:
    - `6.1.` tsv
    - `6.2.` csv
    - `6.3.` xlsx (excel)
  - `7.` Data exported will be in the order the user has sorted it
  - `8.` Every downloaded file will include metadata describing the download, including:
    - `8.1.` Table name
    - `8.2.` Download Time
    - `8.3.` Number of rows
    - `8.4.` Global Search Term
    - `8.5.` Column Filters (column names and filter terms)
    - `8.7.` Sort column name
- [BST Export javascript #1569](https://github.com/Princeton-LSI-ResearchComputing/tracebase/issues/1569)
  - `1.` User should be able to select an export format using the builtin Bootstrap Table toolbar
  - `2.` There should be a fallback to the Bootstrap table export functionality that alerts the user that only the current page of results will be downloaded, and provides them an option to cancel.
  - `3.` A custom export format select list will be rendered.

## Overall Design

The comments on the code in this PR will establish specific requirements and break up this effort into individual Jira issues, but the over-arching design is described here

### [BSTExportedListView #1558](https://github.com/Princeton-LSI-ResearchComputing/tracebase/issues/1558)

The main idea is to add a derived `BSTExportedListView` class at the end of the BST list view class hierarchy:

- `BSTListViewClient` - This class encapsulates the server/client communication for the basic functionality of the web interface
  - `BSTBaseListView` (this is a poorly chosen class name, but fixing that is outside the scope of this design) - This class encapsulates the column setup, for which it uses a series of column classes, in their own hierarchy, including: `BSTColumn`, `BSTRelatedColumn`, `BSTManyRelatedColumn`, and `BSTAnnotColumn` (all of which are derived from `BSTBaseColumn`)
    - `BSTListView` (also not a great name, since it doesn't convey its function: it is the class that encapsulates all the DB queries for the data presented on listview pages)
      - **`BSTExportedListView`** - This is the **new** class.  It supplements the queries of its parent class.  Where the parent class is geared toward pagination and serves model objects among its returned data, this class ensures that all data is returned and converted into string values for streaming.

### [BST Export javascript #1569](https://github.com/Princeton-LSI-ResearchComputing/tracebase/issues/1569)

The only other major component is the javascript component:

- `static/js/bst/exporter.js`

which aids in setting up the Bootstrap Table object with respect to the export functionality.  The overall idea here was to take all of the export-specific javascript code from the old prototype and encapsulate it in its own file, with its own `init` method.

Whereas the python/django-view code is well encapsulated, the existing javascript code is not as well encapsulated.  I did _some_ of the encapsulation when I copied over the old prototype code, but there's more to do.

## Testing

I deployed this prototype branch (`prototype/3_1_9_list_view_export`) on [tracebase-dev](http://tracebase-dev.princeton.edu) and tested it out.  It works quite well (although see the **Limitations** section).  Feel free to check it out.  It will download all 5k samples in (I think) 15 seconds, which is better than the old listview pages which took 3 minutes to load before you could download anything.

## Limitations

There are some caveats to overcome in the current implementation... if you try to download for example, the **1.5M** row `PeakData` table, it will timeout after about 6.5 minutes.  It is the largest table.  The 212k row `PeakGroup` table downloads in about 2.5 minutes.

This effort however will be limited to plain functionality, not performance.  I will disable the `PeakData` export, or possibly set a record threshold, under-which the export option is enabled.  There are a series of 4 existing/outstanding issues dedicated to addressing performance, which are sub-issues of this issue:

[BSTListView Performance #1616](https://github.com/Princeton-LSI-ResearchComputing/tracebase/issues/1616)

- [Make the collapse javascript faster #1629](https://github.com/Princeton-LSI-ResearchComputing/tracebase/issues/1629)
- [Don't search columns when the search term cannot match based on type #1631](https://github.com/Princeton-LSI-ResearchComputing/tracebase/issues/1631)
- [Index some related fields used in some list views #1632](https://github.com/Princeton-LSI-ResearchComputing/tracebase/issues/1632)
- [Create a reverse_subquery QueryMode per field that uses a real subquery #1633](https://github.com/Princeton-LSI-ResearchComputing/tracebase/issues/1633)