### PR TITLE
[out of scope] Download Page 2: Added versioning to exported files

### DIFF
--- a/DataRepo/management/commands/export_studies.py
+++ b/DataRepo/management/commands/export_studies.py
@@ -1,3 +1,5 @@
+from datetime import datetime
+
 from django.conf import settings
 from django.core.management import BaseCommand
 
@@ -6,7 +8,7 @@ from DataRepo.utils.studies_exporter import StudiesExporter
 
 class Command(BaseCommand):
     # Show this when the user types help
-    help = "Export peak data, peak groups, and fcirc formats, organized by study."
+    help = "Export peak data, peak groups, fcirc, and mzxml formats."
 
     def add_arguments(self, parser):
         parser.add_argument(
@@ -36,6 +38,21 @@ class Command(BaseCommand):
             default=False,
             help="Overwrite existing files (not directories).",
         )
+        parser.add_argument(
+            "--host",
+            required=False,
+            default=StudiesExporter.default_instance,
+            help=(
+                f"[{StudiesExporter.default_instance} Host name to include in the exported file names.  "
+                "Use this so users can identify files exported from different TraceBase instances."
+            ),
+        )
+        parser.add_argument(
+            "--date",
+            type=datetime.fromisoformat,
+            help="Date of export.  ISO format: YYYY-MM-DDTHH:MM:SS.",
+            default=datetime.now(),
+        )
 
     def handle(self, *args, **options):
         se = StudiesExporter(
@@ -43,5 +60,11 @@ class Command(BaseCommand):
             study_targets=options["studies"],
             data_types=options["data_type"],
             overwrite=options["overwrite"],
+            host=options["host"],
+            date=(
+                datetime.fromisoformat(options["date"])
+                if isinstance(options["date"], str) and options["date"] != ""
+                else None
+            ),
         )
         se.export()

--- a/DataRepo/management/commands/export_studies.py
+++ b/DataRepo/management/commands/export_studies.py
@@ -13,7 +13,7 @@ class Command(BaseCommand):
     def add_arguments(self, parser):
         parser.add_argument(
             "--outdir",
-            required=True,
+            required=False,
             default=settings.DOWNLOADS_DIR,
             help=f"[{settings.DOWNLOADS_DIR}] Directory to create and save exported files.",
         )

--- a/DataRepo/management/commands/export_studies.py
+++ b/DataRepo/management/commands/export_studies.py
@@ -41,9 +41,9 @@ class Command(BaseCommand):
         parser.add_argument(
             "--host",
             required=False,
-            default=StudiesExporter.default_instance,
+            default=StudiesExporter.default_host,
             help=(
-                f"[{StudiesExporter.default_instance} Host name to include in the exported file names.  "
+                f"[{StudiesExporter.default_host} Host name to include in the exported file names.  "
                 "Use this so users can identify files exported from different TraceBase instances."
             ),
         )

--- a/DataRepo/tests/management/commands/test_export_studies.py
+++ b/DataRepo/tests/management/commands/test_export_studies.py
@@ -158,14 +158,16 @@ class ExportStudiesTests(ExportStudiesTestBase):
             "export_studies",
             outdir=os.path.join(self.tmpdir, "mzxml_study_all_types"),
             studies=["test v3 study"],
+            host="tb9",
+            date="1972-11-24",
         )
         self.assertEqual(
             set(
                 [
-                    "study_0003/study_0003-peakgroups.tsv",
-                    "study_0003/study_0003-peakdata.tsv",
-                    "study_0003/study_0003-fcirc.tsv",
-                    "study_0003/study_0003-mzxml.zip",
+                    "tb9-1972.11.24-test_v3_study-0003-PeakData.tsv",
+                    "tb9-1972.11.24-test_v3_study-0003-PeakGroups.tsv",
+                    "tb9-1972.11.24-test_v3_study-0003-mzXML.zip",
+                    "tb9-1972.11.24-test_v3_study-0003-Fcirc.tsv",
                 ]
             ),
             set(
@@ -184,7 +186,7 @@ class ExportStudiesTests(ExportStudiesTestBase):
                     )
                     for p in Path(
                         os.path.join(self.tmpdir, "mzxml_study_all_types")
-                    ).rglob("*/*/")
+                    ).rglob("*/")
                 ]
             ),
         )

--- a/DataRepo/tests/management/commands/test_export_studies.py
+++ b/DataRepo/tests/management/commands/test_export_studies.py
@@ -158,14 +158,16 @@ class ExportStudiesTests(ExportStudiesTestBase):
             "export_studies",
             outdir=os.path.join(self.tmpdir, "mzxml_study_all_types"),
             studies=["test v3 study"],
