### PR TITLE
Merge the 3.1.8 release (The `AnimalsWithoutSamples` warning fix) into main

### DIFF
--- a/DataRepo/loaders/animals_loader.py
+++ b/DataRepo/loaders/animals_loader.py
@@ -235,6 +235,8 @@ class AnimalsLoader(TableLoader):
             Superclass Args:
                 df (Optional[pandas dataframe]): Data, e.g. as parsed from a table-like file.
                 dry_run (Optional[boolean]) [False]: Dry run mode.
+                debug (bool) [False]: Debug mode causes all buffered exception traces to be printed.  Normally, if an
+                    exception is a subclass of SummarizableError, the printing of its trace is suppressed.
                 defer_rollback (Optional[boolean]) [False]: Defer rollback mode.  DO NOT USE MANUALLY - A PARENT SCRIPT
                     MUST HANDLE THE ROLLBACK.
                 data_sheet (Optional[str]): Sheet name (for error reporting).

--- a/DataRepo/loaders/base/converted_table_loader.py
+++ b/DataRepo/loaders/base/converted_table_loader.py
@@ -998,6 +998,8 @@ class ConvertedTableLoader(TableLoader, ABC):
             Superclass Args:
                 df (Optional[pandas dataframe]): Data, e.g. as parsed from a table-like file.
                 dry_run (Optional[boolean]) [False]: Dry run mode.
+                debug (bool) [False]: Debug mode causes all buffered exception traces to be printed.  Normally, if an
+                    exception is a subclass of SummarizableError, the printing of its trace is suppressed.
                 defer_rollback (Optional[boolean]) [False]: Defer rollback mode.  DO NOT USE MANUALLY - A PARENT SCRIPT
                     MUST HANDLE THE ROLLBACK.
                 data_sheet (Optional[str]): Sheet name (for error reporting).

--- a/DataRepo/loaders/compounds_loader.py
+++ b/DataRepo/loaders/compounds_loader.py
@@ -122,6 +122,8 @@ class CompoundsLoader(TableLoader):
             Superclass Args:
                 df (Optional[pandas dataframe]): Data, e.g. as parsed from a table-like file.
                 dry_run (Optional[boolean]) [False]: Dry run mode.
+                debug (bool) [False]: Debug mode causes all buffered exception traces to be printed.  Normally, if an
+                    exception is a subclass of SummarizableError, the printing of its trace is suppressed.
                 defer_rollback (Optional[boolean]) [False]: Defer rollback mode.  DO NOT USE MANUALLY - A PARENT SCRIPT
                     MUST HANDLE THE ROLLBACK.
                 data_sheet (Optional[str]): Sheet name (for error reporting).

--- a/DataRepo/loaders/infusates_loader.py
+++ b/DataRepo/loaders/infusates_loader.py
@@ -273,6 +273,8 @@ class InfusatesLoader(TableLoader):
             Superclass Args:
                 df (Optional[pandas dataframe]): Data, e.g. as parsed from a table-like file.
                 dry_run (Optional[boolean]) [False]: Dry run mode.
+                debug (bool) [False]: Debug mode causes all buffered exception traces to be printed.  Normally, if an
+                    exception is a subclass of SummarizableError, the printing of its trace is suppressed.
                 defer_rollback (Optional[boolean]) [False]: Defer rollback mode.  DO NOT USE MANUALLY - A PARENT SCRIPT
                     MUST HANDLE THE ROLLBACK.
                 data_sheet (Optional[str]): Sheet name (for error reporting).

--- a/DataRepo/loaders/peak_annotation_files_loader.py
+++ b/DataRepo/loaders/peak_annotation_files_loader.py
@@ -134,6 +134,8 @@ class PeakAnnotationFilesLoader(TableLoader):
             Superclass Args:
                 df (Optional[pandas dataframe]): Data, e.g. as parsed from a table-like file.
                 dry_run (Optional[boolean]) [False]: Dry run mode.
