### PR TITLE
Added ignore of excel cruft (`~$`) to `map_potential_peak_annot_files`

### DIFF
--- a/DataRepo/loaders/peak_annotation_files_loader.py
+++ b/DataRepo/loaders/peak_annotation_files_loader.py
@@ -782,7 +782,11 @@ class PeakAnnotationFilesLoader(TableLoader):
             filename: str
             for filename in fileset:
                 # If the current file matches one of the supplied files
-                if any(filename.lower().endswith(ext) for ext in self.peak_annot_exts):
+                if (
+                    any(filename.lower().endswith(ext) for ext in self.peak_annot_exts)
+                    # Avoid excel cruft
+                    and not filename.startswith("~$")
+                ):
                     filepath = os.path.join(dir_path, filename)
                     potential_peak_annot_files[filename].append(filepath)
 


### PR DESCRIPTION
## What

- [GREATS-305](https://princeton-university.atlassian.net/browse/GREATS-305)

Ignore files that start with `~$` in `DataRepo.loaders.peak_annotation_files_loader.PeakAnnotationFilesLoader.map_potential_peak_annot_files`.

## Why

Test `DataRepo.tests.loaders.test_peak_annotation_files_loader.PeakAnnotationFilesLoaderTests.test_map_peak_annot_files` fails if a test peak annotation file has been opened in excel.

## How

Added `not filename.startswith("~$")` to a conditional in `DataRepo.loaders.peak_annotation_files_loader.PeakAnnotationFilesLoader.map_potential_peak_annot_files` due to a failed test that was due to an excel-created hidden file.

## Tests

- All CI actions pass
- Manual test
  - Opened `DataRepo/data/tests/submission_v3/multitracer_v3/alaglu_cor.xlsx` in excel
  - Confirmed `DataRepo/data/tests/submission_v3/multitracer_v3/~$alaglu_cor.xlsx` existed
  - Confirmed `python manage.py test `DataRepo.tests.loaders.test_peak_annotation_files_loader.PeakAnnotationFilesLoaderTests.test_map_peak_annot_files` passes

## Security Concerns

None

## Others

None