+            host="tb9",
+            date="1972-11-24",
         )
         self.assertEqual(
             set(
                 [
-                    "study_0003/study_0003-peakgroups.tsv",
-                    "study_0003/study_0003-peakdata.tsv",
-                    "study_0003/study_0003-fcirc.tsv",
-                    "study_0003/study_0003-mzxml.zip",
+                    "tb9-1972.11.24-test_v3_study-0003-PeakData.tsv",
+                    "tb9-1972.11.24-test_v3_study-0003-PeakGroups.tsv",
+                    "tb9-1972.11.24-test_v3_study-0003-mzXML.zip",
+                    "tb9-1972.11.24-test_v3_study-0003-Fcirc.tsv",
                 ]
             ),
             set(
@@ -184,7 +186,7 @@ class ExportStudiesTests(ExportStudiesTestBase):
                     )
                     for p in Path(
                         os.path.join(self.tmpdir, "mzxml_study_all_types")
-                    ).rglob("*/*")
+                    ).rglob("*/")
                 ]
             ),
         )

--- a/DataRepo/tests/management/commands/test_export_studies.py
+++ b/DataRepo/tests/management/commands/test_export_studies.py
@@ -1,5 +1,4 @@
 import os
-import re
 import shutil
 import tempfile
 from pathlib import Path
@@ -161,30 +160,24 @@ class ExportStudiesTests(ExportStudiesTestBase):
             host="tb9",
             date="1972-11-24",
         )
+        stdy = Study.objects.get(name="test v3 study")
         self.assertEqual(
             set(
                 [
-                    "tb9-1972.11.24-test_v3_study-0003-PeakData.tsv",
-                    "tb9-1972.11.24-test_v3_study-0003-PeakGroups.tsv",
-                    "tb9-1972.11.24-test_v3_study-0003-mzXML.zip",
-                    "tb9-1972.11.24-test_v3_study-0003-Fcirc.tsv",
+                    f"tb9-1972.11.24-test_v3_study-{stdy.id:04d}-PeakData.tsv",
+                    f"tb9-1972.11.24-test_v3_study-{stdy.id:04d}-PeakGroups.tsv",
+                    f"tb9-1972.11.24-test_v3_study-{stdy.id:04d}-mzXML.zip",
+                    f"tb9-1972.11.24-test_v3_study-{stdy.id:04d}-Fcirc.tsv",
                 ]
             ),
             set(
                 [
-                    # The study ID is random/arbitrary.  Change them all to be the same.  I chose 0003 arbitrarily,
-                    # because that's how they appear when I run the test without modifying them.
-                    re.sub(
-                        r"study_\d+",
-                        "study_0003",
-                        str(
-                            os.path.relpath(
-                                p, os.path.join(self.tmpdir, "mzxml_study_all_types")
-                            )
-                        ),
-                        count=2,
+                    str(
+                        os.path.relpath(
+                            pth, os.path.join(self.tmpdir, "mzxml_study_all_types")
+                        )
                     )
-                    for p in Path(
+                    for pth in Path(
                         os.path.join(self.tmpdir, "mzxml_study_all_types")
                     ).rglob("*/")
                 ]

--- a/DataRepo/tests/management/commands/test_export_studies.py
+++ b/DataRepo/tests/management/commands/test_export_studies.py
@@ -179,7 +179,7 @@ class ExportStudiesTests(ExportStudiesTestBase):
                     )
                     for pth in Path(
                         os.path.join(self.tmpdir, "mzxml_study_all_types")
-                    ).rglob("*/")
+                    ).rglob("*")
                 ]
             ),
         )

--- a/DataRepo/tests/utils/test_studies_exporter.py
+++ b/DataRepo/tests/utils/test_studies_exporter.py
@@ -1,0 +1,23 @@
+from DataRepo.tests.tracebase_test_case import TracebaseTestCase
+from DataRepo.utils.studies_exporter import (
+    BadQueryTerm,
+    DuplicateSlugifiedStudyNames,
+)
+
+
+class StudiesExporterMainTests(TracebaseTestCase):
+    def test_bad_query_term(self):
+        bqt = BadQueryTerm({"bad term": ValueError("Record not found")})
+        self.assertIn(
+            "No study name or ID matches the provided search term(s)", str(bqt)
+        )
+        self.assertIn("bad term: ValueError: Record not found", str(bqt))
+        self.assertIn(
+            "Scroll up to see tracebacks above for each individual exception", str(bqt)
+        )
+
+    def test_duplicate_slugified_study_names(self):
+        dssn = DuplicateSlugifiedStudyNames({"Dupe Study Name": 2})
+        self.assertIn(
+            "These slugified study names are not unique: ['Dupe Study Name']", str(dssn)
+        )