+                debug (bool) [False]: Debug mode causes all buffered exception traces to be printed.  Normally, if an
+                    exception is a subclass of SummarizableError, the printing of its trace is suppressed.
                 defer_rollback (Optional[boolean]) [False]: Defer rollback mode.  DO NOT USE MANUALLY - A PARENT SCRIPT
                     MUST HANDLE THE ROLLBACK.
                 data_sheet (Optional[str]): Sheet name (for error reporting).

--- a/DataRepo/loaders/peak_annotations_loader.py
+++ b/DataRepo/loaders/peak_annotations_loader.py
@@ -251,6 +251,8 @@ class PeakAnnotationsLoader(ConvertedTableLoader, ABC):
             Superclass Args:
                 df (Optional[pandas dataframe]): Data, e.g. as parsed from a table-like file.
                 dry_run (Optional[boolean]) [False]: Dry run mode.
+                debug (bool) [False]: Debug mode causes all buffered exception traces to be printed.  Normally, if an
+                    exception is a subclass of SummarizableError, the printing of its trace is suppressed.
                 defer_rollback (Optional[boolean]) [False]: Defer rollback mode.  DO NOT USE MANUALLY - A PARENT SCRIPT
                     MUST HANDLE THE ROLLBACK.
                 data_sheet (Optional[str]): Sheet name (for error reporting).

--- a/DataRepo/loaders/samples_loader.py
+++ b/DataRepo/loaders/samples_loader.py
@@ -173,6 +173,8 @@ class SamplesLoader(TableLoader):
             Superclass Args:
                 df (Optional[pandas dataframe]): Data, e.g. as parsed from a table-like file.
                 dry_run (Optional[boolean]) [False]: Dry run mode.
+                debug (bool) [False]: Debug mode causes all buffered exception traces to be printed.  Normally, if an
+                    exception is a subclass of SummarizableError, the printing of its trace is suppressed.
                 defer_rollback (Optional[boolean]) [False]: Defer rollback mode.  DO NOT USE MANUALLY - A PARENT SCRIPT
                     MUST HANDLE THE ROLLBACK.
                 data_sheet (Optional[str]): Sheet name (for error reporting).

--- a/DataRepo/loaders/study_loader.py
+++ b/DataRepo/loaders/study_loader.py
@@ -283,6 +283,8 @@ class StudyLoader(ConvertedTableLoader, ABC):
                 df (Optional[Dict[str, pandas dataframe]]): Data, e.g. as parsed from an excel file.  *See
                     ConvertedTableLoader.*
                 dry_run (Optional[boolean]) [False]: Dry run mode.
+                debug (bool) [False]: Debug mode causes all buffered exception traces to be printed.  Normally, if an
+                    exception is a subclass of SummarizableError, the printing of its trace is suppressed.
                 defer_rollback (Optional[boolean]) [False]: Defer rollback mode.  DO NOT USE MANUALLY - A PARENT SCRIPT
                     MUST HANDLE THE ROLLBACK.
                 data_sheet (Optional[str]): Sheet name (for error reporting).
@@ -359,7 +361,7 @@ class StudyLoader(ConvertedTableLoader, ABC):
         self.unexpected_labels_exceptions = []
         self.missing_compound_record_exceptions = []
         self.multiple_pg_reps_exceptions = []
-        self.load_statuses = MultiLoadStatus()
+        self.load_statuses = MultiLoadStatus(debug=kwargs.get("debug", False))
 
         self.derived_loaders = {}
         for derived_class in StudyLoader.__subclasses__():
@@ -832,12 +834,30 @@ class StudyLoader(ConvertedTableLoader, ABC):
                 # We are not going to buffer these individually.  Can't think of a reason to do so.
                 animals_without_samples_exceptions: List[AnimalWithoutSamples] = []
                 for animal in animals_without_samples:
+                    rownum = animals_from_animalssheet.index(animal) + 2
                     aws = AnimalWithoutSamples(
                         animal,
                         file=animals_loader.friendly_file,
                         sheet=animals_loader.sheet,
-                        message=f"Previously loaded animal '{animal}' still has no samples.",
+                        rownum=rownum,
+                        column=animals_loader.DataHeaders.NAME,
                     )
