### PR TITLE
Autoupdate efficiency improvements to allow DB migrations

### DIFF
--- a/DataRepo/formats/dataformat_group.py
+++ b/DataRepo/formats/dataformat_group.py
@@ -39,8 +39,8 @@ class FormatGroup:
         """
         Add formats and set the default to the first class, unless default already set.
         """
-        for cls in format_classes:
-            self.modeldata[cls.id] = cls
+        for kls in format_classes:
+            self.modeldata[kls.id] = kls
         if self.default_format is None:
             self.default_format = format_classes[0].id
 

--- a/DataRepo/models/animal.py
+++ b/DataRepo/models/animal.py
@@ -168,7 +168,7 @@ class Animal(MaintainedModel, HierCachedModel):
         last_serum_sample = (
             self.samples.filter(Tissue.serum_q_expression("tissue__name"))
             .extra(**extra_args)
-            .order_by(f"-{is_null_field}", "time_collected")
+            .order_by(f"-{is_null_field}", "time_collected", "name")
             .last()
         )
 

--- a/DataRepo/models/maintained_model.py
+++ b/DataRepo/models/maintained_model.py
@@ -10,7 +10,7 @@ from typing import Dict, List, Optional, Type
 from django.conf import settings
 from django.core.exceptions import ObjectDoesNotExist
 from django.db import ProgrammingError, transaction
-from django.db.models import Model
+from django.db.models import Model, Q
 from django.db.models.signals import m2m_changed
 
 
@@ -963,7 +963,7 @@ class MaintainedModel(Model):
                         f"{parent_field_name}"
                     )
                 if parent_field_name is not None and len(child_field_names) > 0:
-                    msg += " and "
+                    msg += " and"
                 if child_field_names is not None and len(child_field_names) > 0:
                     msg += (
                         f" trigger updates to children: "
@@ -1662,6 +1662,45 @@ class MaintainedModel(Model):
                         except Exception as e:
                             raise AutoUpdateFailed(rec, e, updater_dicts)
 
+    @classmethod
+    def _get_nulls(cls, label_filters=None, filter_in=True, models_path=None):
+        """This class method constructs a 2-dimensional dict keyed on model name and maintained field name that contains
+        querysets for maintained model records that contain maintained fields whose values are None/null.
+
+        This method was primarily made for testing, but could also be used for targeted updating after loading with the
+        no_autoupdates decorator.
+
+        Args:
+            label_filters (Optional[List[str]]): A list of update_labels to limit the returned null model records to
+                fields with those labels.
+            filter_in (bool) [True]: When False, excludes the label_filters.
+            models_path (Optional[str]): A string like "DataRepo.models".  Only required if called before any of the
+                model classes have been instantiated and after the decorators have registered.
+        Exceptions:
+            None
+        Returns:
+            null_querysets_by_model_and_field (Dict[str, Dict[str, QuerySet]]): dict keyed on model name and maintained
+                field name that contains querysets for maintained model records that contain maintained fields whose
+                values are None/null.
+        """
+        null_querysets_by_model_and_field = defaultdict(lambda: defaultdict(object))
+        mdl_cls: Type[MaintainedModel]
+        for mdl_cls in cls._get_classes(
+            None,
+            label_filters,
+            filter_in,
+            models_path=models_path,
+        ):
+            for fld in mdl_cls.get_my_update_fields(
+                label_filters=label_filters, filter_in=filter_in
+            ):
+                q_exp = Q(**{f"{fld}__isnull": True})
+                null_querysets_by_model_and_field[mdl_cls.__name__][fld] = (
+                    mdl_cls.objects.filter(q_exp)
+                )
+
+        return null_querysets_by_model_and_field
+
     def update_decorated_fields(self, fields_to_autoupdate=None):
         """
         Updates every field identified in each MaintainedModel.setter decorator using the decorated function that
@@ -2124,16 +2163,37 @@ class MaintainedModel(Model):
         return children
 
     @classmethod
-    def get_my_update_fields(cls):
-        """
-        Returns a list of update_fields of the current model that are marked via the MaintainedModel.setter
+    def get_my_update_fields(
+        cls, label_filters: Optional[List[str]] = None, filter_in=True
+    ):
+        """Returns a list of update_fields of the current model that are marked via the MaintainedModel.setter
         decorators in the model.  Returns an empty list if there are none (e.g. if the only decorator in the model is
         the relation decorator on the class).
+
+        Args:
+            label_filters (Optional[List[str]]): A list of update_labels to limit the returned null model records to
+                fields with those labels.
+            filter_in (bool) [True]: When False, excludes the label_filters.
+        Exceptions:
+            None
+        Returns:
+            (List[str]): A list of update_fields of the current model.
         """
         return [
             updater_dict["update_field"]
             for updater_dict in cls.get_my_updaters()
-            if "update_field" in updater_dict.keys() and updater_dict["update_field"]
+            if (
+                "update_field" in updater_dict.keys()
+                and updater_dict["update_field"]
+                and (
+                    label_filters is None
+                    or (filter_in and updater_dict["update_label"] in label_filters)
+                    or (
+                        not filter_in
+                        and updater_dict["update_label"] not in label_filters
+                    )
+                )
+            )
         ]
 
     @classmethod

--- a/DataRepo/models/maintained_model.py
+++ b/DataRepo/models/maintained_model.py
@@ -69,7 +69,7 @@ class MaintainedModelCoordinator:
 
         # These allow the user to turn on or off specific groups of auto-updates.
         label_filters = kwargs.pop("label_filters", [])
-        self.default_label_filters = label_filters
+        self.default_label_filters = sorted(label_filters)
 
         filter_in = kwargs.pop("filter_in", True)
         self.default_filter_in = filter_in
@@ -256,7 +256,9 @@ class MaintainedModelCoordinator:
                 # the filters in both cases), but given the possibility that update order may depend on the update of
                 # related records, it's better to be on the safe side and do each auto-update, so...
                 # If this is the same object but a different set of fields will be updated...
-                # Note, Django model object equivalence (obj1 == obj2) compares primary key values
+                # NOTE: Django model object equivalence (obj1 == obj2) compares primary key values, so even though the
+                # object attributes "filter_in" and "label_filters" may differ in the object, we still have to
+                # explicitly check them.
                 for same_obj in [bo for bo in self.update_buffer if bo == mdl_obj]:
                     if (
                         same_obj.filter_in != mdl_obj.filter_in
@@ -318,8 +320,8 @@ class MaintainedModelCoordinator:
             updater_dicts = buffer_item.get_my_updaters()
 
             if use_object_label_filters:
-                label_filters = buffer_item.get_my_update_labels()
-                filter_in = True
+                label_filters = self.label_filters
+                filter_in = self.filter_in
                 if label_filters is None:
                     label_filters = self.default_label_filters
                     filter_in = self.default_filter_in
@@ -343,7 +345,6 @@ class MaintainedModelCoordinator:
                     # repeated updates of the same record.
                     buffer_item.save(mass_updates=True)
 
-                    print(f"PROPAGATING BECAUSE LABELS: use_object_label_filters: {use_object_label_filters} no_filters: {no_filters} label_filters: {label_filters} filter_in: {filter_in}")
                     # Propagate the changes (if necessary), keeping track of what is updated and what's not.
                     # Note: all the manual changes are assumed to have been made already, so auto-updates only need to
                     # be issued once per record
@@ -551,11 +552,22 @@ class MaintainedModel(Model):
         # the update will be buffered, to be manually triggered later (e.g. upon completion of loading), which
         # mitigates repeated updates to the same record
         if not coordinator.are_autoupdates_enabled():
-            # If autoupdates are happening (and it's not a mass-autoupdate (assumed because mass_updates
-            # can only be true if immediate_updates is False)), set the label filters based on the currently set global
-            # conditions so that only fields matching the filters will be updated.
-            self.label_filters = coordinator.default_label_filters
-            self.filter_in = coordinator.default_filter_in
+            # If autoupdates are happening (and it's not a mass-autoupdate (assumed because mass_updates can only be
+            # true if immediate_updates is False)), set the label filters based on the currently set global conditions
+            # so that only fields matching the filters will be updated.  An explicit setting of the label_filters in the
+            # coordinator overrides the update_label of the decorators applied in the model.  This is so a specific mass
+            # update can be manually achieved via a targeted script.  If there is not label_filters set in the
+            # coordinator, it falls back to the update_labels belonging to the model class's decorators, and propagation
+            # will only follow those paths.
+            if (
+                coordinator.default_label_filters is None
+                or len(coordinator.default_label_filters) == 0
+            ):
+                self.label_filters = self.get_my_update_labels()
+                self.filter_in = True
+            else:
+                self.label_filters = coordinator.default_label_filters
+                self.filter_in = coordinator.default_filter_in
 
             if not mass_updates:
                 # Set the changed value triggering this update
@@ -641,9 +653,11 @@ class MaintainedModel(Model):
         # since updater methods SHOULD NOT rely on maintained fields, there is no change in a query that should affect
         # other maintained fields.
         if coordinator.are_immediate_updates_enabled() and propagate:
-            # Percolate (non-maintained field) record changes up to the related models so they can change their
-            # maintained fields whose values are dependent on this record's non-maintained fields
-            self.call_dfs_related_updaters(label_filters=self.get_my_update_labels(), filter_in=True)
+            # Percolate (non-maintained field) record changes to the related models so they can change their maintained
+            # fields whose values are dependent on this record's non-maintained fields
+            self.call_dfs_related_updaters(
+                label_filters=self.get_my_update_labels(), filter_in=True
+            )
 
     def delete(self, *args, **kwargs):
         """
@@ -670,13 +684,21 @@ class MaintainedModel(Model):
             coordinator.are_immediate_updates_enabled() is False
             and mass_updates is False
         ):
-            if hasattr(self, "label_filters"):
-                print(f"OBJECT self.label_filters: {self.label_filters}")
+            # If autoupdates are happening (and it's not a mass-autoupdate), set the label filters based on the
+            # currently set global conditions so that only fields matching the filters will be updated.  An explicit
+            # setting of the label_filters in the coordinator overrides the update_label of the decorators applied in
+            # the model.  This is so a specific mass update can be manually achieved via a targeted script.  If there is
+            # not label_filters set in the coordinator, it falls back to the update_labels belonging to the model
+            # class's decorators, and propagation will only follow those paths.
+            if (
+                coordinator.default_label_filters is None
+                or len(coordinator.default_label_filters) == 0
+            ):
+                self.label_filters = self.get_my_update_labels()
+                self.filter_in = True
             else:
-                print(f"GLOBAL self.label_filters: {coordinator.default_label_filters}")
-            # When buffering only, apply the global label filters, to be remembered during mass autoupdate
-            self.label_filters = coordinator.default_label_filters
-            self.filter_in = coordinator.default_filter_in
+                self.label_filters = coordinator.default_label_filters
+                self.filter_in = coordinator.default_filter_in
 
             if coordinator.buffering:
                 parents = self.get_parent_instances()
@@ -689,11 +711,22 @@ class MaintainedModel(Model):
 
             return retval
         elif coordinator.are_immediate_updates_enabled():
-            # If autoupdates are happening (and it's not a mass-autoupdate (assumed because mass_updates
-            # can only be true if immediate_updates is False)), set the label filters based on the currently set global
-            # conditions so that only fields matching the filters will be updated.
-            self.label_filters = coordinator.default_label_filters
-            self.filter_in = coordinator.default_filter_in
+            # If autoupdates are happening (and it's not a mass-autoupdate (assumed because mass_updates can only be
+            # true if immediate_updates is False)), set the label filters based on the currently set global conditions
+            # so that only fields matching the filters will be updated.  An explicit setting of the label_filters in the
+            # coordinator overrides the update_label of the decorators applied in the model.  This is so a specific mass
+            # update can be manually achieved via a targeted script.  If there is not label_filters set in the
+            # coordinator, it falls back to the update_labels belonging to the model class's decorators, and propagation
+            # will only follow those paths.
+            if (
+                coordinator.default_label_filters is None
+                or len(coordinator.default_label_filters) == 0
+            ):
+                self.label_filters = self.get_my_update_labels()
+                self.filter_in = True
+            else:
+                self.label_filters = coordinator.default_label_filters
+                self.filter_in = coordinator.default_filter_in
         # Otherwise, we are performing a mass auto-update and want to update the previously set filter conditions
 
         # Delete the record triggering this update.  In the event we were buffering, we had to do that above and return.
@@ -701,7 +734,10 @@ class MaintainedModel(Model):
         retval = super().delete(*args, **kwargs)  # Call the "real" delete() method.
 
         if coordinator.are_immediate_updates_enabled() and propagate:
-            # Percolate changes up to the parents (if any) and mark the deleted record as updated
+            # Percolate changes up to the parents (if any) and mark the deleted record as updated.  Here, we ignore any
+            # label_filters set by the coordinator, because that's only for mass autoupdates, and supply the
+            # update_labels explicitly present in the model for the label_filters argument (and defaulting filter_in to
+            # True).
             self.call_dfs_related_updaters(
                 updated=[self_sig],
                 label_filters=self.get_my_update_labels(),
@@ -1009,7 +1045,7 @@ class MaintainedModel(Model):
         we can propagate the changes.
         """
         obj: MaintainedModel = kwargs.pop("instance", None)
-        act = kwargs.pop("action", None)
+        act: str = kwargs.pop("action", "")
 
         # Retrieve the current coordinator
         coordinator = cls.get_coordinator()
@@ -1019,14 +1055,21 @@ class MaintainedModel(Model):
             and isinstance(obj, MaintainedModel)
             and coordinator.are_immediate_updates_enabled()
         ):
-            obj.call_dfs_related_updaters(label_filters=obj.get_my_update_labels(), filter_in=True)
+            # Percolate (non-maintained field) record changes to the related models so they can change their maintained
+            # fields whose values are dependent on this record's non-maintained fields.  Here, we ignore any
+            # label_filters set by the coordinator, because that's only for mass autoupdates, and supply the
+            # update_labels explicitly present in the model for the label_filters argument (and defaulting filter_in to
+            # True).
+            obj.call_dfs_related_updaters(
+                label_filters=obj.get_my_update_labels(), filter_in=True
+            )
 
     @classmethod
-    def get_coordinator(cls):
+    def get_coordinator(cls) -> MaintainedModelCoordinator:
         return cls._get_current_coordinator()
 
     @classmethod
-    def _get_current_coordinator(cls):
+    def _get_current_coordinator(cls) -> MaintainedModelCoordinator:
         coordinator_stack = cls._get_coordinator_stack()
         if len(coordinator_stack) > 0:
             # Get the current coordinator
@@ -1809,10 +1852,13 @@ class MaintainedModel(Model):
         parents = self.get_parent_instances()
         parent_inst: MaintainedModel
         for parent_inst in parents:
-            if label_filters is not None and not parent_inst.updater_list_has_matching_labels(
-                parent_inst.get_my_updaters(), label_filters, filter_in
+            # Only follow propagation paths that have update_labels that match the active label_filters
+            if (
+                label_filters is not None
+                and not parent_inst.updater_list_has_matching_labels(
+                    parent_inst.get_my_updaters(), label_filters, filter_in
+                )
             ):
-                print(f"SKIPPING PARENT {parent_inst.__class__.__name__} PROPAGATION BECAUSE NOT A LABEL FILTER {label_filters} MATCH")
                 continue
             # If the current instance's update was triggered - and was triggered by the same parent instance whose
             # update we're about to trigger
@@ -1938,10 +1984,13 @@ class MaintainedModel(Model):
         children = self.get_child_instances()
         child_inst: MaintainedModel
         for child_inst in children:
-            if label_filters is not None and not child_inst.updater_list_has_matching_labels(
-                child_inst.get_my_updaters(), label_filters, filter_in
+            # Only follow propagation paths that have update_labels that match the active label_filters
+            if (
+                label_filters is not None
+                and not child_inst.updater_list_has_matching_labels(
+                    child_inst.get_my_updaters(), label_filters, filter_in
+                )
             ):
-                print(f"SKIPPING CHILD {child_inst.__class__.__name__} PROPAGATION BECAUSE NOT A LABEL FILTER {label_filters} MATCH")
                 continue
             # If the current instance's update was triggered - and was triggered by the same child instance whose
             # update we're about to trigger
@@ -1963,7 +2012,7 @@ class MaintainedModel(Model):
                     updated=updated,
                     mass_updates=mass_updates,
                     label_filters=label_filters,
-                    filter_in=filter_in
+                    filter_in=filter_in,
                 )
 
         return updated
@@ -2076,11 +2125,14 @@ class MaintainedModel(Model):
         """
         update_labels: List[str] = []
         if cls.__name__ in cls.updater_list.keys():
-            update_labels = [updater_dict["update_label"] for updater_dict in cls.updater_list[cls.__name__]]
+            update_labels = [
+                updater_dict["update_label"]
+                for updater_dict in cls.updater_list[cls.__name__]
+            ]
         else:
             raise NoDecorators(cls.__name__)
 
-        return update_labels
+        return sorted(update_labels)
 
     class Meta:
         abstract = True

--- a/DataRepo/models/maintained_model.py
+++ b/DataRepo/models/maintained_model.py
@@ -551,9 +551,9 @@ class MaintainedModel(Model):
             # true if immediate_updates is False)), set the label filters based on the currently set global conditions
             # so that only fields matching the filters will be updated.  An explicit setting of the label_filters in the
             # coordinator overrides the update_label of the decorators applied in the model.  This is so a specific mass
-            # update can be manually achieved via a targeted script.  If there is not label_filters set in the
-            # coordinator, it falls back to the update_labels belonging to the model class's decorators, and propagation
-            # will only follow those paths.
+            # update can be manually achieved via a targeted script.  If label_filters is not set in the coordinator, it
+            # falls back to the update_labels belonging to the model class's decorators, and propagation will only
+            # follow those paths.
             if (
                 coordinator.default_label_filters is None
                 or len(coordinator.default_label_filters) == 0
@@ -687,7 +687,7 @@ class MaintainedModel(Model):
                     # currently set global conditions so that only fields matching the filters will be updated.  An
                     # explicit setting of the label_filters in the coordinator overrides the update_label of the
                     # decorators applied in the model.  This is so a specific mass update can be manually achieved via a
-                    # targeted script.  If there is not label_filters set in the coordinator, it falls back to the
+                    # targeted script.  If label_filters is not set in the coordinator, it falls back to the
                     # update_labels belonging to the model class's decorators, and propagation will only follow those
                     # paths.
                     if (

--- a/DataRepo/models/maintained_model.py
+++ b/DataRepo/models/maintained_model.py
@@ -1672,8 +1672,9 @@ class MaintainedModel(Model):
         the current filter conditions.  One exception of the refresh, is if performing a mass auto-update, in which
         case the filters the were in effect during buffering are used.
         """
-        changed = False
+        anything_changed = False
         for updater_dict in self.get_my_updaters():
+            changed = False
             update_fld = updater_dict["update_field"]
             update_label = updater_dict["update_label"]
 
@@ -1742,6 +1743,7 @@ class MaintainedModel(Model):
                 setattr(self, update_fld, new_val)
 
                 if old_val != new_val:
+                    anything_changed = True
                     changed = True
 
                 # Report the auto-update
@@ -1750,8 +1752,8 @@ class MaintainedModel(Model):
 
                 if changed:
                     print(
-                        f"Auto-updated {self.__class__.__name__}.{update_fld} in {self.__class__.__name__}.{self.pk} "
-                        f"using {update_fun.__qualname__} from [{old_val}] to [{new_val}]."
+                        f"Auto-update of {self.__class__.__name__}.{update_fld} in {self.__class__.__name__}.{self.pk} "
+                        f"using {update_fun.__qualname__} resulted in a change from [{old_val}] to [{new_val}]."
                     )
                 else:
                     print(
@@ -1759,7 +1761,7 @@ class MaintainedModel(Model):
                         f"using {update_fun.__qualname__} resulted in the same value: [{new_val}]."
                     )
 
-        return changed
+        return anything_changed
 
     def get_record_signature(self):
         if self.pk is None:

--- a/DataRepo/models/maintained_model.py
+++ b/DataRepo/models/maintained_model.py
@@ -1831,7 +1831,9 @@ class MaintainedModel(Model):
         Returns:
             updated (List[str]): A list of model object signatures that were updated.
         """
-        parents = self.get_parent_instances()
+        parents = self.get_parent_instances(
+            label_filters=label_filters, filter_in=filter_in
+        )
         parent_inst: MaintainedModel
         for parent_inst in parents:
             # Only follow propagation paths that have update_labels that match the active label_filters
@@ -1869,7 +1871,11 @@ class MaintainedModel(Model):
 
         return updated
 
-    def get_parent_instances(self):
+    def get_parent_instances(
+        self,
+        label_filters: Optional[List[str]] = None,
+        filter_in=True,
+    ):
         """
         Returns a list of parent records to the current record (self) (and the parent relationship is stored in the
         updater_list global variable, indexed by class name) based on the parent keys indicated in every decorated
@@ -1880,9 +1886,29 @@ class MaintainedModel(Model):
         fields, they will only ever update when the through model object is specifically saved and will not be updated
         when their "child" object changes.  This will have to be modified to return through model instances if such
         updates come to be required.
+
+        Args:
+            label_filters (Optional[List[str]]): A list of update_labels that define the propagation path(s) that should
+                be followed.
+            filter_in (bool) [True]: When True, label_filters contains the labels where propagation should proceed.
+                When False, label_filters are the paths that should be avoided.
+        Exceptions:
+            NotMaintained
+            ProgrammingError
+        Returns:
+            parents (List[MaintainedModel])
         """
         parents = []
         for updater_dict in self.get_my_updaters():
+            # If label_filters were supplied, only obtain the parent instances that meet the filtering criteria
+            if label_filters is not None:
+                match = (
+                    updater_dict["update_label"] is not None
+                    and updater_dict["update_label"] in label_filters
+                )
+                if filter_in is not match:
+                    continue
+
             parent_fld = updater_dict["parent_field"]
 
             # If there is a parent that should update based on this change
@@ -1964,7 +1990,9 @@ class MaintainedModel(Model):
         Returns:
             updated (List[str]): A list of model object signatures that were updated.
         """
-        children = self.get_child_instances()
+        children = self.get_child_instances(
+            label_filters=label_filters, filter_in=filter_in
+        )
         child_inst: MaintainedModel
         for child_inst in children:
             # Only follow propagation paths that have update_labels that match the active label_filters
@@ -2000,7 +2028,11 @@ class MaintainedModel(Model):
 
         return updated
 
-    def get_child_instances(self):
+    def get_child_instances(
+        self,
+        label_filters: Optional[List[str]] = None,
+        filter_in=True,
+    ):
         """Returns a list of child records to the current record (self) (and the child relationship is stored in the
         updater_list global variable, indexed by class name) based on the child keys indicated in every decorated
         updater method.
@@ -2010,10 +2042,30 @@ class MaintainedModel(Model):
         fields, they will only ever update when the through model object is specifically saved and will not be updated
         when their "child" object changes.  This will have to be modified to return through model instances if such
         updates come to be required.
+
+        Args:
+            label_filters (Optional[List[str]]): A list of update_labels that define the propagation path(s) that should
+                be followed.
+            filter_in (bool) [True]: When True, label_filters contains the labels where propagation should proceed.
+                When False, label_filters are the paths that should be avoided.
+        Exceptions:
+            NotMaintained
+            ProgrammingError
+        Returns:
+            parents (List[MaintainedModel])
         """
         children = []
         updaters = self.get_my_updaters()
         for updater_dict in updaters:
+            # If label_filters were supplied, only obtain the child instances that meet the filtering criteria
+            if label_filters is not None:
+                match = (
+                    updater_dict["update_label"] is not None
+                    and updater_dict["update_label"] in label_filters
+                )
+                if filter_in is not match:
+                    continue
+
             child_flds = updater_dict["child_fields"]
 
             # If there is a child that should update based on this change

--- a/DataRepo/models/maintained_model.py
+++ b/DataRepo/models/maintained_model.py
@@ -235,14 +235,10 @@ class MaintainedModelCoordinator:
         """
 
         # See if this class contains a field with a matching label (if a populated label_filters array was supplied)
-        if (
-            mdl_obj.label_filters is not None
-            and len(mdl_obj.label_filters) > 0
-            and not mdl_obj.updater_list_has_matching_labels(
-                mdl_obj.get_my_updaters(),
-                mdl_obj.label_filters,
-                mdl_obj.filter_in,
-            )
+        if not mdl_obj.updater_list_passes_filtering(
+            mdl_obj.get_my_updaters(),
+            mdl_obj.label_filters,
+            mdl_obj.filter_in,
         ):
             # Do not buffer - nothing to update
             return
@@ -315,7 +311,6 @@ class MaintainedModelCoordinator:
         # Track what's been updated to prevent repeated updates triggered by multiple child updates
         updated = []
         new_buffer = []
-        no_filters = label_filters is None or len(label_filters) == 0
 
         # For each record in the buffer
         buffer_item: MaintainedModel
@@ -334,11 +329,8 @@ class MaintainedModelCoordinator:
 
             # Try to perform the update. It could fail if the affected record was deleted
             try:
-                if key not in updated and (
-                    no_filters
-                    or buffer_item.updater_list_has_matching_labels(
-                        updater_dicts, label_filters, filter_in
-                    )
+                if key not in updated and buffer_item.updater_list_passes_filtering(
+                    updater_dicts, label_filters, filter_in
                 ):
                     # Saving the record while mass_updates is True, causes auto-updates of every field
                     # included among the model's decorated functions.  It does not only update the fields indicated in
@@ -434,7 +426,7 @@ class MaintainedModel(Model):
         class_name = self.__class__.__name__
 
         # Register the class with the coordinator if not already registered
-        if class_name not in MaintainedModel.model_classes.keys():
+        if class_name not in MaintainedModel.model_classes:
             print(
                 f"Registering class {class_name} as a MaintainedModel from _maintained_model_setup: {type(self)}"
             )
@@ -484,7 +476,7 @@ class MaintainedModel(Model):
                 for cfld in updater_dict["child_fields"]:
                     flds[cfld] = "child field"
                 bad_fields = []
-                for field in flds.keys():
+                for field in flds:
                     try:
                         getattr(self.__class__, field)
                     except AttributeError:
@@ -554,10 +546,7 @@ class MaintainedModel(Model):
             # update can be manually achieved via a targeted script.  If label_filters is not set in the coordinator, it
             # falls back to the update_labels belonging to the model class's decorators, and propagation will only
             # follow those paths.
-            if (
-                coordinator.default_label_filters is None
-                or len(coordinator.default_label_filters) == 0
-            ):
+            if not coordinator.default_label_filters:
                 self.label_filters = self.get_my_update_labels()
                 self.filter_in = True
             else:
@@ -690,10 +679,7 @@ class MaintainedModel(Model):
                     # targeted script.  If label_filters is not set in the coordinator, it falls back to the
                     # update_labels belonging to the model class's decorators, and propagation will only follow those
                     # paths.
-                    if (
-                        coordinator.default_label_filters is None
-                        or len(coordinator.default_label_filters) == 0
-                    ):
+                    if not coordinator.default_label_filters:
                         parent_inst.label_filters = parent_inst.get_my_update_labels()
                         parent_inst.filter_in = True
                     else:
@@ -839,7 +825,7 @@ class MaintainedModel(Model):
             class_name = cls.__name__
 
             # Register the class (and the module) with the coordinator if not already registered
-            if class_name not in MaintainedModel.model_classes.keys():
+            if class_name not in MaintainedModel.model_classes:
                 print(
                     f"Registering class {class_name} as a MaintainedModel from the relation decorator: {cls}"
                 )
@@ -934,7 +920,7 @@ class MaintainedModel(Model):
             }
 
             # Try to register the model class.  If this fails, fallback methods will be used when it is needed later.
-            if class_name not in MaintainedModel.model_packages.keys():
+            if class_name not in MaintainedModel.model_packages:
                 models_path = (
                     MaintainedModel.get_model_package_name_from_member_function(fn)
                 )
@@ -1275,10 +1261,7 @@ class MaintainedModel(Model):
                 if disable_opt_names and len(disable_opt_names) > 0:
                     # Check the value of each option and change the mode to "disabled" if *any* of them are True.
                     for disable_opt_name in disable_opt_names:
-                        if (
-                            disable_opt_name in kwargs.keys()
-                            and kwargs[disable_opt_name]
-                        ):
+                        if disable_opt_name in kwargs and kwargs[disable_opt_name]:
                             # This is if the option is in kwargs
                             mode = "disabled"
                             break
@@ -1358,7 +1341,7 @@ class MaintainedModel(Model):
         the model classes have been instantiated and after the decorators have registered.
         """
         class_list = []
-        for model_class_name in cls.updater_list.keys():
+        for model_class_name in cls.updater_list:
             if (
                 len(
                     cls._filter_updaters(
@@ -1379,7 +1362,7 @@ class MaintainedModel(Model):
         models_path is optional and must be a string like "DataRepo.models".  It's only required if called before any of
         the model classes have been instantiated and after the decorators have registered.
         """
-        if model_class_name in cls.model_classes.keys():
+        if model_class_name in cls.model_classes:
             return cls.model_classes[model_class_name]
         access_method = "determiend by the decorator(s)"
         try:
@@ -1428,7 +1411,7 @@ class MaintainedModel(Model):
         all_values = {}
         maintained_fields = cls.get_maintained_fields_query_dict(models_path)
 
-        for key in maintained_fields.keys():
+        for key in maintained_fields:
             mdl: Model = maintained_fields[key]["class"]
             flds = maintained_fields[key]["fields"]
             all_values[mdl.__name__] = []
@@ -1460,11 +1443,9 @@ class MaintainedModel(Model):
             if mdl_name not in cls.updater_list:
                 raise NoDecorators(mdl_name)
 
+            updater_dict: dict
             for updater_dict in cls.updater_list[mdl_name]:
-                if (
-                    "update_field" in updater_dict.keys()
-                    and updater_dict["update_field"]
-                ):
+                if "update_field" in updater_dict and updater_dict["update_field"]:
                     mdl_update_flds.append(updater_dict["update_field"])
 
             if issubclass(mdl, MaintainedModel) and len(mdl_update_flds) > 0:
@@ -1518,10 +1499,28 @@ class MaintainedModel(Model):
         return new_updaters_list
 
     @classmethod
-    def updater_list_has_matching_labels(cls, updaters_list, label_filters, filter_in):
+    def updater_list_passes_filtering(
+        cls,
+        updaters_list: List[dict],
+        label_filters: Optional[List[str]],
+        filter_in: bool = True,
+    ):
+        """Returns True if any updater dict in updaters_list passes the label filtering criteria.
+
+        If there are no label_filters, it is treated as no filtering (in or out), so True is returned.
+
+        Args:
+            updaters_list (List[dict]): This is a list of dicts defining the maintained fields (update_fields).
+            label_filters (Optional[List[str]]): A list of update_labels to use to filter the updaters_list.
+            filter_in (bool) [True]: Whether the label_filters specify the desired or undesired labels.
+        Exceptions:
+            None
+        Returns:
+            (bool)
         """
-        Returns True if any updater dict in updaters_list passes the label filtering criteria.
-        """
+        if not label_filters:
+            # There is no filtering in effect
+            return True
         for updater_dict in updaters_list:
             label = updater_dict["update_label"]
             has_a_label = label is not None
@@ -1602,7 +1601,6 @@ class MaintainedModel(Model):
             )
             # Track what's been updated to prevent repeated updates triggered by multiple child updates
             updated = {}
-            has_filters = len(label_filters) > 0
 
             # For every generation from the youngest leaves/children to root/parent
             for gen in sorted(range(youngest_generation + 1), reverse=True):
@@ -1634,7 +1632,7 @@ class MaintainedModel(Model):
                         break
 
                     # No need to perform updates if none of the updaters match the label filters
-                    if has_filters and not cls.updater_list_has_matching_labels(
+                    if not cls.updater_list_passes_filtering(
                         updater_dicts, label_filters, filter_in
                     ):
                         break
@@ -1715,7 +1713,6 @@ class MaintainedModel(Model):
         for updater_dict in self.get_my_updaters():
             changed = False
             update_fld = updater_dict["update_field"]
-            update_label = updater_dict["update_label"]
 
             # from_db was implemented somewhat more carefully than save was.  The documentation for from_db warns about
             # "DEFERRED" fields, whose values aren't available.  After I implemented it, I realized that the deferred
@@ -1734,28 +1731,8 @@ class MaintainedModel(Model):
             # If there is a maintained field(s) in this model and...
             # If auto-updates are restricted to fields by their update_label and this field matches the label
             # filter criteria
-            if update_fld is not None and (
-                # There are no labels for filtering
-                self.label_filters is None
-                or len(self.label_filters) == 0
-                # or the update_label matches a filter-in label
-                or (
-                    self.filter_in
-                    and update_label is not None
-                    and update_label
-                    in self.label_filters  # pylint: disable=unsupported-membership-test
-                    # For the pylint disable, see: https://github.com/pylint-dev/pylint/issues/3045
-                )
-                # or the update_label does not match a filter-out label
-                or (
-                    not self.filter_in
-                    and (
-                        update_label is None
-                        or update_label
-                        not in self.label_filters  # pylint: disable=unsupported-membership-test
-                        # For the pylint disable, see: https://github.com/pylint-dev/pylint/issues/3045
-                    )
-                )
+            if update_fld is not None and self.updater_list_passes_filtering(
+                [updater_dict], self.label_filters, self.filter_in
             ):
                 update_fun = getattr(self, updater_dict["update_function"])
                 try:
@@ -1878,11 +1855,8 @@ class MaintainedModel(Model):
         parent_inst: MaintainedModel
         for parent_inst in parents:
             # Only follow propagation paths that have update_labels that match the active label_filters
-            if (
-                label_filters is not None
-                and not parent_inst.updater_list_has_matching_labels(
-                    parent_inst.get_my_updaters(), label_filters, filter_in
-                )
+            if not parent_inst.updater_list_passes_filtering(
+                parent_inst.get_my_updaters(), label_filters, filter_in
             ):
                 continue
             # If the current instance's update was triggered - and was triggered by the same parent instance whose
@@ -1941,14 +1915,11 @@ class MaintainedModel(Model):
         """
         parents = []
         for updater_dict in self.get_my_updaters():
-            # If label_filters were supplied, only obtain the parent instances that meet the filtering criteria
-            if label_filters is not None:
-                match = (
-                    updater_dict["update_label"] is not None
-                    and updater_dict["update_label"] in label_filters
-                )
-                if filter_in is not match:
-                    continue
+            # Only obtain the parent instances that meet the filtering criteria
+            if not self.updater_list_passes_filtering(
+                [updater_dict], label_filters, filter_in
+            ):
+                continue
 
             parent_fld = updater_dict["parent_field"]
 
@@ -2037,11 +2008,8 @@ class MaintainedModel(Model):
         child_inst: MaintainedModel
         for child_inst in children:
             # Only follow propagation paths that have update_labels that match the active label_filters
-            if (
-                label_filters is not None
-                and not child_inst.updater_list_has_matching_labels(
-                    child_inst.get_my_updaters(), label_filters, filter_in
-                )
+            if not child_inst.updater_list_passes_filtering(
+                child_inst.get_my_updaters(), label_filters, filter_in
             ):
                 continue
             # If the current instance's update was triggered - and was triggered by the same child instance whose
@@ -2098,14 +2066,11 @@ class MaintainedModel(Model):
         children = []
         updaters = self.get_my_updaters()
         for updater_dict in updaters:
-            # If label_filters were supplied, only obtain the child instances that meet the filtering criteria
-            if label_filters is not None:
-                match = (
-                    updater_dict["update_label"] is not None
-                    and updater_dict["update_label"] in label_filters
-                )
-                if filter_in is not match:
-                    continue
+            # Only obtain the child instances that meet the filtering criteria
+            if not self.updater_list_passes_filtering(
+                [updater_dict], label_filters, filter_in
+            ):
+                continue
 
             child_flds = updater_dict["child_fields"]
 
@@ -2183,15 +2148,10 @@ class MaintainedModel(Model):
             updater_dict["update_field"]
             for updater_dict in cls.get_my_updaters()
             if (
-                "update_field" in updater_dict.keys()
+                "update_field" in updater_dict
                 and updater_dict["update_field"]
-                and (
-                    label_filters is None
-                    or (filter_in and updater_dict["update_label"] in label_filters)
-                    or (
-                        not filter_in
-                        and updater_dict["update_label"] not in label_filters
-                    )
+                and cls.updater_list_passes_filtering(
+                    [updater_dict], label_filters, filter_in
                 )
             )
         ]
@@ -2222,7 +2182,7 @@ class MaintainedModel(Model):
             update_labels (List[str])
         """
         update_labels: List[str] = []
-        if cls.__name__ in cls.updater_list.keys():
+        if cls.__name__ in cls.updater_list:
             update_labels = [
                 updater_dict["update_label"]
                 for updater_dict in cls.updater_list[cls.__name__]

--- a/DataRepo/models/maintained_model.py
+++ b/DataRepo/models/maintained_model.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import importlib
 import warnings
 from collections import defaultdict
@@ -68,14 +70,14 @@ class MaintainedModelCoordinator:
         self.overridden = False
 
         # These allow the user to turn on or off specific groups of auto-updates.
-        label_filters = kwargs.pop("label_filters", [])
+        label_filters = kwargs.pop("label_filters", []) or []
         self.default_label_filters = sorted(label_filters)
 
         filter_in = kwargs.pop("filter_in", True)
         self.default_filter_in = filter_in
 
         self.nondefault_filtering_exists = not (
-            (label_filters is None or len(label_filters) == 0) and filter_in is True
+            len(label_filters) == 0 and filter_in is True
         )
 
         # This is for buffering a large quantity of auto-updates in order to get speed improvements during loading
@@ -160,16 +162,16 @@ class MaintainedModelCoordinator:
         if filter_in is None:
             filter_in = True
         if label_filters is None:
-            label_filters = (
-                []
-            )  # Clear everything by default, regardless of default filters
+            # Clear everything by default, regardless of default filters
+            label_filters = []
             filter_in = True
-        if generation is None and (label_filters is None or len(label_filters) == 0):
+        if generation is None and len(label_filters) == 0:
             self.update_buffer = []
             return
 
         new_buffer = []
         gen_warns = 0
+        buffered_item: MaintainedModel
         for buffered_item in self.update_buffer:
             # Buffered items are entire model objects.  We are going to filter model objects when they DO match the
             # filtering criteria.  A model object matches the filtering criteria based on whether ANY of its updaters
@@ -207,7 +209,7 @@ class MaintainedModelCoordinator:
 
         if gen_warns > 0:
             label_str = ""
-            if label_filters is not None and len(label_filters) > 0:
+            if len(label_filters) > 0:
                 label_str = f"with labels: [{', '.join(label_filters)}] "
             print(
                 f"WARNING: {gen_warns} records {label_str}in the buffer are younger than the generation supplied: "
@@ -221,7 +223,7 @@ class MaintainedModelCoordinator:
     def _peek_update_buffer(self, index=0):
         return self.update_buffer[index]
 
-    def buffer_update(self, mdl_obj):
+    def buffer_update(self, mdl_obj: MaintainedModel):
         """
         This is called when MaintainedModel.save (or delete) is called (if immediate_updates is False), so that
         maintained fields can be updated after loading code finishes (by calling the global method:
@@ -259,10 +261,11 @@ class MaintainedModelCoordinator:
                 # NOTE: Django model object equivalence (obj1 == obj2) compares primary key values, so even though the
                 # object attributes "filter_in" and "label_filters" may differ in the object, we still have to
                 # explicitly check them.
+                same_obj: MaintainedModel
                 for same_obj in [bo for bo in self.update_buffer if bo == mdl_obj]:
                     if (
                         same_obj.filter_in != mdl_obj.filter_in
-                        or same_obj.label_filters != same_obj.label_filters
+                        or same_obj.label_filters != mdl_obj.label_filters
                     ):
                         self.update_buffer.append(mdl_obj)
                         break
@@ -299,7 +302,7 @@ class MaintainedModelCoordinator:
         # If filters were explicitly supplied
         if label_filters is not None:
             use_object_label_filters = False
-            if self.filter_in is None:
+            if filter_in is None:
                 filter_in = self.default_filter_in
         # Else - the filters will be set at each iteration of the buffered item loop below
 
@@ -320,8 +323,8 @@ class MaintainedModelCoordinator:
             updater_dicts = buffer_item.get_my_updaters()
 
             if use_object_label_filters:
-                label_filters = self.label_filters
-                filter_in = self.filter_in
+                label_filters = buffer_item.label_filters
+                filter_in = buffer_item.filter_in
                 if label_filters is None:
                     label_filters = self.default_label_filters
                     filter_in = self.default_filter_in
@@ -528,14 +531,6 @@ class MaintainedModel(Model):
         # fields_to_autoupdate: List of fields to auto-update. - default None = update all maintained fields
         fields_to_autoupdate = kwargs.pop("fields_to_autoupdate", None)
 
-        # If the object is None, then what has happened is, there was a call to create an object off of the class.  That
-        # means that __init__ was not called, so we are going to handle the initialization of MaintainedModel (including
-        # the setting of the coordinator and the disallowing of setting values for maintained fields with a call to
-        # _maintained_model_setup).
-        if self is None:
-            # The coordinator keeps track of the running mode, buffer and filters in use
-            self._maintained_model_setup(**kwargs)
-
         # Retrieve the current coordinator
         coordinator = self.get_coordinator()
 
@@ -684,25 +679,27 @@ class MaintainedModel(Model):
             coordinator.are_immediate_updates_enabled() is False
             and mass_updates is False
         ):
-            # If autoupdates are happening (and it's not a mass-autoupdate), set the label filters based on the
-            # currently set global conditions so that only fields matching the filters will be updated.  An explicit
-            # setting of the label_filters in the coordinator overrides the update_label of the decorators applied in
-            # the model.  This is so a specific mass update can be manually achieved via a targeted script.  If there is
-            # not label_filters set in the coordinator, it falls back to the update_labels belonging to the model
-            # class's decorators, and propagation will only follow those paths.
-            if (
-                coordinator.default_label_filters is None
-                or len(coordinator.default_label_filters) == 0
-            ):
-                self.label_filters = self.get_my_update_labels()
-                self.filter_in = True
-            else:
-                self.label_filters = coordinator.default_label_filters
-                self.filter_in = coordinator.default_filter_in
-
             if coordinator.buffering:
                 parents = self.get_parent_instances()
+                parent_inst: MaintainedModel
                 for parent_inst in parents:
+                    # If autoupdates are happening (and it's not a mass-autoupdate), set the label filters based on the
+                    # currently set global conditions so that only fields matching the filters will be updated.  An
+                    # explicit setting of the label_filters in the coordinator overrides the update_label of the
+                    # decorators applied in the model.  This is so a specific mass update can be manually achieved via a
+                    # targeted script.  If there is not label_filters set in the coordinator, it falls back to the
+                    # update_labels belonging to the model class's decorators, and propagation will only follow those
+                    # paths.
+                    if (
+                        coordinator.default_label_filters is None
+                        or len(coordinator.default_label_filters) == 0
+                    ):
+                        parent_inst.label_filters = parent_inst.get_my_update_labels()
+                        parent_inst.filter_in = True
+                    else:
+                        parent_inst.label_filters = coordinator.default_label_filters
+                        parent_inst.filter_in = coordinator.default_filter_in
+
                     coordinator.buffer_update(parent_inst)
 
             # Delete the record triggering this update after having buffered the parents (because the parent could be a
@@ -710,23 +707,6 @@ class MaintainedModel(Model):
             retval = super().delete(*args, **kwargs)  # Call the "real" delete() method.
 
             return retval
-        elif coordinator.are_immediate_updates_enabled():
-            # If autoupdates are happening (and it's not a mass-autoupdate (assumed because mass_updates can only be
-            # true if immediate_updates is False)), set the label filters based on the currently set global conditions
-            # so that only fields matching the filters will be updated.  An explicit setting of the label_filters in the
-            # coordinator overrides the update_label of the decorators applied in the model.  This is so a specific mass
-            # update can be manually achieved via a targeted script.  If there is not label_filters set in the
-            # coordinator, it falls back to the update_labels belonging to the model class's decorators, and propagation
-            # will only follow those paths.
-            if (
-                coordinator.default_label_filters is None
-                or len(coordinator.default_label_filters) == 0
-            ):
-                self.label_filters = self.get_my_update_labels()
-                self.filter_in = True
-            else:
-                self.label_filters = coordinator.default_label_filters
-                self.filter_in = coordinator.default_filter_in
         # Otherwise, we are performing a mass auto-update and want to update the previously set filter conditions
 
         # Delete the record triggering this update.  In the event we were buffering, we had to do that above and return.
@@ -1044,6 +1024,7 @@ class MaintainedModel(Model):
         MaintainedModel has an M:M field that has been added to.  That causes this method to be called, and from here
         we can propagate the changes.
         """
+        # TODO: Make this able to buffer in deferred mode
         obj: MaintainedModel = kwargs.pop("instance", None)
         act: str = kwargs.pop("action", "")
 
@@ -1080,12 +1061,12 @@ class MaintainedModel(Model):
             return cls._get_default_coordinator()
 
     @classmethod
-    def _get_default_coordinator(cls):
+    def _get_default_coordinator(cls) -> MaintainedModelCoordinator:
         cls._check_set_coordinator_thread_data()
         return cls.data.default_coordinator
 
     @classmethod
-    def _get_coordinator_stack(cls):
+    def _get_coordinator_stack(cls) -> List[MaintainedModelCoordinator]:
         """
         Checks that the coodrinator thread data is initialized and returns the coordinator_stack list
         """
@@ -1177,7 +1158,7 @@ class MaintainedModel(Model):
     @contextmanager
     def custom_coordinator(
         cls,
-        coordinator,
+        coordinator: MaintainedModelCoordinator,
         pre_mass_update_func=None,  # Only used for deferred coordinators
         post_mass_update_func=None,  # Only used for deferred coordinators
     ):
@@ -1626,6 +1607,7 @@ class MaintainedModel(Model):
             # For every generation from the youngest leaves/children to root/parent
             for gen in sorted(range(youngest_generation + 1), reverse=True):
                 # For every MaintainedModel derived class with decorated functions
+                mdl_cls: Type[MaintainedModel]
                 for mdl_cls in cls._get_classes(
                     gen,
                     label_filters,
@@ -1927,6 +1909,7 @@ class MaintainedModel(Model):
                             if tmp_parent_inst.count() > 0 and isinstance(
                                 tmp_parent_inst.first(), MaintainedModel
                             ):
+                                mm_parent_inst: MaintainedModel
                                 for mm_parent_inst in tmp_parent_inst.all():
                                     # We check "exists_in_db" in case these updates are propagated due to a delete, and
                                     # any relation we are traversing, could have been deleted via a cascade
@@ -2056,6 +2039,7 @@ class MaintainedModel(Model):
                         if tmp_child_inst.count() > 0 and isinstance(
                             tmp_child_inst.first(), MaintainedModel
                         ):
+                            mm_child_inst: MaintainedModel
                             for mm_child_inst in tmp_child_inst.all():
                                 # We check "exists_in_db" in case these updates are propagated due to a delete, and any
                                 # relation we are traversing, could have been deleted via a cascade
@@ -2099,7 +2083,7 @@ class MaintainedModel(Model):
         ]
 
     @classmethod
-    def get_my_updaters(cls):
+    def get_my_updaters(cls) -> List[dict]:
         """
         Retrieves all the updater information of each decorated function of the calling model from the global
         updater_list variable.

--- a/DataRepo/models/maintained_model.py
+++ b/DataRepo/models/maintained_model.py
@@ -3,7 +3,7 @@ import warnings
 from collections import defaultdict
 from contextlib import contextmanager
 from threading import local
-from typing import Dict, List, Type
+from typing import Dict, List, Optional, Type
 
 from django.conf import settings
 from django.core.exceptions import ObjectDoesNotExist
@@ -313,12 +313,13 @@ class MaintainedModelCoordinator:
         no_filters = label_filters is None or len(label_filters) == 0
 
         # For each record in the buffer
+        buffer_item: MaintainedModel
         for buffer_item in self.update_buffer:
             updater_dicts = buffer_item.get_my_updaters()
 
             if use_object_label_filters:
-                label_filters = buffer_item.label_filters
-                filter_in = buffer_item.filter_in
+                label_filters = buffer_item.get_my_update_labels()
+                filter_in = True
                 if label_filters is None:
                     label_filters = self.default_label_filters
                     filter_in = self.default_filter_in
@@ -342,11 +343,15 @@ class MaintainedModelCoordinator:
                     # repeated updates of the same record.
                     buffer_item.save(mass_updates=True)
 
+                    print(f"PROPAGATING BECAUSE LABELS: use_object_label_filters: {use_object_label_filters} no_filters: {no_filters} label_filters: {label_filters} filter_in: {filter_in}")
                     # Propagate the changes (if necessary), keeping track of what is updated and what's not.
                     # Note: all the manual changes are assumed to have been made already, so auto-updates only need to
                     # be issued once per record
                     updated = buffer_item.call_dfs_related_updaters(
-                        updated=updated, mass_updates=True
+                        updated=updated,
+                        mass_updates=True,
+                        label_filters=label_filters,
+                        filter_in=filter_in,
                     )
 
                 elif key not in updated and buffer_item not in new_buffer:
@@ -638,7 +643,7 @@ class MaintainedModel(Model):
         if coordinator.are_immediate_updates_enabled() and propagate:
             # Percolate (non-maintained field) record changes up to the related models so they can change their
             # maintained fields whose values are dependent on this record's non-maintained fields
-            self.call_dfs_related_updaters()
+            self.call_dfs_related_updaters(label_filters=self.get_my_update_labels(), filter_in=True)
 
     def delete(self, *args, **kwargs):
         """
@@ -665,6 +670,10 @@ class MaintainedModel(Model):
             coordinator.are_immediate_updates_enabled() is False
             and mass_updates is False
         ):
+            if hasattr(self, "label_filters"):
+                print(f"OBJECT self.label_filters: {self.label_filters}")
+            else:
+                print(f"GLOBAL self.label_filters: {coordinator.default_label_filters}")
             # When buffering only, apply the global label filters, to be remembered during mass autoupdate
             self.label_filters = coordinator.default_label_filters
             self.filter_in = coordinator.default_filter_in
@@ -693,7 +702,11 @@ class MaintainedModel(Model):
 
         if coordinator.are_immediate_updates_enabled() and propagate:
             # Percolate changes up to the parents (if any) and mark the deleted record as updated
-            self.call_dfs_related_updaters(updated=[self_sig])
+            self.call_dfs_related_updaters(
+                updated=[self_sig],
+                label_filters=self.get_my_update_labels(),
+                filter_in=True,
+            )
 
         return retval
 
@@ -995,7 +1008,7 @@ class MaintainedModel(Model):
         MaintainedModel has an M:M field that has been added to.  That causes this method to be called, and from here
         we can propagate the changes.
         """
-        obj = kwargs.pop("instance", None)
+        obj: MaintainedModel = kwargs.pop("instance", None)
         act = kwargs.pop("action", None)
 
         # Retrieve the current coordinator
@@ -1006,7 +1019,7 @@ class MaintainedModel(Model):
             and isinstance(obj, MaintainedModel)
             and coordinator.are_immediate_updates_enabled()
         ):
-            obj.call_dfs_related_updaters()
+            obj.call_dfs_related_updaters(label_filters=obj.get_my_update_labels(), filter_in=True)
 
     @classmethod
     def get_coordinator(cls):
@@ -1728,25 +1741,79 @@ class MaintainedModel(Model):
             return None
         return f"{self.__class__.__name__}.{self.pk}"
 
-    def call_dfs_related_updaters(self, updated=None, mass_updates=False):
+    def call_dfs_related_updaters(
+        self,
+        updated=None,
+        mass_updates=False,
+        label_filters: Optional[List[str]] = None,
+        filter_in=True,
+    ):
+        """This is a recursive method that propagates triggered updates both up and down the propagation path defined by
+        each setter and relation decorator's child and parent fields.
+
+        Args:
+            updated (Optional[List[str]]): A list of model object signatures used to prevent repeated updates.
+            mass_updates (bool) [False]: Whether we're in mass auto-update mode.
+            label_filters (Optional[List[str]]): A list of update_labels that define the propagation path(s) that should
+                be followed.
+            filter_in (bool) [True]: When True, label_filters contains the labels where propagation should proceed.
+                When False, label_filters are the paths that should be avoided.
+        Exceptions:
+            None
+        Returns:
+            updated (List[str]): A list of model object signatures that were updated.
+        """
         # Assume I've been called after I've been updated, so add myself to the updated list
         if updated is None:
             updated = []
         self_sig = self.get_record_signature()
         if self_sig is not None and self_sig not in updated:
             updated.append(self_sig)
-        updated = self.call_child_updaters(updated=updated, mass_updates=mass_updates)
-        updated = self.call_parent_updaters(updated=updated, mass_updates=mass_updates)
+        updated = self.call_child_updaters(
+            updated=updated,
+            mass_updates=mass_updates,
+            label_filters=label_filters,
+            filter_in=filter_in,
+        )
+        updated = self.call_parent_updaters(
+            updated=updated,
+            mass_updates=mass_updates,
+            label_filters=label_filters,
+            filter_in=filter_in,
+        )
         return updated
 
-    def call_parent_updaters(self, updated, mass_updates=False):
-        """
-        This calls parent record's `save` method to trigger updates to their maintained fields (if any) and further
+    def call_parent_updaters(
+        self,
+        updated,
+        mass_updates=False,
+        label_filters: Optional[List[str]] = None,
+        filter_in=True,
+    ):
+        """This calls parent record's `save` method to trigger updates to their maintained fields (if any) and further
         propagate those changes up the hierarchy (if those records have parents). It skips triggering a parent's update
         if that child was the object that triggered its update, to avoid looped repeated updates.
+
+        Args:
+            updated (List[str]): A list of model object signatures used to prevent repeated updates.
+            mass_updates (bool) [False]: Whether we're in mass auto-update mode.
+            label_filters (Optional[List[str]]): A list of update_labels that define the propagation path(s) that should
+                be followed.
+            filter_in (bool) [True]: When True, label_filters contains the labels where propagation should proceed.
+                When False, label_filters are the paths that should be avoided.
+        Exceptions:
+            None
+        Returns:
+            updated (List[str]): A list of model object signatures that were updated.
         """
         parents = self.get_parent_instances()
+        parent_inst: MaintainedModel
         for parent_inst in parents:
+            if label_filters is not None and not parent_inst.updater_list_has_matching_labels(
+                parent_inst.get_my_updaters(), label_filters, filter_in
+            ):
+                print(f"SKIPPING PARENT {parent_inst.__class__.__name__} PROPAGATION BECAUSE NOT A LABEL FILTER {label_filters} MATCH")
+                continue
             # If the current instance's update was triggered - and was triggered by the same parent instance whose
             # update we're about to trigger
             parent_sig = parent_inst.get_record_signature()
@@ -1766,7 +1833,10 @@ class MaintainedModel(Model):
 
                 # Propagate manually
                 updated = parent_inst.call_dfs_related_updaters(
-                    updated=updated, mass_updates=mass_updates
+                    updated=updated,
+                    mass_updates=mass_updates,
+                    label_filters=label_filters,
+                    filter_in=filter_in,
                 )
 
         return updated
@@ -1841,14 +1911,38 @@ class MaintainedModel(Model):
 
         return parents
 
-    def call_child_updaters(self, updated, mass_updates=False):
+    def call_child_updaters(
+        self,
+        updated,
+        mass_updates=False,
+        label_filters: Optional[List[str]] = None,
+        filter_in=True,
+    ):
         """
         This calls child record's `save` method to trigger updates to their maintained fields (if any) and further
         propagate those changes up the hierarchy (if those records have parents). It skips triggering a child's update
         if that child was the object that triggered its update, to avoid looped repeated updates.
+
+        Args:
+            updated (List[str]): A list of model object signatures used to prevent repeated updates.
+            mass_updates (bool) [False]: Whether we're in mass auto-update mode.
+            label_filters (Optional[List[str]]): A list of update_labels that define the propagation path(s) that should
+                be followed.
+            filter_in (bool) [True]: When True, label_filters contains the labels where propagation should proceed.
+                When False, label_filters are the paths that should be avoided.
+        Exceptions:
+            None
+        Returns:
+            updated (List[str]): A list of model object signatures that were updated.
         """
         children = self.get_child_instances()
+        child_inst: MaintainedModel
         for child_inst in children:
+            if label_filters is not None and not child_inst.updater_list_has_matching_labels(
+                child_inst.get_my_updaters(), label_filters, filter_in
+            ):
+                print(f"SKIPPING CHILD {child_inst.__class__.__name__} PROPAGATION BECAUSE NOT A LABEL FILTER {label_filters} MATCH")
+                continue
             # If the current instance's update was triggered - and was triggered by the same child instance whose
             # update we're about to trigger
             child_sig = child_inst.get_record_signature()
@@ -1868,6 +1962,8 @@ class MaintainedModel(Model):
                 updated = child_inst.call_dfs_related_updaters(
                     updated=updated,
                     mass_updates=mass_updates,
+                    label_filters=label_filters,
+                    filter_in=filter_in
                 )
 
         return updated
@@ -1966,6 +2062,25 @@ class MaintainedModel(Model):
             raise NoDecorators(cls.__name__)
 
         return updaters
+
+    @classmethod
+    def get_my_update_labels(cls):
+        """Returns a list of 'update_label's from each decorated function of the calling model.
+
+        Args:
+            None
+        Exceptions:
+            NoDecorators
+        Returns:
+            update_labels (List[str])
+        """
+        update_labels: List[str] = []
+        if cls.__name__ in cls.updater_list.keys():
+            update_labels = [updater_dict["update_label"] for updater_dict in cls.updater_list[cls.__name__]]
+        else:
+            raise NoDecorators(cls.__name__)
+
+        return update_labels
 
     class Meta:
         abstract = True

--- a/DataRepo/models/maintained_model.py
+++ b/DataRepo/models/maintained_model.py
@@ -893,12 +893,13 @@ class MaintainedModel(Model):
         the same, only 1 of those decorators needs to set a parent field.
         """
 
-        if update_field_name is None and (
-            parent_field_name is None and generation != 0
-        ):
+        if not update_field_name and not parent_field_name:
             raise ConditionallyRequiredArgumentError(
                 "Either an update_field_name or parent_field_name argument is required."
             )
+
+        if update_field_name is not None and update_field_name == "":
+            update_field_name = None
 
         # The actual decorator (because a decorator can only take 1 argument (the decorated function).  The "decorator"
         # above is more akin to a global function call that returns this decorator that is immediately applied to the
@@ -930,6 +931,23 @@ class MaintainedModel(Model):
 
             # No way to ensure supplied fields exist because the models aren't actually loaded yet, so while that would
             # be nice to handle here, it will have to be handled in MaintanedModel when objects are created
+
+            # We *can* check that there is only 1 setter per field however...
+            if class_name in MaintainedModel.updater_list and any(
+                update_field_name == fd["update_field"]
+                for fd in MaintainedModel.updater_list[class_name]
+                if fn.__name__ != fd["update_function"]
+                and fd["update_field"] is not None
+            ):
+                setters = [fn.__name__]
+                setters.extend(
+                    [
+                        fd["update_function"]
+                        for fd in MaintainedModel.updater_list[class_name]
+                        if fd["update_field"] == update_field_name
+                    ]
+                )
+                raise MultipleModelFieldSetters(class_name, update_field_name, setters)
 
             # Add this info to our global updater_list
             MaintainedModel.updater_list[class_name].append(func_dict)
@@ -2235,6 +2253,18 @@ class BadModelFields(Exception):
         self.cls = cls
         self.flds = flds
         self.fcn = fcn
+
+
+class MultipleModelFieldSetters(Exception):
+    def __init__(self, model_name: str, field_name: dict, setters: List[str]):
+        message = (
+            f"Model {model_name} has multiple setters for field {field_name}: {setters}.  "
+            "Only 1 setter is allowed per field."
+        )
+        super().__init__(message)
+        self.model_name = model_name
+        self.field_name = field_name
+        self.setters = setters
 
 
 class MaintainedFieldNotSettable(Exception):

--- a/DataRepo/models/msrun_sample.py
+++ b/DataRepo/models/msrun_sample.py
@@ -22,7 +22,6 @@ from DataRepo.models import HierCachedModel, MaintainedModel
 @MaintainedModel.relation(
     generation=2,
     parent_field_name="sample",
-    # child_field_names=["peak_groups"],  # Only propagate up
     update_label="fcirc_calcs",
 )
 class MSRunSample(HierCachedModel, MaintainedModel):

--- a/DataRepo/tests/loaders/test_study_loader.py
+++ b/DataRepo/tests/loaders/test_study_loader.py
@@ -93,6 +93,21 @@ class StudyLoaderTests(TracebaseTestCase):
         self.assertEqual(2, PeakGroupCompound.objects.count())
         self.assertEqual(0, len(sl.aggregated_errors_object.exceptions))
 
+        # Check all the maintained fields
+        expected = {}
+        cls: Type[MaintainedModel]
+        for cls in MaintainedModel._get_classes(None, None, True):
+            for fld in cls.get_my_update_fields():
+                if cls.__name__ not in expected.keys():
+                    expected[cls.__name__] = {fld: cls.objects.none()}
+                else:
+                    expected[cls.__name__][fld] = cls.objects.none()
+
+        null_querysets = dict(
+            (key, dict(val)) for key, val in MaintainedModel._get_nulls().items()
+        )
+        self.assertEquivalent(expected, null_querysets)
+
     def test_study_loader_get_class_dtypes(self):
         sl = StudyV3Loader()
         dt = sl.get_loader_class_dtypes(AnimalsLoader)

--- a/DataRepo/tests/loaders/test_study_loader.py
+++ b/DataRepo/tests/loaders/test_study_loader.py
@@ -95,13 +95,13 @@ class StudyLoaderTests(TracebaseTestCase):
 
         # Check all the maintained fields
         expected = {}
-        cls: Type[MaintainedModel]
-        for cls in MaintainedModel._get_classes(None, None, True):
-            for fld in cls.get_my_update_fields():
-                if cls.__name__ not in expected.keys():
-                    expected[cls.__name__] = {fld: cls.objects.none()}
+        kls: Type[MaintainedModel]
+        for kls in MaintainedModel._get_classes(None, None, True):
+            for fld in kls.get_my_update_fields():
+                if kls.__name__ not in expected.keys():
+                    expected[kls.__name__] = {fld: kls.objects.none()}
                 else:
-                    expected[cls.__name__][fld] = cls.objects.none()
+                    expected[kls.__name__][fld] = kls.objects.none()
 
         null_querysets = dict(
             (key, dict(val)) for key, val in MaintainedModel._get_nulls().items()

--- a/DataRepo/tests/models/test_maintained_model.py
+++ b/DataRepo/tests/models/test_maintained_model.py
@@ -192,13 +192,13 @@ class MaintainedModelTests(MaintainedModelTestBase):
 
         # Check all the maintained fields
         expected = {}
-        cls: Type[MaintainedModel]
-        for cls in MaintainedModel._get_classes(None, None, True):
-            for fld in cls.get_my_update_fields():
-                if cls.__name__ not in expected.keys():
-                    expected[cls.__name__] = {fld: cls.objects.none()}
+        kls: Type[MaintainedModel]
+        for kls in MaintainedModel._get_classes(None, None, True):
+            for fld in kls.get_my_update_fields():
+                if kls.__name__ not in expected.keys():
+                    expected[kls.__name__] = {fld: kls.objects.none()}
                 else:
-                    expected[cls.__name__][fld] = cls.objects.none()
+                    expected[kls.__name__][fld] = kls.objects.none()
 
         # This casts the defaultdicts to dicts for easy comparison if the assertion fails
         null_maintained_field__querysets = dict(

--- a/DataRepo/tests/tracebase_test_case.py
+++ b/DataRepo/tests/tracebase_test_case.py
@@ -138,11 +138,17 @@ def test_case_class_factory(base_class: Type[T]) -> Type[T]:
                 "identity",
                 "_django_version",
                 "fields_cache",
+                "_lookup_joins",
+                "used_aliases",
             ]
             self.assertEqual(
                 set([k for k in d1.keys() if k not in ignores]),
                 set([k for k in d2.keys() if k not in ignores]),
-                msg=f"Object path: {_path} difference: keys differ",
+                msg=(
+                    f"Object path: {_path} difference: keys differ\n"
+                    f"In dict1 only: {list(set(d1.keys()) - set(d2.keys()))}\n"
+                    f"In dict2 only: {list(set(d2.keys()) - set(d1.keys()))}"
+                ),
             )
             for key, v1 in d1.items():
                 if key in ignores:


### PR DESCRIPTION
## What

This work is related to [GREATS-220](https://princeton-university.atlassian.net/browse/GREATS-220), which was initially handled in #1719.  The work in this PR very dramatically increased efficiency such that my test code saved in issue [GREATS-220](https://princeton-university.atlassian.net/browse/GREATS-220) (and then modified [see the **Others** section]) executed in under a second (and in my test, reduced 217 autoupdates to 17).

## Why

The changes in the previous PR (#1719) did not involve any refinement of the underlying autoupdate strategy.  While doing that work, I had initially dramatically increased efficiency, but I'd had to revert 1 change I'd made due to a secondary autoupdate that had to be triggered.  For example, in the scenario where a new "last serum tracer `PeakGroup`" is added, not only does the directly related `FCirc` record have to be updated, but the formerly "last serum sample tracer `PeakGroup`" had to be updated as well.  Reintroducing that path of autoupdate propagation somewhat significantly reduced the previously achieved efficiency, and it occurred to me that my long planned refinement of autoupdate propagation (to make auto-update propagation only follow 1 relevant path triggered by an actual user-directed change) would be fairly easy to implement (which is what this PR represents), by making autoupdate propagation follow specific labeled paths without triggering intersecting paths.

## How

From the git log:

> Updated autoupdate propagation in `MaintainedModel` to limit it to only follow the path(s) defined by the `update_label`s present in the record that changed prior to the autoupdates.
> 
> In other words, auto-updates themselves can no longer trigger other autoupdates.  For example, if a change to `PeakGroup` (record added or deleted) triggers the `fcirc_calcs` autoupdates and travel up to `Animal` and back down to `FCirc`, any auto-update to an `Animal` record should not also trigger autoupdates along the `tracer_stats` or infusate `name` autoupdate paths.  This is because maintained fields' setter methods should not use other maintained fields in their calculations.  The only fields whose changes should necessitate autoupdates are those that are not maintained, and since an autoupdate of an Animal record doesn't change any values that `tracer_stat`s are based on or infusate name is based on, those autoupdate paths should not get triggered.
> 
> Details:
> 
> - Added convenience method: `MaintainedModel.get_my_update_labels`
> - Added arguments for `label_filters` and `filter_in` to the following methods:
>   - `call_child_updaters`
>   - `call_parent_updaters`
>   - `call_dfs_related_updaters`
> - Updated `save` and `delete` methods to call `get_my_update_labels()` to set the `label_filters` argument to `call_dfs_related_updaters` so that autoupdate propagation would only travel the paths specified by the `label_filters` of the triggering record change.
> - Updated `call_parent_updaters` and `call_child_updaters` to skip propagating if `label_filters` was set and the `update_label` was not in the `label_filters` argument value.

> Refined the improvements to `MaitainedModel`'s propagation of autoupdates along selected `update_label` paths.
> 
> Details:
> 
> - When buffering model objects, I differentially apply the model's `update_label`s or the coordinator's default labels to the object's `update_label` instead of setting them in `perform_buffered_updates`.
> - In order to reliably compare `label_filters`, I applied sorting to them whenever they are set or supplied.
> - Added some type hints and comments.

> Added tests, fixed issues the tests revealed, and added more type hinting.
> 
> Details:
> 
> - Tests added:
>   - `test_delete_updates_label_filters`
>   - `test_buffer_update_buffers_when_label_filters_differ`
>   - `test_deferred_only_buffers_matches`
>   - `test_deferred_sets_default_label_filters_in_buffered_objects`
>   - `test_deferred_sets_label_filters_in_buffered_objects_when_no_default`
>   - `test_get_my_update_labels`
> - `MaintainedModel`:
>   - Added a TODO comment to `m2m_propagation_handler` to add support for buffering in deferred mode
>   - `delete`
>     - Fixed the setting of label_filters in the buffered object (it had been setting self instead of the parent instance.
>     - Removed the unnecessary setting of `label_filters` when `coordinator.are_immediate_updates_enabled` is `True`.
>   - `__init__`
>     - Removed the call to `self._maintained_model_setup(**kwargs)` when `self` is `None`.  It made no sense and clearly was added when I didn't understand Django very well yet.
> - `MaintainedModelCoordinator`
>   - Fixed the setting of `label_filters` and `filter_in` to be on the buffered item instead of self.
>   - Streamlined the handling of the `label_filters` arguments so that there would be no need to check if it was `None`.

## Tests

- CI tests pass
- New tests added
- Tests were run in the console on dev as described here:

I compared the running time and number of autoupdates performed before and after the changes in this PR, when deleting a serum tracer peak group for a "last" serum tracer `PeakGroup`.  I arbitrarily selected a `PeakGroup` to try deleting in the following manner.  I started with an arbitrarily selected serum sample (`col005c_A1b`) and identified a tracer `PeakGroup` to delete that would trigger 2 changes (2 FCirc.is_last booleans would flip - The formerly last FCirc record would change to False and the formerly next to last would change to True).  This is how I identified the target `PeakGroup` record to try deleting:

```
In [0]: FCirc.objects.filter(is_last=True, serum_sample__name="col005c_A1b").first().id
Out[0]: 517

In [1]: FCirc.objects.get(id=517).is_last
Out[1]: True

In [2]: FCirc.objects.get(id=517)
Out[2]: <FCirc: FCirc calculations object for element 'C' from tracer 'C16:0-[13C16]' in sample 'col005c_A1b'>

In [3]: Sample.objects.get(name="col005c_A1b").last_tracer_peak_groups
Out[3]: <QuerySet [<PeakGroup: C16:0>]>

In [4]: Sample.objects.get(name="col005c_A1b").last_tracer_peak_groups.first().id
Out[4]: 6833
```

And this is the test code to try the deletion and observe the propagation of autoupdates:

```
In [0]: from django.db import transaction
    ...: 
    ...: from DataRepo.models import *
    ...: from DataRepo.models.maintained_model import MaintainedModelCoordinator
    ...: from DataRepo.models.hier_cached_model import disable_caching_updates
    ...: from DataRepo.utils.exceptions import DryRun
    ...: 
    ...: 
    ...: disable_caching_updates()
    ...: 
    ...: # PeakGroup 6833
    ...: # Sample: col005c_A1b
    ...: # Compound: C16:0
    ...: pg = PeakGroup.objects.get(id=6833)
    ...: 
    ...: 
    ...: def test_delete_autoupdate():
    ...:     with transaction.atomic():
    ...:         deferred_filtered = MaintainedModelCoordinator(auto_update_mode="deferred")
    ...:         with MaintainedModel.custom_coordinator(deferred_filtered):
    ...:             pg.delete()
    ...:         raise DryRun()
    ...: 
    ...: test_delete_autoupdate()
```

In this case, the number of auto-updates in main was 217 and the number of auto-updates in this branch totalled only 17.

See the **Others** section below for test output...

## Security Concerns

None.  These changes only affect server-side loading.  There is no possibility of injection.

## Others

The following is the test output before (in `main`) and after this code (this branch).  The number of auto-updates in `main` was 217 and the number of auto-updates in this branch totaled only 17.  Of all the autoupdates that actually changed any values, all were in both sets.  I.e. most of the unnecessary auto-updates were eliminated.

Main:

```
Propagating change from child MSRunSample.1268 to parent Sample.837
Auto-update of Sample.is_serum_sample in Sample.837 using Sample._is_serum_sample resulted in the same value: [True].
Propagating change from parent Sample.837 to child FCirc.517
Auto-update of FCirc.is_last in FCirc.517 using FCirc.is_last_serum_peak_group resulted in a change from [True] to [False].
Propagating change from child Sample.837 to parent Animal.124
Auto-update of Animal.last_serum_sample in Animal.124 using Animal._last_serum_sample resulted in the same value: [col005c_A1b].
Auto-update of Animal.label_combo in Animal.124 using Animal._label_combo resulted in the same value: [C].
Propagating change from parent Animal.124 to child Sample.849
Auto-update of Sample.is_serum_sample in Sample.849 using Sample._is_serum_sample resulted in the same value: [True].
Propagating change from parent Sample.849 to child FCirc.529
Auto-update of FCirc.is_last in FCirc.529 using FCirc.is_last_serum_peak_group resulted in the same value: [False].
Propagating change from parent Animal.124 to child Sample.850
Auto-update of Sample.is_serum_sample in Sample.850 using Sample._is_serum_sample resulted in the same value: [True].
Propagating change from parent Sample.850 to child FCirc.530
Auto-update of FCirc.is_last in FCirc.530 using FCirc.is_last_serum_peak_group resulted in the same value: [False].
Propagating change from parent Animal.124 to child Sample.851
Auto-update of Sample.is_serum_sample in Sample.851 using Sample._is_serum_sample resulted in the same value: [True].
Propagating change from parent Sample.851 to child FCirc.531
Auto-update of FCirc.is_last in FCirc.531 using FCirc.is_last_serum_peak_group resulted in a change from [False] to [True].
Propagating change from parent Animal.124 to child Sample.885
Auto-update of Sample.is_serum_sample in Sample.885 using Sample._is_serum_sample resulted in the same value: [False].
Propagating change from parent Animal.124 to child Sample.886
Auto-update of Sample.is_serum_sample in Sample.886 using Sample._is_serum_sample resulted in the same value: [False].
Propagating change from parent Animal.124 to child Sample.887
Auto-update of Sample.is_serum_sample in Sample.887 using Sample._is_serum_sample resulted in the same value: [False].
Propagating change from parent Animal.124 to child Sample.888
Auto-update of Sample.is_serum_sample in Sample.888 using Sample._is_serum_sample resulted in the same value: [False].
Propagating change from parent Animal.124 to child Sample.933
Auto-update of Sample.is_serum_sample in Sample.933 using Sample._is_serum_sample resulted in the same value: [False].
Propagating change from parent Animal.124 to child Sample.945
Auto-update of Sample.is_serum_sample in Sample.945 using Sample._is_serum_sample resulted in the same value: [False].
Propagating change from parent Animal.124 to child Sample.957
Auto-update of Sample.is_serum_sample in Sample.957 using Sample._is_serum_sample resulted in the same value: [False].
Propagating change from child Animal.124 to parent Infusate.35
Auto-update of Infusate.name in Infusate.35 using Infusate._name resulted in the same value: [C16:0-[13C16][4]].
Auto-update of Infusate.label_combo in Infusate.35 using Infusate._label_combo resulted in the same value: [C].
Propagating change from parent Infusate.35 to child Animal.125
Auto-update of Animal.last_serum_sample in Animal.125 using Animal._last_serum_sample resulted in the same value: [col005c_A2b].
Auto-update of Animal.label_combo in Animal.125 using Animal._label_combo resulted in the same value: [C].
Propagating change from parent Animal.125 to child Sample.852
Auto-update of Sample.is_serum_sample in Sample.852 using Sample._is_serum_sample resulted in the same value: [True].
Propagating change from parent Sample.852 to child FCirc.532
Auto-update of FCirc.is_last in FCirc.532 using FCirc.is_last_serum_peak_group resulted in the same value: [False].
Propagating change from parent Animal.125 to child Sample.853
Auto-update of Sample.is_serum_sample in Sample.853 using Sample._is_serum_sample resulted in the same value: [True].
Propagating change from parent Sample.853 to child FCirc.533
Auto-update of FCirc.is_last in FCirc.533 using FCirc.is_last_serum_peak_group resulted in the same value: [False].
Propagating change from parent Animal.125 to child Sample.854
Auto-update of Sample.is_serum_sample in Sample.854 using Sample._is_serum_sample resulted in the same value: [True].
Propagating change from parent Sample.854 to child FCirc.534
Auto-update of FCirc.is_last in FCirc.534 using FCirc.is_last_serum_peak_group resulted in the same value: [False].
Propagating change from parent Animal.125 to child Sample.838
Auto-update of Sample.is_serum_sample in Sample.838 using Sample._is_serum_sample resulted in the same value: [True].
Propagating change from parent Sample.838 to child FCirc.518
Auto-update of FCirc.is_last in FCirc.518 using FCirc.is_last_serum_peak_group resulted in the same value: [True].
Propagating change from parent Animal.125 to child Sample.889
Auto-update of Sample.is_serum_sample in Sample.889 using Sample._is_serum_sample resulted in the same value: [False].
Propagating change from parent Animal.125 to child Sample.890
Auto-update of Sample.is_serum_sample in Sample.890 using Sample._is_serum_sample resulted in the same value: [False].
Propagating change from parent Animal.125 to child Sample.891
Auto-update of Sample.is_serum_sample in Sample.891 using Sample._is_serum_sample resulted in the same value: [False].
Propagating change from parent Animal.125 to child Sample.892
Auto-update of Sample.is_serum_sample in Sample.892 using Sample._is_serum_sample resulted in the same value: [False].
Propagating change from parent Animal.125 to child Sample.934
Auto-update of Sample.is_serum_sample in Sample.934 using Sample._is_serum_sample resulted in the same value: [False].
Propagating change from parent Animal.125 to child Sample.946
Auto-update of Sample.is_serum_sample in Sample.946 using Sample._is_serum_sample resulted in the same value: [False].
Propagating change from parent Animal.125 to child Sample.958
Auto-update of Sample.is_serum_sample in Sample.958 using Sample._is_serum_sample resulted in the same value: [False].
Propagating change from parent Infusate.35 to child Animal.126
Auto-update of Animal.last_serum_sample in Animal.126 using Animal._last_serum_sample resulted in the same value: [col005c_A3b].
Auto-update of Animal.label_combo in Animal.126 using Animal._label_combo resulted in the same value: [C].
Propagating change from parent Animal.126 to child Sample.855
Auto-update of Sample.is_serum_sample in Sample.855 using Sample._is_serum_sample resulted in the same value: [True].
Propagating change from parent Sample.855 to child FCirc.535
Auto-update of FCirc.is_last in FCirc.535 using FCirc.is_last_serum_peak_group resulted in the same value: [False].
Propagating change from parent Animal.126 to child Sample.856
Auto-update of Sample.is_serum_sample in Sample.856 using Sample._is_serum_sample resulted in the same value: [True].
Propagating change from parent Sample.856 to child FCirc.536
Auto-update of FCirc.is_last in FCirc.536 using FCirc.is_last_serum_peak_group resulted in the same value: [False].
Propagating change from parent Animal.126 to child Sample.857
Auto-update of Sample.is_serum_sample in Sample.857 using Sample._is_serum_sample resulted in the same value: [True].
Propagating change from parent Sample.857 to child FCirc.537
Auto-update of FCirc.is_last in FCirc.537 using FCirc.is_last_serum_peak_group resulted in the same value: [False].
Propagating change from parent Animal.126 to child Sample.839
Auto-update of Sample.is_serum_sample in Sample.839 using Sample._is_serum_sample resulted in the same value: [True].
Propagating change from parent Sample.839 to child FCirc.519
Auto-update of FCirc.is_last in FCirc.519 using FCirc.is_last_serum_peak_group resulted in the same value: [True].
Propagating change from parent Animal.126 to child Sample.893
Auto-update of Sample.is_serum_sample in Sample.893 using Sample._is_serum_sample resulted in the same value: [False].
Propagating change from parent Animal.126 to child Sample.894
Auto-update of Sample.is_serum_sample in Sample.894 using Sample._is_serum_sample resulted in the same value: [False].
Propagating change from parent Animal.126 to child Sample.895
Auto-update of Sample.is_serum_sample in Sample.895 using Sample._is_serum_sample resulted in the same value: [False].
Propagating change from parent Animal.126 to child Sample.896
Auto-update of Sample.is_serum_sample in Sample.896 using Sample._is_serum_sample resulted in the same value: [False].
Propagating change from parent Animal.126 to child Sample.935
Auto-update of Sample.is_serum_sample in Sample.935 using Sample._is_serum_sample resulted in the same value: [False].
Propagating change from parent Animal.126 to child Sample.947
Auto-update of Sample.is_serum_sample in Sample.947 using Sample._is_serum_sample resulted in the same value: [False].
Propagating change from parent Animal.126 to child Sample.959
Auto-update of Sample.is_serum_sample in Sample.959 using Sample._is_serum_sample resulted in the same value: [False].
Propagating change from parent Infusate.35 to child Animal.127
Auto-update of Animal.last_serum_sample in Animal.127 using Animal._last_serum_sample resulted in the same value: [col005c_A4b].
Auto-update of Animal.label_combo in Animal.127 using Animal._label_combo resulted in the same value: [C].
Propagating change from parent Animal.127 to child Sample.858
Auto-update of Sample.is_serum_sample in Sample.858 using Sample._is_serum_sample resulted in the same value: [True].
Propagating change from parent Sample.858 to child FCirc.538
Auto-update of FCirc.is_last in FCirc.538 using FCirc.is_last_serum_peak_group resulted in the same value: [False].
Propagating change from parent Animal.127 to child Sample.859
Auto-update of Sample.is_serum_sample in Sample.859 using Sample._is_serum_sample resulted in the same value: [True].
Propagating change from parent Sample.859 to child FCirc.539
Auto-update of FCirc.is_last in FCirc.539 using FCirc.is_last_serum_peak_group resulted in the same value: [False].
Propagating change from parent Animal.127 to child Sample.860
Auto-update of Sample.is_serum_sample in Sample.860 using Sample._is_serum_sample resulted in the same value: [True].
Propagating change from parent Sample.860 to child FCirc.540
Auto-update of FCirc.is_last in FCirc.540 using FCirc.is_last_serum_peak_group resulted in the same value: [False].
Propagating change from parent Animal.127 to child Sample.840
Auto-update of Sample.is_serum_sample in Sample.840 using Sample._is_serum_sample resulted in the same value: [True].
Propagating change from parent Sample.840 to child FCirc.520
Auto-update of FCirc.is_last in FCirc.520 using FCirc.is_last_serum_peak_group resulted in the same value: [True].
Propagating change from parent Animal.127 to child Sample.897
Auto-update of Sample.is_serum_sample in Sample.897 using Sample._is_serum_sample resulted in the same value: [False].
Propagating change from parent Animal.127 to child Sample.898
Auto-update of Sample.is_serum_sample in Sample.898 using Sample._is_serum_sample resulted in the same value: [False].
Propagating change from parent Animal.127 to child Sample.899
Auto-update of Sample.is_serum_sample in Sample.899 using Sample._is_serum_sample resulted in the same value: [False].
Propagating change from parent Animal.127 to child Sample.900
Auto-update of Sample.is_serum_sample in Sample.900 using Sample._is_serum_sample resulted in the same value: [False].
Propagating change from parent Animal.127 to child Sample.936
Auto-update of Sample.is_serum_sample in Sample.936 using Sample._is_serum_sample resulted in the same value: [False].
Propagating change from parent Animal.127 to child Sample.948
Auto-update of Sample.is_serum_sample in Sample.948 using Sample._is_serum_sample resulted in the same value: [False].
Propagating change from parent Animal.127 to child Sample.960
Auto-update of Sample.is_serum_sample in Sample.960 using Sample._is_serum_sample resulted in the same value: [False].
Propagating change from parent Infusate.35 to child Animal.128
Auto-update of Animal.last_serum_sample in Animal.128 using Animal._last_serum_sample resulted in the same value: [col005c_A5b].
Auto-update of Animal.label_combo in Animal.128 using Animal._label_combo resulted in the same value: [C].
Propagating change from parent Animal.128 to child Sample.861
Auto-update of Sample.is_serum_sample in Sample.861 using Sample._is_serum_sample resulted in the same value: [True].
Propagating change from parent Sample.861 to child FCirc.541
Auto-update of FCirc.is_last in FCirc.541 using FCirc.is_last_serum_peak_group resulted in the same value: [False].
Propagating change from parent Animal.128 to child Sample.862
Auto-update of Sample.is_serum_sample in Sample.862 using Sample._is_serum_sample resulted in the same value: [True].
Propagating change from parent Sample.862 to child FCirc.542
Auto-update of FCirc.is_last in FCirc.542 using FCirc.is_last_serum_peak_group resulted in the same value: [False].
Propagating change from parent Animal.128 to child Sample.863
Auto-update of Sample.is_serum_sample in Sample.863 using Sample._is_serum_sample resulted in the same value: [True].
Propagating change from parent Sample.863 to child FCirc.543
Auto-update of FCirc.is_last in FCirc.543 using FCirc.is_last_serum_peak_group resulted in the same value: [False].
Propagating change from parent Animal.128 to child Sample.841
Auto-update of Sample.is_serum_sample in Sample.841 using Sample._is_serum_sample resulted in the same value: [True].
Propagating change from parent Sample.841 to child FCirc.521
Auto-update of FCirc.is_last in FCirc.521 using FCirc.is_last_serum_peak_group resulted in the same value: [True].
Propagating change from parent Animal.128 to child Sample.901
Auto-update of Sample.is_serum_sample in Sample.901 using Sample._is_serum_sample resulted in the same value: [False].
Propagating change from parent Animal.128 to child Sample.902
Auto-update of Sample.is_serum_sample in Sample.902 using Sample._is_serum_sample resulted in the same value: [False].
Propagating change from parent Animal.128 to child Sample.903
Auto-update of Sample.is_serum_sample in Sample.903 using Sample._is_serum_sample resulted in the same value: [False].
Propagating change from parent Animal.128 to child Sample.904
Auto-update of Sample.is_serum_sample in Sample.904 using Sample._is_serum_sample resulted in the same value: [False].
Propagating change from parent Animal.128 to child Sample.937
Auto-update of Sample.is_serum_sample in Sample.937 using Sample._is_serum_sample resulted in the same value: [False].
Propagating change from parent Animal.128 to child Sample.949
Auto-update of Sample.is_serum_sample in Sample.949 using Sample._is_serum_sample resulted in the same value: [False].
Propagating change from parent Animal.128 to child Sample.961
Auto-update of Sample.is_serum_sample in Sample.961 using Sample._is_serum_sample resulted in the same value: [False].
Propagating change from parent Infusate.35 to child Animal.129
Auto-update of Animal.last_serum_sample in Animal.129 using Animal._last_serum_sample resulted in the same value: [col005c_A6b].
Auto-update of Animal.label_combo in Animal.129 using Animal._label_combo resulted in the same value: [C].
Propagating change from parent Animal.129 to child Sample.864
Auto-update of Sample.is_serum_sample in Sample.864 using Sample._is_serum_sample resulted in the same value: [True].
Propagating change from parent Sample.864 to child FCirc.544
Auto-update of FCirc.is_last in FCirc.544 using FCirc.is_last_serum_peak_group resulted in the same value: [False].
Propagating change from parent Animal.129 to child Sample.865
Auto-update of Sample.is_serum_sample in Sample.865 using Sample._is_serum_sample resulted in the same value: [True].
Propagating change from parent Sample.865 to child FCirc.545
Auto-update of FCirc.is_last in FCirc.545 using FCirc.is_last_serum_peak_group resulted in the same value: [False].
Propagating change from parent Animal.129 to child Sample.866
Auto-update of Sample.is_serum_sample in Sample.866 using Sample._is_serum_sample resulted in the same value: [True].
Propagating change from parent Sample.866 to child FCirc.546
Auto-update of FCirc.is_last in FCirc.546 using FCirc.is_last_serum_peak_group resulted in the same value: [False].
Propagating change from parent Animal.129 to child Sample.842
Auto-update of Sample.is_serum_sample in Sample.842 using Sample._is_serum_sample resulted in the same value: [True].
Propagating change from parent Sample.842 to child FCirc.522
Auto-update of FCirc.is_last in FCirc.522 using FCirc.is_last_serum_peak_group resulted in the same value: [True].
Propagating change from parent Animal.129 to child Sample.905
Auto-update of Sample.is_serum_sample in Sample.905 using Sample._is_serum_sample resulted in the same value: [False].
Propagating change from parent Animal.129 to child Sample.906
Auto-update of Sample.is_serum_sample in Sample.906 using Sample._is_serum_sample resulted in the same value: [False].
Propagating change from parent Animal.129 to child Sample.907
Auto-update of Sample.is_serum_sample in Sample.907 using Sample._is_serum_sample resulted in the same value: [False].
Propagating change from parent Animal.129 to child Sample.908
Auto-update of Sample.is_serum_sample in Sample.908 using Sample._is_serum_sample resulted in the same value: [False].
Propagating change from parent Animal.129 to child Sample.938
Auto-update of Sample.is_serum_sample in Sample.938 using Sample._is_serum_sample resulted in the same value: [False].
Propagating change from parent Animal.129 to child Sample.950
Auto-update of Sample.is_serum_sample in Sample.950 using Sample._is_serum_sample resulted in the same value: [False].
Propagating change from parent Animal.129 to child Sample.962
Auto-update of Sample.is_serum_sample in Sample.962 using Sample._is_serum_sample resulted in the same value: [False].
Propagating change from parent Infusate.35 to child Animal.130
Auto-update of Animal.last_serum_sample in Animal.130 using Animal._last_serum_sample resulted in the same value: [col005c_A7b].
Auto-update of Animal.label_combo in Animal.130 using Animal._label_combo resulted in the same value: [C].
Propagating change from parent Animal.130 to child Sample.867
Auto-update of Sample.is_serum_sample in Sample.867 using Sample._is_serum_sample resulted in the same value: [True].
Propagating change from parent Sample.867 to child FCirc.547
Auto-update of FCirc.is_last in FCirc.547 using FCirc.is_last_serum_peak_group resulted in the same value: [False].
Propagating change from parent Animal.130 to child Sample.868
Auto-update of Sample.is_serum_sample in Sample.868 using Sample._is_serum_sample resulted in the same value: [True].
Propagating change from parent Sample.868 to child FCirc.548
Auto-update of FCirc.is_last in FCirc.548 using FCirc.is_last_serum_peak_group resulted in the same value: [False].
Propagating change from parent Animal.130 to child Sample.869
Auto-update of Sample.is_serum_sample in Sample.869 using Sample._is_serum_sample resulted in the same value: [True].
Propagating change from parent Sample.869 to child FCirc.549
Auto-update of FCirc.is_last in FCirc.549 using FCirc.is_last_serum_peak_group resulted in the same value: [False].
Propagating change from parent Animal.130 to child Sample.843
Auto-update of Sample.is_serum_sample in Sample.843 using Sample._is_serum_sample resulted in the same value: [True].
Propagating change from parent Sample.843 to child FCirc.523
Auto-update of FCirc.is_last in FCirc.523 using FCirc.is_last_serum_peak_group resulted in the same value: [True].
Propagating change from parent Animal.130 to child Sample.909
Auto-update of Sample.is_serum_sample in Sample.909 using Sample._is_serum_sample resulted in the same value: [False].
Propagating change from parent Animal.130 to child Sample.910
Auto-update of Sample.is_serum_sample in Sample.910 using Sample._is_serum_sample resulted in the same value: [False].
Propagating change from parent Animal.130 to child Sample.911
Auto-update of Sample.is_serum_sample in Sample.911 using Sample._is_serum_sample resulted in the same value: [False].
Propagating change from parent Animal.130 to child Sample.912
Auto-update of Sample.is_serum_sample in Sample.912 using Sample._is_serum_sample resulted in the same value: [False].
Propagating change from parent Animal.130 to child Sample.939
Auto-update of Sample.is_serum_sample in Sample.939 using Sample._is_serum_sample resulted in the same value: [False].
Propagating change from parent Animal.130 to child Sample.951
Auto-update of Sample.is_serum_sample in Sample.951 using Sample._is_serum_sample resulted in the same value: [False].
Propagating change from parent Animal.130 to child Sample.963
Auto-update of Sample.is_serum_sample in Sample.963 using Sample._is_serum_sample resulted in the same value: [False].
Propagating change from parent Infusate.35 to child Animal.131
Auto-update of Animal.last_serum_sample in Animal.131 using Animal._last_serum_sample resulted in the same value: [col005c_A8b].
Auto-update of Animal.label_combo in Animal.131 using Animal._label_combo resulted in the same value: [C].
Propagating change from parent Animal.131 to child Sample.870
Auto-update of Sample.is_serum_sample in Sample.870 using Sample._is_serum_sample resulted in the same value: [True].
Propagating change from parent Sample.870 to child FCirc.550
Auto-update of FCirc.is_last in FCirc.550 using FCirc.is_last_serum_peak_group resulted in the same value: [False].
Propagating change from parent Animal.131 to child Sample.871
Auto-update of Sample.is_serum_sample in Sample.871 using Sample._is_serum_sample resulted in the same value: [True].
Propagating change from parent Sample.871 to child FCirc.551
Auto-update of FCirc.is_last in FCirc.551 using FCirc.is_last_serum_peak_group resulted in the same value: [False].
Propagating change from parent Animal.131 to child Sample.872
Auto-update of Sample.is_serum_sample in Sample.872 using Sample._is_serum_sample resulted in the same value: [True].
Propagating change from parent Sample.872 to child FCirc.552
Auto-update of FCirc.is_last in FCirc.552 using FCirc.is_last_serum_peak_group resulted in the same value: [False].
Propagating change from parent Animal.131 to child Sample.844
Auto-update of Sample.is_serum_sample in Sample.844 using Sample._is_serum_sample resulted in the same value: [True].
Propagating change from parent Sample.844 to child FCirc.524
Auto-update of FCirc.is_last in FCirc.524 using FCirc.is_last_serum_peak_group resulted in the same value: [True].
Propagating change from parent Animal.131 to child Sample.913
Auto-update of Sample.is_serum_sample in Sample.913 using Sample._is_serum_sample resulted in the same value: [False].
Propagating change from parent Animal.131 to child Sample.914
Auto-update of Sample.is_serum_sample in Sample.914 using Sample._is_serum_sample resulted in the same value: [False].
Propagating change from parent Animal.131 to child Sample.915
Auto-update of Sample.is_serum_sample in Sample.915 using Sample._is_serum_sample resulted in the same value: [False].
Propagating change from parent Animal.131 to child Sample.916
Auto-update of Sample.is_serum_sample in Sample.916 using Sample._is_serum_sample resulted in the same value: [False].
Propagating change from parent Animal.131 to child Sample.940
Auto-update of Sample.is_serum_sample in Sample.940 using Sample._is_serum_sample resulted in the same value: [False].
Propagating change from parent Animal.131 to child Sample.952
Auto-update of Sample.is_serum_sample in Sample.952 using Sample._is_serum_sample resulted in the same value: [False].
Propagating change from parent Animal.131 to child Sample.964
Auto-update of Sample.is_serum_sample in Sample.964 using Sample._is_serum_sample resulted in the same value: [False].
Propagating change from parent Infusate.35 to child Animal.132
Auto-update of Animal.last_serum_sample in Animal.132 using Animal._last_serum_sample resulted in the same value: [col005c_A9b].
Auto-update of Animal.label_combo in Animal.132 using Animal._label_combo resulted in the same value: [C].
Propagating change from parent Animal.132 to child Sample.873
Auto-update of Sample.is_serum_sample in Sample.873 using Sample._is_serum_sample resulted in the same value: [True].
Propagating change from parent Sample.873 to child FCirc.553
Auto-update of FCirc.is_last in FCirc.553 using FCirc.is_last_serum_peak_group resulted in the same value: [False].
Propagating change from parent Animal.132 to child Sample.874
Auto-update of Sample.is_serum_sample in Sample.874 using Sample._is_serum_sample resulted in the same value: [True].
Propagating change from parent Sample.874 to child FCirc.554
Auto-update of FCirc.is_last in FCirc.554 using FCirc.is_last_serum_peak_group resulted in the same value: [False].
Propagating change from parent Animal.132 to child Sample.875
Auto-update of Sample.is_serum_sample in Sample.875 using Sample._is_serum_sample resulted in the same value: [True].
Propagating change from parent Sample.875 to child FCirc.555
Auto-update of FCirc.is_last in FCirc.555 using FCirc.is_last_serum_peak_group resulted in the same value: [False].
Propagating change from parent Animal.132 to child Sample.845
Auto-update of Sample.is_serum_sample in Sample.845 using Sample._is_serum_sample resulted in the same value: [True].
Propagating change from parent Sample.845 to child FCirc.525
Auto-update of FCirc.is_last in FCirc.525 using FCirc.is_last_serum_peak_group resulted in the same value: [True].
Propagating change from parent Animal.132 to child Sample.917
Auto-update of Sample.is_serum_sample in Sample.917 using Sample._is_serum_sample resulted in the same value: [False].
Propagating change from parent Animal.132 to child Sample.918
Auto-update of Sample.is_serum_sample in Sample.918 using Sample._is_serum_sample resulted in the same value: [False].
Propagating change from parent Animal.132 to child Sample.919
Auto-update of Sample.is_serum_sample in Sample.919 using Sample._is_serum_sample resulted in the same value: [False].
Propagating change from parent Animal.132 to child Sample.920
Auto-update of Sample.is_serum_sample in Sample.920 using Sample._is_serum_sample resulted in the same value: [False].
Propagating change from parent Animal.132 to child Sample.941
Auto-update of Sample.is_serum_sample in Sample.941 using Sample._is_serum_sample resulted in the same value: [False].
Propagating change from parent Animal.132 to child Sample.953
Auto-update of Sample.is_serum_sample in Sample.953 using Sample._is_serum_sample resulted in the same value: [False].
Propagating change from parent Animal.132 to child Sample.965
Auto-update of Sample.is_serum_sample in Sample.965 using Sample._is_serum_sample resulted in the same value: [False].
Propagating change from parent Infusate.35 to child Animal.133
Auto-update of Animal.last_serum_sample in Animal.133 using Animal._last_serum_sample resulted in the same value: [col005c_A10b].
Auto-update of Animal.label_combo in Animal.133 using Animal._label_combo resulted in the same value: [C].
Propagating change from parent Animal.133 to child Sample.876
Auto-update of Sample.is_serum_sample in Sample.876 using Sample._is_serum_sample resulted in the same value: [True].
Propagating change from parent Sample.876 to child FCirc.556
Auto-update of FCirc.is_last in FCirc.556 using FCirc.is_last_serum_peak_group resulted in the same value: [False].
Propagating change from parent Animal.133 to child Sample.877
Auto-update of Sample.is_serum_sample in Sample.877 using Sample._is_serum_sample resulted in the same value: [True].
Propagating change from parent Sample.877 to child FCirc.557
Auto-update of FCirc.is_last in FCirc.557 using FCirc.is_last_serum_peak_group resulted in the same value: [False].
Propagating change from parent Animal.133 to child Sample.878
Auto-update of Sample.is_serum_sample in Sample.878 using Sample._is_serum_sample resulted in the same value: [True].
Propagating change from parent Sample.878 to child FCirc.558
Auto-update of FCirc.is_last in FCirc.558 using FCirc.is_last_serum_peak_group resulted in the same value: [False].
Propagating change from parent Animal.133 to child Sample.846
Auto-update of Sample.is_serum_sample in Sample.846 using Sample._is_serum_sample resulted in the same value: [True].
Propagating change from parent Sample.846 to child FCirc.526
Auto-update of FCirc.is_last in FCirc.526 using FCirc.is_last_serum_peak_group resulted in the same value: [True].
Propagating change from parent Animal.133 to child Sample.921
Auto-update of Sample.is_serum_sample in Sample.921 using Sample._is_serum_sample resulted in the same value: [False].
Propagating change from parent Animal.133 to child Sample.922
Auto-update of Sample.is_serum_sample in Sample.922 using Sample._is_serum_sample resulted in the same value: [False].
Propagating change from parent Animal.133 to child Sample.923
Auto-update of Sample.is_serum_sample in Sample.923 using Sample._is_serum_sample resulted in the same value: [False].
Propagating change from parent Animal.133 to child Sample.924
Auto-update of Sample.is_serum_sample in Sample.924 using Sample._is_serum_sample resulted in the same value: [False].
Propagating change from parent Animal.133 to child Sample.942
Auto-update of Sample.is_serum_sample in Sample.942 using Sample._is_serum_sample resulted in the same value: [False].
Propagating change from parent Animal.133 to child Sample.954
Auto-update of Sample.is_serum_sample in Sample.954 using Sample._is_serum_sample resulted in the same value: [False].
Propagating change from parent Animal.133 to child Sample.966
Auto-update of Sample.is_serum_sample in Sample.966 using Sample._is_serum_sample resulted in the same value: [False].
Propagating change from parent Infusate.35 to child Animal.134
Auto-update of Animal.last_serum_sample in Animal.134 using Animal._last_serum_sample resulted in the same value: [col005c_A11b].
Auto-update of Animal.label_combo in Animal.134 using Animal._label_combo resulted in the same value: [C].
Propagating change from parent Animal.134 to child Sample.879
Auto-update of Sample.is_serum_sample in Sample.879 using Sample._is_serum_sample resulted in the same value: [True].
Propagating change from parent Sample.879 to child FCirc.559
Auto-update of FCirc.is_last in FCirc.559 using FCirc.is_last_serum_peak_group resulted in the same value: [False].
Propagating change from parent Animal.134 to child Sample.880
Auto-update of Sample.is_serum_sample in Sample.880 using Sample._is_serum_sample resulted in the same value: [True].
Propagating change from parent Sample.880 to child FCirc.560
Auto-update of FCirc.is_last in FCirc.560 using FCirc.is_last_serum_peak_group resulted in the same value: [False].
Propagating change from parent Animal.134 to child Sample.881
Auto-update of Sample.is_serum_sample in Sample.881 using Sample._is_serum_sample resulted in the same value: [True].
Propagating change from parent Sample.881 to child FCirc.561
Auto-update of FCirc.is_last in FCirc.561 using FCirc.is_last_serum_peak_group resulted in the same value: [False].
Propagating change from parent Animal.134 to child Sample.847
Auto-update of Sample.is_serum_sample in Sample.847 using Sample._is_serum_sample resulted in the same value: [True].
Propagating change from parent Sample.847 to child FCirc.527
Auto-update of FCirc.is_last in FCirc.527 using FCirc.is_last_serum_peak_group resulted in the same value: [True].
Propagating change from parent Animal.134 to child Sample.925
Auto-update of Sample.is_serum_sample in Sample.925 using Sample._is_serum_sample resulted in the same value: [False].
Propagating change from parent Animal.134 to child Sample.926
Auto-update of Sample.is_serum_sample in Sample.926 using Sample._is_serum_sample resulted in the same value: [False].
Propagating change from parent Animal.134 to child Sample.927
Auto-update of Sample.is_serum_sample in Sample.927 using Sample._is_serum_sample resulted in the same value: [False].
Propagating change from parent Animal.134 to child Sample.928
Auto-update of Sample.is_serum_sample in Sample.928 using Sample._is_serum_sample resulted in the same value: [False].
Propagating change from parent Animal.134 to child Sample.943
Auto-update of Sample.is_serum_sample in Sample.943 using Sample._is_serum_sample resulted in the same value: [False].
Propagating change from parent Animal.134 to child Sample.955
Auto-update of Sample.is_serum_sample in Sample.955 using Sample._is_serum_sample resulted in the same value: [False].
Propagating change from parent Animal.134 to child Sample.967
Auto-update of Sample.is_serum_sample in Sample.967 using Sample._is_serum_sample resulted in the same value: [False].
Propagating change from parent Infusate.35 to child Animal.135
Auto-update of Animal.last_serum_sample in Animal.135 using Animal._last_serum_sample resulted in the same value: [col005c_A12b].
Auto-update of Animal.label_combo in Animal.135 using Animal._label_combo resulted in the same value: [C].
Propagating change from parent Animal.135 to child Sample.882
Auto-update of Sample.is_serum_sample in Sample.882 using Sample._is_serum_sample resulted in the same value: [True].
Propagating change from parent Sample.882 to child FCirc.562
Auto-update of FCirc.is_last in FCirc.562 using FCirc.is_last_serum_peak_group resulted in the same value: [False].
Propagating change from parent Animal.135 to child Sample.883
Auto-update of Sample.is_serum_sample in Sample.883 using Sample._is_serum_sample resulted in the same value: [True].
Propagating change from parent Sample.883 to child FCirc.563
Auto-update of FCirc.is_last in FCirc.563 using FCirc.is_last_serum_peak_group resulted in the same value: [False].
Propagating change from parent Animal.135 to child Sample.884
Auto-update of Sample.is_serum_sample in Sample.884 using Sample._is_serum_sample resulted in the same value: [True].
Propagating change from parent Sample.884 to child FCirc.564
Auto-update of FCirc.is_last in FCirc.564 using FCirc.is_last_serum_peak_group resulted in the same value: [False].
Propagating change from parent Animal.135 to child Sample.848
Auto-update of Sample.is_serum_sample in Sample.848 using Sample._is_serum_sample resulted in the same value: [True].
Propagating change from parent Sample.848 to child FCirc.528
Auto-update of FCirc.is_last in FCirc.528 using FCirc.is_last_serum_peak_group resulted in the same value: [True].
Propagating change from parent Animal.135 to child Sample.929
Auto-update of Sample.is_serum_sample in Sample.929 using Sample._is_serum_sample resulted in the same value: [False].
Propagating change from parent Animal.135 to child Sample.930
Auto-update of Sample.is_serum_sample in Sample.930 using Sample._is_serum_sample resulted in the same value: [False].
Propagating change from parent Animal.135 to child Sample.931
Auto-update of Sample.is_serum_sample in Sample.931 using Sample._is_serum_sample resulted in the same value: [False].
Propagating change from parent Animal.135 to child Sample.932
Auto-update of Sample.is_serum_sample in Sample.932 using Sample._is_serum_sample resulted in the same value: [False].
Propagating change from parent Animal.135 to child Sample.944
Auto-update of Sample.is_serum_sample in Sample.944 using Sample._is_serum_sample resulted in the same value: [False].
Propagating change from parent Animal.135 to child Sample.956
Auto-update of Sample.is_serum_sample in Sample.956 using Sample._is_serum_sample resulted in the same value: [False].
Propagating change from parent Animal.135 to child Sample.968
Auto-update of Sample.is_serum_sample in Sample.968 using Sample._is_serum_sample resulted in the same value: [False].
Propagating change from child Infusate.35 to parent Tracer.13
Auto-update of Tracer.name in Tracer.13 using Tracer._name resulted in the same value: [C16:0-[13C16]].
Auto-update of Tracer.label_combo in Tracer.13 using Tracer._label_combo resulted in the same value: [C].
Propagating change from parent Tracer.13 to child Infusate.55
Auto-update of Infusate.name in Infusate.55 using Infusate._name resulted in the same value: [C16:0-[13C16][10]].
Auto-update of Infusate.label_combo in Infusate.55 using Infusate._label_combo resulted in the same value: [C].
Propagating change from parent Tracer.13 to child Infusate.62
Auto-update of Infusate.name in Infusate.62 using Infusate._name resulted in the same value: [C16:0-[13C16][2.22]].
Auto-update of Infusate.label_combo in Infusate.62 using Infusate._label_combo resulted in the same value: [C].
Propagating change from parent Tracer.13 to child Infusate.42
Auto-update of Infusate.name in Infusate.42 using Infusate._name resulted in the same value: [C16:0-[13C16][8.8]].
Auto-update of Infusate.label_combo in Infusate.42 using Infusate._label_combo resulted in the same value: [C].
Propagating change from parent Tracer.13 to child Infusate.41
Auto-update of Infusate.name in Infusate.41 using Infusate._name resulted in the same value: [C16:0-[13C16][8]].
Auto-update of Infusate.label_combo in Infusate.41 using Infusate._label_combo resulted in the same value: [C].
Propagating change from child Tracer.13 to parent Compound.214
Auto-update of Compound.animals_by_tracer in Compound.214 using Compound._animals_by_tracer resulted in the same value: [12].
```

After the changes in this PR, the auto-update propagation looks like this:

```
Propagating change from child MSRunSample.1268 to parent Sample.837
Auto-update of Sample.is_serum_sample in Sample.837 using Sample._is_serum_sample resulted in the same value: [True].
Propagating change from parent Sample.837 to child FCirc.517
Auto-update of FCirc.is_last in FCirc.517 using FCirc.is_last_serum_peak_group resulted in a change from [True] to [False].
Propagating change from child Sample.837 to parent Animal.124
Auto-update of Animal.last_serum_sample in Animal.124 using Animal._last_serum_sample resulted in the same value: [col005c_A1b].
Auto-update of Animal.label_combo in Animal.124 using Animal._label_combo resulted in the same value: [C].
Propagating change from parent Animal.124 to child Sample.849
Auto-update of Sample.is_serum_sample in Sample.849 using Sample._is_serum_sample resulted in the same value: [True].
Propagating change from parent Sample.849 to child FCirc.529
Auto-update of FCirc.is_last in FCirc.529 using FCirc.is_last_serum_peak_group resulted in the same value: [False].
Propagating change from parent Animal.124 to child Sample.850
Auto-update of Sample.is_serum_sample in Sample.850 using Sample._is_serum_sample resulted in the same value: [True].
Propagating change from parent Sample.850 to child FCirc.530
Auto-update of FCirc.is_last in FCirc.530 using FCirc.is_last_serum_peak_group resulted in the same value: [False].
Propagating change from parent Animal.124 to child Sample.851
Auto-update of Sample.is_serum_sample in Sample.851 using Sample._is_serum_sample resulted in the same value: [True].
Propagating change from parent Sample.851 to child FCirc.531
Auto-update of FCirc.is_last in FCirc.531 using FCirc.is_last_serum_peak_group resulted in a change from [False] to [True].
Propagating change from parent Animal.124 to child Sample.885
Auto-update of Sample.is_serum_sample in Sample.885 using Sample._is_serum_sample resulted in the same value: [False].
Propagating change from parent Animal.124 to child Sample.886
Auto-update of Sample.is_serum_sample in Sample.886 using Sample._is_serum_sample resulted in the same value: [False].
Propagating change from parent Animal.124 to child Sample.887
Auto-update of Sample.is_serum_sample in Sample.887 using Sample._is_serum_sample resulted in the same value: [False].
Propagating change from parent Animal.124 to child Sample.888
Auto-update of Sample.is_serum_sample in Sample.888 using Sample._is_serum_sample resulted in the same value: [False].
Propagating change from parent Animal.124 to child Sample.933
Auto-update of Sample.is_serum_sample in Sample.933 using Sample._is_serum_sample resulted in the same value: [False].
Propagating change from parent Animal.124 to child Sample.945
Auto-update of Sample.is_serum_sample in Sample.945 using Sample._is_serum_sample resulted in the same value: [False].
Propagating change from parent Animal.124 to child Sample.957
Auto-update of Sample.is_serum_sample in Sample.957 using Sample._is_serum_sample resulted in the same value: [False].
```