--- a/DataRepo/utils/studies_exporter.py
+++ b/DataRepo/utils/studies_exporter.py
@@ -1,12 +1,15 @@
 import os
+import socket
 import tempfile
+from collections import defaultdict
 from datetime import datetime
-from typing import Callable, Iterator
+from typing import Callable, Dict, Iterator, List, Optional, Tuple
 
 from django.db.models import Q
-from django.template.defaultfilters import slugify
 from django.template.loader import get_template
+from django.utils.text import get_valid_filename
 
+from DataRepo.formats.mzxml_dataformat import MzxmlFormat
 from DataRepo.formats.search_group import SearchGroup
 from DataRepo.models import Study
 from DataRepo.utils.exceptions import AggregatedErrors, trace
@@ -17,20 +20,70 @@ from DataRepo.views.search.download import (
 
 
 class StudiesExporter:
+    """Exports the SearchGroup formats with one file per study and and data type combo.
+
+    Output filenames will be slugified (replacing dashes with underscores) and have the following naming structure:
+        {instance_name}-{export_datestamp}-{study_name}-{study_id}-{data_type}.{extension}
+
+    Example:
+        tb9-pub-2026.04.11-Acute_Stress-0004-mzXML.zip
+
+    The reasoning/value for each filename element:
+        instance_name (E.g. "tb9" for the tracebase-rabinowitz instance):
+            Since TraceBase instances are loaded separately, when users download exported data, including the instance
+            name can be used to differentiate between downloads from different instances.  They should theoretically be
+            identical for the same study, but if any data is manually edited, knowing the source can be critical.
+        export_datestamp (E.g. "2026.04.11"):
+            This is the date of the export.  This serves as a version number for the export.
+        study_name (E.g. "Acute_Stress"):
+            Note that study names may contain dashes.  The study name is slugified, so it will not necessarily exactly
+            match the study's name as displayed in TraceBase.
+        study_id (E.g. "0004"):
+            This is the internal database ID of the study.
+        data_type (E.g. "mzXML"):
+            This is the name of the SearchGroup format
+        extension (E.g. "tsv"):
+            There are 2 extensions currently: tsv and zip.  The zip extension is specific to the mzXML search format.
+
+    Class Attributes:
+        sg (SearchGroup): This defines the data types and is the means by which queries are executed.
+        all_data_types (List[str]): These are the names of all of the DataFormat objects contained by sg.
+        all_zipped_data_types (List[str]):  This is the subset of all_data_types that should be exported as zip files.
+        header_template (Template): Used to render the commented metadata header of exported TSV files.
+        row_template (Template): Used to render the content of the exported TSV files.
+        datestamp_format (str): The date string used in the exported filenames.
+        default_instance (str): Hostname of the TraceBase instance (with dashes replaced with underscores).
+    Instance Attributes:
+        bad_searches (Dict[str, Exception]): Query exceptions by study ID or name.
+        outdir (str): Output directory.
+        study_targets (List[str]): List of study IDs and/or names.
+        data_types (List[str]): The data types to be exported.  Must be a subset of cls.all_data_types.
+        zipped_data_types (List[str]): The zipped data types to be exported.  Must be a subset of data_types.
+        overwrite (bool) [False]: Whether to overwrite existing exported files.
+    """
+
     sg = SearchGroup()
     all_data_types = [fmtobj.name for fmtobj in sg.modeldata.values()]
-    all_zipped_data_types = ["mzXML"]
+    all_zipped_data_types = [MzxmlFormat.name]
     header_template = get_template("search/downloads/download_header.tsv")
     row_template = get_template("search/downloads/download_row.tsv")
+    default_instance = socket.gethostname().replace("-", "_")
+
+    # NOTE: datestamp_format intentionally differs from AdvancedSearchDownloadView.datestamp_format in that it does not
+    # include the time (since the intention is to run the export in a cron less than or equal to once a day) and we
+    # would like the dates to sort chronologically (i.e. numeric year-month-day)
+    datestamp_format = "%Y.%m.%d"
 
     def __init__(
         self,
-        outdir,
-        study_targets=None,
-        data_types=None,
-        overwrite=False,
+        outdir: str,
+        study_targets: Optional[List[str]] = None,
+        data_types: Optional[List[str]] = None,
+        overwrite: bool = False,
+        host: Optional[str] = None,
+        date: Optional[datetime] = None,
     ):
-        self.bad_searches = {}
+        self.bad_searches: Dict[str, int] = {}
 
         if isinstance(data_types, str):
             data_types = [data_types]
@@ -45,16 +98,36 @@ class StudiesExporter:
         ]
         self.overwrite = overwrite
 