+
+                    # TODO: Figure out a more uniform and consistent way to handle the summarization exceptions that
+                    # takes advantage of self._loader instead of using setattr to set the error type and manually
+                    # creating them calling set_load_exception.  I had played around with buffering the exception in
+                    # StudyLoader, with the thinking that SummarizableErrors would be automatically taken care of, but
+                    # that happens after load_data ends and we will be raising a MultiLoadStatus exception from here
+                    # that has to already have had the summarizations done.
+
+                    # Buffer the warning in the StudyLoader object so that the individual exceptions can be seen when we
+                    # are in debug mode.  NOTE: We do not want to buffer it in the AnimalsLoader object because that
+                    # load has completed and its exceptions post-processed.
+                    if self.debug:
+                        self.aggregated_errors_object.buffer_warning(
+                            aws, is_fatal=self.validate
+                        )
+
                     # Superficially set it as a warning, as if it came from an AggregatedErrors object buffer_warning
                     # method
                     setattr(aws, "is_error", False)
@@ -847,6 +867,8 @@ class StudyLoader(ConvertedTableLoader, ABC):
                 self.load_statuses.set_load_exception(
                     AnimalsWithoutSamples(animals_without_samples_exceptions),
                     "Animals Check",
+                    default_is_error=False,
+                    default_is_fatal=self.validate,
                 )
 
             # Only check for additional missing serum samples if samples are being loaded or if samples already have
@@ -873,14 +895,13 @@ class StudyLoader(ConvertedTableLoader, ABC):
                 ] = []
                 for animal in animals_without_serum_samples:
                     # Create an individual exception, so we can add it to the summary exception
+                    rownum = animals_from_animalssheet.index(animal) + 2
                     awss = AnimalWithoutSerumSamples(
                         animal,
                         file=animals_loader.friendly_file,
                         sheet=animals_loader.sheet,
-                        message=(
-                            f"Previously loaded animal '{animal}' still has no serum samples necessary to "
-                            "perform FCirc calculations."
-                        ),
+                        rownum=rownum,
+                        column=animals_loader.DataHeaders.NAME,
                     )
                     # Superficially set it as a warning, as if it came from an AggregatedErrors object buffer_warning
                     # method
@@ -921,18 +942,23 @@ class StudyLoader(ConvertedTableLoader, ABC):
                     else:
                         more_animals_without_serum_exceptions.append(awss)
 
+                for awss in more_animals_without_serum_exceptions:
+                    # Buffer the warning in the StudyLoader object.  We do not want to buffer it in the SamplesLoader
+                    # object because that load has completed and its exceptions post-processed.  If we were to buffer
+                    # exceptions in it after-the-fact, summary exceptions would not be taken care of.  Buffering it in
+                    # this class means that it will get post-processed by this method's _loader wrapper.  The mean
+                    # reason for this is to summarize SummarizableError exceptions.
+                    if self.debug:
+                        self.aggregated_errors_object.buffer_warning(
+                            awss, is_fatal=self.validate
+                        )
+
                 # If there are any previously loaded animals, that are still in the animals sheet that still have no
                 # serum samples, buffer a warning that they still have no serum samples.
                 if len(more_animals_without_serum_exceptions) > 0:
