### PR TITLE
[out of scope] Download Page 3.2: Staging mode

### DIFF
--- a/DataRepo/loaders/msruns_loader.py
+++ b/DataRepo/loaders/msruns_loader.py
@@ -2412,7 +2412,8 @@ class MSRunsLoader(TableLoader):
                                 orig_exception=dne,
                             )
 
-                            return rec
+                    if rec is not None:
+                        return rec
 
                 # The mzXMLs need to be iterated to create or `UnmatchedMzXML` or `UnmatchedBlankMzXML` exceptions for
                 # each file so that this script doesn't need to be run multiple times to add files to the 'Peak

--- a/DataRepo/management/commands/export_studies.py
+++ b/DataRepo/management/commands/export_studies.py
@@ -53,6 +53,15 @@ class Command(BaseCommand):
             help="Date of export.  ISO format: YYYY-MM-DDTHH:MM:SS.",
             default=datetime.now(),
         )
+        parser.add_argument(
+            "--staging-mode",
+            action="store_true",
+            default=False,
+            help=(
+                "Append a '.staged' extension to output files.  Note, this will not create staged files for existing "
+                "unstaged files.  See --overwrite."
+            ),
+        )
 
     def handle(self, *args, **options):
         se = StudiesExporter(
@@ -66,5 +75,6 @@ class Command(BaseCommand):
                 if isinstance(options["date"], str) and options["date"] != ""
                 else None
             ),
+            staging_mode=options["staging_mode"],
         )
         se.export()

--- a/DataRepo/utils/export_base.py
+++ b/DataRepo/utils/export_base.py
@@ -1,0 +1,9 @@
+class ExportBase:
+    """The base class of StudiesExporter and ExportsOrganizer.
+
+    Class Attributes:
+        staged_ext (str): The string to be appended-to/removed-from export and zip archive filenames when in
+            staging_mode.
+    """
+
+    staged_ext = ".staged"

--- a/DataRepo/utils/studies_exporter.py
+++ b/DataRepo/utils/studies_exporter.py
@@ -5,6 +5,7 @@ from collections import defaultdict
 from datetime import datetime
 from typing import Callable, Dict, Iterator, List, Optional, Tuple
 
+from django.conf import settings
 from django.db.models import Q
 from django.template.loader import get_template
 from django.utils.text import get_valid_filename
@@ -13,13 +14,14 @@ from DataRepo.formats.mzxml_dataformat import MzxmlFormat
 from DataRepo.formats.search_group import SearchGroup
 from DataRepo.models import Study
 from DataRepo.utils.exceptions import AggregatedErrors, trace
+from DataRepo.utils.export_base import ExportBase
 from DataRepo.views.search.download import (
     AdvancedSearchDownloadMzxmlZIPView,
     AdvancedSearchDownloadView,
 )
 
 