+        self.instance_name = host if host else self.default_instance
+        self.date = date
+
+        # A script on a cron-job uses the study ID in the file name to compare exported files with previously exported
+        # versions.  It does this by splitting on dash and taking the study ID from the file name, relative to the end
+        # of the file, thus the format value at the end of the file name may not have dashes.
+        if any("-" in datatype_name for datatype_name in self.all_data_types):
+            bad_format_names = [dtn for dtn in self.all_data_types if "-" in dtn]
+            raise ValueError(
+                "The following SearchGroup format names contain dashes ('-') which are not allowed in order to parse "
+                f"export file names: {bad_format_names}."
+            )
+
     def export(self):
         # For individual traceback prints
         aes = AggregatedErrors()
 
         # Export time for the outfile headers
-        now = datetime.now()
-        dt_string = now.strftime("%d/%m/%Y %H:%M:%S")
+        if self.date:
+            export_time = self.date
+        else:
+            export_time = datetime.now()
+
+        dt_string = export_time.strftime(AdvancedSearchDownloadView.date_format)
+
+        # Export time for the outfile name
+        export_datestamp = export_time.strftime(self.datestamp_format)
 
         # Identify the study records to export (by name)
-        study_ids = []
+        study_ids_names = []
         if len(self.study_targets) > 0:
             for study_target in self.study_targets:
                 # Always check for name match
@@ -66,7 +139,12 @@ class StudiesExporter:
                 try:
                     # Perform a `get` for each record so that non-matching values will raise an exception
                     study_rec = Study.objects.get(or_query)
-                    study_ids.append(study_rec.id)
+                    study_ids_names.append(
+                        (
+                            study_rec.id,
+                            get_valid_filename(study_rec.name.replace("-", "_")),
+                        )
+                    )
                 except Exception as e:
                     # Buffering exception to just print the traceback
                     aes.buffer_error(e)
@@ -77,7 +155,15 @@ class StudiesExporter:
             if len(self.bad_searches.keys()) > 0:
                 raise BadQueryTerm(self.bad_searches)
         else:
-            study_ids = list(Study.objects.all().values_list("id", flat=True))
+            study_ids_names = list(
+                (
+                    stdy.id,
+                    get_valid_filename(stdy.name.replace("-", "_")),
+                )
+                for stdy in Study.objects.all()
+            )
+
+        self.check_study_names(study_ids_names)
 
         # Make output directory
         if not os.path.exists(self.outdir):
@@ -85,26 +171,21 @@ class StudiesExporter:
 
         existing_files = []
 
-        # For each study (name)
-        for study_id in study_ids:
-            study_id_str = f"study_{study_id:04d}"
-
-            # Make study directory
-            study_dir = os.path.join(self.outdir, study_id_str)
-            if not os.path.exists(study_dir):
-                os.mkdir(study_dir)
+        # For each study (ID/name)
+        for study_id, study_name in study_ids_names:
+            study_str = (
+                f"{self.instance_name}-{export_datestamp}-{study_name}-{study_id:04d}"
+            )
 
             # For each data type
             for data_type in self.data_types:
-                datatype_slug = slugify(data_type)
-
                 if data_type in self.zipped_data_types:
                     filepath = os.path.join(
-                        study_dir, f"{study_id_str}-{datatype_slug}.zip"
+                        self.outdir, get_valid_filename(f"{study_str}-{data_type}.zip")
                     )
                 else:
                     filepath = os.path.join(
-                        study_dir, f"{study_id_str}-{datatype_slug}.tsv"
+                        self.outdir, get_valid_filename(f"{study_str}-{data_type}.tsv")
                     )
 
                 if os.path.exists(filepath) and not self.overwrite:
@@ -271,10 +352,25 @@ class StudiesExporter:
 
             raise e
 
