### PR TITLE
Security update for superlinter (into `release/1_0_2_manuscript`)

### DIFF
--- a/.github/ISSUE_TEMPLATE/new_release.md
+++ b/.github/ISSUE_TEMPLATE/new_release.md
@@ -28,7 +28,7 @@ None
     - [ ] `npx textlint -c .textlintrc.json CHANGELOG.md`
     - [ ] `git commit`
   - [ ] `git push` - commit and push updated changelog
-    - [ ] Ensure all tests pass in GitHub actions
+    - [ ] Ensure all tests pass in GitHub Actions
   - [ ] `git tag -a [TAG_NAME]`
     - [ ] Enter a description of the release when prompted
   - [ ] `git push origin [TAG_NAME]`

--- a/.github/linters/.python-lint
+++ b/.github/linters/.python-lint
@@ -1,232 +1,141 @@
-[MASTER]
-errors-only=
+[MAIN]
+
+# Analyse import fallback blocks. This can be used to support both Python 2 and
+# 3 compatible code, which means that the block might have code that exists
+# only in one or another interpreter, leading to false positives when analysed.
+analyse-fallback-blocks=no
+
+# Clear in-memory caches upon conclusion of linting. Useful if running pylint
+# in a server-like mode.
+clear-cache-post-run=no
+
+# Load and enable all available extensions. Use --list-extensions to see a list
+# all available extensions.
+#enable-all-extensions=
+
+# In error mode, messages with a category besides ERROR or FATAL are
+# suppressed, and no reports are done by default. Error mode is compatible with
+# disabling specific errors.
+#errors-only=
+
+# Always return a 0 (non-error) status code, even if lint errors are found.
+# This is primarily useful in continuous integration scripts.
+#exit-zero=
 
 # A comma-separated list of package or module names from where C extensions may
 # be loaded. Extensions are loading into the active Python interpreter and may
-# run arbitrary code
+# run arbitrary code.
+extension-pkg-allow-list=
+
+# A comma-separated list of package or module names from where C extensions may
+# be loaded. Extensions are loading into the active Python interpreter and may
+# run arbitrary code. (This is an alternative name to extension-pkg-allow-list
+# for backward compatibility.)
 extension-pkg-whitelist=
 
-# Add files or directories to the blacklist. They should be base names, not
-# paths.
+# Return non-zero exit code if any of these messages/categories are detected,
+# even if score is above --fail-under value. Syntax same as enable. Messages
+# specified are enabled, while categories only check already-enabled messages.
+fail-on=
+
+# Specify a score threshold under which the program will exit with error.
+fail-under=10
+
+# Interpret the stdin as a python script, whose filename needs to be passed as
+# the module_or_package argument.
+#from-stdin=
+
+# Files or directories to be skipped. They should be base names, not paths.
 ignore=CVS
 
-# Add files or directories matching the regex patterns to the blacklist. The
-# regex matches against base names, not paths.
+# Add files or directories matching the regular expressions patterns to the
+# ignore-list. The regex matches against paths and can be in Posix or Windows
+# format. Because '\\' represents the directory delimiter on Windows systems,
+# it can't be used as an escape character.
+ignore-paths=^scratch.*,^\.venv/,^\.git/,node_modules/
+
+# Files or directories matching the regular expression patterns are skipped.
+# The regex matches against base names, not paths. The default value ignores
+# Emacs file locks
 ignore-patterns=
+
+# List of module names for which member attributes should not be checked and
+# will not be imported (useful for modules/projects where namespaces are
+# manipulated during runtime and thus existing member attributes cannot be
+# deduced by static analysis). It supports qualified module names, as well as
+# Unix pattern matching.
+ignored-modules=
 
 # Python code to execute, usually for sys.path manipulation such as
 # pygtk.require().
-#init-hook=
+init-hook='import sys, pathlib; sys.path.insert(0, str(pathlib.Path().resolve()))'
 
-# Use multiple processes to speed up Pylint.
+# Use multiple processes to speed up Pylint. Specifying 0 will auto-detect the
+# number of processors available to use, and will cap the count on Windows to
+# avoid hangs.
 jobs=1
 
-# List of plugins (as comma separated values of python modules names) to load,
+# Control the amount of potential inferred values when inferring a single
+# object. This can help the performance when dealing with large functions or
+# complex, nested conditions.
+limit-inference-results=100
+
+# List of plugins (as comma separated values of python module names) to load,
 # usually to register additional checkers.
-load-plugins=
+# load-plugins=pylint_django
 
 # Pickle collected data for later comparisons.
 persistent=yes
 
-# Specify a configuration file.
-#rcfile=
+# Resolve imports to .pyi stubs if available. May reduce no-member messages and
+# increase not-an-iterable messages.
+# Rob: This was added when I used pylint 3.3.8, but the CI actions use 3.1.0
+# prefer-stubs=no
+
+# Minimum Python version to use for version dependent checks. Will default to
+# the version used to run pylint.
+py-version=3.9
+
+# Discover python modules and packages in the file system subtree.
+recursive=no
+
+# Add paths to the list of the source roots. Supports globbing patterns. The
+# source root is an absolute path or a path relative to the current working
+# directory used to determine a package namespace for modules located under the
+# source root.
+source-roots=
 
 # When enabled, pylint would attempt to guess common misconfiguration and emit
-# user-friendly hints instead of false-positive error messages
-suggestion-mode=yes
+# user-friendly hints instead of false-positive error messages.
+# suggestion-mode=yes
 
 # Allow loading of arbitrary C extensions. Extensions are imported into the
 # active Python interpreter and may run arbitrary code.
 unsafe-load-any-extension=no
 
