### PR TITLE
Split the settings file and moved the .env files

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,11 +4,8 @@ DATABASE_NAME=db_name
 DATABASE_PASSWORD=password
 DATABASE_PORT=5432
 DATABASE_USER=db_user
-DEBUG=False
-DEBUG_TOOLBAR=False
 GATEWAY_TIMEOUT=180
 SECRET_KEY=CHANGETHISKEY
-SQL_LOGGING=False
 
 # Set READONLY to True if users are not allowed to submit data.
 READONLY=False
@@ -27,7 +24,7 @@ READONLY=False
 # "entry.1881422913=Animals".  You can create custom links to use this field for whatever feedback subject you want.
 FEEDBACK_URL="https://link.to.feedback.form/goes/here/viewform?usp=pp_url&entry.1881422913="
 
-# Submissions
+# Data Submission Settings
 # The shared drive (not managed by TraceBase) where submission data is deposited.
 SUBMISSION_DRIVE_DOC_URL=http://link.to.shared.drive/docs/describing/account/creation/etc/goes/here
 # If there is a particular subfolder into which submission data should be deposited, supply that relative path here.
@@ -39,7 +36,7 @@ SUBMISSION_DRIVE_TYPE="Google Drive, for example"
 # what folder is was deposited in in the shared drive.  If submissions are not accepted, set READONLY above to True.
 SUBMISSION_FORM_URL=https://link.to.study.submission.form/goes/here
 
-# Security
+# Security Settings
 CSRF_COOKIE_SECURE=False
 # Subdomains must use HTTPS
 SECURE_HSTS_INCLUDE_SUBDOMAINS=False
@@ -60,3 +57,8 @@ SESSION_COOKIE_SECURE=False
 #     - runserver does not support https
 #     - If you get 400 from it being non-0, set 0, clear browser cache, and manually enter 'http' to reset.
 SECURE_HSTS_SECONDS=0
+
+# Settings for DEBUG mode (ignored in production - see /TraceBase/settings/)
+DEBUG=False
+DEBUG_TOOLBAR=False
+SQL_LOGGING=False

--- a/.github/linters/.flake8
+++ b/.github/linters/.flake8
@@ -1,3 +1,4 @@
 [flake8]
 max-line-length = 120
 extend-exclude = .venv, migrations, node_modules
