### PR TITLE
[out of scope] Download Page 3.4: Zipping

### DIFF
--- a/DataRepo/tests/utils/test_exports_organizer.py
+++ b/DataRepo/tests/utils/test_exports_organizer.py
@@ -1,7 +1,10 @@
 import os
 import shutil
 import tempfile
+import zipfile
 from pathlib import Path
+from typing import List
+from unittest.mock import patch
 
 from django.test import override_settings
 
@@ -36,6 +39,11 @@ class ExportsOrganizerTests(TracebaseTestCase):
             {0: "Test_Study_1", 1: "Test_Study_2"},
             exports_organizer.slugified_study_names,
         )
+
+    def assert_zip_file_contents(self, zip_path: str, expected_root_files: List[str]):
+        with zipfile.ZipFile(zip_path) as zf:
+            root_files = [name for name in zf.namelist()]
+        self.assertEqual(expected_root_files, root_files)
 
     def test_parse_export_filename(self):
         self.assertEqual(
@@ -106,6 +114,620 @@ class ExportsOrganizerTests(TracebaseTestCase):
             "tb9", "2026.04.17", "FCirc"
         )
         self.assertEqual("tb9-2026.04.17-allstudies-FCirc.zip", filename)
+
+    def test_zip_export_combos(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            with override_settings(
+                MEDIA_ROOT=tmpdir,
+                FILE_UPLOAD_TEMP_DIR=tmpdir,
+            ):
+                export_dir = os.path.join(tmpdir, "two_exports_one_study_add_study")
+                shutil.copytree(
+                    "DataRepo/data/tests/exports_organizer/two_exports_one_study_add_study",
+                    export_dir,
+                )
+
+                study_packages = {
+                    "tb9": {
+                        "0001": {
+                            "2026.04.24": {
+                                "Fcirc": {
+                                    "date": "2026.04.24",
+                                    "file": os.path.join(
+                                        export_dir,
+                                        "tb9-2026.04.24-Test_Study_2-0001-Fcirc.tsv",
+                                    ),
+                                    "id": 1,
+                                    "name": "Test Study 2",
+                                    "slug": "Test_Study_2",
+                                    "ext": "tsv",
+                                    "data_type": "Fcirc",
+                                    "staged": False,
+                                },
+                                "PeakData": {
+                                    "date": "2026.04.24",
+                                    "file": os.path.join(
+                                        export_dir,
+                                        "tb9-2026.04.24-Test_Study_2-0001-PeakData.tsv",
+                                    ),
+                                    "id": 1,
+                                    "name": "Test Study 2",
+                                    "slug": "Test_Study_2",
+                                    "ext": "tsv",
+                                    "data_type": "PeakData",
+                                    "staged": False,
+                                },
+                            },
+                        },
+                    },
+                }
+                datatype_packages = {
+                    "tb9": {
+                        "Fcirc": {
+                            "2026.04.24": {
+                                "0001": {
+                                    "date": "2026.04.24",
+                                    "file": os.path.join(
+                                        export_dir,
+                                        "tb9-2026.04.24-Test_Study_2-0001-Fcirc.tsv",
+                                    ),
+                                    "id": 1,
+                                    "name": "Test Study 2",
+                                    "slug": "Test_Study_2",
+                                    "ext": "tsv",
+                                    "data_type": "Fcirc",
+                                    "staged": False,
+                                },
+                            },
+                        },
+                    },
+                }
+                all_packages = {
+                    "tb9": {
+                        "2026.04.24": {
+                            "0001": {
+                                "Fcirc": {
+                                    "date": "2026.04.24",
+                                    "file": os.path.join(
+                                        export_dir,
+                                        "tb9-2026.04.24-Test_Study_2-0001-Fcirc.tsv",
+                                    ),
+                                    "id": 1,
+                                    "name": "Test Study 2",
+                                    "slug": "Test_Study_2",
+                                    "ext": "tsv",
+                                    "data_type": "Fcirc",
+                                    "staged": False,
+                                },
+                                "PeakData": {
+                                    "date": "2026.04.24",
+                                    "file": os.path.join(
+                                        export_dir,
+                                        "tb9-2026.04.24-Test_Study_2-0001-PeakData.tsv",
+                                    ),
+                                    "id": 1,
+                                    "name": "Test Study 2",
+                                    "slug": "Test_Study_2",
+                                    "ext": "tsv",
+                                    "data_type": "PeakData",
+                                    "staged": False,
+                                },
+                            },
+                        },
+                    },
+                }
+
+                base = Path(export_dir)
+                export_dir_contents = sorted(
+                    str(p.relative_to(base)) for p in base.rglob("*")
+                )
+                self.assertEqual(
+                    [
+                        "tb9-2026.04.17-Test_Study_1-0000-Fcirc.tsv",
+                        "tb9-2026.04.17-Test_Study_1-0000-PeakData.tsv",
+                        "tb9-2026.04.17-Test_Study_1-0000-PeakGroups.tsv",
+                        "tb9-2026.04.17-Test_Study_1-0000-mzXML.zip",
+                        "tb9-2026.04.24-Test_Study_1-0000-Fcirc.tsv",
+                        "tb9-2026.04.24-Test_Study_1-0000-PeakData.tsv",
+                        "tb9-2026.04.24-Test_Study_1-0000-PeakGroups.tsv",
+                        "tb9-2026.04.24-Test_Study_1-0000-mzXML.zip",
+                        "tb9-2026.04.24-Test_Study_2-0001-Fcirc.tsv",
+                        "tb9-2026.04.24-Test_Study_2-0001-PeakData.tsv",
+                        "tb9-2026.04.24-Test_Study_2-0001-PeakGroups.tsv",
+                        "tb9-2026.04.24-Test_Study_2-0001-mzXML.zip",
+                    ],
+                    export_dir_contents,
+                )
+                exports_organizer = ExportsOrganizer()
+                exports_organizer.export_dir = export_dir
+                exports_organizer.zip_export_combos(
+                    study_packages,
+                    datatype_packages,
+                    all_packages,
+                )
+                export_dir_contents = sorted(
+                    str(p.relative_to(base)) for p in base.rglob("*")
+                )
+                expected_files = [
+                    "tb9-2026.04.17-Test_Study_1-0000-Fcirc.tsv",
+                    "tb9-2026.04.17-Test_Study_1-0000-PeakData.tsv",
+                    "tb9-2026.04.17-Test_Study_1-0000-PeakGroups.tsv",
+                    "tb9-2026.04.17-Test_Study_1-0000-mzXML.zip",
+                    "tb9-2026.04.24-Test_Study_1-0000-Fcirc.tsv",
+                    "tb9-2026.04.24-Test_Study_1-0000-PeakData.tsv",
+                    "tb9-2026.04.24-Test_Study_1-0000-PeakGroups.tsv",
+                    "tb9-2026.04.24-Test_Study_1-0000-mzXML.zip",
+                    "tb9-2026.04.24-Test_Study_2-0001-Fcirc.tsv",
+                    "tb9-2026.04.24-Test_Study_2-0001-PeakData.tsv",
+                    "tb9-2026.04.24-Test_Study_2-0001-PeakGroups.tsv",
+                    "tb9-2026.04.24-Test_Study_2-0001-mzXML.zip",
+                    # These are the zip archives created by the dictionaries:
+                    "tb9-2026.04.24-Test_Study_2-alldatatypes.zip",
+                    "tb9-2026.04.24-allstudies-Fcirc.zip",
+                    "tb9-2026.04.24-allstudies-alldatatypes.zip",
+                ]
+                self.assertEqual(
+                    expected_files,
+                    export_dir_contents,
+                )
+                self.assertTrue(
+                    all(
+                        [
+                            os.path.getsize(os.path.join(export_dir, fp)) > 0
+                            for fp in expected_files
+                        ]
+                    )
+                )
+
+            self.assert_zip_file_contents(
+                os.path.join(
+                    export_dir, "tb9-2026.04.24-Test_Study_2-alldatatypes.zip"
+                ),
+                [
+                    "tb9-2026.04.24-Test_Study_2-0001-Fcirc.tsv",
+                    "tb9-2026.04.24-Test_Study_2-0001-PeakData.tsv",
+                ],
+            )
+
+            self.assert_zip_file_contents(
+                os.path.join(export_dir, "tb9-2026.04.24-allstudies-Fcirc.zip"),
+                ["tb9-2026.04.24-Test_Study_2-0001-Fcirc.tsv"],
+            )
+
+            self.assert_zip_file_contents(
+                os.path.join(
+                    export_dir,
+                    "tb9-2026.04.24-allstudies-alldatatypes.zip",
+                ),
+                [
+                    "tb9-2026.04.24-Test_Study_2-0001-Fcirc.tsv",
+                    "tb9-2026.04.24-Test_Study_2-0001-PeakData.tsv",
+                ],
+            )
+
+    def test_zip_study_packages(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            with override_settings(
+                MEDIA_ROOT=tmpdir,
+                FILE_UPLOAD_TEMP_DIR=tmpdir,
+            ):
+                export_dir = os.path.join(tmpdir, "two_exports_one_study_add_study")
+                shutil.copytree(
+                    "DataRepo/data/tests/exports_organizer/two_exports_one_study_add_study",
+                    export_dir,
+                )
+
+                study_packages = {
+                    "tb9": {
+                        "0001": {
+                            "2026.04.24": {
+                                "Fcirc": {
+                                    "date": "2026.04.24",
+                                    "file": os.path.join(
+                                        export_dir,
+                                        "tb9-2026.04.24-Test_Study_2-0001-Fcirc.tsv",
+                                    ),
+                                    "id": 1,
+                                    "name": "Test Study 2",
+                                    "slug": "Test_Study_2",
+                                    "ext": "tsv",
+                                    "data_type": "Fcirc",
+                                    "staged": False,
+                                },
+                                "PeakData": {
+                                    "date": "2026.04.24",
+                                    "file": os.path.join(
+                                        export_dir,
+                                        "tb9-2026.04.24-Test_Study_2-0001-PeakData.tsv",
+                                    ),
+                                    "id": 1,
+                                    "name": "Test Study 2",
+                                    "slug": "Test_Study_2",
+                                    "ext": "tsv",
+                                    "data_type": "PeakData",
+                                    "staged": False,
+                                },
+                            },
+                        },
+                    },
+                }
+
+                base = Path(export_dir)
+                export_dir_contents = sorted(
+                    str(p.relative_to(base)) for p in base.rglob("*")
+                )
+                self.assertEqual(
+                    [
+                        "tb9-2026.04.17-Test_Study_1-0000-Fcirc.tsv",
+                        "tb9-2026.04.17-Test_Study_1-0000-PeakData.tsv",
+                        "tb9-2026.04.17-Test_Study_1-0000-PeakGroups.tsv",
+                        "tb9-2026.04.17-Test_Study_1-0000-mzXML.zip",
+                        "tb9-2026.04.24-Test_Study_1-0000-Fcirc.tsv",
+                        "tb9-2026.04.24-Test_Study_1-0000-PeakData.tsv",
+                        "tb9-2026.04.24-Test_Study_1-0000-PeakGroups.tsv",
+                        "tb9-2026.04.24-Test_Study_1-0000-mzXML.zip",
+                        "tb9-2026.04.24-Test_Study_2-0001-Fcirc.tsv",
+                        "tb9-2026.04.24-Test_Study_2-0001-PeakData.tsv",
+                        "tb9-2026.04.24-Test_Study_2-0001-PeakGroups.tsv",
+                        "tb9-2026.04.24-Test_Study_2-0001-mzXML.zip",
+                    ],
+                    export_dir_contents,
+                )
+                exports_organizer = ExportsOrganizer()
+                exports_organizer.export_dir = export_dir
+                exports_organizer.zip_study_packages(study_packages)
+                export_dir_contents = sorted(
+                    str(p.relative_to(base)) for p in base.rglob("*")
+                )
+                expected_files = [
+                    "tb9-2026.04.17-Test_Study_1-0000-Fcirc.tsv",
+                    "tb9-2026.04.17-Test_Study_1-0000-PeakData.tsv",
+                    "tb9-2026.04.17-Test_Study_1-0000-PeakGroups.tsv",
+                    "tb9-2026.04.17-Test_Study_1-0000-mzXML.zip",
+                    "tb9-2026.04.24-Test_Study_1-0000-Fcirc.tsv",
+                    "tb9-2026.04.24-Test_Study_1-0000-PeakData.tsv",
+                    "tb9-2026.04.24-Test_Study_1-0000-PeakGroups.tsv",
+                    "tb9-2026.04.24-Test_Study_1-0000-mzXML.zip",
+                    "tb9-2026.04.24-Test_Study_2-0001-Fcirc.tsv",
+                    "tb9-2026.04.24-Test_Study_2-0001-PeakData.tsv",
+                    "tb9-2026.04.24-Test_Study_2-0001-PeakGroups.tsv",
+                    "tb9-2026.04.24-Test_Study_2-0001-mzXML.zip",
+                    # This is the zip archive created by the dictionary:
+                    "tb9-2026.04.24-Test_Study_2-alldatatypes.zip",
+                ]
+                self.assertEqual(
+                    expected_files,
+                    export_dir_contents,
+                )
+                self.assertTrue(
+                    all(
+                        [
+                            os.path.getsize(os.path.join(export_dir, fp)) > 0
+                            for fp in expected_files
+                        ]
+                    )
+                )
+
+            self.assert_zip_file_contents(
+                os.path.join(
+                    export_dir, "tb9-2026.04.24-Test_Study_2-alldatatypes.zip"
+                ),
+                [
+                    "tb9-2026.04.24-Test_Study_2-0001-Fcirc.tsv",
+                    "tb9-2026.04.24-Test_Study_2-0001-PeakData.tsv",
+                ],
+            )
+
+            # Assert that the file is not re-zipped if it exists by patching the filepaths_to_zip method and checking if
+            # it was called
+            with patch.object(
+                ExportsOrganizer, "filepaths_to_zip"
+            ) as mock_filepaths_to_zip:
+                exports_organizer.zip_study_packages(study_packages)
+            mock_filepaths_to_zip.assert_not_called()
+
+    def test_zip_datatype_packages(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            with override_settings(
+                MEDIA_ROOT=tmpdir,
+                FILE_UPLOAD_TEMP_DIR=tmpdir,
+            ):
+                export_dir = os.path.join(tmpdir, "two_exports_one_study_add_study")
+                shutil.copytree(
+                    "DataRepo/data/tests/exports_organizer/two_exports_one_study_add_study",
+                    export_dir,
+                )
+
+                datatype_packages = {
+                    "tb9": {
+                        "Fcirc": {
+                            "2026.04.24": {
+                                "0001": {
+                                    "date": "2026.04.24",
+                                    "file": os.path.join(
+                                        export_dir,
+                                        "tb9-2026.04.24-Test_Study_2-0001-Fcirc.tsv",
+                                    ),
+                                    "id": 1,
+                                    "name": "Test Study 2",
+                                    "slug": "Test_Study_2",
+                                    "ext": "tsv",
+                                    "data_type": "Fcirc",
+                                    "staged": False,
+                                },
+                            },
+                        },
+                    },
+                }
+
+                base = Path(export_dir)
+                export_dir_contents = sorted(
+                    str(p.relative_to(base)) for p in base.rglob("*")
+                )
+                self.assertEqual(
+                    [
+                        "tb9-2026.04.17-Test_Study_1-0000-Fcirc.tsv",
+                        "tb9-2026.04.17-Test_Study_1-0000-PeakData.tsv",
+                        "tb9-2026.04.17-Test_Study_1-0000-PeakGroups.tsv",
+                        "tb9-2026.04.17-Test_Study_1-0000-mzXML.zip",
+                        "tb9-2026.04.24-Test_Study_1-0000-Fcirc.tsv",
+                        "tb9-2026.04.24-Test_Study_1-0000-PeakData.tsv",
+                        "tb9-2026.04.24-Test_Study_1-0000-PeakGroups.tsv",
+                        "tb9-2026.04.24-Test_Study_1-0000-mzXML.zip",
+                        "tb9-2026.04.24-Test_Study_2-0001-Fcirc.tsv",
+                        "tb9-2026.04.24-Test_Study_2-0001-PeakData.tsv",
+                        "tb9-2026.04.24-Test_Study_2-0001-PeakGroups.tsv",
+                        "tb9-2026.04.24-Test_Study_2-0001-mzXML.zip",
+                    ],
+                    export_dir_contents,
+                )
+                exports_organizer = ExportsOrganizer()
+                exports_organizer.export_dir = export_dir
+                exports_organizer.zip_datatype_packages(
+                    datatype_packages,
+                )
+                export_dir_contents = sorted(
+                    str(p.relative_to(base)) for p in base.rglob("*")
+                )
+                expected_files = [
+                    "tb9-2026.04.17-Test_Study_1-0000-Fcirc.tsv",
+                    "tb9-2026.04.17-Test_Study_1-0000-PeakData.tsv",
+                    "tb9-2026.04.17-Test_Study_1-0000-PeakGroups.tsv",
+                    "tb9-2026.04.17-Test_Study_1-0000-mzXML.zip",
+                    "tb9-2026.04.24-Test_Study_1-0000-Fcirc.tsv",
+                    "tb9-2026.04.24-Test_Study_1-0000-PeakData.tsv",
+                    "tb9-2026.04.24-Test_Study_1-0000-PeakGroups.tsv",
+                    "tb9-2026.04.24-Test_Study_1-0000-mzXML.zip",
+                    "tb9-2026.04.24-Test_Study_2-0001-Fcirc.tsv",
+                    "tb9-2026.04.24-Test_Study_2-0001-PeakData.tsv",
+                    "tb9-2026.04.24-Test_Study_2-0001-PeakGroups.tsv",
+                    "tb9-2026.04.24-Test_Study_2-0001-mzXML.zip",
+                    # This is the zip archive created by the dictionary:
+                    "tb9-2026.04.24-allstudies-Fcirc.zip",
+                ]
+                self.assertEqual(
+                    expected_files,
+                    export_dir_contents,
+                )
+                self.assertTrue(
+                    all(
+                        [
+                            os.path.getsize(os.path.join(export_dir, fp)) > 0
+                            for fp in expected_files
+                        ]
+                    )
+                )
+
+            self.assert_zip_file_contents(
+                os.path.join(export_dir, "tb9-2026.04.24-allstudies-Fcirc.zip"),
+                ["tb9-2026.04.24-Test_Study_2-0001-Fcirc.tsv"],
+            )
+
+            # Assert that the file is not re-zipped if it exists by patching the filepaths_to_zip method and checking if
+            # it was called
+            with patch.object(
+                ExportsOrganizer, "filepaths_to_zip"
+            ) as mock_filepaths_to_zip:
+                exports_organizer.zip_datatype_packages(datatype_packages)
+            mock_filepaths_to_zip.assert_not_called()
+
+    def test_zip_everything_packages(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            with override_settings(
+                MEDIA_ROOT=tmpdir,
+                FILE_UPLOAD_TEMP_DIR=tmpdir,
+            ):
+                export_dir = os.path.join(tmpdir, "two_exports_one_study_add_study")
+                shutil.copytree(
+                    "DataRepo/data/tests/exports_organizer/two_exports_one_study_add_study",
+                    export_dir,
+                )
+
+                all_packages = {
+                    "tb9": {
+                        "2026.04.24": {
+                            "0001": {
+                                "Fcirc": {
+                                    "date": "2026.04.24",
+                                    "file": os.path.join(
+                                        export_dir,
+                                        "tb9-2026.04.24-Test_Study_2-0001-Fcirc.tsv",
+                                    ),
+                                    "id": 1,
+                                    "name": "Test Study 2",
+                                    "slug": "Test_Study_2",
+                                    "ext": "tsv",
+                                    "data_type": "Fcirc",
+                                    "staged": False,
+                                },
+                                "PeakData": {
+                                    "date": "2026.04.24",
+                                    "file": os.path.join(
+                                        export_dir,
+                                        "tb9-2026.04.24-Test_Study_2-0001-PeakData.tsv",
+                                    ),
+                                    "id": 1,
+                                    "name": "Test Study 2",
+                                    "slug": "Test_Study_2",
+                                    "ext": "tsv",
+                                    "data_type": "PeakData",
+                                    "staged": False,
+                                },
+                            },
+                        },
+                    },
+                }
+
+                base = Path(export_dir)
+                export_dir_contents = sorted(
+                    str(p.relative_to(base)) for p in base.rglob("*")
+                )
+                self.assertEqual(
+                    [
+                        "tb9-2026.04.17-Test_Study_1-0000-Fcirc.tsv",
+                        "tb9-2026.04.17-Test_Study_1-0000-PeakData.tsv",
+                        "tb9-2026.04.17-Test_Study_1-0000-PeakGroups.tsv",
+                        "tb9-2026.04.17-Test_Study_1-0000-mzXML.zip",
+                        "tb9-2026.04.24-Test_Study_1-0000-Fcirc.tsv",
+                        "tb9-2026.04.24-Test_Study_1-0000-PeakData.tsv",
+                        "tb9-2026.04.24-Test_Study_1-0000-PeakGroups.tsv",
+                        "tb9-2026.04.24-Test_Study_1-0000-mzXML.zip",
+                        "tb9-2026.04.24-Test_Study_2-0001-Fcirc.tsv",
+                        "tb9-2026.04.24-Test_Study_2-0001-PeakData.tsv",
+                        "tb9-2026.04.24-Test_Study_2-0001-PeakGroups.tsv",
+                        "tb9-2026.04.24-Test_Study_2-0001-mzXML.zip",
+                    ],
+                    export_dir_contents,
+                )
+                exports_organizer = ExportsOrganizer()
+                exports_organizer.export_dir = export_dir
+                exports_organizer.zip_everything_packages(all_packages)
+                export_dir_contents = sorted(
+                    str(p.relative_to(base)) for p in base.rglob("*")
+                )
+                expected_files = [
+                    "tb9-2026.04.17-Test_Study_1-0000-Fcirc.tsv",
+                    "tb9-2026.04.17-Test_Study_1-0000-PeakData.tsv",
+                    "tb9-2026.04.17-Test_Study_1-0000-PeakGroups.tsv",
+                    "tb9-2026.04.17-Test_Study_1-0000-mzXML.zip",
+                    "tb9-2026.04.24-Test_Study_1-0000-Fcirc.tsv",
+                    "tb9-2026.04.24-Test_Study_1-0000-PeakData.tsv",
+                    "tb9-2026.04.24-Test_Study_1-0000-PeakGroups.tsv",
+                    "tb9-2026.04.24-Test_Study_1-0000-mzXML.zip",
+                    "tb9-2026.04.24-Test_Study_2-0001-Fcirc.tsv",
+                    "tb9-2026.04.24-Test_Study_2-0001-PeakData.tsv",
+                    "tb9-2026.04.24-Test_Study_2-0001-PeakGroups.tsv",
+                    "tb9-2026.04.24-Test_Study_2-0001-mzXML.zip",
+                    # This is the zip archive created by the dictionary:
+                    "tb9-2026.04.24-allstudies-alldatatypes.zip",
+                ]
+                self.assertEqual(
+                    expected_files,
+                    export_dir_contents,
+                )
+                self.assertTrue(
+                    all(
+                        [
+                            os.path.getsize(os.path.join(export_dir, fp)) > 0
+                            for fp in expected_files
+                        ]
+                    )
+                )
+
+            self.assert_zip_file_contents(
+                os.path.join(
+                    export_dir,
+                    "tb9-2026.04.24-allstudies-alldatatypes.zip",
+                ),
+                [
+                    "tb9-2026.04.24-Test_Study_2-0001-Fcirc.tsv",
+                    "tb9-2026.04.24-Test_Study_2-0001-PeakData.tsv",
+                ],
+            )
+
+            # Assert that the file is not re-zipped if it exists by patching the filepaths_to_zip method and checking if
+            # it was called
+            with patch.object(
+                ExportsOrganizer, "filepaths_to_zip"
+            ) as mock_filepaths_to_zip:
+                exports_organizer.zip_everything_packages(all_packages)
+            mock_filepaths_to_zip.assert_not_called()
+
+    def test_filepaths_to_zip(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            with override_settings(
+                MEDIA_ROOT=tmpdir,
+                FILE_UPLOAD_TEMP_DIR=tmpdir,
+            ):
+                export_dir = os.path.join(tmpdir, "one_export")
+                shutil.copytree(
+                    "DataRepo/data/tests/exports_organizer/one_export", export_dir
+                )
+
+                base = Path(export_dir)
+                export_dir_contents = sorted(
+                    str(p.relative_to(base)) for p in base.rglob("*")
+                )
+                self.assertEqual(
+                    [
+                        "tb9-2026.04.17-Test_Study_2-0001-Fcirc.tsv",
+                        "tb9-2026.04.17-Test_Study_2-0001-PeakData.tsv",
+                        "tb9-2026.04.17-Test_Study_2-0001-PeakGroups.tsv",
+                        "tb9-2026.04.17-Test_Study_2-0001-mzXML.zip",
+                    ],
+                    export_dir_contents,
+                )
+                exports_organizer = ExportsOrganizer()
+                exports_organizer.export_dir = export_dir
+                exports_organizer.filepaths_to_zip(
+                    [
+                        os.path.join(
+                            export_dir,
+                            "tb9-2026.04.17-Test_Study_2-0001-Fcirc.tsv",
+                        ),
+                        os.path.join(
+                            export_dir,
+                            "tb9-2026.04.17-Test_Study_2-0001-PeakData.tsv",
+                        ),
+                    ],
+                    os.path.join(
+                        export_dir,
+                        "test.zip",
+                    ),
+                )
+                export_dir_contents = sorted(
+                    str(p.relative_to(base)) for p in base.rglob("*")
+                )
+                expected_files = [
+                    "tb9-2026.04.17-Test_Study_2-0001-Fcirc.tsv",
+                    "tb9-2026.04.17-Test_Study_2-0001-PeakData.tsv",
+                    "tb9-2026.04.17-Test_Study_2-0001-PeakGroups.tsv",
+                    "tb9-2026.04.17-Test_Study_2-0001-mzXML.zip",
+                    "test.zip",
+                ]
+                self.assertEqual(
+                    expected_files,
+                    export_dir_contents,
+                )
+                self.assertTrue(
+                    all(
+                        [
+                            os.path.getsize(os.path.join(export_dir, fp)) > 0
+                            for fp in expected_files
+                        ]
+                    )
+                )
+
+            self.assert_zip_file_contents(
+                os.path.join(
+                    export_dir,
+                    "test.zip",
+                ),
+                [
+                    "tb9-2026.04.17-Test_Study_2-0001-Fcirc.tsv",
+                    "tb9-2026.04.17-Test_Study_2-0001-PeakData.tsv",
+                ],
+            )
 
     def test_package_exists(self):
         with tempfile.TemporaryDirectory() as tmpdir:

--- a/DataRepo/utils/exports_organizer.py
+++ b/DataRepo/utils/exports_organizer.py
@@ -1,6 +1,7 @@
 import os
+import zipfile
 from pathlib import Path
-from typing import Optional
+from typing import Any, Dict, List, Optional, cast
 
 from django.utils.text import get_valid_filename
 
@@ -281,6 +282,87 @@ class ExportsOrganizer(ExportBase):
 
         return "-".join([host, package_date, self.allstudies_str, data_type_with_ext])
 
+    def zip_export_combos(
+        self,
+        study_packages: Dict[str, Dict[str, Dict[str, Dict[str, Dict[str, Any]]]]],
+        datatype_packages: Dict[str, Dict[str, Dict[str, Dict[str, Dict[str, Any]]]]],
+        all_packages: Dict[str, Dict[str, Dict[str, Dict[str, Dict[str, Any]]]]],
+    ):
+        """Creates zip archives for all study, datatype, and all-data packages, as described in the supplied package
+        dictionaries.  This method is a wrapper for the methods that make each set of zip archive types.
+
+        Example Argument Structure:
+            study_packages     [host][study_id][package_date][data_type] = file_dict
+            datatype_packages  [host][data_type][package_date][study_id] = file_dict
+            all_packages       [host][package_date][study_id][data_type] = file_dict
+
+        Example Filename Accessed Inside the above file_dict's:
+            {hostname}-{datestamp}-{study_name}-{study_id}-{data_type}.{extension}
+
+        Example Zip Archive Filename Structure:
+            study_packages     {hostname}-{datestamp}-{study_name}-{study_id}-alldatatypes.zip
+            datatype_packages  {hostname}-{datestamp}-allstudies-{data_type}.zip
+            all_packages       {hostname}-{datestamp}-allstudies-alldatatypes.zip
+
+        Args:
+            study_packages (Dict[str, Dict[str, Dict[str, Dict[str, Dict[str, Any]]]]]):
+                Dictionary of file dictionaries that describe a all-data zip archives, keyed by: host, package_date,
+                study_id, and data_type
+            datatype_packages (Dict[str, Dict[str, Dict[str, Dict[str, Dict[str, Any]]]]]):
+                Dictionary of file dictionaries that describe study zip archives, keyed by: host, study_id,
+                package_date, and data_type
+            all_packages (Dict[str, Dict[str, Dict[str, Dict[str, Dict[str, Any]]]]]):
+                Dictionary of file dictionaries that describe datatype zip archives, keyed by: host, data_type,
+                package_date, and study_id
+        Exceptions:
+            None
+        Returns:
+            None
+        """
+        self.zip_study_packages(study_packages)
+        self.zip_datatype_packages(datatype_packages)
+        self.zip_everything_packages(all_packages)
+
+    def zip_study_packages(
+        self,
+        study_packages: Dict[str, Dict[str, Dict[str, Dict[str, Dict[str, Any]]]]],
+    ):
+        """Creates zip archives for study packages, as described in the supplied package dictionary.
+
+        Example Argument Structure:
+            study_packages[host][study_id][package_date][data_type] = file_dict
+
+        Example filename accessed inside the file_dict:
+            {hostname}-{datestamp}-{study_name}-{study_id}-{data_type}.{extension}
+
+        Example Zip Archive Filename:
+            study_packages: {hostname}-{datestamp}-{study_name}-{study_id}-alldatatypes.zip
+
+        Args:
+            study_packages (Dict[str, Dict[str, Dict[str, Dict[str, Dict[str, Any]]]]]):
+                Dictionary of file dictionaries that describe a all-data zip archives, keyed by: host, package_date,
+                study_id, and data_type
+        Exceptions:
+            None
+        Returns:
+            None
+        """
+        # Create study zips (which is all data types of 1 study)
+        for host, study_dict in study_packages.items():
+            for study_id, package_dict in study_dict.items():
+                for package_date, datatype_dict in package_dict.items():
+                    study_package_file = os.path.join(
+                        self.export_dir,
+                        self.compute_study_package_filename(
+                            host,
+                            package_date,
+                            study_id,
+                        ),
+                    )
+                    if not self.package_exists(study_package_file):
+                        datatype_files = [d["file"] for d in datatype_dict.values()]
+                        self.filepaths_to_zip(datatype_files, study_package_file)
+
     @classmethod
     def package_exists(cls, filepath: str):
         """Determine if the zip archive package already exists (accounting for staging mode).
@@ -303,6 +385,123 @@ class ExportsOrganizer(ExportBase):
                 and os.path.exists(f"{filepath}{cls.staged_ext}")
             )
         )
+
+    def zip_datatype_packages(
+        self,
+        datatype_packages: Dict[str, Dict[str, Dict[str, Dict[str, Dict[str, Any]]]]],
+    ):
+        """Creates zip archives for datatype packages, as described in the supplied package dictionary.
+
+        Example Argument Structure:
+            datatype_packages[host][data_type][package_date][study_id] = file_dict
+
+        Example Filename Accessed Inside the above file_dict's:
+            {hostname}-{datestamp}-{study_name}-{study_id}-{data_type}.{extension}
+
+        Example Zip Archive Filename Structure:
+            datatype_packages: {hostname}-{datestamp}-allstudies-{data_type}.zip
+
+        Args:
+            datatype_packages (Dict[str, Dict[str, Dict[str, Dict[str, Dict[str, Any]]]]]):
+                Dictionary of file dictionaries that describe study zip archives, keyed by: host, study_id,
+                package_date, and data_type
+        Exceptions:
+            None
+        Returns:
+            None
+        """
+        # Create datatype zips (which is all study data of 1 data type)
+        for host, datatype_dict in datatype_packages.items():
+            for data_type, package_dict in datatype_dict.items():
+                for package_date, study_dict in package_dict.items():
+                    datatype_package_file = os.path.join(
+                        self.export_dir,
+                        self.compute_datatype_package_filename(
+                            host,
+                            package_date,
+                            data_type,
+                        ),
+                    )
+                    if not self.package_exists(datatype_package_file):
+                        study_files = [
+                            cast(str, d["file"]) for d in study_dict.values()
+                        ]
+                        self.filepaths_to_zip(study_files, datatype_package_file)
+
+    def zip_everything_packages(
+        self,
+        all_packages: Dict[str, Dict[str, Dict[str, Dict[str, Dict[str, Any]]]]],
+    ):
+        """Creates zip archives for all-data packages, as described in the supplied package dictionary.
+
+        Example Argument Structure:
+            all_packages[host][package_date][study_id][data_type] = file_dict
+
+        Example Filename Accessed Inside the above file_dict's:
+            {hostname}-{datestamp}-{study_name}-{study_id}-{data_type}.{extension}
+
+        Example Zip Archive Filename Structure:
+            all_packages: {hostname}-{datestamp}-allstudies-alldatatypes.zip
+
+        Args:
+            all_packages (Dict[str, Dict[str, Dict[str, Dict[str, Dict[str, Any]]]]]):
+                Dictionary of file dictionaries that describe datatype zip archives, keyed by: host, data_type,
+                package_date, and study_id
+        Exceptions:
+            None
+        Returns:
+            None
+        """
+
+        # Create "all" zips (which is all data from all studies [for each host and change-date])
+        for host, package_dict in all_packages.items():
+            for package_date, study_dict in package_dict.items():
+                all_package_file = os.path.join(
+                    self.export_dir,
+                    self.compute_all_package_filename(
+                        host,
+                        package_date,
+                    ),
+                )
+                if not self.package_exists(all_package_file):
+                    all_files = [
+                        cast(str, file_dict["file"])
+                        for datatype_dict in study_dict.values()
+                        for file_dict in datatype_dict.values()
+                    ]
+                    self.filepaths_to_zip(all_files, all_package_file)
+
+    def filepaths_to_zip(self, filepaths: List[str], zip_filepath: str):
+        """Create a zip archive of the files in filepaths.
+
+        Args:
+            filepaths (List[str]): Paths to files to be included in the zip archive.  May be absolute paths, but only
+                paths relative to the self.export_dir will be in the archive.
+            zip_filepath (str): Output filepath of the zip archive.
+        Exceptions:
+            TypeError: if the arguments are the wrong type.
+        Returns:
+            None
+        """
+        if not isinstance(filepaths, list):
+            raise TypeError(
+                f"file_paths must be a list, not '{type(filepaths).__name__}'."
+            )
+        elif not isinstance(zip_filepath, str):
+            raise TypeError(
+                f"zip_filepath must be a str, not '{type(zip_filepath).__name__}'."
+            )
+
+        with zipfile.ZipFile(
+            zip_filepath, "w", compression=zipfile.ZIP_DEFLATED
+        ) as zipf:
+            for file_path in filepaths:
+                zipf.write(
+                    file_path,
+                    arcname=os.path.relpath(
+                        file_path, start=self.export_dir
+                    ).removesuffix(self.staged_ext),
+                )
 
     def unstage_all_files(self):
         """Remove the ".staged" suffix from all staged files under the self.export_dir.

--- a/DataRepo/utils/studies_exporter.py
+++ b/DataRepo/utils/studies_exporter.py
@@ -115,7 +115,7 @@ class StudiesExporter(ExportBase):
                 f"export file names: {bad_format_names}."
             )
 
-        self.instance_name = host if host else self.default_instance
+        self.instance_name = host if host else self.default_host
         self.date = date
 
         # A script on a cron-job uses the study ID in the file name to compare exported files with previously exported

--- a/DataRepo/utils/studies_exporter.py
+++ b/DataRepo/utils/studies_exporter.py
@@ -115,19 +115,6 @@ class StudiesExporter(ExportBase):
                 f"export file names: {bad_format_names}."
             )
 
-        self.instance_name = host if host else self.default_host
-        self.date = date
-
-        # A script on a cron-job uses the study ID in the file name to compare exported files with previously exported
-        # versions.  It does this by splitting on dash and taking the study ID from the file name, relative to the end
-        # of the file, thus the format value at the end of the file name may not have dashes.
-        if any("-" in datatype_name for datatype_name in self.all_data_types):
-            bad_format_names = [dtn for dtn in self.all_data_types if "-" in dtn]
-            raise ValueError(
-                "The following SearchGroup format names contain dashes ('-') which are not allowed in order to parse "
-                f"export file names: {bad_format_names}."
-            )
-
     def export(self):
         # For individual traceback prints
         aes = AggregatedErrors()

--- a/DataRepo/utils/studies_exporter.py
+++ b/DataRepo/utils/studies_exporter.py
@@ -115,6 +115,19 @@ class StudiesExporter(ExportBase):
                 f"export file names: {bad_format_names}."
             )
 
+        self.instance_name = host if host else self.default_instance
+        self.date = date
+
+        # A script on a cron-job uses the study ID in the file name to compare exported files with previously exported
+        # versions.  It does this by splitting on dash and taking the study ID from the file name, relative to the end
+        # of the file, thus the format value at the end of the file name may not have dashes.
+        if any("-" in datatype_name for datatype_name in self.all_data_types):
+            bad_format_names = [dtn for dtn in self.all_data_types if "-" in dtn]
+            raise ValueError(
+                "The following SearchGroup format names contain dashes ('-') which are not allowed in order to parse "
+                f"export file names: {bad_format_names}."
+            )
+
     def export(self):
         # For individual traceback prints
         aes = AggregatedErrors()


### PR DESCRIPTION
## What

- Partially addresses [GREATS-318](https://princeton-university.atlassian.net/browse/GREATS-318)
- Partially addresses [GREATS-290](https://princeton-university.atlassian.net/browse/GREATS-290)

Add the ability to build each of the zip archives for each zip archive combo, to the `ExportsOrganizer` class.  The inputs are data structures that are yet to be constructed.  (We're doing this PR stack from the bottom up, to keep the PR size down.)

Since this partially addresses GREATS-318 and GREATS-290, what you should check in this PR is that:

- A zip archive is created for all data (by export date)
- A zip archive is created per study
- A zip archive is created per datatype

## Why

Site downloads are broken.  See [GREATS-318](https://princeton-university.atlassian.net/browse/GREATS-318).  The fix is downloading actual files instead of streaming the data.  It makes no sense to stream.  Streaming downloads are only needed for the advanced search, when you're downloading a custom subset of data.

Users sometimes want to download a subset of data without needing to click multiple times, or all data, in one click.

## How

Added the methods that create the zip archives.

Details:

- ExportsOrganizer
  - Methods added:
    - zip_export_combos - This wraps all the different zip archive methods to create archives for all data, study data, and datatype-specific data.
    - zip_study_packages
    - zip_datatype_packages
    - zip_everything_packages
    - filepaths_to_zip - This zips a list of files and is called by the other methods to actually generate the zips.
- There are some lengthy tests that were added, but their lengths is just due to the size of the data structures they define.

## Tests

- Tests added
- CI tests pass
- Manual tests: `organize_exports` was run (with `--staging-mode`) at the end of this stacked PR series and the output files were manually confirmed to be correct.

## Security Concerns

- Exports default to the `DOWNLOADS_DIR`, but all data is accessible already on the website.  Only file names matching the export naming format should (will) be permitted and the ability to list the directory will be restricted.
- No authentication/authorization changes
- No dependencies or third-party libraries introduced
- No potential attack surface increase

## Others

None