### PR TITLE
Fixed upload exceptions

### DIFF
--- a/DataRepo/forms.py
+++ b/DataRepo/forms.py
@@ -23,7 +23,11 @@ from DataRepo.formats.peakdata_dataformat import PeakDataFormat
 from DataRepo.formats.peakgroups_dataformat import PeakGroupsFormat
 from DataRepo.formats.search_group import SearchGroup
 from DataRepo.models import LCMethod, MSRunSequence, Researcher
-from DataRepo.utils.file_utils import date_to_string, is_excel
+from DataRepo.utils.file_utils import (
+    date_to_string,
+    ensure_temporary_uploaded_file,
+    is_excel,
+)
 from DataRepo.widgets.base import AutoCompleteTextInput, MultipleFileInput
 from DataRepo.widgets.search import RowsPerPageSelectWidget
 
@@ -462,7 +466,9 @@ def create_BuildSubmissionForm() -> Type[Form]:
 
             # Fields we need to check
             study_doc = self.cleaned_data.get("study_doc", None)
-            peak_annotation_file = self.cleaned_data.get("peak_annotation_file", None)
+            peak_annotation_file = ensure_temporary_uploaded_file(
+                self.cleaned_data.get("peak_annotation_file", None)
+            )
 
             if (study_doc is None and peak_annotation_file is None) or (
                 study_doc is not None and not is_excel(study_doc)
@@ -500,7 +506,9 @@ def create_BuildSubmissionForm() -> Type[Form]:
 
             # Fields (excluding mode)
             study_doc = self.cleaned_data.get("study_doc", None)
-            peak_annotation_file = self.cleaned_data.get("peak_annotation_file", None)
+            peak_annotation_file = ensure_temporary_uploaded_file(
+                self.cleaned_data.get("peak_annotation_file", None)
+            )
             mode = self.cleaned_data.get("mode", None)
 
             # NOTE: All of these errors are added as non-field-errors because the form is processed as a form inside a

--- a/DataRepo/forms.py
+++ b/DataRepo/forms.py
@@ -465,17 +465,19 @@ def create_BuildSubmissionForm() -> Type[Form]:
             allowed_delimited_exts = [".csv", ".tsv"]
 
             # Fields we need to check
-            study_doc = self.cleaned_data.get("study_doc", None)
+            study_doc = ensure_temporary_uploaded_file(
+                self.cleaned_data.get("study_doc", None)
+            )
             peak_annotation_file = ensure_temporary_uploaded_file(
                 self.cleaned_data.get("peak_annotation_file", None)
             )
 
-            if (study_doc is None and peak_annotation_file is None) or (
-                study_doc is not None and not is_excel(study_doc)
+            if (not study_doc and not peak_annotation_file) or (
+                study_doc and not is_excel(study_doc)
             ):
                 return False
 
-            if peak_annotation_file is not None:
+            if peak_annotation_file:
                 peak_annot_filepath = peak_annotation_file.temporary_file_path()
                 if not is_excel(peak_annot_filepath):
                     # Excel files do not need a specific extension, but delimited files do...
@@ -505,7 +507,9 @@ def create_BuildSubmissionForm() -> Type[Form]:
             allowed_delimited_exts = [".csv", ".tsv"]
 
             # Fields (excluding mode)
-            study_doc = self.cleaned_data.get("study_doc", None)
+            study_doc = ensure_temporary_uploaded_file(
+                self.cleaned_data.get("study_doc", None)
+            )
             peak_annotation_file = ensure_temporary_uploaded_file(
                 self.cleaned_data.get("peak_annotation_file", None)
             )
@@ -516,7 +520,7 @@ def create_BuildSubmissionForm() -> Type[Form]:
             # object containing errors cannot associate field errors with fields that do not get re-populated (and
             # they're not bothered to be repopulated because you cannot repopulate files anyway).
 
-            if study_doc is None and peak_annotation_file is None:
+            if not study_doc and not peak_annotation_file:
                 if mode is None or mode not in ["autofill", "validate"]:
                     self.add_error(
                         None,
@@ -541,7 +545,7 @@ def create_BuildSubmissionForm() -> Type[Form]:
                             code="TooFewFiles",
                         ),
                     )
-            elif study_doc is not None and not is_excel(study_doc):
+            elif study_doc and not is_excel(study_doc):
                 self.add_error(
                     None,
                     ValidationError(
@@ -550,7 +554,7 @@ def create_BuildSubmissionForm() -> Type[Form]:
                     ),
                 )
 
-            if peak_annotation_file is not None:
+            if peak_annotation_file:
                 peak_annot_filepath = peak_annotation_file.temporary_file_path()
                 if not is_excel(peak_annot_filepath):
                     # Excel files do not need a specific extension, but delimited files do...

--- a/DataRepo/forms.py
+++ b/DataRepo/forms.py
@@ -472,12 +472,12 @@ def create_BuildSubmissionForm() -> Type[Form]:
                 self.cleaned_data.get("peak_annotation_file", None)
             )
 