-                    nlt = "\n\t"
                     self.load_statuses.set_load_exception(
                         AnimalsWithoutSerumSamples(
-                            more_animals_without_serum_exceptions,
-                            message=(
-                                "The following previously loaded animals still do not have the necessary serum samples "
-                                "to perform FCirc calculations:\n"
-                                f"\t{nlt.join(sorted([e.animal for e in more_animals_without_serum_exceptions]))}\n"
-                            ),
+                            more_animals_without_serum_exceptions
                         ),
                         "Animals Check",
                         default_is_error=False,
@@ -1741,7 +1767,7 @@ class StudyV2Loader(StudyLoader):
 
                     # TODO: Right now, this error doesn't get in front of the user on the validation page.  I'm using
                     # load_statuses.set_load_exception below to do that and I'm buffering here to be able to see the
-                    # trace in the console.  I should fix this so that buffered errors from the comnversion get their
+                    # trace in the console.  I should fix this so that buffered errors from the conversion get their
                     # own load_key and get in front of the user.
                     self.aggregated_errors_object.buffer_error(ie, orig_exception=e)
 

--- a/DataRepo/loaders/tracers_loader.py
+++ b/DataRepo/loaders/tracers_loader.py
@@ -278,6 +278,8 @@ class TracersLoader(TableLoader):
             Superclass Args:
                 df (Optional[pandas dataframe]): Data, e.g. as parsed from a table-like file.
                 dry_run (Optional[boolean]) [False]: Dry run mode.
+                debug (bool) [False]: Debug mode causes all buffered exception traces to be printed.  Normally, if an
+                    exception is a subclass of SummarizableError, the printing of its trace is suppressed.
                 defer_rollback (Optional[boolean]) [False]: Defer rollback mode.  DO NOT USE MANUALLY - A PARENT SCRIPT
                     MUST HANDLE THE ROLLBACK.
                 data_sheet (Optional[str]): Sheet name (for error reporting).

--- a/DataRepo/tests/loaders/test_study_loader.py
+++ b/DataRepo/tests/loaders/test_study_loader.py
@@ -420,6 +420,9 @@ class StudyLoaderTests(TracebaseTestCase):
         # fact that it is under the study doc load key
         self.assertEqual(1, len(study_doc_aes.exceptions))
         self.assertIsInstance(study_doc_aes.exceptions[0], AnimalsWithoutSerumSamples)
+        # The exception should be a warning
+        self.assertFalse(study_doc_aes.exceptions[0].is_error)
+        # And it should contain all of the animals' names
         self.assertEqual(["xz971"], study_doc_aes.exceptions[0].animals)
 
         self.assertIn("Animals Check", ar.exception.statuses.keys())
@@ -430,6 +433,9 @@ class StudyLoaderTests(TracebaseTestCase):
         # be filtered by the presence of the samples sheet exception.
         self.assertEqual(1, len(animal_check_aes.exceptions))
         self.assertIsInstance(animal_check_aes.exceptions[0], AnimalsWithoutSamples)
+        # The exception should be a warning
+        self.assertFalse(animal_check_aes.exceptions[0].is_error)
+        # And it should contain all of the animals' names
         self.assertEqual(["xz972"], animal_check_aes.exceptions[0].animals)
 
 

--- a/DataRepo/tests/utils/test_exceptions.py
+++ b/DataRepo/tests/utils/test_exceptions.py
@@ -5,6 +5,10 @@ from DataRepo.models.utilities import get_model_by_name
 from DataRepo.tests.tracebase_test_case import TracebaseTestCase
 from DataRepo.utils.exceptions import (
     AggregatedErrors,
+    AnimalsWithoutSamples,
+    AnimalsWithoutSerumSamples,
+    AnimalWithoutSamples,
+    AnimalWithoutSerumSamples,
     CompoundDoesNotExist,
     DateParseError,
     DefaultSequenceNotFound,
@@ -1461,6 +1465,107 @@ class ExceptionTests(TracebaseTestCase):
             "The compound name was automatically repaired to be 'compound_test_name__'",
             str(e),
         )
+
+    def test_AnimalWithoutSamples(self):
+        e = AnimalWithoutSamples(
+            "George", file="doc.xlsx", sheet="Animals", column="Name", rownum=5
+        )
+        # Contains all pertinent data to solve the problem
+        self.assertIn("George", str(e))
+        self.assertIn("column [Name] on row [5] of sheet [Animals] in doc.xlsx", str(e))
+        # Explanation
+        self.assertIn("Animal ", str(e))
+        self.assertIn("does not have any samples", str(e))
+        # Suggestion
+        self.assertIn(
+            "You can ignore this for now and submit samples for this animal in the future",
+            str(e),
+        )
+        self.assertIn(
+            "you can address the issue now by adding overlooked samples", str(e)
+        )
+        self.assertIn("or remove the animal from the Animals sheet", str(e))
+
+    def test_AnimalsWithoutSamples(self):
+        e1 = AnimalWithoutSamples(
+            "George", file="doc.xlsx", sheet="Animals", column="Name", rownum=5
+        )
+        e2 = AnimalWithoutSamples(
+            "Henrietta", file="doc.xlsx", sheet="Animals", column="Name", rownum=19
+        )
+        e = AnimalsWithoutSamples([e1, e2])
+        # Contains all pertinent data to solve the problem
+        self.assertIn("column [Name] of sheet [Animals] in doc.xlsx", str(e))
+        self.assertIn("'George' on row 5", str(e))
+        self.assertIn("'Henrietta' on row 19", str(e))
+        # Explanation
+        self.assertIn("Animals ", str(e))
+        self.assertIn("do not have any samples", str(e))
+        # Suggestion
+        self.assertIn(
+            "You can ignore this for now and submit samples for these animals in the future",
+            str(e),
+        )
+        self.assertIn(
+            "you can address the issue now by adding overlooked samples", str(e)
+        )
+        self.assertIn("or remove the animals from the Animals sheet", str(e))
+
+    def test_AnimalWithoutSerumSamples(self):
+        e = AnimalWithoutSerumSamples(
+            "Kramer", file="doc.xlsx", sheet="Animals", column="Name", rownum=10
+        )
+        # Contains all pertinent data to solve the problem
+        self.assertIn("Kramer", str(e))
+        self.assertIn(
+            "column [Name] on row [10] of sheet [Animals] in doc.xlsx", str(e)
+        )
+        # Explanation
+        self.assertIn("Animal ", str(e))
+        self.assertIn(
+            "does not have the necessary serum samples to perform FCirc calc", str(e)
+        )
+        self.assertIn("FCirc calculations on TraceBase are done using", str(e))
+        self.assertIn("the last serum sample", str(e))
+        # Suggestion
+        self.assertIn(
+            "You can ignore this for now and submit serum samples for this animal in the future",
+            str(e),
+        )
+        self.assertIn(
+            "you can address the issue now by adding overlooked serum samples", str(e)
+        )
+        self.assertIn("or remove the animal from the Animals sheet", str(e))
+
+    def test_AnimalsWithoutSerumSamples(self):
+        e1 = AnimalWithoutSerumSamples(
+            "Kramer", file="doc.xlsx", sheet="Animals", column="Name", rownum=10
+        )
+        e2 = AnimalWithoutSerumSamples(
+            "Molly", file="doc.xlsx", sheet="Animals", column="Name", rownum=11
+        )
+        e = AnimalsWithoutSerumSamples([e1, e2])
+        # Contains all pertinent data to solve the problem
+        self.assertIn("column [Name] of sheet [Animals] in doc.xlsx", str(e))
+        self.assertIn("'Kramer' on row 10", str(e))
+        self.assertIn("'Molly' on row 11", str(e))
+        # Explanation
+        self.assertIn("animals ", str(e))
+        self.assertIn(
+            "do not have the necessary serum samples to perform FCirc calculations",
+            str(e),
+        )
+        self.assertIn("FCirc calculations on TraceBase are done using", str(e))
+        self.assertIn("the last serum sample", str(e))
+        # Suggestion
+        self.assertIn(
+            "You can ignore this for now and submit serum samples for these animals in the future",
+            str(e),
+        )
+        self.assertIn(
+            "you can address the issue now by adding overlooked serum samples", str(e)
+        )
+        self.assertIn("or remove the animals from the Animals sheet", str(e))
 
     def test_trace(self):
         trc = trace()


### PR DESCRIPTION
## What

I don't know how this PR should differ from PR #1681 (which merged the dev branch into this release branch).  It's the same issue and the acceptance criteria is equivalent (e.g. all the rabinowitz repo study tests pass, which they do).  The "validation" and "verification" seem no different from what was already done in PR #1681.  The errors are now warnings and studies can all now be loaded.

Also, does this release merge of 3.1.8 have to wait for 3.1.7 to be merged (#1682)?

## Why

I don't know how this PR should differ from PR #1681.  It's the same "why".

## How

I don't know how this PR should differ from PR #1681.  It's the same "how".

## Tests

No tests were added since the dev branch merge into this release branch.

## Security Concerns

None

## Others

None