+    def check_study_names(self, study_ids_names: List[Tuple[int, str]]):
+        """This checks the sanitized study names for uniqueness"""
+        unique_study_names = []
+        dupe_study_names: Dict[str, int] = defaultdict(int)
+        for _, study_name in study_ids_names:
+            if study_name in unique_study_names:
+                if study_name in dupe_study_names:
+                    dupe_study_names[study_name] += 1
+                else:
+                    dupe_study_names[study_name] = 2
+            else:
+                unique_study_names.append(study_name)
+        if dupe_study_names:
+            raise DuplicateSlugifiedStudyNames(dupe_study_names)
+
 
 class BadQueryTerm(Exception):
-    def __init__(self, bad_searches_dict: dict):
-        deets = [f"{k}: {type(v).__name__}: {v}" for k, v in bad_searches_dict.items()]
+    def __init__(self, bad_searches: Dict[str, Exception]):
+        deets = [f"{k}: {type(v).__name__}: {v}" for k, v in bad_searches.items()]
         nt = "\n\t"
         message = (
             "No study name or ID matches the provided search term(s):\n"
@@ -282,4 +378,11 @@ class BadQueryTerm(Exception):
             "Scroll up to see tracebacks above for each individual exception encountered."
         )
         super().__init__(message)
-        self.bad_searches_dict = bad_searches_dict
+        self.bad_searches = bad_searches
+
+
+class DuplicateSlugifiedStudyNames(Exception):
+    def __init__(self, dupe_study_names: Dict[str, int]):
+        message = f"These slugified study names are not unique: {list(dupe_study_names.keys())}."
+        super().__init__(message)
+        self.dupe_study_names = dupe_study_names

--- a/DataRepo/utils/studies_exporter.py
+++ b/DataRepo/utils/studies_exporter.py
@@ -173,9 +173,7 @@ class StudiesExporter:
 
         # For each study (ID/name)
         for study_id, study_name in study_ids_names:
-            study_str = (
-                f"{self.host}-{export_datestamp}-{study_name}-{study_id:04d}"
-            )
+            study_str = f"{self.host}-{export_datestamp}-{study_name}-{study_id:04d}"
 
             # For each data type
             for data_type in self.data_types:

--- a/DataRepo/utils/studies_exporter.py
+++ b/DataRepo/utils/studies_exporter.py
@@ -1,12 +1,15 @@
 import os
+import socket
 import tempfile
+from collections import defaultdict
 from datetime import datetime
-from typing import Callable, Iterator
+from typing import Callable, Dict, Iterator, List, Optional, Tuple
 
 from django.db.models import Q
-from django.template.defaultfilters import slugify
 from django.template.loader import get_template
+from django.utils.text import get_valid_filename
 
+from DataRepo.formats.mzxml_dataformat import MzxmlFormat
 from DataRepo.formats.search_group import SearchGroup
 from DataRepo.models import Study
 from DataRepo.utils.exceptions import AggregatedErrors, trace