-            if (not study_doc and not peak_annotation_file) or (
-                study_doc and not is_excel(study_doc)
+            if (study_doc is None and peak_annotation_file is None) or (
+                study_doc is not None and not is_excel(study_doc)
             ):
                 return False
 
-            if peak_annotation_file:
+            if peak_annotation_file is not None:
                 peak_annot_filepath = peak_annotation_file.temporary_file_path()
                 if not is_excel(peak_annot_filepath):
                     # Excel files do not need a specific extension, but delimited files do...
@@ -520,7 +520,7 @@ def create_BuildSubmissionForm() -> Type[Form]:
             # object containing errors cannot associate field errors with fields that do not get re-populated (and
             # they're not bothered to be repopulated because you cannot repopulate files anyway).
 
-            if not study_doc and not peak_annotation_file:
+            if study_doc is None and peak_annotation_file is None:
                 if mode is None or mode not in ["autofill", "validate"]:
                     self.add_error(
                         None,
@@ -545,7 +545,7 @@ def create_BuildSubmissionForm() -> Type[Form]:
                             code="TooFewFiles",
                         ),
                     )
-            elif study_doc and not is_excel(study_doc):
+            elif study_doc is not None and not is_excel(study_doc):
                 self.add_error(
                     None,
                     ValidationError(
@@ -554,7 +554,7 @@ def create_BuildSubmissionForm() -> Type[Form]:
                     ),
                 )
 
-            if peak_annotation_file:
+            if peak_annotation_file is not None:
                 peak_annot_filepath = peak_annotation_file.temporary_file_path()
                 if not is_excel(peak_annot_filepath):
                     # Excel files do not need a specific extension, but delimited files do...

--- a/DataRepo/tests/utils/test_file_utils.py
+++ b/DataRepo/tests/utils/test_file_utils.py
@@ -1,10 +1,16 @@
+from io import BytesIO
+
 import pandas as pd