-
-[MESSAGES CONTROL]
-
-# Only show warnings with the listed confidence levels. Leave empty to show
-# all. Valid levels: HIGH, INFERENCE, INFERENCE_FAILURE, UNDEFINED
-confidence=
-
-# Disable the message, report, category or checker with the given id(s). You
-# can either give multiple identifiers separated by comma (,) or put this
-# option multiple times (only on the command line, not in the configuration
-# file where it should appear only once).You can also use "--disable=all" to
-# disable everything first and then reenable specific checks. For example, if
-# you want to run only the similarities checker, you can use "--disable=all
-# --enable=similarities". If you want to run only the classes checker, but have
-# no Warning level messages displayed, use"--disable=all --enable=classes
-# --disable=W"
-disable=raw-checker-failed,
-        bad-inline-option,
-        locally-disabled,
-        file-ignored,
-        suppressed-message,
-        useless-suppression,
-        deprecated-pragma,
-        import-error
-
-# Enable the message, report, category or checker with the given id(s). You can
-# either give multiple identifier separated by comma (,) or put this option
-# multiple time (only on the command line, not in the configuration file where
-# it should appear only once). See also the "--disable" option for examples.
-enable=c-extension-no-member
-
-
-[REPORTS]
-
-# Python expression which should return a note less than 10 (10 is the highest
-# note). You have access to the variables errors warning, statement which
-# respectively contain the number of errors / warnings messages and the total
-# number of statements analyzed. This is used by the global evaluation report
-# (RP0004).
-evaluation=10.0 - ((float(5 * error + warning + refactor + convention) / statement) * 10)
-
-# Template used to display messages. This is a python new-style format string
-# used to format the message information. See doc for all details
-#msg-template=
-
-# Set the output format. Available formats are text, parseable, colorized, json
-# and msvs (visual studio).You can also give a reporter class, eg
-# mypackage.mymodule.MyReporterClass.
-output-format=text
-
-# Tells whether to display a full report or only the messages
-reports=no
-
-# Activate the evaluation score.
-score=no
-
-
-[REFACTORING]
-
-# Maximum number of nested blocks for function / method body
-max-nested-blocks=5
-
-# Complete name of functions that never returns. When checking for
-# inconsistent-return-statements if a never returning function is called then
-# it will be considered as an explicit return statement and no message will be
-# printed.
-never-returning-functions=optparse.Values,sys.exit
-
-
-[VARIABLES]
-
-# List of additional names supposed to be defined in builtins. Remember that
-# you should avoid to define new builtins when possible.
-additional-builtins=
-
-# Tells whether unused global variables should be treated as a violation.
-allow-global-unused-variables=yes
-
-# List of strings which can identify a callback function by name. A callback
-# name must start or end with one of those strings.
-callbacks=cb_,
-          _cb
-
-# A regular expression matching the name of dummy variables (i.e. expectedly
-# not used).
-dummy-variables-rgx=_+$|(_[a-zA-Z0-9_]*[a-zA-Z0-9]+?$)|dummy|^ignored_|^unused_
-
-# Argument names that match this expression will be ignored. Default to name
-# with leading underscore
-ignored-argument-names=_.*|^ignored_|^unused_
-
-# Tells whether we should check for unused import in __init__ files.
-init-import=no
-
-# List of qualified module names which can have objects that can redefine
-# builtins.
-redefining-builtins-modules=six.moves,past.builtins,future.builtins
-
-
-[LOGGING]
-
-# Logging modules to check that the string format arguments are in logging
-# function parameter format
-logging-modules=logging
-
-
-[TYPECHECK]
-
-# List of decorators that produce context managers, such as
-# contextlib.contextmanager. Add to this list to register other decorators that
-# produce valid context managers.
-contextmanager-decorators=contextlib.contextmanager
-
-# List of members which are set dynamically and missed by pylint inference
-# system, and so shouldn't trigger E1101 when accessed. Python regular
-# expressions are accepted.
-generated-members=
-    objects,
-    DoesNotExist,
-    .*\.final_serum_sample,
-    fss\..*,
-    .*\.animal,
-    .*\.peak_data,
-    .*\.filter
-    .*\.studies
-    .*\.peakgroups
-
-# Tells whether missing members accessed in mixin class should be ignored. A
-# mixin class is detected if its name ends with "mixin" (case insensitive).
-ignore-mixin-members=yes
-
-# This flag controls whether pylint should warn about no-member and similar
-# checks whenever an opaque object is returned when inferring. The inference
-# can return multiple potential results while evaluating a Python object, but
-# some branches might not be evaluated, which results in partial inference. In
-# that case, it might be useful to still emit no-member and other checks for
-# the rest of the inferred objects.
-ignore-on-opaque-inference=yes
-
-# List of class names for which member attributes should not be checked (useful
-# for classes with dynamically set attributes). This supports the use of
-# qualified names.
-ignored-classes=optparse.Values,thread._local,_thread._local
-
-# List of module names for which member attributes should not be checked
-# (useful for modules/projects where namespaces are manipulated during runtime
-# and thus existing member attributes cannot be deduced by static analysis. It
-# supports qualified module names, as well as Unix pattern matching.
-ignored-modules=
-
-# Show a hint with possible names when a member name was not found. The aspect
-# of finding the hint is based on edit distance.
-missing-member-hint=yes
-
-# The minimum edit distance a name should have in order to be considered a
-# similar match for a missing member name.
-missing-member-hint-distance=1
-
-# The total number of similar names that should be taken in consideration when
-# showing a hint for a missing member.
-missing-member-max-choices=1
-
-
-[MISCELLANEOUS]
-
-# List of note tags to take in consideration, separated by a comma.
-notes=FIXME,
-      XXX,
-      TODO
+# In verbose mode, extra non-checker-related info will be displayed.
+#verbose=
 
 
 [BASIC]
 
-# Naming style matching correct argument names
+# Naming style matching correct argument names.
 argument-naming-style=snake_case
 
 # Regular expression matching correct argument names. Overrides argument-
-# naming-style
+# naming-style. If left empty, argument names will be checked with the set
+# naming style.
 #argument-rgx=
 
-# Naming style matching correct attribute names
+# Naming style matching correct attribute names.
 attr-naming-style=snake_case
 
 # Regular expression matching correct attribute names. Overrides attr-naming-
-# style
+# style. If left empty, attribute names will be checked with the set naming
+# style.
 #attr-rgx=
 
-# Bad variable names which should always be refused, separated by a comma
+# Bad variable names which should always be refused, separated by a comma.
 bad-names=foo,
           bar,
           baz,
@@ -234,67 +143,90 @@ bad-names=foo,
           tutu,
           tata
 
-# Naming style matching correct class attribute names
+# Bad variable names regexes, separated by a comma. If names match any regex,
+# they will always be refused
+bad-names-rgxs=
+
+# Naming style matching correct class attribute names.
 class-attribute-naming-style=any
 
 # Regular expression matching correct class attribute names. Overrides class-
-# attribute-naming-style
+# attribute-naming-style. If left empty, class attribute names will be checked
+# with the set naming style.
 #class-attribute-rgx=
 
-# Naming style matching correct class names
+# Naming style matching correct class constant names.
+class-const-naming-style=UPPER_CASE
+
+# Regular expression matching correct class constant names. Overrides class-
+# const-naming-style. If left empty, class constant names will be checked with
+# the set naming style.
+#class-const-rgx=
+
+# Naming style matching correct class names.
 class-naming-style=PascalCase
 
-# Regular expression matching correct class names. Overrides class-naming-style
+# Regular expression matching correct class names. Overrides class-naming-
+# style. If left empty, class names will be checked with the set naming style.
 #class-rgx=
 
-# Naming style matching correct constant names
+# Naming style matching correct constant names.
 const-naming-style=UPPER_CASE
 
 # Regular expression matching correct constant names. Overrides const-naming-
-# style
+# style. If left empty, constant names will be checked with the set naming
+# style.
 #const-rgx=
 
 # Minimum line length for functions/classes that require docstrings, shorter
 # ones are exempt.
 docstring-min-length=-1
 
-# Naming style matching correct function names
+# Naming style matching correct function names.
 function-naming-style=snake_case
 
 # Regular expression matching correct function names. Overrides function-
-# naming-style
+# naming-style. If left empty, function names will be checked with the set
+# naming style.
 #function-rgx=
 
-# Good variable names which should always be accepted, separated by a comma
+# Good variable names which should always be accepted, separated by a comma.
 good-names=i,
-            j,
-            k,
-            ex,
-            Run,
-            _
+           j,
+           k,
+           ex,
+           Run,
+           _,
+           TraceBase,
+           DataRepo
 