@@ -17,20 +20,70 @@ from DataRepo.views.search.download import (
 
 
 class StudiesExporter:
+    """Exports the SearchGroup formats with one file per study and and data type combo.
+
+    Output filenames will be slugified (replacing dashes with underscores) and have the following naming structure:
+        {instance_name}-{export_datestamp}-{study_name}-{study_id}-{data_type}.{extension}
+
+    Example:
+        tb9-pub-2026.04.11-Acute_Stress-0004-mzXML.zip
+
+    The reasoning/value for each filename element:
+        instance_name (E.g. "tb9" for the tracebase-rabinowitz instance):
+            Since TraceBase instances are loaded separately, when users download exported data, including the instance
+            name can be used to differentiate between downloads from different instances.  They should theoretically be
+            identical for the same study, but if any data is manually edited, knowing the source can be critical.
+        export_datestamp (E.g. "2026.04.11"):
+            This is the date of the export.  This serves as a version number for the export.
+        study_name (E.g. "Acute_Stress"):
+            Note that study names may contain dashes.  The study name is slugified, so it will not necessarily exactly
+            match the study's name as displayed in TraceBase.
+        study_id (E.g. "0004"):
+            This is the internal database ID of the study.
+        data_type (E.g. "mzXML"):
+            This is the name of the SearchGroup format
+        extension (E.g. "tsv"):
+            There are 2 extensions currently: tsv and zip.  The zip extension is specific to the mzXML search format.
+
+    Class Attributes:
+        sg (SearchGroup): This defines the data types and is the means by which queries are executed.
+        all_data_types (List[str]): These are the names of all of the DataFormat objects contained by sg.
+        all_zipped_data_types (List[str]):  This is the subset of all_data_types that should be exported as zip files.
+        header_template (Template): Used to render the commented metadata header of exported TSV files.
+        row_template (Template): Used to render the content of the exported TSV files.
+        datestamp_format (str): The date string used in the exported filenames.
+        default_instance (str): Hostname of the TraceBase instance (with dashes replaced with underscores).
+    Instance Attributes:
+        bad_searches (Dict[str, Exception]): Query exceptions by study ID or name.
+        outdir (str): Output directory.
+        study_targets (List[str]): List of study IDs and/or names.
+        data_types (List[str]): The data types to be exported.  Must be a subset of cls.all_data_types.
+        zipped_data_types (List[str]): The zipped data types to be exported.  Must be a subset of data_types.
+        overwrite (bool) [False]: Whether to overwrite existing exported files.
+    """
+
     sg = SearchGroup()
     all_data_types = [fmtobj.name for fmtobj in sg.modeldata.values()]
-    all_zipped_data_types = ["mzXML"]
+    all_zipped_data_types = [MzxmlFormat.name]
     header_template = get_template("search/downloads/download_header.tsv")
     row_template = get_template("search/downloads/download_row.tsv")
+    default_instance = socket.gethostname().replace("-", "_")
+
+    # NOTE: datestamp_format intentionally differs from AdvancedSearchDownloadView.datestamp_format in that it does not
+    # include the time (since the intention is to run the export in a cron less than or equal to once a day) and we
+    # would like the dates to sort chronologically (i.e. numeric year-month-day)
+    datestamp_format = "%Y.%m.%d"
 
     def __init__(
         self,
-        outdir,
-        study_targets=None,
-        data_types=None,
-        overwrite=False,
+        outdir: str,
+        study_targets: Optional[List[str]] = None,
+        data_types: Optional[List[str]] = None,
+        overwrite: bool = False,
+        host: Optional[str] = None,
+        date: Optional[datetime] = None,
     ):
-        self.bad_searches = {}
+        self.bad_searches: Dict[str, int] = {}
 
         if isinstance(data_types, str):
             data_types = [data_types]
@@ -45,16 +98,36 @@ class StudiesExporter:
         ]
         self.overwrite = overwrite
 
+        self.instance_name = host if host else self.default_instance
+        self.date = date
+
+        # A script on a cron-job uses the study ID in the file name to compare exported files with previously exported
+        # versions.  It does this by splitting on dash and taking the study ID from the file name, relative to the end
+        # of the file, thus the format value at the end of the file name may not have dashes.
+        if any("-" in datatype_name for datatype_name in self.all_data_types):
+            bad_format_names = [dtn for dtn in self.all_data_types if "-" in dtn]
+            raise ValueError(
+                "The following SearchGroup format names contain dashes ('-') which are not allowed in order to parse "
+                f"export file names: {bad_format_names}."
+            )
+
     def export(self):
         # For individual traceback prints
         aes = AggregatedErrors()
 
         # Export time for the outfile headers
-        now = datetime.now()
-        dt_string = now.strftime("%d/%m/%Y %H:%M:%S")
+        if self.date:
+            export_time = self.date
+        else:
+            export_time = datetime.now()
+
+        dt_string = export_time.strftime(AdvancedSearchDownloadView.date_format)
+
+        # Export time for the outfile name
+        export_datestamp = export_time.strftime(self.datestamp_format)
 
         # Identify the study records to export (by name)
-        study_ids = []
+        study_ids_names = []
         if len(self.study_targets) > 0:
             for study_target in self.study_targets:
                 # Always check for name match
@@ -66,7 +139,12 @@ class StudiesExporter:
                 try:
                     # Perform a `get` for each record so that non-matching values will raise an exception
                     study_rec = Study.objects.get(or_query)
-                    study_ids.append(study_rec.id)
+                    study_ids_names.append(
+                        (
+                            study_rec.id,
+                            get_valid_filename(study_rec.name.replace("-", "_")),
+                        )
+                    )
                 except Exception as e:
                     # Buffering exception to just print the traceback
                     aes.buffer_error(e)
@@ -77,7 +155,15 @@ class StudiesExporter:
             if len(self.bad_searches.keys()) > 0:
                 raise BadQueryTerm(self.bad_searches)
         else:
-            study_ids = list(Study.objects.all().values_list("id", flat=True))
+            study_ids_names = list(
+                (
+                    stdy.id,
+                    get_valid_filename(stdy.name.replace("-", "_")),
+                )
+                for stdy in Study.objects.all()
+            )
+
+        self.check_study_names(study_ids_names)
 
         # Make output directory
         if not os.path.exists(self.outdir):
@@ -85,22 +171,17 @@ class StudiesExporter:
 
         existing_files = []
 
