### PR TITLE
Added a directory walk to find peak annotation files

### DIFF
--- a/DataRepo/loaders/peak_annotation_files_loader.py
+++ b/DataRepo/loaders/peak_annotation_files_loader.py
@@ -1,6 +1,6 @@
 import os
 from collections import defaultdict, namedtuple
-from typing import Dict
+from typing import Dict, List, Optional
 
 from django.db import transaction
 
@@ -15,6 +15,8 @@ from DataRepo.utils.exceptions import (
     AggregatedErrors,
     AggregatedErrorsSet,
     FileFromInputNotFound,
+    InvalidPeakAnnotationFileFormat,
+    MultipleMatchingPeakAnnotationFiles,
     RollbackException,
 )
 from DataRepo.utils.file_utils import get_sheet_names, is_excel, read_from_file
@@ -122,6 +124,8 @@ class PeakAnnotationFilesLoader(TableLoader):
     # List of model classes that the loader enters records into.  Used for summarized results & some exception handling
     Models = [ArchiveFile]
 
+    peak_annot_exts = ["xlsx", "csv", "tsv"]
+
     def __init__(self, *args, **kwargs):
         """Constructor.
 
@@ -207,6 +211,9 @@ class PeakAnnotationFilesLoader(TableLoader):
 
         # For tracking exceptions of the individual peak annotation loaders
         self.aggregated_errors_dict = {}
+
+        # Walk the dir once to identify potential peak annot files for the find_annot_file method
+        self.potential_peak_annot_files = self.map_potential_peak_annot_files()
 
     def load_data(self):
         """Loads the ArchiveFile table from the dataframe and calls the PeakAnnotationsLoader for each file.
@@ -305,9 +312,11 @@ class PeakAnnotationFilesLoader(TableLoader):
                     # In case the path is relative to the current directory
                     filepath = filepath_str
                 else:
-                    # Make the forthcoming error show the path relative to the study doc, which we should encourange
-                    # users to use.
-                    filepath = os.path.join(study_dir, filepath_str)
+                    # Try and find the file
+                    filepath = self.find_annot_file(filepath_str, study_dir=study_dir)
+                    if not os.path.isfile(filepath):
+                        self.add_skip_row_index()
+                        return filename, None, format_code
             else:
                 # We will look relative to the current directory
                 filepath = filepath_str