+per-file-ignores = TraceBase/settings/*.py:F403,F405

--- a/.github/scripts/check-prod-settings.sh
+++ b/.github/scripts/check-prod-settings.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+export DEBUG=True
+export SECRET_KEY=dummy
+
+python -c "
+from TraceBase.settings import prod
+print('prod.DEBUG =', prod.DEBUG)
+assert prod.DEBUG is False
+"

--- a/.github/workflows/superlinter.yml
+++ b/.github/workflows/superlinter.yml
@@ -50,7 +50,7 @@ jobs:
           # pylint-django has a new way to be installed
           PYTHON_PYLINT_CONFIG_FILE: .pylintrc
           PYTHON_LINT_REQUIREMENTS_FILE: .github/linters/python-lint-requirements.txt
-          DJANGO_SETTINGS_MODULE: TraceBase.settings
+          DJANGO_SETTINGS_MODULE: TraceBase.settings.dev
 
           # The new version of JSCPD checks between files and there is no way to disable it alone
           VALIDATE_JSCPD: false

--- a/.github/workflows/tracebase-tests.yml
+++ b/.github/workflows/tracebase-tests.yml
@@ -57,7 +57,7 @@ jobs:
       - name: Make the cache table
         run: python manage.py createcachetable
       - name: Run tests
-        run: python manage.py test
+        run: python manage.py test --settings=TraceBase.settings.test
       - name: Load fixtures
         run: |
           python manage.py loaddata \

--- a/.github/workflows/tracebase-tests.yml
+++ b/.github/workflows/tracebase-tests.yml
@@ -69,3 +69,5 @@ jobs:
           python manage.py load_study \
           --infile \
           "DataRepo/data/tests/small_obob/glucose/small_obob_animal_and_sample_table.xlsx"
+      - name: Verify production ignores DEBUG env var
+        run: .github/scripts/check-prod-settings.sh

--- a/.gitignore
+++ b/.gitignore
@@ -148,7 +148,6 @@ scratch*
 # Robs custom ignores - I use the following file that I haven't made into an "app" yet
 DataRepo/management/commands/list_tests.py
 
-# Django debug toolbar.  See traceBase/settings.py.
+# Django debug toolbar.  See TraceBase/settings/dev.py.
 static/admin
 static/debug_toolbar
-TraceBase/static

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -102,7 +102,7 @@ is pre- configured to be ignored by the repository, so do not explicitly check i
 
 Copy the TraceBase environment example:
 
-    cp TraceBase/.env.example TraceBase/.env
+    cp .env.example .env
 
 Update the .env file to reflect the new secret key and the database credentials you used when setting up Postgres.
 
@@ -260,7 +260,7 @@ All pull requests must pass new and all previous continuous integration tests,
 all JavaScript tests, and pass a migration check before merging.  Run the
 following locally before submitting a pull request:
 
-    python manage.py test
+    python manage.py test --settings=TraceBase.settings.test
     python manage.py makemigrations --check --dry-run
     python -m http.server
 

--- a/DataRepo/loaders/peak_annotation_files_loader.py
+++ b/DataRepo/loaders/peak_annotation_files_loader.py
@@ -782,11 +782,7 @@ class PeakAnnotationFilesLoader(TableLoader):
             filename: str
             for filename in fileset:
                 # If the current file matches one of the supplied files
-                if (
-                    any(filename.lower().endswith(ext) for ext in self.peak_annot_exts)
-                    # Avoid excel cruft
-                    and not filename.startswith("~$")
-                ):
+                if any(filename.lower().endswith(ext) for ext in self.peak_annot_exts):
                     filepath = os.path.join(dir_path, filename)
                     potential_peak_annot_files[filename].append(filepath)
 

--- a/DataRepo/loaders/peak_annotation_files_loader.py
+++ b/DataRepo/loaders/peak_annotation_files_loader.py
@@ -782,7 +782,11 @@ class PeakAnnotationFilesLoader(TableLoader):
             filename: str
             for filename in fileset:
                 # If the current file matches one of the supplied files
-                if any(filename.lower().endswith(ext) for ext in self.peak_annot_exts):
+                if (
+                    any(filename.lower().endswith(ext) for ext in self.peak_annot_exts)
+                    # Avoid excel cruft
+                    and not filename.startswith("~$")
+                ):
                     filepath = os.path.join(dir_path, filename)
                     potential_peak_annot_files[filename].append(filepath)
 

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -135,7 +135,7 @@ Create a tracebase postgres user:
     > ALTER USER tracebase CREATEDB;
     > grant all privileges on database tracebase to tracebase;
 
-See **TraceBase Setup** below for adding these `tracebase` user credentials to the `TraceBase/.env` file.
+See **TraceBase Setup** below for adding these `tracebase` user credentials to the `.env` file.
 
 ### TraceBase Setup
 
@@ -147,13 +147,13 @@ Ensure you are the `tracebase` user, the environment is activated, and that you 
 
 Create a TraceBase environment file using the example file in the repository:
 
-    cp TraceBase/.env.example TraceBase/.env
+    cp .env.example .env
 
-Create a secret token for secure API access.  This will be saved in the `TraceBase/.env` file.
+Create a secret token for secure API access.  This will be saved in the `.env` file.
 
     python -c "import secrets; print(secrets.token_urlsafe())"
 
-Update the `TraceBase/.env` file to:
+Update the `.env` file to:
 
 - Add the new `SECRET_KEY` that was just generated above.
 - Add the `tracebase` user database credentials you used in the **Postgres Setup** section.
@@ -200,7 +200,7 @@ TraceBase has a single `static` directory, containing:
 - favicon.ico
 
 It also serves files from the administrator-selected archive location, which should be set up outside the `tracebase`
-code repository directory and configured with the `ARCHIVE` variable in the `TraceBase/.env` file.
+code repository directory and configured with the `ARCHIVE` variable in the `.env` file.
 
 The webserver needs to be set up to allow file access to both directories.
 
@@ -244,14 +244,17 @@ The following is an example `/etc/httpd/conf.d/tracebase.conf` file:
         </Directory>
     </VirtualHost>
 
-Note that it:
+Note:
 
-- Creates an alias for the archive, which should be independent of any other tracebase instances (if you intend to run a
-  public instance for sharing data).
-  - Be sure that the ARCHIVE_DIR variable in `/var/www/tracebase/TraceBase/.env` matches the alias.
-- Creates an `alias` to match the `/var/www/tracebase/static` directory.
-- Sets the gateway timeout to match what's in the `TraceBase/.env` file.  This allows the software to end gracefully if
+- This creates an alias for the archive, which should be independent of any other tracebase instances (if you intend to
+  run a public instance for sharing data).
+  - Be sure that the ARCHIVE_DIR variable in `/var/www/tracebase/.env` matches the alias.
+- This creates an `alias` to match the `/var/www/tracebase/static` directory.
+- This sets the gateway timeout to match what's in the `.env` file.  This allows the software to end gracefully if
   submission processing takes too long.
+- If you want to set up a development server using apache/nginx, `DJANGO_SETTINGS_MODULE` must be set as a system
+  environment variable to "`TraceBase.settings.dev`", but this only works if all virtual hosts on that machine use this
+  same setting.  Using `SetEnv` in the virtual host settings will not work.
 
 ## Authorization and Security
 
@@ -262,8 +265,7 @@ Note that it:
 TraceBase does not provide differential public versus private access.  To "publish" any study data, a separate public
 instance of TraceBase must be created that must be separately loaded with the studies that have been selected to be
 "public"/published.  To create a public instance, follow these installation instructions, but do not apply any
-authentication mechanism.  It is also recommended that you set the `READONLY` environment variable in `TraceBase/.env`
-to `True`.
+authentication mechanism.  It is also recommended that you set the `READONLY` environment variable in `.env` to True.
 
 NOTE: Retain copies of submitted study docs and all associated data for this purpose.
 
@@ -298,7 +300,7 @@ You can check your environment to ensure it is set up securely using the followi
 
 Running the test suite will verify everything is installed correctly.  Note, this can take up to 20 minutes:
 
-    python manage.py test
+    python manage.py test --settings=TraceBase.settings.test
 
 ### Backups
 
@@ -318,7 +320,7 @@ regularly.
 
         mv tracebase tracebase-old
         tar -zxvf tracebase-vX.X.X.tar.gz
-        cp tracebase-old/TraceBase/.env tracebase/TraceBase/
+        cp tracebase-old/.env tracebase/
 
 3. Update the virtual environment.
 
@@ -329,10 +331,10 @@ regularly.
 
         python manage.py migrate
 
-5. Update for new or deleted environment variables in `TraceBase/.env` by comparing it with `TraceBase/.env.example`.
+5. Update for new or deleted environment variables in `.env` by comparing it with `.env.example`.
 
-        diff --side-by-side TraceBase/.env TraceBase/.env.example
-        vi TraceBase/.env
+        diff --side-by-side .env .env.example
+        vi .env
 
 8. Check the deployment for security issues.
 

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ See `INSTALL.md`.
 
 In brief, the main test package can be run using:
 
-    python manage.py test
+    python manage.py test --settings=TraceBase.settings.test
 
 For detailed and comprehensive testing instructions and verification, see:
 

--- a/TraceBase/asgi.py
+++ b/TraceBase/asgi.py
@@ -11,6 +11,6 @@ import os
 
 from django.core.asgi import get_asgi_application
 
-os.environ.setdefault("DJANGO_SETTINGS_MODULE", "TraceBase.settings")
+os.environ.setdefault("DJANGO_SETTINGS_MODULE", "TraceBase.settings.prod")
 
 application = get_asgi_application()

--- a/TraceBase/settings/__init__.py
+++ b/TraceBase/settings/__init__.py
@@ -1,0 +1,5 @@
+from .dev import *  # noqa: F401
+
+# The above is a backward-compatibility import.  This makes it possible for the dev site to work while remaining
+# compatible with old branches.  I.e. Both old and new branches are able to work on the dev site in DEBUG mode by
+# setting DJANGO_SETTINGS_MODULE in the system environment settings that apache picks up and passes to wsgi.py.

--- a/TraceBase/settings/__init__.py
+++ b/TraceBase/settings/__init__.py
@@ -1,5 +1,6 @@
 from .dev import *  # noqa: F401
 
-# The above is a backward-compatibility import.  This makes it possible for the dev site to work while remaining
-# compatible with old branches.  I.e. Both old and new branches are able to work on the dev site in DEBUG mode by
-# setting DJANGO_SETTINGS_MODULE in the system environment settings that apache picks up and passes to wsgi.py.
+# TODO: The import from .dev is temporary.  See ticket: https://princeton-university.atlassian.net/browse/GREATS-304 for
+# the plan for its removal.  The import is a backward-compatibility shim.  It makes it possible for the dev site to work
+# while remaining compatible with old branches.  I.e. Both old and new branches can work on the dev site in DEBUG mode
+# by setting DJANGO_SETTINGS_MODULE in the system environment settings that apache picks up and passes to wsgi.py.

--- a/TraceBase/settings/base.py
+++ b/TraceBase/settings/base.py
@@ -11,34 +11,22 @@ https://docs.djangoproject.com/en/4.2/ref/settings/
 """
 
 import os
-import sys
 from pathlib import Path
 from typing import Dict
 
 import environ
 from django.db.backends.postgresql.psycopg_any import IsolationLevel
 
+# Build paths inside the project like this: BASE_DIR / 'subdir'.
+BASE_DIR = Path(__file__).resolve().parent.parent.parent
+ENV_FILE = BASE_DIR / ".env"
+
 env = environ.Env()
 # reading .env file
-environ.Env.read_env()
-
-# Build paths inside the project like this: BASE_DIR / 'subdir'.
-BASE_DIR = Path(__file__).resolve().parent.parent
-
+environ.Env.read_env(ENV_FILE)
 
 # Quick-start development settings - unsuitable for production
 # See https://docs.djangoproject.com/en/4.2/howto/deployment/checklist/
-
-# Raises django's ImproperlyConfigured exception if SECRET_KEY not in os.environ
-# SECURITY WARNING: keep the secret key used in production secret!
-SECRET_KEY = env("SECRET_KEY", default="unsafe-secret-key")
-
-# SECURITY WARNING: don't run with debug turned on in production!
-# NOTE: If you want to test what you would see in production when DEBUG=False, you must start the server with:
-#     python manage.py runserver --insecure
-# because runserver will not load static files without it (whereas in a production environment, the web server would
-# serve those files).  See https://stackoverflow.com/a/5836728/2057516
-DEBUG = env.bool("DEBUG", default=False)
 
 # Setting READONLY to True disables the upload page, among other potential things.  Set it to True if the site is
 # accessible by the public and you don't want the public to be able to submit upload data, i.e. the site's only purpose
@@ -61,7 +49,6 @@ INSTALLED_APPS = [
     "django.contrib.sessions",
     "django.contrib.messages",
     "django.contrib.staticfiles",
-    "DataRepo.tests.apps.test_apps.LoaderTestConfig",
 ]
 
 CUSTOM_INSTALLED_APPS = env.list("CUSTOM_INSTALLED_APPS", default=None)
@@ -154,7 +141,6 @@ AUTH_PASSWORD_VALIDATORS = [
     },
 ]
 
-
 # Security
 # https://docs.djangoproject.com/en/5.1/howto/deployment/checklist/
 
@@ -183,7 +169,6 @@ USE_I18N = True
 USE_L10N = True
 USE_TZ = True
 
-
 # Static files (CSS, JavaScript, Images)
 # https://docs.djangoproject.com/en/4.2/howto/static-files/
 STATIC_URL = "static/"
@@ -192,11 +177,8 @@ STATICFILES_DIRS = [os.path.join(BASE_DIR, "static")]
 # File storage location
 MEDIA_URL = "/archive/"
 MEDIA_ROOT = env.str("ARCHIVE_DIR", default=os.path.join(BASE_DIR, "archive"))
-TEST_MEDIA_ROOT = env.str(
-    "TEST_ARCHIVE_DIR", default=os.path.join(BASE_DIR, "archive_test")
-)
 
-DEFAULT_STORAGES = {
+STORAGES = {
     # Django defaults:
     "default": {
         "BACKEND": "django.core.files.storage.FileSystemStorage",
@@ -208,30 +190,6 @@ DEFAULT_STORAGES = {
         "BACKEND": "django.core.files.storage.FileSystemStorage",
     },
 }
-TEST_STORAGES = {
-    "default": {
-        "BACKEND": "django.core.files.storage.InMemoryStorage",
-    },
-    "staticfiles": {
-        "BACKEND": "django.contrib.staticfiles.storage.StaticFilesStorage",
-    },
-}
-TEST_FILE_STORAGES = {
-    "default": {
-        "BACKEND": "django.core.files.storage.FileSystemStorage",
-    },
-    "staticfiles": {
-        "BACKEND": "django.contrib.staticfiles.storage.StaticFilesStorage",
-    },
-}
-
-STORAGES = DEFAULT_STORAGES
-
-# File storage handling for tests
-# https://stackoverflow.com/questions/38345977/filefield-force-using-temporaryuploadedfile
-# Added to make the submission.html form work.  Could not figure out how to specify this handler for individual fields.
-# This avoids files using the InMemoryUploadedFile, which the load script complains about.
-FILE_UPLOAD_HANDLERS = ["django.core.files.uploadhandler.TemporaryFileUploadHandler"]
 
 # Custom URLs and content
 FEEDBACK_URL = env.str("FEEDBACK_URL", default=None)
@@ -245,7 +203,7 @@ SUBMISSION_DRIVE_FOLDER = env.str(
 
 # Set up caching used by model cached_properties
 # See: https://docs.djangoproject.com/en/dev/topics/cache/#setting-up-the-cache
-PROD_CACHES = {
+CACHES: Dict[str, Dict[str, object]] = {
     "default": {
         "BACKEND": "django.core.cache.backends.db.DatabaseCache",
         "LOCATION": "tracebase_cache_table",
@@ -255,110 +213,7 @@ PROD_CACHES = {
     }
 }
 
-TEST_CACHES = {
-    "default": {
-        "BACKEND": "django.core.cache.backends.db.DatabaseCache",
-        "LOCATION": "tracebase_cache_table",
-        "TIMEOUT": 1200,
-        "OPTIONS": {"MAX_ENTRIES": 1000},
-        "KEY_PREFIX": "TEST",
-    }
-}
-
-CACHES_SETTING = env.str("CACHES", default="PROD_CACHES")
-
-CACHES: Dict[str, Dict] = PROD_CACHES
-if CACHES_SETTING == "TEST_CACHES":
-    CACHES = TEST_CACHES
-elif CACHES_SETTING != "PROD_CACHES":
-    print(
-        f"Invalid CACHE_SETTINGS value: {CACHES_SETTING} in .env. Defaulting to PROD_CACHES. Valid values are "
-        "TEST_CACHES and PROD_CACHES."
-    )
-
-# Define a custom test runner
-# https://docs.djangoproject.com/en/4.2/topics/testing/advanced/#using-different-testing-frameworks
-TEST_RUNNER = "TraceBase.runner.TraceBaseTestSuiteRunner"
-
-# Logging settings
-# NOTE: to print SQL, DEBUG must be True, and to print SQL during a particular test, each test method must be decorated
-# with: `@override_settings(DEBUG=True)`
-SQL_LOGGING = env.bool("SQL_LOGGING", default=False)
-if SQL_LOGGING is True:
-    LOGGING = {
-        "version": 1,
-        "filters": {
-            "require_debug_true": {
-                "()": "django.utils.log.RequireDebugTrue",
-            }
-        },
-        "handlers": {
-            "console": {
-                "level": "DEBUG",
-                "filters": ["require_debug_true"],
-                "class": "logging.StreamHandler",
-            }
-        },
-        "loggers": {
-            "django.db.backends": {
-                "level": "DEBUG",
-                "handlers": ["console"],
-            }
-        },
-    }
-
-MIDDLEWARE = [
-    "django.middleware.security.SecurityMiddleware",
-    "django.contrib.sessions.middleware.SessionMiddleware",
-    "django.middleware.common.CommonMiddleware",
-    "django.middleware.csrf.CsrfViewMiddleware",
-    "django.contrib.auth.middleware.AuthenticationMiddleware",
-    "django.contrib.messages.middleware.MessageMiddleware",
-    "django.middleware.clickjacking.XFrameOptionsMiddleware",
-]
-
-# See: django-debug-toolbar.readthedocs.io/en/latest/installation.html#disable-the-toolbar-when-running-tests-optional
-DEBUG_TOOLBAR_ENABLED = False
-DEBUG_TOOLBAR = env.bool("DEBUG_TOOLBAR", default=True)
-if DEBUG_TOOLBAR is True:
-    TESTING = "test" in sys.argv
-    try:
-        import debug_toolbar  # noqa: F401 # pylint: disable=unused-import
-
-        DEBUG_TOOLBAR_INSTALLED = True
-    except ImportError:
-        DEBUG_TOOLBAR_INSTALLED = False
-
-    if (
-        DEBUG
-        and not TESTING
-        and DEBUG_TOOLBAR_INSTALLED
-        # Static files are configured to debug_toolbar's requirements
-        and "django.contrib.staticfiles" in INSTALLED_APPS
-        and STATIC_URL == "static/"
-        # Templates are configured to debug_toolbar's requirements
-        and any(
-            [
-                template["BACKEND"] == "django.template.backends.django.DjangoTemplates"
-                and template["APP_DIRS"] is True
-                for template in TEMPLATES
-            ]
-        )
-    ):
-        # On the dev site, you need to run `python manage.py collectstatic` to be able to use the toolbar
-        # NOTE: Running collectstatic puts the aggregated static files in tracebase/static.  After running it, (which
-        # you should only need to do once), run `mv TraceBase/static static`.
-        PROJECT_DIR = os.path.dirname(os.path.abspath(__file__))
-        STATIC_ROOT = os.path.join(PROJECT_DIR, "static")
-
-        DEBUG_TOOLBAR_ENABLED = True
-        INSTALLED_APPS.append("debug_toolbar")
-        # See https://django-debug-toolbar.readthedocs.io/en/latest/installation.html#add-the-middleware
-        MIDDLEWARE.insert(0, "debug_toolbar.middleware.DebugToolbarMiddleware")
-        INTERNAL_IPS = ALLOWED_HOSTS[:]
-        # Override the debug toolbar's logic to decide whether to run or not (we're using the conditional logic above)
-        DEBUG_TOOLBAR_CONFIG = {
-            "SHOW_TOOLBAR_CALLBACK": lambda _: True,
-            "SHOW_COLLAPSED": True,
-            "SQL_WARNING_THRESHOLD": 70,
-        }
+# For backward compatibility with older branches...  This gets overwritten in prod.py.  The development site must have
+# `SetEnv DJANGO_SETTINGS_MODULE TraceBase.settings`. in the virtual host settings, but do not put it in the production
+# site's virtual host settings (so it defaults to prod).
+DEBUG = True

--- a/TraceBase/settings/dev.py
+++ b/TraceBase/settings/dev.py
@@ -1,0 +1,85 @@
+import sys
+
+from .base import *
+
+SECRET_KEY = env("SECRET_KEY", default="unsafe-secret-key")
+
+# SECURITY WARNING: don't run with debug turned on in production!
+# NOTE: If you want to test what you would see in production when DEBUG=False, you must start the server with:
+#     python manage.py runserver --insecure
+# because runserver will not load static files without it (whereas in a production environment, the web server would
+# serve those files).  See https://stackoverflow.com/a/5836728/2057516
+DEBUG = env.bool("DEBUG", default=True)
+
+# Logging settings
+# NOTE: to print SQL, DEBUG must be True, and to print SQL during a particular test, each test method must be decorated
+# with: `@override_settings(DEBUG=True)`
+SQL_LOGGING = env.bool("SQL_LOGGING", default=False)
+if SQL_LOGGING is True:
+    LOGGING = {
+        "version": 1,
+        "filters": {
+            "require_debug_true": {
+                "()": "django.utils.log.RequireDebugTrue",
+            }
+        },
+        "handlers": {
+            "console": {
+                "level": "DEBUG",
+                "filters": ["require_debug_true"],
+                "class": "logging.StreamHandler",
+            }
+        },
+        "loggers": {
+            "django.db.backends": {
+                "level": "DEBUG",
+                "handlers": ["console"],
+            }
+        },
+    }
+
+# See: django-debug-toolbar.readthedocs.io/en/latest/installation.html#disable-the-toolbar-when-running-tests-optional
+DEBUG_TOOLBAR_ENABLED = False
+DEBUG_TOOLBAR = env.bool("DEBUG_TOOLBAR", default=True)
+if DEBUG_TOOLBAR is True:
+    TESTING = "test" in sys.argv
+    try:
+        import debug_toolbar  # noqa: F401 # pylint: disable=unused-import
+
+        DEBUG_TOOLBAR_INSTALLED = True
+    except ImportError:
+        DEBUG_TOOLBAR_INSTALLED = False
+
+    if (
+        DEBUG
+        and not TESTING
+        and DEBUG_TOOLBAR_INSTALLED
+        # Static files are configured to debug_toolbar's requirements
+        and "django.contrib.staticfiles" in INSTALLED_APPS
+        and STATIC_URL == "static/"
+        # Templates are configured to debug_toolbar's requirements
+        and any(
+            [
+                template["BACKEND"] == "django.template.backends.django.DjangoTemplates"
+                and template["APP_DIRS"] is True
+                for template in TEMPLATES
+            ]
+        )
+    ):
+        # On the dev site, you need to run `python manage.py collectstatic` to be able to use the toolbar
+        # NOTE: Running collectstatic puts the aggregated static files in tracebase/static.  After running it, (which
+        # you should only need to do once), run `mv TraceBase/static static`.
+        PROJECT_DIR = os.path.dirname(os.path.abspath(__file__))
+        STATIC_ROOT = os.path.join(PROJECT_DIR, "static")
+
+        DEBUG_TOOLBAR_ENABLED = True
+        INSTALLED_APPS.append("debug_toolbar")
+        # See https://django-debug-toolbar.readthedocs.io/en/latest/installation.html#add-the-middleware
+        MIDDLEWARE.insert(0, "debug_toolbar.middleware.DebugToolbarMiddleware")
+        INTERNAL_IPS = ALLOWED_HOSTS[:]
+        # Override the debug toolbar's logic to decide whether to run or not (we're using the conditional logic above)
+        DEBUG_TOOLBAR_CONFIG = {
+            "SHOW_TOOLBAR_CALLBACK": lambda _: True,
+            "SHOW_COLLAPSED": True,
+            "SQL_WARNING_THRESHOLD": 70,
+        }

--- a/TraceBase/settings/prod.py
+++ b/TraceBase/settings/prod.py
@@ -1,0 +1,11 @@
+from .base import *
+
+# Raises django's ImproperlyConfigured exception if SECRET_KEY not in os.environ
+# SECURITY WARNING: keep the secret key used in production secret!
+SECRET_KEY = env("SECRET_KEY")
+
+# NOTE: Explicitly setting DEBUG to false.  This is a security issue.  See dev.py for controlling DEBUG with .env.
+DEBUG = False
+SQL_LOGGING = False
+DEBUG_TOOLBAR_ENABLED = False
+DEBUG_TOOLBAR = False

--- a/TraceBase/settings/prod.py
+++ b/TraceBase/settings/prod.py
@@ -4,7 +4,8 @@ from .base import *
 # SECURITY WARNING: keep the secret key used in production secret!
 SECRET_KEY = env("SECRET_KEY")
 
-# NOTE: Explicitly setting DEBUG to false.  This is a security issue.  See dev.py for controlling DEBUG with .env.
+# NOTE: Explicitly forcing these debug environment variables to false *after* importing from base.  They cannot be
+# overridden by the values set in .env.  This is a security issue.
 DEBUG = False
 SQL_LOGGING = False
 DEBUG_TOOLBAR_ENABLED = False

--- a/TraceBase/settings/test.py
+++ b/TraceBase/settings/test.py
@@ -1,0 +1,71 @@
+import os
+from copy import deepcopy
+from typing import Dict
+
+from .dev import *
+
+INSTALLED_APPS.extend(
+    [
+        "DataRepo.tests.apps.test_apps.LoaderTestConfig",
+    ]
+)
+
+# NOTE: TEST_MEDIA_ROOT is used in DataRepo/tests/tracebase_test_case.py
+TEST_MEDIA_ROOT = env.str(
+    "TEST_ARCHIVE_DIR", default=os.path.join(BASE_DIR, "archive_test")
+)
+
+DEFAULT_STORAGES = deepcopy(STORAGES)
+
+# NOTE: TEST_STORAGES is used in TraceBase/runner.py
+TEST_STORAGES = {
+    "default": {
+        "BACKEND": "django.core.files.storage.InMemoryStorage",
+    },
+    "staticfiles": {
+        "BACKEND": "django.contrib.staticfiles.storage.StaticFilesStorage",
+    },
+}
+
+# NOTE: TEST_FILE_STORAGES is used in DataRepo/tests/tracebase_test_case.py
+TEST_FILE_STORAGES = {
+    "default": {
+        "BACKEND": "django.core.files.storage.FileSystemStorage",
+    },
+    "staticfiles": {
+        "BACKEND": "django.contrib.staticfiles.storage.StaticFilesStorage",
+    },
+}
+
+# File storage handling for tests
+# https://stackoverflow.com/questions/38345977/filefield-force-using-temporaryuploadedfile
+# Added to make the submission.html form work.  Could not figure out how to specify this handler for individual fields.
+# This avoids files using the InMemoryUploadedFile, which the load script complains about.
+FILE_UPLOAD_HANDLERS = ["django.core.files.uploadhandler.TemporaryFileUploadHandler"]
+
+# NOTE: TEST_CACHES is used in various tests as an argument to @override_settings()
+TEST_CACHES: Dict[str, Dict[str, object]] = {
+    "default": {
+        "BACKEND": "django.core.cache.backends.db.DatabaseCache",
+        "LOCATION": "tracebase_cache_table",
+        "TIMEOUT": 1200,
+        "OPTIONS": {"MAX_ENTRIES": 1000},
+        "KEY_PREFIX": "TEST",
+    }
+}
+
+# NOTE: CACHES affects the usage of @cached_properties
+# See: https://docs.djangoproject.com/en/dev/topics/cache/#setting-up-the-cache
+CACHES_SETTING = env.str("CACHES", default="PROD_CACHES")
+if CACHES_SETTING == "TEST_CACHES":
+    CACHES = TEST_CACHES
+elif CACHES_SETTING != "PROD_CACHES":
+    print(
+        f"Invalid CACHE_SETTINGS value: {CACHES_SETTING} in .env. Defaulting to PROD_CACHES. Valid values are "
+        "TEST_CACHES and PROD_CACHES."
+    )
+
+# Define a custom test runner
+# https://docs.djangoproject.com/en/4.2/topics/testing/advanced/#using-different-testing-frameworks
+# NOTE: This is implicitly used by TraceBase/runner.py
+TEST_RUNNER = "TraceBase.runner.TraceBaseTestSuiteRunner"

--- a/TraceBase/wsgi.py
+++ b/TraceBase/wsgi.py
@@ -11,6 +11,6 @@ import os
 
 from django.core.wsgi import get_wsgi_application
 
-os.environ.setdefault("DJANGO_SETTINGS_MODULE", "TraceBase.settings")
+os.environ.setdefault("DJANGO_SETTINGS_MODULE", "TraceBase.settings.prod")
 
 application = get_wsgi_application()

--- a/docs/operations/User_Docs_Deployment.md
+++ b/docs/operations/User_Docs_Deployment.md
@@ -111,7 +111,7 @@ import django
 sys.path.insert(0, os.path.abspath(".."))
 
 # Set the DJANGO_SETTINGS_MODULE environment variable
-os.environ["DJANGO_SETTINGS_MODULE"] = "TraceBase.settings"
+os.environ["DJANGO_SETTINGS_MODULE"] = "TraceBase.settings.dev"
 
 # Now we can initialize Django
 django.setup()

--- a/manage.py
+++ b/manage.py
@@ -7,7 +7,7 @@ import sys
 
 def main():
     """Run administrative tasks."""
-    os.environ.setdefault("DJANGO_SETTINGS_MODULE", "TraceBase.settings")
+    os.environ.setdefault("DJANGO_SETTINGS_MODULE", "TraceBase.settings.dev")
     try:
         from django.core.management import execute_from_command_line
     except ImportError as exc:


### PR DESCRIPTION
## What

- [GREATS-293](https://princeton-university.atlassian.net/browse/GREATS-293)

- Move `.env.example` to the root level directory
  - Update documentation referencing .env for location
  - Put the debug settings in 1 section of the .env and add a comment that they are ignored in production
  - Group debug-related settings in one section of the `.env.example` file, with comments explaining override behavior.
- Delete `TraceBase/settings.py`
  - `TraceBase/settings/base.py` - all common settings.
  - `TraceBase/settings/test.py` - settings related to running tests efficiently.
  - `TraceBase/settings/dev.py` - `DEBUG=True` and the `SQL_LOGGING` and `DEBUG_TOOLBAR` settings
  - `TraceBase/settings/prod.py` - `DEBUG=False`, `SQL_LOGGING=False`, and `DEBUG_TOOLBAR=False`
- Update documentation to
  - Say how to run tests, e.g. use `python manage.py test --settings=TraceBase.settings.test`
  - Update references to `DEBUG`
- Neither `DEBUG`, `SQL_LOGGING`, nor `DEBUG_TOOLBAR` should ever be turned on in production, but can be set in the `.env` file for the dev settings.  (I.e. these settings in the `.env` file only take effect in the dev settings - they are ignored/overridden in the prod settings to always be off).
- Configuration
  - The following environment variables are forced off in `prod.py` after inheriting from `base.py` but are configurable in `.env` and respected in `dev.py`.  They are included and grouped in `.env.example` with a comment explaining where/when they apply:
    - `DEBUG`
    - `SQL_LOGGING`
    - `DEBUG_TOOLBAR`

## Why

Splitting the Django settings file is an industry-standard practice for professional projects. While a single file is simpler for small apps, modularizing settings improves security, scalability, and maintainability as a project grows.

- Security:
  - If the settings file is exposed, it won't reveal production secrets **if the secret is not hard-coded** *(Note: secrets should be kept out of version controlled files.)*.
  - Prevents accidental DEBUG mode in production ensuring that dev tools (like the Django Debug Toolbar) aren't active.
  - Allows for different security levels (e.g., HTTPS settings, strict host headers) without editing the file before deploying.
- Allows you to use faster tools for testing (like in-memory databases or faster password hashers) without affecting production performance.
- Reduces logic complexity, making the configuration easier to read.

## How

Split the settings file into base, prod, dev, and test, and moved the `.env/.env.example` into the root directory.

Details:

- Appended `.dev` or `.prod` to settings of `DJANGO_SETTINGS_MODULE`
- Removed `TraceBase/settings.py`
- Added:
  - `TraceBase/settings/base.py`
  - `TraceBase/settings/dev.py`
  - `TraceBase/settings/prod.py`
  - `TraceBase/settings/test.py`
- Updated documentation
  - Added `--settings=TraceBase.settings.test` to test calls.
  - Removed "`TraceBase/`" from references to `.env*`
- Added `per-file-ignores = TraceBase/settings/*.py:F403,F405` to the `.flake8` config.
- ~Added `not filename.startswith("~$")` to a conditional in DataRepo.loaders.peak_annotation_files_loader.PeakAnnotationFilesLoader.map_potential_peak_annot_files due to a failed test that was due to an excel-created hidden file.~ **REMOVED in next commit (below)**
- Added a note about setting up a development server to the `INSTALL.md` doc.

Addressed PR review issues about documentation/comments and production security testing.

Details:

- Added a comment that debug settings cannot be overridden in `.env`
- Added a TODO in `TraceBase/settings/__init__.py` that portends the removal of `from .dev import *`
- Added a test in `.github/workflows/tracebase-tests.yml` to ensure that `.env` DEBUG settings cannot be overridden in production.
- Linked to ticket `GREATS-304` in the TODO comment added to `TraceBase/settings/__init__.py`.
- Undid the changes to `DataRepo/loaders/peak_annotation_files_loader.py` as out of scope
- Fixed the permissions on `.github/scripts/check-prod-settings.sh`

## Tests

- Tests pass
- Added test in `.github/workflows/tracebase-tests.yml` to test that setting `.env` dev variables does not change their value in production
- Checked out branch on tb9-dev and restarted apache
  - Moved `TraceBase/.env` to `.env` and created a temporary symlink
  - Browsed the site: no problems
- Checked out branch on tb9 and restarted apache
  - Moved `TraceBase/.env` to `.env` and created a temporary symlink
  - Browsed the site: no problems

## Security Concerns

- Splitting the settings file has the following security benefits
  - Improves maintainability
  - Reduces the chance of accidental dev settings activation in production (e.g. ensuring that dev tools, like the Django Debug Toolbar, aren't active)
  - Mitigates exposure of production secrets if the settings file is exposed, as long as production secrets are not included in the settings files (e.g. `prod.py`).

This list confirms all relevant settings entry points are updated, specifically including:

- `manage.py`
- `wsgi.py`
- `asgi.py`
- CI commands: `tracebase-tests.yml`
- Apache deployment config on `tb9-dev`
- management scripts or cron jobs that set or rely on `DJANGO_SETTINGS_MODULE`: none

## Others

Note that in order to make the `tb9-dev` site work for this and other branches, and be in development mode, we had to set a system level environment variable for apache to pick up that sets `DJANGO_SETTINGS_MODULE` to `TraceBase.settings`.  `TraceBase.settings` is used instead of `TraceBase.settings.dev` in order to be backward compatible with other ongoing work in other branches.  And to make that work, the `__init__.py` file has an import from `.dev`.  This is the recommended approach based on my research and collaboration with the folks on the Django forum.  However, the specific use of `TraceBase.settings` is a temporary solution.  The plan is to change it to change it to `TraceBase.settings.dev`.  See [GREATS-304](https://princeton-university.atlassian.net/browse/GREATS-304) for details, but in summary:

- Only `tb9-dev` needs `DJANGO_SETTINGS_MODULE=TraceBase.settings`
- `tb9-dev` cannot use `TraceBase.settings.dev` because checking out other parallel branches would cause the `apachectl restart` command to fail because those branches don't have `TraceBase/settings/dev.py`
- `tb9` and `tb9-pub` do not explicitly set `TraceBase.settings.prod` because that's the default
- The `TraceBase/.env` symlink to `.env` is necessary so that parallel branches, if deployed on `tb9-dev`
  - The symlinks will not be needed on `tb9` and `tb9-pub`
  - The symlink will be removed once the blocking tickets are done