-        # For each study (name)
-        for study_id in study_ids:
-            study_id_str = f"study_{study_id:04d}"
-
-            # Make study directory
-            study_dir = os.path.join(self.outdir, study_id_str)
-            if not os.path.exists(study_dir):
-                os.mkdir(study_dir)
+        # For each study (ID/name)
+        for study_id, study_name in study_ids_names:
+            study_str = (
+                f"{self.instance_name}-{export_datestamp}-{study_name}-{study_id:04d}"
+            )
 
             # For each data type
             for data_type in self.data_types:
-                datatype_slug = slugify(data_type)
-
                 suffix = "zip" if data_type in self.zipped_data_types else "tsv"
                 filepath = os.path.join(
-                    study_dir, f"{study_id_str}-{datatype_slug}.{suffix}"
+                    self.outdir, f"{study_str}-{data_type}.{suffix}"
                 )
 
                 if os.path.exists(filepath) and not self.overwrite:
@@ -267,10 +348,25 @@ class StudiesExporter:
 
             raise e
 
+    def check_study_names(self, study_ids_names: List[Tuple[int, str]]):
+        """This checks the sanitized study names for uniqueness"""
+        unique_study_names = []
+        dupe_study_names: Dict[str, int] = defaultdict(int)
+        for _, study_name in study_ids_names:
+            if study_name in unique_study_names:
+                if study_name in dupe_study_names:
+                    dupe_study_names[study_name] += 1
+                else:
+                    dupe_study_names[study_name] = 2
+            else:
+                unique_study_names.append(study_name)
+        if dupe_study_names:
+            raise DuplicateSlugifiedStudyNames(dupe_study_names)
+
 
 class BadQueryTerm(Exception):
-    def __init__(self, bad_searches_dict: dict):
-        deets = [f"{k}: {type(v).__name__}: {v}" for k, v in bad_searches_dict.items()]
+    def __init__(self, bad_searches: Dict[str, Exception]):
+        deets = [f"{k}: {type(v).__name__}: {v}" for k, v in bad_searches.items()]
         nt = "\n\t"
         message = (
             "No study name or ID matches the provided search term(s):\n"
@@ -278,4 +374,11 @@ class BadQueryTerm(Exception):
             "Scroll up to see tracebacks above for each individual exception encountered."
         )
         super().__init__(message)
-        self.bad_searches_dict = bad_searches_dict
+        self.bad_searches = bad_searches
+
+
+class DuplicateSlugifiedStudyNames(Exception):
+    def __init__(self, dupe_study_names: Dict[str, int]):
+        message = f"These slugified study names are not unique: {list(dupe_study_names.keys())}."
+        super().__init__(message)
+        self.dupe_study_names = dupe_study_names

--- a/DataRepo/utils/studies_exporter.py
+++ b/DataRepo/utils/studies_exporter.py
@@ -26,7 +26,7 @@ class StudiesExporter:
         {host_name}-{export_datestamp}-{study_name}-{study_id}-{data_type}.{extension}
 
     Example:
-        tb9-pub-2026.04.11-Acute_Stress-0004-mzXML.zip
+        tb9_pub-2026.04.11-Acute_Stress-0004-mzXML.zip
 
     The reasoning/value for each filename element:
         host_name (E.g. "tb9" for the tracebase-rabinowitz instance):