-# Include a hint for the correct naming format with invalid-name
+# Good variable names regexes, separated by a comma. If names match any regex,
+# they will always be accepted
+good-names-rgxs=
+
+# Include a hint for the correct naming format with invalid-name.
 include-naming-hint=no
 
-# Naming style matching correct inline iteration names
+# Naming style matching correct inline iteration names.
 inlinevar-naming-style=any
 
 # Regular expression matching correct inline iteration names. Overrides
-# inlinevar-naming-style
+# inlinevar-naming-style. If left empty, inline iteration names will be checked
+# with the set naming style.
 #inlinevar-rgx=
 
-# Naming style matching correct method names
+# Naming style matching correct method names.
 method-naming-style=snake_case
 
 # Regular expression matching correct method names. Overrides method-naming-
-# style
+# style. If left empty, method names will be checked with the set naming style.
 #method-rgx=
 
-# Naming style matching correct module names
+# Naming style matching correct module names.
 module-naming-style=snake_case
 
 # Regular expression matching correct module names. Overrides module-naming-
-# style
+# style. If left empty, module names will be checked with the set naming style.
 #module-rgx=
 
 # Colon-delimited sets of names that determine each other's naming style when
@@ -307,34 +239,101 @@ no-docstring-rgx=^_
 
 # List of decorators that produce properties, such as abc.abstractproperty. Add
 # to this list to register other decorators that produce valid properties.
+# These decorators are taken in consideration only for invalid-name.
 property-classes=abc.abstractproperty
 
-# Naming style matching correct variable names
+# Regular expression matching correct type alias names. If left empty, type
+# alias names will be checked with the set naming style.
+#typealias-rgx=
+
+# Regular expression matching correct type variable names. If left empty, type
+# variable names will be checked with the set naming style.
+#typevar-rgx=
+
+# Naming style matching correct variable names.
 variable-naming-style=snake_case
 
 # Regular expression matching correct variable names. Overrides variable-
-# naming-style
-#variable-rgx=
+# naming-style. If left empty, variable names will be checked with the set
+# naming style.
+# This is a work-around for superlinter 8.6.0 not loading pylint-django
+variable-rgx=^[a-z_][a-z0-9_]*$|^[A-Z_]+$
 
 
-[SPELLING]
+[CLASSES]
 
-# Limits count of emitted suggestions for spelling mistakes
-max-spelling-suggestions=4
+# Warn about protected attribute access inside special methods
+check-protected-access-in-special-methods=no
 
-# Spelling dictionary name. Available dictionaries: none. To make it working
-# install python-enchant package.
-spelling-dict=
+# List of method names used to declare (i.e. assign) instance attributes.
+defining-attr-methods=__init__,
+                      __new__,
+                      setUp
 
-# List of comma separated words that should not be checked.
-spelling-ignore-words=
+# List of member names, which should be excluded from the protected access
+# warning.
+exclude-protected=_asdict,
+                  _fields,
+                  _replace,
+                  _source,
+                  _make
 
-# A path to a file that contains private dictionary; one word per line.
-spelling-private-dict-file=
+# List of valid names for the first argument in a class method.
+valid-classmethod-first-arg=cls
 
-# Tells whether to store unknown words to indicated private dictionary in
-# --spelling-private-dict-file option instead of raising a message.
-spelling-store-unknown-words=no
+# List of valid names for the first argument in a metaclass class method.
+valid-metaclass-classmethod-first-arg=mcs
+
+
+[DESIGN]
+
+# List of regular expressions of class ancestor names to ignore when counting
+# public methods (see R0903)
+exclude-too-few-public-methods=
+
+# List of qualified class names to ignore when counting class parents (see
+# R0901)
+ignored-parents=
+
+# Maximum number of arguments for function / method.
+max-args=5
+
+# Maximum number of attributes for a class (see R0902).
+max-attributes=7
+
+# Maximum number of boolean expressions in an if statement (see R0916).
+max-bool-expr=5
+
+# Maximum number of branch for function / method body.
+max-branches=12
+
+# Maximum number of locals for function / method body.
+max-locals=15
+
+# Maximum number of parents for a class (see R0901).
+max-parents=7
+
+# Maximum number of positional arguments for function / method.
+# Rob: This was added when I used pylint 3.3.8, but the CI actions use 3.1.0
+# max-positional-arguments=5
+
+# Maximum number of public methods for a class (see R0904).
+max-public-methods=20
+
+# Maximum number of return / yield for function / method body.
+max-returns=6
+
+# Maximum number of statements in function / method body.
+max-statements=50
+
+# Minimum number of public methods for a class (see R0903).
+min-public-methods=2
+
+
+[EXCEPTIONS]
+
+# Exceptions that will emit a warning when caught.
+overgeneral-exceptions=builtins.Exception
 
 
 [FORMAT]