-from django.core.files.uploadedfile import TemporaryUploadedFile
+from django.core.files.uploadedfile import (
+    InMemoryUploadedFile,
+    TemporaryUploadedFile,
+)
 
 from DataRepo.tests.tracebase_test_case import TracebaseTestCase
 from DataRepo.utils.file_utils import (
     _get_file_type,
     _read_from_xlsx,
+    ensure_temporary_uploaded_file,
     get_column_dupes,
     read_headers_from_file,
     string_to_date,
@@ -136,3 +142,31 @@ class FileUtilsTests(TracebaseTestCase):
         """Assert the _get_file_type() works when supplied a TemporaryUploadedFile."""
         tuf = TemporaryUploadedFile("test.tsv", None, None, None)
         self.assertEqual("tsv", _get_file_type(tuf))
+
+    def test_ensure_temporary_uploaded_file(self):
+        """This tests that the ensure_temporary_uploaded_file method returns a TemporaryUploadedFile when given an
+        InMemoryUploadedFile, None, or a TemporaryUploadedFile
+        """
+        file_io = BytesIO(b"This will be the content of an InMemoryUploadedFile")
+        file_size = file_io.getbuffer().nbytes
+        inmemoryuploadedfile = InMemoryUploadedFile(
+            file=file_io,
+            field_name="file_field_name",
+            name="myfile.txt",
+            content_type="text/plain",
+            size=file_size,
+            charset="utf-8",
+        )
+        file_io.seek(0)
+
+        self.assertIsInstance(
+            ensure_temporary_uploaded_file(inmemoryuploadedfile),
+            TemporaryUploadedFile,
+        )
+        self.assertIsInstance(
+            ensure_temporary_uploaded_file(
+                TemporaryUploadedFile("test.tsv", None, None, None)
+            ),
+            TemporaryUploadedFile,
+        )
+        self.assertIsNone(ensure_temporary_uploaded_file(None))

--- a/DataRepo/utils/file_utils.py
+++ b/DataRepo/utils/file_utils.py
@@ -642,7 +642,7 @@ def date_to_string(date_in: datetime.date, format_str: Optional[str] = None):
 
 
 def ensure_temporary_uploaded_file(
-    uploaded_file: Optional[Union[TemporaryUploadedFile, InMemoryUploadedFile]]
+    uploaded_file: Optional[Union[TemporaryUploadedFile, InMemoryUploadedFile]],
 ):
     """Takes an uploaded file object and returns a TemporaryUploadedFile object (or None, if the uploaded file was None)
 

--- a/DataRepo/utils/file_utils.py
+++ b/DataRepo/utils/file_utils.py
@@ -1,14 +1,17 @@
 import datetime
 import pathlib
 from collections import defaultdict
-from typing import Optional
+from typing import Optional, Union
 from zipfile import BadZipFile
 
 import pandas as pd
 import yaml
 from dateutil.parser import ParserError as DateParserError
 from dateutil.parser import parse as parsedate
-from django.core.files.uploadedfile import TemporaryUploadedFile
+from django.core.files.uploadedfile import (
+    InMemoryUploadedFile,
+    TemporaryUploadedFile,
+)
 from django.core.management import CommandError
 from openpyxl.utils.exceptions import InvalidFileException
 
@@ -169,6 +172,8 @@ def _get_file_type(filepath, filetype=None):
 
     if isinstance(filepath, TemporaryUploadedFile):
         filepath = filepath.temporary_file_path()
+    elif isinstance(filepath, InMemoryUploadedFile):
+        filepath = filepath.name
 
     if filetype is None:
         ext = pathlib.Path(filepath).suffix.strip(".")
@@ -633,3 +638,36 @@ def datetime_to_string(date_in: datetime.datetime, format_str: Optional[str] = N
 def date_to_string(date_in: datetime.date, format_str: Optional[str] = None):
     format = date_format if format_str is None else format_str
     return datetime.date.strftime(date_in, format)
+
+
+def ensure_temporary_uploaded_file(
+    uploaded_file: Optional[Union[TemporaryUploadedFile, InMemoryUploadedFile]]
+):
+    """Takes an uploaded file object and returns a TemporaryUploadedFile object (or None, if the uploaded file was None)
+
+    Args:
+        uploaded_file (Optional[Union[TemporaryUploadedFile, InMemoryUploadedFile]])
+    Exceptions:
+        TypeError
+    Returns:
+        (Optional[TemporaryUploadedFile])
+    """
+    if not uploaded_file or isinstance(uploaded_file, (TemporaryUploadedFile)):
+        return uploaded_file
+
+    if isinstance(uploaded_file, InMemoryUploadedFile):
+        tmp = TemporaryUploadedFile(
+            name=uploaded_file.name,
+            content_type=uploaded_file.content_type,
+            size=uploaded_file.size,
+            charset=uploaded_file.charset,
+        )
+
+        for chunk in uploaded_file.chunks():
+            tmp.write(chunk)
+
+        tmp.seek(0)
+
+        return tmp
+
+    raise TypeError(f"Unsupported upload type: {type(uploaded_file)}")

--- a/DataRepo/utils/file_utils.py
+++ b/DataRepo/utils/file_utils.py
@@ -667,7 +667,7 @@ def ensure_temporary_uploaded_file(
     Returns:
         (Optional[TemporaryUploadedFile])
     """
-    if not uploaded_file or isinstance(uploaded_file, (TemporaryUploadedFile)):
+    if not uploaded_file or isinstance(uploaded_file, TemporaryUploadedFile):
         return uploaded_file
 
     if isinstance(uploaded_file, InMemoryUploadedFile):
@@ -687,8 +687,9 @@ def ensure_temporary_uploaded_file(
         for chunk in uploaded_file.chunks():
             tmp.write(chunk)
 
+        tmp.flush()
         tmp.seek(0)
 
         return tmp
 
-    raise TypeError(f"Unsupported upload type: {type(uploaded_file)}")
+    raise TypeError(f"Unsupported upload type: {type(uploaded_file).__name__}")

--- a/DataRepo/utils/file_utils.py
+++ b/DataRepo/utils/file_utils.py
@@ -2,6 +2,7 @@ import datetime
 import pathlib
 from collections import defaultdict
 from typing import Optional, Union
+from warnings import warn
 from zipfile import BadZipFile
 
 import pandas as pd
@@ -645,6 +646,20 @@ def ensure_temporary_uploaded_file(
 ):
     """Takes an uploaded file object and returns a TemporaryUploadedFile object (or None, if the uploaded file was None)
 
+    NOTE: Temporary files are forced due to pandas and openpyxl not being able to handle these objects.  This method is
+    a fallback in case this setting forcing temporary files from TraceBase/settings/base.py gets inadvertently removed:
+
+    FILE_UPLOAD_HANDLERS = ["django.core.files.uploadhandler.TemporaryFileUploadHandler"]
+
+    While pandas functions could take a file-like object, that could be created from each object, openpyxl expects a
+    true local file path as input.  The code base thus forces a TemporaryFileUploadHandler and obtains the file path
+    from that object where needed.
+
+    Usage:
+        # Do this whenever you get an uploaded file from a form submission
+        tmp_file_obj = ensure_temporary_uploaded_file(form.get("file_form_field"))
+        if tmp_file_obj:
+            filepath = tmp_file_obj.temporary_file_path()
     Args:
         uploaded_file (Optional[Union[TemporaryUploadedFile, InMemoryUploadedFile]])
     Exceptions:
@@ -656,6 +671,12 @@ def ensure_temporary_uploaded_file(
         return uploaded_file
 
     if isinstance(uploaded_file, InMemoryUploadedFile):
+        warn(
+            f'It appears that uploaded file "{uploaded_file.name}" is an InMemoryUploadedFile.  Fallbacking back to '
+            "conversion to a TemporaryUploadedFile object.  Please ensure this is in the project settings: "
+            'FILE_UPLOAD_HANDLERS = ["django.core.files.uploadhandler.TemporaryFileUploadHandler"].'
+        )
+
         tmp = TemporaryUploadedFile(
             name=uploaded_file.name,
             content_type=uploaded_file.content_type,

--- a/DataRepo/views/upload/submission.py
+++ b/DataRepo/views/upload/submission.py
@@ -71,7 +71,12 @@ from DataRepo.utils.exceptions import (
     UnknownPeakAnnotationFileFormat,
     UnknownStudyDocVersion,
 )
-from DataRepo.utils.file_utils import get_sheet_names, is_excel, read_from_file
+from DataRepo.utils.file_utils import (
+    ensure_temporary_uploaded_file,
+    get_sheet_names,
+    is_excel,
+    read_from_file,
+)
 from DataRepo.utils.infusate_name_parser import (
     parse_infusate_name_with_concs,
     parse_tracer_string,
@@ -758,13 +763,17 @@ class BuildSubmissionView(FormView):
             # We only need/allow a single mode and study_doc, which is saved only in the first rowform
             if index == 0:
                 mode = rowform["mode"]
-                study_file_object = rowform.get("study_doc")
+                study_file_object = ensure_temporary_uploaded_file(
+                    rowform.get("study_doc")
+                )
                 if study_file_object is not None:
                     study_file = study_file_object.temporary_file_path()
                     study_filename = str(study_file_object)
 
             # Process the peak annotation files
-            peak_annotation_file_object = rowform.get("peak_annotation_file")
+            peak_annotation_file_object = ensure_temporary_uploaded_file(
+                rowform.get("peak_annotation_file")
+            )
             if peak_annotation_file_object is not None:
                 peak_annot_file = peak_annotation_file_object.temporary_file_path()
                 peak_annot_filename = str(peak_annotation_file_object)

--- a/DataRepo/views/upload/submission.py
+++ b/DataRepo/views/upload/submission.py
@@ -766,7 +766,7 @@ class BuildSubmissionView(FormView):
                 study_file_object = ensure_temporary_uploaded_file(
                     rowform.get("study_doc")
                 )
-                if study_file_object is not None:
+                if study_file_object:
                     study_file = study_file_object.temporary_file_path()
                     study_filename = str(study_file_object)
 
@@ -774,7 +774,7 @@ class BuildSubmissionView(FormView):
             peak_annotation_file_object = ensure_temporary_uploaded_file(
                 rowform.get("peak_annotation_file")
             )
-            if peak_annotation_file_object is not None:
+            if peak_annotation_file_object:
                 peak_annot_file = peak_annotation_file_object.temporary_file_path()
                 peak_annot_filename = str(peak_annotation_file_object)
 

--- a/TraceBase/settings/base.py
+++ b/TraceBase/settings/base.py
@@ -18,7 +18,7 @@ import environ
 from django.db.backends.postgresql.psycopg_any import IsolationLevel
 
 # Build paths inside the project like this: BASE_DIR / 'subdir'.
-BASE_DIR = Path(__file__).resolve().parent.parent
+BASE_DIR = Path(__file__).resolve().parent.parent.parent
 ENV_FILE = BASE_DIR / ".env"
 
 env = environ.Env()

--- a/TraceBase/settings/base.py
+++ b/TraceBase/settings/base.py
@@ -18,7 +18,7 @@ import environ
 from django.db.backends.postgresql.psycopg_any import IsolationLevel
 
 # Build paths inside the project like this: BASE_DIR / 'subdir'.
-BASE_DIR = Path(__file__).resolve().parent.parent.parent
+BASE_DIR = Path(__file__).resolve().parent.parent
 ENV_FILE = BASE_DIR / ".env"
 
 env = environ.Env()

--- a/TraceBase/settings/base.py
+++ b/TraceBase/settings/base.py
@@ -191,6 +191,15 @@ STORAGES = {
     },
 }
 
+# File storage handling for uploaded files
+# https://stackoverflow.com/questions/38345977/filefield-force-using-temporaryuploadedfile
+# Added to make the submission.html form work.  Could not figure out how to specify this handler for individual fields.
+# This avoids files using the InMemoryUploadedFile, which the load script complains about.
+# NOTE: Temporary files are forced due to pandas and openpyxl not being able to handle these objects.  In fact, while
+# pandas functions could take a file-like object, that could be created from each object, openpyxl expects a true local
+# file path as input.
+FILE_UPLOAD_HANDLERS = ["django.core.files.uploadhandler.TemporaryFileUploadHandler"]
+
 # Custom URLs and content
 FEEDBACK_URL = env.str("FEEDBACK_URL", default=None)
 # Data submission and validation

--- a/TraceBase/settings/test.py
+++ b/TraceBase/settings/test.py
@@ -37,12 +37,6 @@ TEST_FILE_STORAGES = {
     },
 }
 
-# File storage handling for tests
-# https://stackoverflow.com/questions/38345977/filefield-force-using-temporaryuploadedfile
-# Added to make the submission.html form work.  Could not figure out how to specify this handler for individual fields.
-# This avoids files using the InMemoryUploadedFile, which the load script complains about.
-FILE_UPLOAD_HANDLERS = ["django.core.files.uploadhandler.TemporaryFileUploadHandler"]
-
 # NOTE: TEST_CACHES is used in various tests as an argument to @override_settings()
 TEST_CACHES: Dict[str, Dict[str, object]] = {
     "default": {


### PR DESCRIPTION
## What

- [GREATS-319](https://princeton-university.atlassian.net/browse/GREATS-319)

Debug and fix the file upload bug introduced by the split settings PR.

## Why

Every file upload feature on the release branch has been broken since the settings split.  Whenever a file is uploaded, you get an exception about `InMemoryUploadedFile` not having a method attribute.  There were a couple other manifestations, but it all came down to the fact that `InMemoryUploadedFile` is not what the TraceBase code-base expected.  It was expecting a `TemporaryUploadedFile` object.  That’s because a setting was inadvertently moved to the `test.py` settings because the comment about it related to testing.

## How

Fixed the settings split bug that caused the site file uploads to fail and implemented a fallback if this setting flub ever happens again.
    
Details:
    
- Moved the `FILE_UPLOAD_HANDLERS` setting from `test.py` to `base.py` and edited the comment to not imply that the setting is just for tests.
- Updated handling of the `TemporaryUploadedFile` object to align with best practices.
- Added file utility method: `ensure_temporary_uploaded_file`
  - Added a warning to the `ensure_temporary_uploaded_file` method if an `InMemoryUploadedFile` object is encountered.
  - Fleshed the docstring for `ensure_temporary_uploaded_file` to explain why it exists.
- Added calls to `ensure_temporary_uploaded_file` whenever a file is obtained from a form
- Added `test_ensure_temporary_uploaded_file` method.

## Tests

- CI tests and linting pass
- A test was added to ensure the the fallback method works
- A warning was added in case the fallback method is ever triggered
- Manually tested by uploading a file to the submission start page and there were no errors.

## Security Concerns

- Any change to the settings introduces a security risk.  This change moved the `FILE_UPLOAD_HANDLERS` setting from the test settings to the base settings.  Not much security risk involved there.

## Others

This turned out to be a very simple fix.  The hardest part was debugging it.