--- a/DataRepo/utils/studies_exporter.py
+++ b/DataRepo/utils/studies_exporter.py
@@ -23,14 +23,14 @@ class StudiesExporter:
     """Exports the SearchGroup formats with one file per study and and data type combo.
 
     Output filenames will be slugified (replacing dashes with underscores) and have the following naming structure:
-        {instance_name}-{export_datestamp}-{study_name}-{study_id}-{data_type}.{extension}
+        {host_name}-{export_datestamp}-{study_name}-{study_id}-{data_type}.{extension}
 
     Example:
         tb9-pub-2026.04.11-Acute_Stress-0004-mzXML.zip
 
     The reasoning/value for each filename element:
-        instance_name (E.g. "tb9" for the tracebase-rabinowitz instance):
-            Since TraceBase instances are loaded separately, when users download exported data, including the instance
+        host_name (E.g. "tb9" for the tracebase-rabinowitz instance):
+            Since TraceBase instances are loaded separately, when users download exported data, including the host
             name can be used to differentiate between downloads from different instances.  They should theoretically be
             identical for the same study, but if any data is manually edited, knowing the source can be critical.
         export_datestamp (E.g. "2026.04.11"):
@@ -52,7 +52,7 @@ class StudiesExporter:
         header_template (Template): Used to render the commented metadata header of exported TSV files.
         row_template (Template): Used to render the content of the exported TSV files.
         datestamp_format (str): The date string used in the exported filenames.
-        default_instance (str): Hostname of the TraceBase instance (with dashes replaced with underscores).
+        default_host (str): Host/domain name of the TraceBase instance (with dashes replaced with underscores).
     Instance Attributes:
         bad_searches (Dict[str, Exception]): Query exceptions by study ID or name.
         outdir (str): Output directory.
@@ -67,7 +67,7 @@ class StudiesExporter:
     all_zipped_data_types = [MzxmlFormat.name]
     header_template = get_template("search/downloads/download_header.tsv")
     row_template = get_template("search/downloads/download_row.tsv")
-    default_instance = socket.gethostname().replace("-", "_")
+    default_host = socket.getfqdn().replace("-", "_")
 
     # NOTE: datestamp_format intentionally differs from AdvancedSearchDownloadView.datestamp_format in that it does not
     # include the time (since the intention is to run the export in a cron less than or equal to once a day) and we
@@ -80,8 +80,8 @@ class StudiesExporter:
         study_targets: Optional[List[str]] = None,
         data_types: Optional[List[str]] = None,
         overwrite: bool = False,
-        host: Optional[str] = None,
-        date: Optional[datetime] = None,
+        host: Optional[str] = None,  # Defaults to current host/domain
+        date: Optional[datetime] = None,  # Defaults to now
     ):
         self.bad_searches: Dict[str, int] = {}
 
@@ -98,7 +98,7 @@ class StudiesExporter:
         ]
         self.overwrite = overwrite
 
-        self.instance_name = host if host else self.default_instance
+        self.host = host if host else self.default_host
         self.date = date
 
         # A script on a cron-job uses the study ID in the file name to compare exported files with previously exported
@@ -174,7 +174,7 @@ class StudiesExporter:
         # For each study (ID/name)
         for study_id, study_name in study_ids_names:
             study_str = (
-                f"{self.instance_name}-{export_datestamp}-{study_name}-{study_id:04d}"
+                f"{self.host}-{export_datestamp}-{study_name}-{study_id:04d}"
             )
 
             # For each data type


### PR DESCRIPTION
## What

- Partially addresses [GREATS-318](https://princeton-university.atlassian.net/browse/GREATS-318)
- [GREATS-289](https://princeton-university.atlassian.net/browse/GREATS-289)

> Add the following features to the studies_exporter:
> 
> 1. Name the exported file, including name elements that can convey the following information:
>    1. A slugified/sanitized version of the study name
>    2. Host (e.g. tracebase-rabinowitz)
>    3. date stamp
>    4. study id (so that it can be programmatically related to the database)
>    5. data type (PeakGroups, PeakData, FCirc, and mzXML)
>    6. extension (zip or tsv)

## Why

Site downloads are broken.  See [GREATS-318](https://princeton-university.atlassian.net/browse/GREATS-318).  The fix is downloading actual files instead of streaming the data.  It makes no sense to stream.  Streaming downloads are only needed for the advanced search, when you're downloading a custom set of data.

In order to supply/manage downloads as files, we have an opportunity to version the downloads...

> Users need to know if their downloaded files are current or not or if there are updates to obtain so that they can be assured as having the latest data.  Current exports of the studies_exporter contain the export date in their headers, but there is no indication that any previously downloaded file is still current or if new or changed data is available.
> 
> Also, [the current] file names [as provided by the `export_studies` script] do not indicate the study names in a human readable fashion.  They are currently only composed of the internal study ID and the data type.

## How

> Added host, version, and a human readable study name to exported study data.
> 
> Details:
> 
> - Added the ability to include a hostname so that users can tell what instance they downloaded an exported file from.  Included the ability to set a custom hostname.
> - Added a sortable datestamp to the exported file names.
> - Added a human readable study name (retaining the study ID for programmatic handling).
> - Ensured exported file names could be parsed using a delimiter by disallowing that delimiter in any of the file name components.
> - Added checks to the file names for uniqueness.
> - Improved documentation.
> - Made the outdir option optional (because a default had been added previously).

## Tests

- CI tests pass
- Updated tests
- Manually tested on `tb9-dev`.  Ran the export and manually checked the file names.

## Security Concerns

- Data handling hasn't changed other than the export file names, which are checked for collisions.
- No authentication/authorization changes
- No dependencies or third-party libraries introduced
- No potential attack surface increase

## Others

None