@@ -345,7 +344,7 @@ expected-line-ending-format=
 # Regexp for a line that is allowed to be longer than the limit.
 ignore-long-lines=^\s*(# )?<?https?://\S+>?$
 
-# Number of spaces of indent required inside a hanging  or continued line.
+# Number of spaces of indent required inside a hanging or continued line.
 indent-after-paren=4
 
 # String used as indentation unit. This is usually "    " (4 spaces) or "\t" (1
@@ -353,9 +352,9 @@ indent-after-paren=4
 indent-string='    '
 
 # Maximum number of characters on a single line.
-max-line-length=100
+max-line-length=120
 
-# Maximum number of lines in a module
+# Maximum number of lines in a module.
 max-module-lines=1000
 
 # Allow the body of a class to be on the same line as the declaration if body
@@ -535,7 +534,8 @@ disable=raw-checker-failed,
         wildcard-import,
         unused-argument,
         super-init-not-called,
-        too-many-positional-arguments
+        too-many-positional-arguments,
+        invalid-name
 
 # Enable the message, report, category or checker with the given id(s). You can
 # either give multiple identifier separated by comma (,) or put this option
@@ -607,113 +607,149 @@ score=no
 
 [SIMILARITIES]
 
-# Ignore comments when computing similarities.
+# Comments are removed from the similarity computation
 ignore-comments=yes
 
-# Ignore docstrings when computing similarities.
+# Docstrings are removed from the similarity computation
 ignore-docstrings=yes
 
-# Ignore imports when computing similarities.
+# Imports are removed from the similarity computation
 ignore-imports=no
+
+# Signatures are removed from the similarity computation
+ignore-signatures=yes
 
 # Minimum lines number of a similarity.
 min-similarity-lines=4
 
 
-[DESIGN]
+[SPELLING]
 
-# Maximum number of arguments for function / method
-max-args=5
+# Limits count of emitted suggestions for spelling mistakes.
+max-spelling-suggestions=4
 
-# Maximum number of attributes for a class (see R0902).
-max-attributes=7
+# Spelling dictionary name. No available dictionaries : You need to install
+# both the python package and the system dependency for enchant to work.
+spelling-dict=
 
-# Maximum number of boolean expressions in a if statement
-max-bool-expr=5
+# List of comma separated words that should be considered directives if they
+# appear at the beginning of a comment and should not be checked.
+spelling-ignore-comment-directives=fmt: on,fmt: off,noqa:,noqa,nosec,isort:skip,mypy:
 
-# Maximum number of branch for function / method body
-max-branches=12
+# List of comma separated words that should not be checked.
+spelling-ignore-words=
 
-# Maximum number of locals for function / method body
-max-locals=15
+# A path to a file that contains the private dictionary; one word per line.
+spelling-private-dict-file=
 
-# Maximum number of parents for a class (see R0901).
-max-parents=7
-
-# Maximum number of public methods for a class (see R0904).
-max-public-methods=20
-
-# Maximum number of return / yield for function / method body
-max-returns=6
-
-# Maximum number of statements in function / method body
-max-statements=50
-
-# Minimum number of public methods for a class (see R0903).
-min-public-methods=2
+# Tells whether to store unknown words to the private dictionary (see the
+# --spelling-private-dict-file option) instead of raising a message.
+spelling-store-unknown-words=no
 
 
-[IMPORTS]
+[STRING]
 
-# Allow wildcard imports from modules that define __all__.
-allow-wildcard-with-all=no
+# This flag controls whether inconsistent-quotes generates a warning when the
+# character used as a quote delimiter is used inconsistently within a module.
+check-quote-consistency=no
 
-# Analyse import fallback blocks. This can be used to support both Python 2 and
-# 3 compatible code, which means that the block might have code that exists
-# only in one or another interpreter, leading to false positives when analysed.
-analyse-fallback-blocks=no
-
-# Deprecated modules which should not be used, separated by a comma
-deprecated-modules=regsub,
-                  TERMIOS,
-                  Bastion,
-                  rexec
-
-# Create a graph of external dependencies in the given file (report RP0402 must
-# not be disabled)
-ext-import-graph=
-
-# Create a graph of every (i.e. internal and external) dependencies in the
-# given file (report RP0402 must not be disabled)
-import-graph=
-
-# Create a graph of internal dependencies in the given file (report RP0402 must
-# not be disabled)
-int-import-graph=
-
-# Force import order to recognize a module as part of the standard
-# compatibility libraries.
-known-standard-library=
-
-# Force import order to recognize a module as part of a third party library.
-known-third-party=enchant
+# This flag controls whether the implicit-str-concat should generate a warning
+# on implicit string concatenation in sequences defined over several lines.
+check-str-concat-over-line-jumps=no
 
 
-[CLASSES]
+[TYPECHECK]
 
-# List of method names used to declare (i.e. assign) instance attributes.
-defining-attr-methods=__init__,
-                      __new__,
-                      setUp
+# List of decorators that produce context managers, such as
+# contextlib.contextmanager. Add to this list to register other decorators that
+# produce valid context managers.
+contextmanager-decorators=contextlib.contextmanager
 
-# List of member names, which should be excluded from the protected access
-# warning.
-exclude-protected=_asdict,
-                  _fields,
-                  _replace,
-                  _source,
-                  _make
+# List of members which are set dynamically and missed by pylint inference
+# system, and so shouldn't trigger E1101 when accessed. Python regular
+# expressions are accepted.
+generated-members=objects,
+                  DoesNotExist,
+                  .*\.final_serum_sample,
+                  fss\..*,
+                  .*\.animal,
+                  .*\.peak_data,
+                  .*\.filter,
+                  .*\.studies,
+                  .*\.peakgroups
 
-# List of valid names for the first argument in a class method.
-valid-classmethod-first-arg=cls
+# Tells whether to warn about missing members when the owner of the attribute
+# is inferred to be None.
+ignore-none=yes
 
-# List of valid names for the first argument in a metaclass class method.
-valid-metaclass-classmethod-first-arg=mcs
+# This flag controls whether pylint should warn about no-member and similar
+# checks whenever an opaque object is returned when inferring. The inference
+# can return multiple potential results while evaluating a Python object, but
+# some branches might not be evaluated, which results in partial inference. In
+# that case, it might be useful to still emit no-member and other checks for
+# the rest of the inferred objects.
+ignore-on-opaque-inference=yes
+
+# List of symbolic message names to ignore for Mixin members.
+ignored-checks-for-mixins=no-member,
+                          not-async-context-manager,
+                          not-context-manager,
+                          attribute-defined-outside-init
+
+# List of class names for which member attributes should not be checked (useful
+# for classes with dynamically set attributes). This supports the use of
+# qualified names.
+ignored-classes=optparse.Values,thread._local,_thread._local
+
+# Show a hint with possible names when a member name was not found. The aspect
+# of finding the hint is based on edit distance.
+missing-member-hint=yes
+
+# The maximum edit distance a name should have in order to be considered a
+# similar match for a missing member name.
+missing-member-hint-distance=1
+
+# The total number of similar names that should be taken in consideration when
+# showing a hint for a missing member.
+missing-member-max-choices=1
+
+# Regex pattern to define which classes are considered mixins.
+mixin-class-rgx=.*[Mm]ixin
+
+# List of decorators that change the signature of a decorated function.
+signature-mutators=
 
 
-[EXCEPTIONS]
+[VARIABLES]
 
-# Exceptions that will emit a warning when being caught. Defaults to
-# "Exception"
-overgeneral-exceptions=builtins.Exception
+# List of additional names supposed to be defined in builtins. Remember that
+# you should avoid defining new builtins when possible.
+additional-builtins=
 
+# Tells whether unused global variables should be treated as a violation.
+allow-global-unused-variables=yes
+
+# List of names allowed to shadow builtins
+allowed-redefined-builtins=
+
+# List of strings which can identify a callback function by name. A callback
+# name must start or end with one of those strings.
+callbacks=cb_,
+          _cb
+
+# A regular expression matching the name of dummy variables (i.e. expected to
+# not be used).
+dummy-variables-rgx=_+$|(_[a-zA-Z0-9_]*[a-zA-Z0-9]+?$)|dummy|^ignored_|^unused_
+
+# Argument names that match this expression will be ignored.
+ignored-argument-names=_.*|^ignored_|^unused_
+
+# Tells whether we should check for unused import in __init__ files.
+init-import=no
+
+# List of qualified module names which can have objects that can redefine
+# builtins.
+redefining-builtins-modules=six.moves,past.builtins,future.builtins
+
+# [DJANGO]
+# django-settings-module=TraceBase.settings

--- a/.github/linters/python-lint-requirements.txt
+++ b/.github/linters/python-lint-requirements.txt
@@ -1,0 +1,1 @@
+pylint-django

--- a/.github/workflows/superlinter.yml
+++ b/.github/workflows/superlinter.yml
@@ -37,11 +37,50 @@ jobs:
 
       # Runs the Super-Linter action
       - name: Run Super-Linter
-        uses: super-linter/super-linter/slim@v6.3.0
+        uses: super-linter/super-linter@v8.6.0
         env:
           # To report GitHub Actions status checks
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           DEFAULT_BRANCH: main
-          LINTER_RULES_PATH: /.github/linters/
+          LINTER_RULES_PATH: .github/linters
           IGNORE_GITIGNORED_FILES: true
           FILTER_REGEX_EXCLUDE: (\.pylintrc|migrations|.*\.xlsx|static\/bootstrap.*)
+
+          # In the transition from superlinter 6.x to 8.x, stabilize by disabling new linters
+          # pylint-django has a new way to be installed
+          PYTHON_PYLINT_CONFIG_FILE: .pylintrc
+          PYTHON_LINT_REQUIREMENTS_FILE: .github/linters/python-lint-requirements.txt
+          DJANGO_SETTINGS_MODULE: TraceBase.settings
+
+          # The new version of JSCPD checks between files and there is no way to disable it alone
+          VALIDATE_JSCPD: false
+
+          # New linters
+          VALIDATE_PYTHON_RUFF: false
+          VALIDATE_PYTHON_RUFF_FORMAT: false
+          VALIDATE_PYTHON_BANDIT: false
+          VALIDATE_YAML: false
+          VALIDATE_DOCKERFILE: false
+          VALIDATE_GITHUB_ACTIONS: false
+          VALIDATE_BIOME_FORMAT: false
+          VALIDATE_BIOME_LINT: false
+          VALIDATE_SPELL_CODESPELL: false
+          VALIDATE_GITHUB_ACTIONS_ZIZMOR: false
+          VALIDATE_TRIVY: false
+
+          # The "prettier" linters
+          VALIDATE_CSS_PRETTIER: false
+          VALIDATE_HTML_PRETTIER: false
+          VALIDATE_JAVASCRIPT_PRETTIER: false
+          VALIDATE_JSON_PRETTIER: false
+          VALIDATE_MARKDOWN_PRETTIER: false
+          VALIDATE_YAML_PRETTIER: false
+
+          # These linters are true by default.
+          # VALIDATE_PYTHON: true
+          # VALIDATE_PYTHON_PYLINT: true
+          # VALIDATE_PYTHON_FLAKE8: true
+          # VALIDATE_MARKDOWN: true
+          # VALIDATE_JAVASCRIPT: true
+          # VALIDATE_JSON: true
+          # VALIDATE_NATURAL_LANGUAGE: true

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -69,7 +69,7 @@ Create a tracebase postgres user:
 
 #### Create a virtual environment
 
-Create a virtual environment (from a bash shell) and activate it, for example:
+Create a virtual environment (from a Bash shell) and activate it, for example:
 
     python3 -m venv .venv
     source .venv/bin/activate
@@ -218,15 +218,14 @@ trouble, consider running Super-Linter locally, as described below.
 
 ##### Superlinter
 
-In addition to linting files as you write them, developers may wish to [run
-Superlinter on the entire repository
-locally](https://github.com/github/super-linter/blob/master/docs/run-linter-locally.md).
+In addition to linting files as you write them, developers may wish to
+[run Superlinter on the entire repository locally](https://github.com/github/super-linter/blob/master/docs/run-linter-locally.md).
 This is most easily accomplished using [Docker](https://docs.docker.com/get-docker/).
-Create a script outside of the repository that runs superlinter via docker and run it
+Create a script outside of the repository that runs superlinter via Docker and run it
 from the repository root directory. Example script:
 
     #!/usr/bin/env sh
-    docker pull github/super-linter:slim-v6
+    docker pull ghcr.io/super-linter/super-linter:v8.6.0
 
     docker run \
         -e FILTER_REGEX_EXCLUDE="(\.pylintrc|migrations|static\/bootstrap.*)" \

--- a/DataRepo/management/commands/load_study.py
+++ b/DataRepo/management/commands/load_study.py
@@ -82,7 +82,7 @@ class Command(LoadTableCommand):
         parser.add_argument(
             # Legacy support - catch this option and issue an error if it is used.
             "study_params",
-            type=argparse.FileType("r"),
+            type=argparse.FileType("r"),  # pylint: disable=deprecated-class
             nargs="?",
             help=argparse.SUPPRESS,
         )

--- a/DataRepo/management/commands/load_study_set.py
+++ b/DataRepo/management/commands/load_study_set.py
@@ -17,7 +17,7 @@ class Command(BaseCommand):
     def add_arguments(self, parser):
         parser.add_argument(
             "study_set_list",
-            type=argparse.FileType("r"),
+            type=argparse.FileType("r"),  # pylint: disable=deprecated-class
             help=("File of study doc filenames, one per line."),
         )
 

--- a/DataRepo/models/animal.py
+++ b/DataRepo/models/animal.py
@@ -161,7 +161,7 @@ class Animal(MaintainedModel, HierCachedModel):
         no serum samples or if the retrieved serum sample has no annotated time_collected, a warning will be issued.
         """
         # Create an is_null field for time_collected to be able to sort them
-        (extra_args, is_null_field) = create_is_null_field("time_collected")
+        extra_args, is_null_field = create_is_null_field("time_collected")
         last_serum_sample = (
             self.samples.filter(Tissue.serum_q_expression("tissue__name"))
             .extra(**extra_args)
@@ -200,7 +200,7 @@ class Animal(MaintainedModel, HierCachedModel):
 
         # Get the last peakgroup for each tracer
         last_serum_peakgroup_ids = []
-        (tc_extra_args, tc_is_null_field) = create_is_null_field(
+        tc_extra_args, tc_is_null_field = create_is_null_field(
             "msrun_sample__sample__time_collected"
         )
         for tracer in self.tracers.all():
@@ -272,7 +272,7 @@ class Animal(MaintainedModel, HierCachedModel):
             rec (Optional[AnimalStudy])
             created (boolean)
         """
-        AnimalStudy = Animal.studies.through
+        AnimalStudy = Animal.studies.through  # pylint: disable=invalid-name
 
         # This is the effective rec_dict
         rec_dict = {

--- a/DataRepo/models/compound.py
+++ b/DataRepo/models/compound.py
@@ -75,7 +75,7 @@ class Compound(MaintainedModel):
     def get_or_create_synonym(self, synonym_name=None):
         if not synonym_name:
             synonym_name = self.name
-        (compound_synonym, created) = CompoundSynonym.objects.get_or_create(
+        compound_synonym, created = CompoundSynonym.objects.get_or_create(
             name=synonym_name, compound_id=self.id
         )
         return (compound_synonym, created)
@@ -85,9 +85,9 @@ class Compound(MaintainedModel):
         compound_synonym(s) which we are auto-creating afterwards.
         """
         super().save(*args, **kwargs)
-        (_primary_synonym, created) = self.get_or_create_synonym()
+        _primary_synonym, created = self.get_or_create_synonym()
         ucfirst_synonym = self.name[0].upper() + self.name[1:]
-        (_secondary_synonym, created) = self.get_or_create_synonym(ucfirst_synonym)
+        _secondary_synonym, created = self.get_or_create_synonym(ucfirst_synonym)
 
     def clean(self, *args, **kwargs):
         """super.clean will raise an error about existing compounds, if this entire record already exists.

--- a/DataRepo/models/infusate.py
+++ b/DataRepo/models/infusate.py
@@ -43,12 +43,14 @@ class InfusateQuerySet(models.QuerySet):
         infusate = self.create(tracer_group_name=infusate_data["infusate_name"])
 
         # create tracers
-        Tracer = get_model_by_name("Tracer")
-        InfusateTracer = get_model_by_name("InfusateTracer")
+        Tracer = get_model_by_name("Tracer")  # pylint: disable=invalid-name
+        InfusateTracer = get_model_by_name(  # pylint: disable=invalid-name
+            "InfusateTracer"
+        )
         for infusate_tracer in infusate_data["tracers"]:
             tracer = Tracer.objects.get_tracer(infusate_tracer["tracer"])
             if tracer is None:
-                (tracer, _) = Tracer.objects.get_or_create_tracer(
+                tracer, _ = Tracer.objects.get_or_create_tracer(
                     infusate_tracer["tracer"],
                 )
             # associate tracers with specific conectrations
@@ -79,7 +81,7 @@ class InfusateQuerySet(models.QuerySet):
         )
         # Check that the tracers match
         for infusate_tracer in infusate_data["tracers"]:
-            Tracer = get_model_by_name("Tracer")
+            Tracer = get_model_by_name("Tracer")  # pylint: disable=invalid-name
             tracer = Tracer.objects.get_tracer(infusate_tracer["tracer"])
             infusates = infusates.filter(
                 tracer_links__tracer=tracer,
@@ -111,7 +113,7 @@ class InfusateQuerySet(models.QuerySet):
         )
         # Limit to the infusates that have the right tracers
         for infusate_tracer in infusate_data["tracers"]:
-            Tracer = get_model_by_name("Tracer")
+            Tracer = get_model_by_name("Tracer")  # pylint: disable=invalid-name
             tracer = Tracer.objects.get_tracer(infusate_tracer["tracer"])
             infusates = infusates.filter(
                 tracer_links__tracer=tracer,

--- a/DataRepo/static/js/bst_list_view/value.js
+++ b/DataRepo/static/js/bst_list_view/value.js
@@ -15,7 +15,7 @@ function getVisibleValue (v) { // eslint-disable-line no-unused-vars
   const isHTMLregex = /^(?:\s*(<[\w\W]+>)[^>]*|#([\w-]*))$/
 
   // Extract the inner HTML, if the content is inside an HTML element
-  if (isHTMLregex.test(v)) v = $(v).text().trim()
+  if (isHTMLregex.test(v)) v = $(v).text().trim() // eslint-disable-line no-undef
   else v = v.trim()
 
   // Do not alphabetically sort "None" (special case from Python/Django)

--- a/DataRepo/tests/models/test_infusate.py
+++ b/DataRepo/tests/models/test_infusate.py
@@ -14,10 +14,10 @@ from DataRepo.tests.tracebase_test_case import TracebaseTestCase
 
 
 def create_infusate_records():
-    (glu, _) = Compound.objects.get_or_create(
+    glu, _ = Compound.objects.get_or_create(
         name="glucose", formula="C6H12O6", hmdb_id="HMDB0000122"
     )
-    (c16, _) = Compound.objects.get_or_create(
+    c16, _ = Compound.objects.get_or_create(
         name="C16:0", formula="C16H32O2", hmdb_id="HMDB0000220"
     )
 
@@ -62,7 +62,9 @@ class InfusateTests(TracebaseTestCase):
         MaintainedModel._reset_coordinators()
         # INFUSATE1: ti {C16:0-[5,6-13C2,17O2][2];glucose-[2,3-13C2,4-17O1][1]}
         # INFUSATE2: C16:0-[5,6-13C2,17O2][4];glucose-[2,3-13C2,4-17O1][3]
-        self.INFUSATE1, self.INFUSATE2 = create_infusate_records()
+        self.INFUSATE1, self.INFUSATE2 = (  # pylint: disable=invalid-name
+            create_infusate_records()
+        )
 
     @classmethod
     def setUpTestData(cls):

--- a/DataRepo/tests/models/test_msrun_sequence.py
+++ b/DataRepo/tests/models/test_msrun_sequence.py
@@ -40,7 +40,7 @@ class MSRunSequenceTests(TracebaseTestCase):
         self.assertEqual(ValidationError, type(exc))
 
     def test_parse_sequence_name(self):
-        (operator, lc_protocol_name, instrument, date) = (
+        operator, lc_protocol_name, instrument, date = (
             MSRunSequence.parse_sequence_name("Rob, polar-HILIC-25-min, QE, 1972-11-24")
         )
         self.assertEqual(

--- a/DataRepo/tests/utils/test_infusate_name_parser.py
+++ b/DataRepo/tests/utils/test_infusate_name_parser.py
@@ -311,7 +311,7 @@ class InfusateValidationTests(InfusateTestData):
 
     def test_tracer_creation(self):
         """Test creation of a valid tracer object from TracerData"""
-        (tracer, created) = Tracer.objects.get_or_create_tracer(
+        tracer, created = Tracer.objects.get_or_create_tracer(
             self.tracer_data_l_leucine
         )
         self.assertTrue(created)
@@ -352,7 +352,7 @@ class InfusateValidationTests(InfusateTestData):
     def test_tracer_validation_fully_labeled_no_positions(self):
         """Test tracer validation allows no postions on fully labeled compound"""
         tracer_data_leucine_fully_labeled = parse_tracer_string("Leucine-[13C6]")
-        (tracer, _) = Tracer.objects.get_or_create_tracer(
+        tracer, _ = Tracer.objects.get_or_create_tracer(
             tracer_data_leucine_fully_labeled
         )
         self.assertEqual(tracer.name, "leucine-[13C6]")
@@ -369,7 +369,7 @@ class InfusateValidationTests(InfusateTestData):
 
     def test_infusion_creation(self):
         """Test the creation of a valid infusate from InfusateData"""
-        (infusate, created) = Infusate.objects.get_or_create_infusate(
+        infusate, created = Infusate.objects.get_or_create_infusate(
             self.infusate_data_bcaas
         )
         self.assertTrue(created)
@@ -382,7 +382,7 @@ class InfusateValidationTests(InfusateTestData):
 
     def test_infusion_creation_without_optional_name(self):
         """Test the creation of a valid infusate without the optional name"""
-        (infusate, created) = Infusate.objects.get_or_create_infusate(
+        infusate, created = Infusate.objects.get_or_create_infusate(
             self.infusate_data_l_leucine
         )
         self.assertTrue(created)
@@ -395,9 +395,7 @@ class InfusateValidationTests(InfusateTestData):
 
     def test_infusion_validation_name_conflict(self):
         """Test infusate validation when two groups of tracers share the same infusate name"""
-        (infusate, _) = Infusate.objects.get_or_create_infusate(
-            self.infusate_data_bcaas
-        )
+        infusate, _ = Infusate.objects.get_or_create_infusate(self.infusate_data_bcaas)
         self.assertEqual(infusate.tracer_group_name, "BCAAs")
         with self.assertRaisesRegex(
             ValidationError, "Tracer group name BCAAs is inconsistent."
@@ -411,13 +409,13 @@ class InfusateValidationTests(InfusateTestData):
 
     def test_infusion_validation_same_name(self):
         """Test invusate validation when two infusates have the same group of tracers and the same name"""
-        (infusate_conc1, created1) = Infusate.objects.get_or_create_infusate(
+        infusate_conc1, created1 = Infusate.objects.get_or_create_infusate(
             self.infusate_data_leucine_named_1
         )
         self.assertTrue(created1)
         self.assertEqual(infusate_conc1.tracer_group_name, "leucine")
 
-        (infusate_conc2, created2) = Infusate.objects.get_or_create_infusate(
+        infusate_conc2, created2 = Infusate.objects.get_or_create_infusate(
             self.infusate_data_leucine_named_2
         )
         self.assertTrue(created2)
@@ -425,7 +423,7 @@ class InfusateValidationTests(InfusateTestData):
 
     def test_infusion_get_by_data(self):
         """Test getting infusion record using InfusateData"""
-        (infusate, created) = Infusate.objects.get_or_create_infusate(
+        infusate, created = Infusate.objects.get_or_create_infusate(
             self.infusate_data_bcaas
         )
         self.assertTrue(created)
@@ -434,7 +432,7 @@ class InfusateValidationTests(InfusateTestData):
 
     def test_infusion_get_by_data_diffconc(self):
         """Test that concentration must match to get infusion record using InfusateData"""
-        (_, created) = Infusate.objects.get_or_create_infusate(
+        _, created = Infusate.objects.get_or_create_infusate(
             self.infusate_data_leucine_named_1
         )
         self.assertTrue(created)
@@ -631,12 +629,12 @@ class InfusateValidationTests(InfusateTestData):
         obs = parse_isotope_label(label, possible_obs)
         self.assertEqual(expected, obs)
 
-    def test_parse_isotope_label_ObservedIsotopeUnbalancedError(self):
+    def test_parse_isotope_label_observed_isotope_unbalanced_error(self):
         label = "C13N15-label-3-1-5"
         with self.assertRaises(ObservedIsotopeUnbalancedError):
             parse_isotope_label(label)
 
-    def test_parse_isotope_label_UnexpectedLabels(self):
+    def test_parse_isotope_label_unexpected_labels(self):
         label = "C13N15-label-3-1"
         possible_obs = [
             ObservedIsotopeData(
@@ -649,12 +647,12 @@ class InfusateValidationTests(InfusateTestData):
         with self.assertRaises(UnexpectedLabel):
             parse_isotope_label(label, possible_obs)
 
-    def test_parse_isotope_label_IsotopeStringDupe(self):
+    def test_parse_isotope_label_isotope_string_dupe(self):
         label = "C13N15C13-label-3-1-5"
         with self.assertRaises(IsotopeStringDupe):
             parse_isotope_label(label)
 
-    def test_parse_isotope_label_ObservedIsotopeParsingError(self):
+    def test_parse_isotope_label_observed_isotope_parsing_error(self):
         label = "nonsense"
         with self.assertRaises(ObservedIsotopeParsingError):
             parse_isotope_label(label)

--- a/DataRepo/utils/exceptions.py
+++ b/DataRepo/utils/exceptions.py
@@ -6,7 +6,7 @@ import warnings
 from abc import ABC, abstractmethod
 from collections import defaultdict
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Any, Dict, List, Optional
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple
 
 from django.core.exceptions import (
     MultipleObjectsReturned,
@@ -17,6 +17,8 @@ from django.core.management import CommandError
 from django.db.models import Model, Q
 from django.db.utils import ProgrammingError
 from django.forms.models import model_to_dict
+
+from DataRepo.utils.text_utils import indent
 
 if TYPE_CHECKING:
     from DataRepo.models.animal import Animal
@@ -230,7 +232,7 @@ class InfileError(Exception):
 class SummarizableError(Exception, ABC):
     @property
     @abstractmethod
-    def SummarizerExceptionClass(self):
+    def SummarizerExceptionClass(self):  # pylint: disable=invalid-name
         """An exception class that takes a list of Exceptions of derived exception classes of this class as the sole
         required positional argument to its constructor.  All keyword arguments are ignored (if they exist).
 
@@ -736,12 +738,12 @@ class MissingModelRecords(MissingRecords, ABC):
 
     @property
     @abstractmethod
-    def ModelName(self):
+    def ModelName(self):  # pylint: disable=invalid-name
         pass
 
     @property
     @abstractmethod
-    def RecordName(self):
+    def RecordName(self):  # pylint: disable=invalid-name
         pass
 
     def __init__(
@@ -815,12 +817,12 @@ class MissingModelRecordsByFile(MissingRecords, ABC):
 
     @property
     @abstractmethod
-    def ModelName(self):
+    def ModelName(self):  # pylint: disable=invalid-name
         pass
 
     @property
     @abstractmethod
-    def RecordName(self):
+    def RecordName(self):  # pylint: disable=invalid-name
         pass
 
     def __init__(

--- a/DataRepo/utils/text_utils.py
+++ b/DataRepo/utils/text_utils.py
@@ -607,3 +607,18 @@ def get_plural(word: str):
         words[last] = inflect_engine.plural_noun(valid_last_word)
         return " ".join(words)
     return word
+
+
+def indent(string: str, degree=1, indent_str="\t"):
+    """Takes a multi-line string and returns the string with an indent inserted on each line.
+
+    Args:
+        string (str): A multi-line string containing newline characters delineating each line.
+        degree (int) [1]: The indent level.  I.e. The number of indent_strs to prepend on each line.
+        indent_str (str) [\t]: The string to use to insert the indent on each line.
+    Exceptions:
+        None
+    Returns:
+        (str): The indented version of the input string.
+    """
+    return "\n".join([indent_str * degree + line for line in string.splitlines()])

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -45,7 +45,7 @@ Ensure you are using Python 3.10, e.g.:
     python3 --version
     # Python 3.10.11
 
-Create a virtual environment (from a bash shell) in `/usr/local` and activate it, for example:
+Create a virtual environment (from a Bash shell) in `/usr/local` and activate it, for example:
 
     sudo mkdir /usr/local/tracebase
     sudo chown tracebase:tracebase /usr/local/tracebase

--- a/TraceBase/.env.example
+++ b/TraceBase/.env.example
@@ -6,9 +6,9 @@ DATABASE_PORT=5432
 DATABASE_USER=db_user
 DEBUG=False
 DEBUG_TOOLBAR=False
+GATEWAY_TIMEOUT=180
 SECRET_KEY=CHANGETHISKEY
 SQL_LOGGING=False
-GATEWAY_TIMEOUT=180
 
 # Set READONLY to True if users are not allowed to submit data.
 READONLY=False
@@ -28,26 +28,26 @@ READONLY=False
 FEEDBACK_URL="https://link.to.feedback.form/goes/here/viewform?usp=pp_url&entry.1881422913="
 
 # Submissions
-# We use a google form (SUBMISSION_FORM_URL) for our submissions.  The essential data captured should be the study and
-# what folder is was deposited in in the shared drive.  If submissions are not accepted, set READONLY above to True.
-SUBMISSION_FORM_URL="https://link.to.study.submission.form/goes/here"
 # The shared drive (not managed by TraceBase) where submission data is deposited.
-SUBMISSION_DRIVE_DOC_URL="http://link.to.shared.drive/docs/describing/account/creation/etc/goes/here"
-SUBMISSION_DRIVE_TYPE="Google Drive, for example"
+SUBMISSION_DRIVE_DOC_URL=http://link.to.shared.drive/docs/describing/account/creation/etc/goes/here
 # If there is a particular subfolder into which submission data should be deposited, supply that relative path here.
 # Note, this is not a URL.  The site does not provide a link to the folder on the submissions drive (yet).  This path
 # should stop just shy of user folders.
-SUBMISSION_DRIVE_FOLDER="path/to/tracebase/top/level/submissions/folder"
+SUBMISSION_DRIVE_FOLDER=path/to/tracebase/top/level/submissions/folder
+SUBMISSION_DRIVE_TYPE="Google Drive, for example"
+# We use a google form (SUBMISSION_FORM_URL) for our submissions.  The essential data captured should be the study and
+# what folder is was deposited in in the shared drive.  If submissions are not accepted, set READONLY above to True.
+SUBMISSION_FORM_URL=https://link.to.study.submission.form/goes/here
 
 # Security
-SESSION_COOKIE_SECURE=False
 CSRF_COOKIE_SECURE=False
-# Redirect HTTP to HTTPS
-SECURE_SSL_REDIRECT=False
 # Subdomains must use HTTPS
 SECURE_HSTS_INCLUDE_SUBDOMAINS=False
 # Prevent modern browser access when cert expired
 SECURE_HSTS_PRELOAD=False
+# Redirect HTTP to HTTPS
+SECURE_SSL_REDIRECT=False
+SESSION_COOKIE_SECURE=False
 
 # This tells browsers to refuse to connect to your domain via an insecure connection for this number of secs.
 # Guidance

--- a/TraceBase/settings.py
+++ b/TraceBase/settings.py
@@ -323,7 +323,7 @@ DEBUG_TOOLBAR = env.bool("DEBUG_TOOLBAR", default=True)
 if DEBUG_TOOLBAR is True:
     TESTING = "test" in sys.argv
     try:
-        import debug_toolbar  # noqa: F401
+        import debug_toolbar  # noqa: F401 # pylint: disable=unused-import
 
         DEBUG_TOOLBAR_INSTALLED = True
     except ImportError:

--- a/manage.py
+++ b/manage.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 """Django's command-line utility for administrative tasks."""
+
 import os
 import sys
 

--- a/static/css/bootstrap_table_cus1.css
+++ b/static/css/bootstrap_table_cus1.css
@@ -28,8 +28,8 @@ body::-webkit-scrollbar {
 /* customize Bootstrap-table settings for td */
 .bootstrap-table .fixed-table-container .table tbody tr.no-records-found td {
   text-align: center;
-  overflow-wrap: word-wrap !important; /* added new variable and value */
-  word-wrap: break-all !important; /* added new variable and value */
+  overflow-wrap: word-wrap !important; /* stylelint-disable-line declaration-property-value-no-unknown */
+  word-wrap: break-all !important; /* stylelint-disable-line declaration-property-value-no-unknown, property-no-deprecated */
   word-break: break-all !important; /* added new variable and value */
 }
 

--- a/static/css/file_tree.css
+++ b/static/css/file_tree.css
@@ -126,7 +126,7 @@
   background-color: lightgray;
   width: max-content;
   opacity: 0;
-  word-wrap: normal;
+  word-wrap: normal; /* stylelint-disable-line property-no-deprecated */
   pointer-events: none;
   -webkit-transition: opacity 0.0s; /* Change timing to control how fast tooltip appears. */
   transition: none;

--- a/static/css/tabbar.css
+++ b/static/css/tabbar.css
@@ -37,7 +37,7 @@
 
 .tabbar-item {
   display: flex;
-  flex-grow: auto;
+  flex-grow: auto; /* stylelint-disable-line declaration-property-value-no-unknown */
   flex-basis: 20%;
   justify-content: space-around;
 }

--- a/static/js/cookies.js
+++ b/static/js/cookies.js
@@ -26,7 +26,7 @@ function getCookie (name, defval) { // eslint-disable-line no-unused-vars
     // ^ A regular string can look like an encoded string, in which case, the return value will be invalid, but those
     // cases will eventually flush out.
     return tmpval
-  } catch (e) {
+  } catch (e) { // eslint-disable-line no-unused-vars
     return val
   }
 }

--- a/static/js/file_list_drop_area.js
+++ b/static/js/file_list_drop_area.js
@@ -46,11 +46,11 @@ function preventDefaults (e) { // eslint-disable-line no-unused-vars
   e.stopPropagation()
 }
 
-function highlight (e) {
+function highlight (e) { // eslint-disable-line no-unused-vars
   dropArea.classList.add('highlight')
 }
 
-function unhighlight (e) {
+function unhighlight (e) { // eslint-disable-line no-unused-vars
   dropArea.classList.remove('highlight')
 }
 

--- a/static/js/htmlSorter.js
+++ b/static/js/htmlSorter.js
@@ -55,7 +55,7 @@ function getSortValue (v) {
   const isHTMLregex = /^(?:\s*(<[\w\W]+>)[^>]*|#([\w-]*))$/
 
   // Extract the inner HTML, if the content is inside an HTML element
-  if (isHTMLregex.test(v)) v = $(v).text().trim()
+  if (isHTMLregex.test(v)) v = $(v).text().trim() // eslint-disable-line no-undef
 
   // Do not alphabetically sort "None" (special case from Python/Django)
   // Nones should appear first (or last if desc sorting)


### PR DESCRIPTION
# NOTE: The contents/changes of this PR are exactly the same as those in #1738, which was reviewed and merged into `main`.  But the `release/1_0_2_manuscript` branch had the same issue.  This PR is the same commit merged into main, cherry-picked off main and applied to branch `dev/superlinter_8_6_0_manuscript`, which was created off `release/1_0_2_manuscript`.

## What

- [GREATS-284](https://princeton-university.atlassian.net/browse/GREATS-284)

From jira issue:

> Update to the latest superlinter (8.6.0).

## Why

From jira issue:

> High severity superlinter vulnerability CVE-2026-25761

## How

From the git log:

> Updated superlinter slim from 6.3.0 to regular superlinter 8.6.0.
> 
> Details:
> 
> - Disabled all the new linters to stabilize the repository's linting.
> - JavaScript
>   - Removed unused variables
>   - Disabled some rules as necessary
> - Sorted the variables in .env.example
> - Fixed some terminology in the markdown files
> - Commented the suggestion-mode setting in the .python-lint config file
> - Added an install of pylint-django to the superlinter yaml.  This change was also made elsewhere, but done differently.  The pip install elsewhere will need to be removed when this is merged.
> - Removed the option for argparse.FileType in one management file and disabled the deprecated rule in the other (because it hasn't been updated since v2-beta yet).
> - Added ignores for some CSS lines.
> - Updated the CONTRIBUTING.md file to reference the non-slim superlinter 8.6.0 version.
> - Removed django-pylint from the .pylintrc.

## Tests

- Ran the new superlinter locally
- CI tests pass

## Security Concerns

- Command injection that can change repository contents in superlinter vulnerability CVE-2026-25761

## Others

None