@@ -474,9 +483,8 @@ class PeakAnnotationFilesLoader(TableLoader):
             or format_code not in PeakAnnotationsLoader.get_supported_formats()
         ):
             self.buffer_infile_exception(
-                (
-                    f"Skipping load of peak annotations file '{filename}'.  Unrecognized format code: {format_code}.  "
-                    f"Must be one of {PeakAnnotationsLoader.get_supported_formats()}."
+                InvalidPeakAnnotationFileFormat(
+                    format_code, PeakAnnotationsLoader.get_supported_formats(), filepath
                 ),
                 column=self.headers.FORMAT,
                 is_error=False,
@@ -675,3 +683,91 @@ class PeakAnnotationFilesLoader(TableLoader):
         if self.file is None:
             return os.getcwd()
         return os.path.dirname(os.path.abspath(self.file))
+
+    def find_annot_file(
+        self, supplied_file_with_opt_path: str, study_dir: Optional[str] = None
+    ):
+        """Given a supplied file name with optional path information that was not found to exist, find the file under
+        the supplied study directory and return it with its filepath (if explicitly 1 was found with an identical name).
+
+        Args:
+            supplied_files_with_opt_path (str): A peak annotation file with optional path (derived from the Peak
+                Annotation Files sheet).
+            study_dir (Optional[str]) [current directory]: A directory under which peak annotation files reside (in
+                subdirectories).
+        Exceptions:
+            None
+        Returns:
+            (str): A peak annotation filepath if one was found, the supplied_file_with_opt_path if one was not found.
+        """
+
+        if study_dir is None or study_dir == "":
+            study_dir = os.getcwd()
+
+        if os.path.exists(supplied_file_with_opt_path):
+            return supplied_file_with_opt_path
+
+        # Use a list to track the paths of potentially multiple files with the same name
+        matching_annot_files: List[str] = []
+
+        # Determine the path the user supplied in the Peak Annotation Files sheet (if any)
+        supplied_dirpath, supplied_filename = os.path.split(supplied_file_with_opt_path)
+
+        if supplied_filename in self.potential_peak_annot_files:
+            matching_annot_files = self.potential_peak_annot_files[supplied_filename]
+
+        # If there are multiple files with this name (which is not allowed)
+        if len(matching_annot_files) > 1:
+            self.buffer_infile_exception(
+                MultipleMatchingPeakAnnotationFiles(matching_annot_files),
+                is_error=False,
+                is_fatal=self.validate,
+                column=self.headers.FILE,
+            )
+            # Return the supplied file name if 1 file was not found (the caller will deal with the ensuing error)
+            return supplied_file_with_opt_path
+        elif len(matching_annot_files) == 0:
+            # Return the supplied file name if not found at all (the caller will deal with the ensuing error)
+            return supplied_file_with_opt_path
+        elif len(matching_annot_files) == 1 and supplied_dirpath not in ["", "."]:
+            # Buffer a warning that the supplied path was wrong, (but the file was found).
+            self.buffer_infile_exception(
+                ValueError(
+                    f"The peak annotation filepath supplied '{supplied_file_with_opt_path}' was incorrect but a "
+                    "file matching this filename was found in the study directory, so this is just a warning.  "
+                    "Correct the Peak Annotation Files sheet to eliminate this warning."
+                ),
+                is_error=False,
+                is_fatal=self.validate,
+                column=self.headers.FILE,
+            )
+
+        return matching_annot_files[0]
+
+    def map_potential_peak_annot_files(self):
+        """This finds all **potential** peak annotation files and returns a dict keyed on filename, containing a list of
+        filepaths to all files with the same name.
+
+        The intended purpose is for use in self.find_annot_file(), so that the directory is only walked once.
+        """
+        potential_peak_annot_files: Dict[List[str]] = defaultdict(list)
+
+        # We do not need to map the files if no study doc was supplied, because the purpose is to find files from the
+        # Peak Annotation File column of the Peak Annotation Files sheet.  If there is no sheet, there's no need to find
+        # those files.
+        if self.file is None:
+            return {}
+
+        # Determine the study directory
+        study_dir = None if self.file is None else os.path.dirname(self.file)
+
+        # Walk the directory
+        for dir_path, _, fileset in os.walk(study_dir):
+            filename: str
+            for filename in fileset:
+                # If the current file matches one of the supplied files
+                if any(filename.lower().endswith(ext) for ext in self.peak_annot_exts):
+                    filepath = os.path.join(dir_path, filename)
+                    potential_peak_annot_files[filename].append(filepath)
+
+        return potential_peak_annot_files

--- a/DataRepo/management/commands/rebuild_maintained_fields.py
+++ b/DataRepo/management/commands/rebuild_maintained_fields.py
@@ -12,9 +12,11 @@ from DataRepo.models.maintained_model import MaintainedModel
 
 class Command(BaseCommand):
     # Show this when the user types help
-    help = "Update all maintained fields for every record in the database containing maintained fields.  Note that "
-    "this assumes that no @MaintainedModel.setter function uses a maintained field in its calculation, because that "
-    "would make the auto-updates order-dependent."
+    help = (
+        "Update all maintained fields for every record in the database containing maintained fields.  Note that this "
+        "assumes that no @MaintainedModel.setter function uses a maintained field in its calculation, because that "
+        "would make the auto-updates order-dependent."
+    )
 
     def add_arguments(self, parser):
         parser.add_argument(

--- a/DataRepo/tests/loaders/test_peak_annotation_files_loader.py
+++ b/DataRepo/tests/loaders/test_peak_annotation_files_loader.py
@@ -22,7 +22,11 @@ from DataRepo.models import (
     Tissue,
 )
 from DataRepo.tests.tracebase_test_case import TracebaseTestCase
-from DataRepo.utils.exceptions import AggregatedErrorsSet, InfileError
+from DataRepo.utils.exceptions import (
+    AggregatedErrorsSet,
+    InfileError,
+    MultipleMatchingPeakAnnotationFiles,
+)
 from DataRepo.utils.file_utils import read_from_file
 from DataRepo.utils.infusate_name_parser import parse_infusate_name_with_concs
 
@@ -450,3 +454,119 @@ class PeakAnnotationFilesLoaderTests(TracebaseTestCase):
             },
             dtsd,
         )
+
+    def test_find_annot_file_success_when_multiple(self):
+        """This tests that when there are multiple files with the same name, but one was fully specified, there is no
+        error and that file is returned."""
+        pafl = PeakAnnotationFilesLoader(
+            file="DataRepo/data/tests/small_obob/study.xlsx"
+        )
+        exp_file = "DataRepo/data/tests/small_obob/small_obob_maven_6eaas_serum/small_obob_maven_6eaas_serum.xlsx"
+        file = pafl.find_annot_file(exp_file, "DataRepo/data/tests/small_obob")
+        self.assertEqual(exp_file, file)
+        self.assertEqual(0, len(pafl.aggregated_errors_object.exceptions))
+
+    def test_find_annot_file_success_found_no_path(self):
+        # NOTE: The study doc supplied here doesn't exist, but that doesn't matter because we're not testing the load.
+        # I only selected that study dir because it had multiple files with the same name under it, and that's the only
+        # test data dir that does.
+        pafl = PeakAnnotationFilesLoader(
+            file="DataRepo/data/tests/multiple_representations/study.xlsx"
+        )
+        exp_file = "DataRepo/data/tests/multiple_representations/resolution_handling/negative_cor.xlsx"
+        file = pafl.find_annot_file(
+            "negative_cor.xlsx", "DataRepo/data/tests/multiple_representations"
+        )
+        self.assertEqual(exp_file, file)
+        self.assertEqual(0, len(pafl.aggregated_errors_object.exceptions))
+
+    def test_find_annot_file_success_found_bad_path(self):
+        # NOTE: The study doc supplied here doesn't exist, but that doesn't matter because we're not testing the load.
+        # I only selected that study dir because it had multiple files with the same name under it, and that's the only
+        # test data dir that does.
+        pafl = PeakAnnotationFilesLoader(
+            file="DataRepo/data/tests/multiple_representations/study.xlsx"
+        )
+        exp_file = "DataRepo/data/tests/multiple_representations/resolution_handling/negative_cor.xlsx"
+        file = pafl.find_annot_file(
+            "bad/path/negative_cor.xlsx", "DataRepo/data/tests/multiple_representations"
+        )
+        self.assertEqual(exp_file, file)
+        self.assertEqual(1, len(pafl.aggregated_errors_object.exceptions))
+        self.assertIsInstance(pafl.aggregated_errors_object.exceptions[0], InfileError)
+        self.assertEqual(1, pafl.aggregated_errors_object.num_warnings)
+        self.assertIn(
+            "filepath supplied 'bad/path/negative_cor.xlsx' was incorrect",
+            str(pafl.aggregated_errors_object.exceptions[0]),
+        )
+        self.assertIn(
+            "a file matching this filename was found in the study directory",
+            str(pafl.aggregated_errors_object.exceptions[0]),
+        )
+
+    def test_find_annot_file_not_found(self):
+        """This test asserts that the supplied file (with optional path) is returned as-is without error.
+
+        When a file is not found, the supplied file (with optional path) is returned as-is and the caller handles the
+        fact that the file does not exist.  This is because the validate page has no access to the study directory and
+        an error would make no sense in that context.  When an actual load occurs, a FileFromInputNotFound error will be
+        issued.
+        """
+        # NOTE: The study doc supplied here doesn't exist, but that doesn't matter because we're not testing the load.
+        # I only selected that study dir because it had multiple files with the same name under it, and that's the only
+        # test data dir that does.
+        pafl = PeakAnnotationFilesLoader(
+            file="DataRepo/data/tests/multiple_representations/study.xlsx"
+        )
+        exp_file = "doesnotexist.xlsx"
+        file = pafl.find_annot_file(
+            exp_file, "DataRepo/data/tests/multiple_representations"
+        )
+        self.assertEqual(exp_file, file)
+        self.assertEqual(0, len(pafl.aggregated_errors_object.exceptions))
+
+    def test_find_annot_file_multiple_found(self):
+        """This ensures that the original supplied file (without a path) is returned and a warning is buffered.  Note
+        that the surrounding code will issue a FileFromInputNotFound error (which is why this is a warning, because
+        otherwise, it would be fully redundant).  This was a change made to accommodate a review issue about using a
+        single return type."""
+        pafl = PeakAnnotationFilesLoader(
+            file="DataRepo/data/tests/small_obob/study.xlsx"
+        )
+        filename = "small_obob_maven_6eaas_serum.xlsx"
+        file = pafl.find_annot_file(filename, "DataRepo/data/tests/small_obob")
+        self.assertEqual(filename, file)
+        self.assertEqual(1, len(pafl.aggregated_errors_object.exceptions))
+        self.assertEqual(1, pafl.aggregated_errors_object.num_warnings)
+        self.assertIsInstance(
+            pafl.aggregated_errors_object.exceptions[0],
+            MultipleMatchingPeakAnnotationFiles,
+        )
+
+    def test_map_peak_annot_files(self):
+        pafl = PeakAnnotationFilesLoader(
+            file="DataRepo/data/tests/submission_v3/study.xlsx"
+        )
+        expected = {
+            "study_no_defs.xlsx": [
+                "DataRepo/data/tests/submission_v3/study_no_defs.xlsx"
+            ],
+            "lcprotocols.tsv": ["DataRepo/data/tests/submission_v3/lcprotocols.tsv"],
+            "study_with_autofill_seeds.xlsx": [
+                "DataRepo/data/tests/submission_v3/study_with_autofill_seeds.xlsx"
+            ],
+            "sequences.tsv": ["DataRepo/data/tests/submission_v3/sequences.tsv"],
+            "defaults.tsv": ["DataRepo/data/tests/submission_v3/defaults.tsv"],
+            "study.xlsx": [
+                "DataRepo/data/tests/submission_v3/study.xlsx",
+                "DataRepo/data/tests/submission_v3/multitracer_v3/study.xlsx",
+            ],
+            "alaglu_cor.xlsx": [
+                "DataRepo/data/tests/submission_v3/multitracer_v3/alaglu_cor.xlsx"
+            ],
+            "study_missing_data.xlsx": [
+                "DataRepo/data/tests/submission_v3/multitracer_v3/study_missing_data.xlsx"
+            ],
+        }
+        ptntl_annot_fls = pafl.map_potential_peak_annot_files()
+        self.assertEqual(expected, ptntl_annot_fls)

--- a/DataRepo/tests/utils/test_exceptions.py
+++ b/DataRepo/tests/utils/test_exceptions.py
@@ -48,6 +48,8 @@ from DataRepo.utils.exceptions import (
     MultipleConflictingValueMatches,
     MultipleConflictingValueMatchesSummary,
     MultipleDefaultSequencesFound,
+    MultipleMatchingPeakAnnotationFiles,
+    MultipleMatchingPeakAnnotationFilesSummary,
     MutuallyExclusiveOptions,
     MzxmlColocatedWithMultipleAnnot,
     MzxmlColocatedWithMultipleAnnots,
@@ -2259,3 +2261,39 @@ class ExceptionTests(TracebaseTestCase):
         )
         self.assertIn("blank", str(exc))
         self.assertIn("Test suggestion", str(exc))
+
+    def test_multiple_matching_peakannotation_file(self):
+        mmpaf = MultipleMatchingPeakAnnotationFiles(
+            ["path/to/match1/dupe_filename.xlsx", "path/to/match2/dupe_filename.xlsx"]
+        )
+        mmpaf_sum = MultipleMatchingPeakAnnotationFilesSummary([mmpaf])
+        self.assertIn(
+            "A peak annotation filename from the load file data had multiple matching files",
+            str(mmpaf),
+        )
+        self.assertIn("\tdupe_filename.xlsx", str(mmpaf))
+        self.assertIn(
+            "\tpath/to/match1/dupe_filename.xlsx\n\t\tpath/to/match2/dupe_filename.xlsx",
+            str(mmpaf),
+        )
+        self.assertIn(
+            "Either delete the duplicate(s) (recommended) or specify the path",
+            str(mmpaf),
+        )
+
+        self.assertIn(
+            "1 peak annotation filenames from the Peak Annotation Files sheet",
+            str(mmpaf_sum),
+        )
+        self.assertIn(
+            "multiple matching files found in the study directory", str(mmpaf_sum)
+        )
+        self.assertIn("\tdupe_filename.xlsx", str(mmpaf_sum))
+        self.assertIn(
+            "\tpath/to/match1/dupe_filename.xlsx\n\t\tpath/to/match2/dupe_filename.xlsx",
+            str(mmpaf_sum),
+        )
+        self.assertIn(
+            "Either delete the duplicate(s) (recommended) or specify the path",
+            str(mmpaf_sum),
+        )

--- a/DataRepo/utils/exceptions.py
+++ b/DataRepo/utils/exceptions.py
@@ -5756,7 +5756,8 @@ class InvalidPeakAnnotationFileFormat(InfileError):
     """The peak annotation file format code is either unrecognized, or doesn't appear to match the auto-detected format
     of the supplied file.
 
-    This exception is raised as an error on the Upload **Start** page only.
+    This exception is raised as an error on the Upload **Start** page.  It can also occur during loading on the command
+    line.
 
     To resolve this issue, select the format code using the dropdown menus in the `File Format` column of the
     `Peak Annotation Files` sheet in the Study Doc that corresponds to the reported file.
@@ -5840,6 +5841,64 @@ class DuplicatePeakAnnotationFileName(Exception):
         message = f"Peak annotation filenames must be unique.  Filename {filename} was encountered multiple times."
         super().__init__(message)
         self.filename = filename
+
+
+class MultipleMatchingPeakAnnotationFilesSummary(Exception):
+    """One or more peak annotation filenames supplied in the Peak Annotation Files sheet had multiple matching files
+    found in the study directory.
+
+    To resolve this issue, either delete the duplicates (recommended) or specify the path (relative to the study
+    directory) to the desired file in the Peak Annotation Files sheet.
+
+    TraceBase requires that peak annotation filenames be globally unique to avoid ambiguities when sharing or
+    referencing data files.
+    """
+
+    def __init__(self, exceptions: List[MultipleMatchingPeakAnnotationFiles]):
+        # Collect all the files in a 2D dict
+        files_dict: Dict[str, List[str]] = defaultdict(list)
+        for exc in exceptions:
+            filename = os.path.basename(exc.annot_files[0])
+            for file in exc.annot_files:
+                files_dict[filename].append(file)
+
+        # Craft the message
+        nlt = "\n\t"
+        nltt = "\n\t\t"
+        message = (
+            f"{len(exceptions)} peak annotation filenames from the Peak Annotation Files sheet had multiple matching "
+            "files found in the study directory:\n"
+            f"\t{nlt.join([name + nltt + nltt.join(paths) for name, paths in files_dict.items()])}\n"
+            "Either delete the duplicate(s) (recommended) or specify the path (relative to the study directory) to the "
+            "desired file in the Peak Annotation Files sheet for each filename listed."
+        )
+        super().__init__(message)
+        self.exceptions = exceptions
+
+
+class MultipleMatchingPeakAnnotationFiles(InfileError, SummarizableError):
+    """A peak annotation filename supplied in the Peak Annotation Files sheet had multiple matching files found in the
+    study directory.
+
+    To resolve this issue, either delete the duplicates (recommended) or specify the path (relative to the study
+    directory) to the desired file in the Peak Annotation Files sheet.
+
+    TraceBase requires that peak annotation filenames be globally unique to avoid ambiguities when sharing or
+    referencing data files.
+    """
+
+    SummarizerExceptionClass = MultipleMatchingPeakAnnotationFilesSummary
+
+    def __init__(self, annot_files: List[str], **kwargs):
+        nltt = "\n\t\t"
+        message = (
+            f"A peak annotation filename from %s had multiple matching files found in the study directory:\n"
+            f"\t{os.path.basename(annot_files[0])}\n\t\t{nltt.join(annot_files)}\n"
+            "Either delete the duplicate(s) (recommended) or specify the path (relative to the study directory) to the "
+            "desired file in the Peak Annotation Files sheet for each file listed."
+        )
+        super().__init__(message, **kwargs)
+        self.annot_files = annot_files
 
 
 class InvalidStudyDocVersion(Exception):


### PR DESCRIPTION
**NOTE**: This PR is a merge into main.  When this PR is approved, the same commit will be applied to `release/1_0_2_manuscript` from this branch, into which this commit was cherry-picked: `dev/peak_annot_paths_manuscript102` (and updated after addressing review items).  (I'm still not used to main not being the bleeding edge.)

## What

- [GREATS-251](https://princeton-university.atlassian.net/browse/GREATS-251)

Use the same strategy of directory-walking (that is used for locating the mzXML files) to identify the peak annotation file paths in the PeakAnnotationFilesLoader.

Note, this will not update the study doc contents and will assume each file name is unique (which is already assumed/required by other code).

## Why

1 required step for loading (excluding changes required by errors, such as resolving mzXML file ambiguities) is the addition of the study-directory-relative paths to the Peak Annotation Files sheet.  This is a labor-intensive step when there are lots of files.

## How

Added a directory walk to find peak annotation files.

Details:

- Added exception classes: `MultipleMatchingPeakAnnotationFilesSummary` and `MultipleMatchingPeakAnnotationFiles`
- `PeakAnnotationFilesLoader`
  - Added methods:
    - `find_annot_file`
    - `map_potential_peak_annot_files`
  - Made call to `find_annot_file` from `get_file_and_format`.
  - Made call to `map_potential_peak_annot_files` from the constructor.

## Tests

- Tests added
- CI tests pass

## Security Concerns

None

## Others

There is a separate ticket that will handle this via a submission interface refactor that will allow users to drop a study folder, but until that larger effort is implemented (which solves more issues than this issue).