-class StudiesExporter:
+class StudiesExporter(ExportBase):
     """Exports the SearchGroup formats with one file per study and and data type combo.
 
     Output filenames will be slugified (replacing dashes with underscores) and have the following naming structure:
@@ -82,6 +84,7 @@ class StudiesExporter:
         overwrite: bool = False,
         host: Optional[str] = None,  # Defaults to current host/domain
         date: Optional[datetime] = None,  # Defaults to now
+        staging_mode=False,
     ):
         self.bad_searches: Dict[str, int] = {}
 
@@ -97,6 +100,7 @@ class StudiesExporter:
             dt for dt in self.data_types if dt in self.all_zipped_data_types
         ]
         self.overwrite = overwrite
+        self.staging_mode = staging_mode
 
         self.host = host if host else self.default_host
         self.date = date
@@ -167,7 +171,12 @@ class StudiesExporter:
 
         # Make output directory
         if not os.path.exists(self.outdir):
-            os.mkdir(self.outdir)
+            if os.path.realpath(settings.DOWNLOADS_DIR) == os.path.realpath(
+                self.outdir
+            ):
+                os.makedirs(self.outdir)
+            else:
+                os.mkdir(self.outdir)
 
         existing_files = []
 
@@ -182,9 +191,15 @@ class StudiesExporter:
                     self.outdir, get_valid_filename(f"{study_str}-{data_type}.{suffix}")
                 )
 
-                if os.path.exists(filepath) and not self.overwrite:
+                unstaged_filepath = filepath
+                if self.staging_mode:
+                    filepath += self.staged_ext
+
+                if (
+                    os.path.exists(filepath) or os.path.exists(unstaged_filepath)
+                ) and not self.overwrite:
                     file_exists = FileExistsError(
-                        f"File {filepath} exists.  Use the overwrite option to overwrite existing files."
+                        f"File {unstaged_filepath} exists.  Use the overwrite option to overwrite existing files."
                     )
                     print(
                         f"{trace(file_exists)}\n{type(file_exists).__name__}: {file_exists}"

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -202,9 +202,18 @@ TraceBase has a single `static` directory, containing:
 It also serves files from the administrator-selected archive location, which should be set up outside the `tracebase`
 code repository directory and configured with the `ARCHIVE` variable in the `.env` file.
 
-The webserver needs to be set up to allow file access to both directories.
+#### Create the `MEDIA_ROOT` Directory
 
-Both locations need to be configured as aliases in the webserver.  See **Apache Setup** below.
+TraceBase also serves static files from the administrator-selected `MEDIA_ROOT` location, which should be set up
+outside the `tracebase` code repository directory and configured with the `MEDIA_ROOT` variable in the
+`TraceBase/.env` file.  The default directory name is `tracebase_files`.  Under it, will be created 2 subdirectories:
+
+- `archive_files`
+- `download_files`
+
+The webserver needs to be set up to allow file access to the `tracebase_files` directory at a location of your
+choosing, outside the codebase.  It also needs to be configured as an alias in the webserver.  See **Apache Setup**
+below.
 
 ## Web Server Configuration
 


### PR DESCRIPTION
## What

- Partially addresses [GREATS-318](https://princeton-university.atlassian.net/browse/GREATS-318)
- Partially addresses [GREATS-290](https://princeton-university.atlassian.net/browse/GREATS-290)

Add a `staging_mode` argument to the `StudiesExporter`'s constructor, defaulted to `False`.

Add an `ExportBase` superclass to store the `.staged` extension which will be used by the script that makes the zip archives as well.

Since this partially addresses GREATS-318 and GREATS-290, what you should check in this PR is that:

- files can be identified as "incomplete" or "in process" during the time that the exports are being generated and packages into zip archives.
- It is easy to set up the cron job and have it work, right off the bat, e.g.:
  - The export directory defaults to the `DOWNLOADS_DIR`
  - The `DOWNLOADS_DIR` directory is created if it doesn't exist
  - The install documentation is up to date regarding the setup of the `MEDIA_ROOT` (under which the `DOWNLOADS_DIR` resides)

## Why

Site downloads are broken.  See [GREATS-318](https://princeton-university.atlassian.net/browse/GREATS-318).  The fix is downloading actual files instead of streaming the data.  It makes no sense to stream.  Streaming downloads are only needed for the advanced search, when you're downloading a custom subset of data.

The reason for having a staging mode is that this process is expected to generate export files on a cron job.  It is only after they are all generated when they can be checked to see if any data changed.  If nothing changed (except the export date), the exported file will be removed.  But all this PR accomplishes is it applies the `.staged` extension so that when the downloads page is created, it can exclude those staged/in-process files.

## How

> Added the ability to stage exported files.
> 
> Details:
> 
> - Updated the install documentation regarding the MEDIA_ROOT.  It was still referencing ARCHIVE_DIR, but in order to support file downloads as well as archived files from the DB, it was obfuscated to support both download files of exports and the archive.
> - Added the ability to make the entire path to the downloads dir the same way the ArchiveFile model does, only in this case from the export script.
> - Added a staging_mode argument to the StudiesExporter's constructor, defaulted to False.
> - Added a ExportBase superclass to store the .staged extension which will be used by the script that makes the zip archives as well.
> - Fixed a linting issue in DataRepo/loaders/msruns_loader.py.

## Tests

- Tests added
- CI tests pass
- Manual tests: `export_studies` was run with `--staging-mode` and the output files had the `.staged` extension.

## Security Concerns

- Exports default to the `DOWNLOADS_DIR`, but all data is accessible already on the website.  Only file names matching the export naming format should (will) be permitted and the ability to list the directory will be restricted.
- No authentication/authorization changes
- No dependencies or third-party libraries introduced
- No potential attack surface increase

## Others

None