### PR TITLE
[out of scope] Download Page 3.5: Remove unchanged exports

### DIFF
--- a/DataRepo/tests/utils/test_exports_organizer.py
+++ b/DataRepo/tests/utils/test_exports_organizer.py
@@ -10,7 +10,11 @@ from django.test import override_settings
 
 from DataRepo.models.study import Study
 from DataRepo.tests.tracebase_test_case import TracebaseTestCase
-from DataRepo.utils.exports_organizer import ExportParseError, ExportsOrganizer
+from DataRepo.utils.exports_organizer import (
+    ExportParseError,
+    ExportsOrganizer,
+    NotOneMzxmlMetadataFile,
+)
 
 
 class ExportsOrganizerTests(TracebaseTestCase):
@@ -91,6 +95,264 @@ class ExportsOrganizerTests(TracebaseTestCase):
             ExportsOrganizer.parse_export_filename(
                 "tracebase-2026.04.17-allstudies-PeakData.zip"
             ),
+        )
+
+    def test_remove_unchanged_exports(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            with override_settings(
+                MEDIA_ROOT=tmpdir,
+                FILE_UPLOAD_TEMP_DIR=tmpdir,
+            ):
+                test_dir = (
+                    "DataRepo/data/tests/exports_organizer/two_exports_one_tsv_change"
+                )
+
+                # Copy in files that don't change and ones that do
+                for src in [
+                    "tb9-2026.04.17-Test_Study_2-0001-Fcirc.tsv",
+                    "tb9-2026.04.17-Test_Study_2-0001-PeakData.tsv",
+                    "tb9-2026.04.24-Test_Study_2-0001-Fcirc.tsv",  # unchanged
+                    "tb9-2026.04.24-Test_Study_2-0001-PeakData.tsv",  # changed
+                ]:
+                    shutil.copy2(os.path.join(test_dir, src), tmpdir)
+
+                exports_organizer = ExportsOrganizer()
+                exports_organizer.export_dir = tmpdir
+                exports_by_study = {
+                    "tb9": {
+                        "0001": {
+                            "Fcirc": [
+                                {
+                                    "date": "2026.04.17",
+                                    "file": os.path.join(
+                                        # The export dir is prepended in ExportsOrganizer.organize()
+                                        tmpdir,
+                                        "tb9-2026.04.17-Test_Study_2-0001-Fcirc.tsv",
+                                    ),
+                                    "id": 1,
+                                    "name": "Test Study 2",
+                                    "slug": "Test_Study_2",
+                                    "ext": "tsv",
+                                    "data_type": "Fcirc",
+                                    "staged": False,
+                                },
+                                {
+                                    "date": "2026.04.24",
+                                    "file": os.path.join(
+                                        # The export dir is prepended in ExportsOrganizer.organize()
+                                        tmpdir,
+                                        "tb9-2026.04.24-Test_Study_2-0001-Fcirc.tsv",
+                                    ),
+                                    "id": 1,
+                                    "name": "Test Study 2",
+                                    "slug": "Test_Study_2",
+                                    "ext": "tsv",
+                                    "data_type": "Fcirc",
+                                    "staged": False,
+                                },
+                            ],
+                            "PeakData": [
+                                {
+                                    "date": "2026.04.17",
+                                    "file": os.path.join(
+                                        # The export dir is prepended in ExportsOrganizer.organize()
+                                        tmpdir,
+                                        "tb9-2026.04.17-Test_Study_2-0001-PeakData.tsv",
+                                    ),
+                                    "id": 1,
+                                    "name": "Test Study 2",
+                                    "slug": "Test_Study_2",
+                                    "ext": "tsv",
+                                    "data_type": "PeakData",
+                                    "staged": False,
+                                },
+                                {
+                                    "date": "2026.04.24",
+                                    "file": os.path.join(
+                                        # The export dir is prepended in ExportsOrganizer.organize()
+                                        tmpdir,
+                                        "tb9-2026.04.24-Test_Study_2-0001-PeakData.tsv",
+                                    ),
+                                    "id": 1,
+                                    "name": "Test Study 2",
+                                    "slug": "Test_Study_2",
+                                    "ext": "tsv",
+                                    "data_type": "PeakData",
+                                    "staged": False,
+                                },
+                            ],
+                        },
+                    },
+                }
+                package_dates_by_host = exports_organizer.remove_unchanged_exports(
+                    exports_by_study
+                )
+
+                # Check that only tb9-2026.04.24-Test_Study_2-0001-Fcirc.tsv was removed
+                base = Path(tmpdir)
+                export_dir_contents = sorted(
+                    str(p.relative_to(base)) for p in base.rglob("*")
+                )
+                expected_files = [
+                    "tb9-2026.04.17-Test_Study_2-0001-Fcirc.tsv",
+                    "tb9-2026.04.17-Test_Study_2-0001-PeakData.tsv",
+                    "tb9-2026.04.24-Test_Study_2-0001-PeakData.tsv",
+                ]
+                self.assertEqual(
+                    expected_files,
+                    export_dir_contents,
+                )
+
+                # Check that the returned dict of sets is correct
+                self.assertEqual(
+                    {"tb9": set(["2026.04.17", "2026.04.24"])}, package_dates_by_host
+                )
+
+    def test_files_differ(self):
+        export_dir = "DataRepo/data/tests/exports_organizer/two_exports_one_tsv_change"
+
+        same_file1 = os.path.join(
+            export_dir, "tb9-2026.04.17-Test_Study_2-0001-Fcirc.tsv"
+        )
+        same_file2 = os.path.join(
+            export_dir, "tb9-2026.04.24-Test_Study_2-0001-Fcirc.tsv"
+        )
+        self.assertFalse(ExportsOrganizer.files_differ(same_file1, same_file2))
+
+        same_file1 = os.path.join(
+            export_dir, "tb9-2026.04.17-Test_Study_2-0001-mzXML.zip"
+        )
+        same_file2 = os.path.join(
+            export_dir, "tb9-2026.04.24-Test_Study_2-0001-mzXML.zip"
+        )
+        self.assertFalse(ExportsOrganizer.files_differ(same_file1, same_file2))
+
+        diff_file1 = os.path.join(
+            export_dir, "tb9-2026.04.17-Test_Study_2-0001-PeakData.tsv"
+        )
+        diff_file2 = os.path.join(
+            export_dir, "tb9-2026.04.24-Test_Study_2-0001-PeakData.tsv"
+        )
+        self.assertTrue(ExportsOrganizer.files_differ(diff_file1, diff_file2))
+
+        # Check the mzXML zip files that differ
+        export_dir = (
+            "DataRepo/data/tests/exports_organizer/two_exports_one_mzxml_change"
+        )
+        diff_file1 = os.path.join(
+            export_dir, "tb9-2026.04.17-Test_Study_2-0001-mzXML.zip"
+        )
+        diff_file2 = os.path.join(
+            export_dir, "tb9-2026.04.24-Test_Study_2-0001-mzXML.zip"
+        )
+        self.assertTrue(ExportsOrganizer.files_differ(diff_file1, diff_file2))
+
+        export_dir = (
+            "DataRepo/data/tests/exports_organizer/two_exports_one_mzxmltsv_change"
+        )
+        diff_file1 = os.path.join(
+            export_dir, "tb9-2026.04.17-Test_Study_2-0001-mzXML.zip"
+        )
+        diff_file2 = os.path.join(
+            export_dir, "tb9-2026.04.24-Test_Study_2-0001-mzXML.zip"
+        )
+        self.assertTrue(ExportsOrganizer.files_differ(diff_file1, diff_file2))
+
+    def test_mzxml_zips_differ(self):
+        export_dir = "DataRepo/data/tests/exports_organizer/two_exports_one_tsv_change"
+        same_file1 = os.path.join(
+            export_dir, "tb9-2026.04.17-Test_Study_2-0001-mzXML.zip"
+        )
+        same_file2 = os.path.join(
+            export_dir, "tb9-2026.04.24-Test_Study_2-0001-mzXML.zip"
+        )
+        self.assertFalse(ExportsOrganizer.mzxml_zips_differ(same_file1, same_file2))
+
+        export_dir = (
+            "DataRepo/data/tests/exports_organizer/two_exports_one_mzxml_change"
+        )
+        diff_file1 = os.path.join(
+            export_dir, "tb9-2026.04.17-Test_Study_2-0001-mzXML.zip"
+        )
+        diff_file2 = os.path.join(
+            export_dir, "tb9-2026.04.24-Test_Study_2-0001-mzXML.zip"
+        )
+        self.assertTrue(ExportsOrganizer.mzxml_zips_differ(diff_file1, diff_file2))
+
+        export_dir = (
+            "DataRepo/data/tests/exports_organizer/two_exports_one_mzxmltsv_change"
+        )
+        diff_file1 = os.path.join(
+            export_dir, "tb9-2026.04.17-Test_Study_2-0001-mzXML.zip"
+        )
+        diff_file2 = os.path.join(
+            export_dir, "tb9-2026.04.24-Test_Study_2-0001-mzXML.zip"
+        )
+        self.assertTrue(ExportsOrganizer.mzxml_zips_differ(diff_file1, diff_file2))
+
+    def test_tsv_files_differ(self):
+        export_dir = "DataRepo/data/tests/exports_organizer/two_exports_one_tsv_change"
+
+        same_file1 = os.path.join(
+            export_dir, "tb9-2026.04.17-Test_Study_2-0001-Fcirc.tsv"
+        )
+        same_file2 = os.path.join(
+            export_dir, "tb9-2026.04.24-Test_Study_2-0001-Fcirc.tsv"
+        )
+        self.assertFalse(ExportsOrganizer.tsv_files_differ(same_file1, same_file2))
+
+        diff_file1 = os.path.join(
+            export_dir, "tb9-2026.04.17-Test_Study_2-0001-PeakData.tsv"
+        )
+        diff_file2 = os.path.join(
+            export_dir, "tb9-2026.04.24-Test_Study_2-0001-PeakData.tsv"
+        )
+        self.assertTrue(ExportsOrganizer.tsv_files_differ(diff_file1, diff_file2))
+
+    def test_tsv_file_objs_differ(self):
+        export_dir = "DataRepo/data/tests/exports_organizer/two_exports_one_tsv_change"
+
+        same_file1 = os.path.join(
+            export_dir, "tb9-2026.04.17-Test_Study_2-0001-Fcirc.tsv"
+        )
+        same_file2 = os.path.join(
+            export_dir, "tb9-2026.04.24-Test_Study_2-0001-Fcirc.tsv"
+        )
+        with open(same_file1, "r") as f1, open(same_file2, "r") as f2:
+            self.assertFalse(ExportsOrganizer.tsv_file_objs_differ(f1, f2))
+
+        diff_file1 = os.path.join(
+            export_dir, "tb9-2026.04.17-Test_Study_2-0001-PeakData.tsv"
+        )
+        diff_file2 = os.path.join(
+            export_dir, "tb9-2026.04.24-Test_Study_2-0001-PeakData.tsv"
+        )
+        with open(diff_file1, "r") as f1, open(diff_file2, "r") as f2:
+            self.assertTrue(ExportsOrganizer.tsv_file_objs_differ(f1, f2))
+
+    def test_get_mzxml_zip_checksums(self):
+        checksum_dict = ExportsOrganizer.get_mzxml_zip_checksums(
+            (
+                "DataRepo/data/tests/exports_organizer/two_exports_one_mzxmltsv_change/"
+                "tb9-2026.04.17-Test_Study_2-0001-mzXML.zip"
+            )
+        )
+        self.assertDictEqual(
+            {
+                (
+                    "mzXML_mzxmls_28.05.2026.15.50.31/2024-11-10/Edmundo Leiva/QEPlus/polar-HILIC-25-min/negative/"
+                    "70-900/1NP24.mzXML"
+                ): "a24e2886e05d8e004495174959640f68044a955d7af90809fdba525b0e3fd268",
+                (
+                    "mzXML_mzxmls_28.05.2026.15.50.31/2024-11-10/Edmundo Leiva/QEPlus/polar-HILIC-25-min/positive/"
+                    "118.5-600/1NP24.mzXML"
+                ): "adcd5337f7747fef9dc3576c5367c57640c42d62f3bc04f9f9649d0b15df9326",
+                (
+                    "mzXML_mzxmls_28.05.2026.15.50.31/2024-11-10/Edmundo Leiva/QEPlus/polar-HILIC-25-min/positive/"
+                    "56-67.05/1NP24.mzXML"
+                ): "de03f822a7f2abc026bbaa3054757b0062f557063d9d31bea94300f9bcddebe5",
+            },
+            checksum_dict,
         )
 
     def test_compute_all_package_filename(self):
@@ -889,4 +1151,17 @@ class ExportParseErrorTests(TracebaseTestCase):
         exportparseerror = ExportParseError("file.txt")
         self.assertEqual(
             "Unable to parse export filename: 'file.txt'.", str(exportparseerror)
+        )
+
+
+class NotOneMzxmlMetadataFileTests(TracebaseTestCase):
+    def test_notonemzxmlmetadatafile(self):
+        notonemzxmlmetadatafile = NotOneMzxmlMetadataFile(
+            "file.zip", ["metadata1.tsv", "metadata2.tsv"]
+        )
+        self.assertIn("Zip archive 'file.zip'", str(notonemzxmlmetadatafile))
+        self.assertIn("expected to have 1 TSV file", str(notonemzxmlmetadatafile))
+        self.assertIn("found to have 2:", str(notonemzxmlmetadatafile))
+        self.assertIn(
+            "['metadata1.tsv', 'metadata2.tsv']", str(notonemzxmlmetadatafile)
         )

--- a/DataRepo/utils/exports_organizer.py
+++ b/DataRepo/utils/exports_organizer.py
@@ -1,7 +1,11 @@
+import hashlib
+import io
 import os
 import zipfile
+from collections import defaultdict
+from itertools import zip_longest
 from pathlib import Path
-from typing import Any, Dict, List, Optional, cast
+from typing import Any, Dict, List, Optional, Set, TextIO, cast
 
 from django.utils.text import get_valid_filename
 
@@ -181,6 +185,237 @@ class ExportsOrganizer(ExportBase):
             raise ExportParseError(filename)
 
         return (host, date_str, slugged_study_name, study_id, data_type, ext, staged)
+
+    def remove_unchanged_exports(
+        self, exports_by_study: Dict[str, Dict[str, Dict[str, List[Dict[str, str]]]]]
+    ):
+        """This compares export files generated on different dates and if they do not differ (other than by date), keeps
+        the older one.  It removes the newer file from the file system and from the exports_by_study dict.  It returns
+        data structures defining all the files that should go into study and datatype packages by date.
+        """
+        package_dates_by_host: Dict[str, Set[str]] = defaultdict(set)
+
+        # Go through all the exports and cull any later exports that have not changed compared to previous exports
+        for host, study_dict in exports_by_study.items():
+            for datatype_dict in study_dict.values():
+                for data_type, file_dict_list in datatype_dict.items():
+
+                    # We're going to be culling the list for identical exports (aside from export date).  We will
+                    # replace the current list with this new one.
+                    new_file_dict_list = []
+
+                    # Sort the file_dict_list by export date.  (NOTE: Technically, file_dict_list is already sorted by
+                    # date because the files were sorted and the filename starts with (the host, then) the date, but
+                    # we're soring here because we don't want to assume the list was constructed correctly.)
+                    date_sorted_file_dict_list = sorted(
+                        file_dict_list, key=lambda d: d["date"]
+                    )
+                    prev_file_dict = date_sorted_file_dict_list[0]
+                    new_file_dict_list.append(prev_file_dict)
+
+                    # The first date is a package because if "differs" from the previous export (no export)
+                    package_dates_by_host[host].add(
+                        date_sorted_file_dict_list[0]["date"]
+                    )
+
+                    for file_dict in date_sorted_file_dict_list[1:]:
+
+                        # Remove newer exports that do not differ from previous exports
+                        if not self.files_differ(
+                            prev_file_dict["file"], file_dict["file"]
+                        ):
+                            # Delete the last file and set the last dict's file to the previous
+                            os.remove(file_dict["file"])
+                        else:
+                            prev_file_dict = file_dict
+                            package_dates_by_host[host].add(file_dict["date"])
+                            new_file_dict_list.append(file_dict)
+
+                    datatype_dict[data_type] = new_file_dict_list
+
+        return package_dates_by_host
+
+    @classmethod
+    def files_differ(cls, filepath1: str, filepath2: str):
+        """This is a wrapper for mzxml_zips_differ and tsv_files_differ, which are called based on the value of zip.  It
+        only works for tsv and zip files and ignores commented lines (in order to ignore different export dates in the
+        commented header).
+
+        Args:
+            filepath1 (str)
+            filepath2 (str)
+        Exceptions:
+            ValueError: When there's a problem with the file extensions.
+        Returns:
+            (bool): Whether TraceBase export the files differ or not (by anoything other than export date)
+        """
+        filepath1_basename, ext1 = os.path.splitext(filepath1)
+        # Account for the "staged" extension
+        if ext1 == cls.staged_ext:
+            ext1 = os.path.splitext(filepath1_basename)[1]
+
+        filepath2_basename, ext2 = os.path.splitext(filepath2)
+        # Account for the "staged" extension
+        if ext2 == cls.staged_ext:
+            ext2 = os.path.splitext(filepath2_basename)[1]
+
+        if ext1 != ext2:
+            raise ValueError(
+                "files_differ is only intended to compare files with the same extension. "
+                f"'{ext1}' != '{ext2}'."
+            )
+
+        if ext1.lower() == ".zip":
+            return cls.mzxml_zips_differ(filepath1, filepath2)
+        if ext1.lower() != ".tsv":
+            raise ValueError(
+                f"files_differ supports only zip and tsv files, not '{ext1}'."
+            )
+
+        return cls.tsv_files_differ(filepath1, filepath2)
+
+    @classmethod
+    def mzxml_zips_differ(cls, filepath1: str, filepath2: str):
+        """Determines if 2 mzXML zip export files differ by anything other than export date.  It specifically looks at
+        the mzXML files themselves and the single tsv metadata file at the top level of the zip archive.
+
+        Args:
+            filepath1 (str)
+            filepath2 (str)
+        Exceptions:
+            NotOneMzxmlMetadataFile
+        Returns:
+            (bool): Whether the files differ by anything other than export date
+        """
+        differs = False
+
+        with (
+            zipfile.ZipFile(filepath1, "r") as zp,
+            zipfile.ZipFile(filepath2, "r") as zn,
+        ):
+            # This avoids retrieving zip archive metadata files by restricting to matches in the root level directory
+            prev_tsv_files = [
+                name
+                for name in zp.namelist()
+                if (name.endswith(".tsv") or name.endswith(f".tsv{cls.staged_ext}"))
+                and len(name.split("/")) == 2
+            ]
+            current_tsv_files = [
+                name
+                for name in zn.namelist()
+                if (name.endswith(".tsv") or name.endswith(f".tsv{cls.staged_ext}"))
+                and len(name.split("/")) == 2
+            ]
+
+            if len(prev_tsv_files) != 1:
+                raise NotOneMzxmlMetadataFile(filepath1, prev_tsv_files)
+
+            if len(current_tsv_files) != 1:
+                raise NotOneMzxmlMetadataFile(filepath2, current_tsv_files)
+
+            prev_tsv = prev_tsv_files[0]
+            current_tsv = current_tsv_files[0]
+
+            # Access the member as a binary file-like object
+            with (
+                zp.open(prev_tsv) as prev_binary_file,
+                zn.open(current_tsv) as current_binary_file,
+            ):
+                # Wrap the binary stream to handle text decoding
+                with (
+                    io.TextIOWrapper(
+                        prev_binary_file, encoding="utf-8"
+                    ) as prev_file_obj,
+                    io.TextIOWrapper(
+                        current_binary_file, encoding="utf-8"
+                    ) as current_file_obj,
+                ):
+                    differs = cls.tsv_file_objs_differ(prev_file_obj, current_file_obj)
+                    if differs:
+                        return differs
+
+        # If the tsvs are the same, also check if the actual mzXML files changed
+        prev_mzxml_checksums = cls.get_mzxml_zip_checksums(filepath1)
+        next_mzxml_checksums = cls.get_mzxml_zip_checksums(filepath2)
+
+        return prev_mzxml_checksums.items() != next_mzxml_checksums.items()
+
+    @classmethod
+    def tsv_files_differ(cls, filepath1: str, filepath2: str):
+        """Determines if 2 tsv export files differ by anything other than export date.  It ignores commented lines to
+        avoid the different export dates in the commented header.
+
+        Args:
+            filepath1 (str)
+            filepath2 (str)
+        Exceptions:
+            None
+        Returns:
+            (bool): Whether the files differ by anything other than export date
+        """
+        with open(filepath1, "r") as f1, open(filepath2, "r") as f2:
+            return cls.tsv_file_objs_differ(f1, f2)
+
+    @classmethod
+    def tsv_file_objs_differ(cls, file1_obj: TextIO, file2_obj: TextIO):
+        """Determines if 2 tsv export file objects differ by anything other than export date.  It ignores commented
+        lines to avoid the different export dates in the commented header.
+
+        Args:
+            file1_obj (TextIO)
+            file2_obj (TextIO)
+        Exceptions:
+            NotOneMzxmlMetadataFile
+        Returns:
+            (bool): Whether the file objects differ by anything other than export date
+        """
+        # Create generators that skip comments
+        file1_generator = (line for line in file1_obj if not str(line).startswith("#"))
+        file2_generator = (line for line in file2_obj if not str(line).startswith("#"))
+
+        # compare line by line; return False immediately if a mismatch is found
+        for file1_line, file2_line in zip_longest(file1_generator, file2_generator):
+            if file1_line != file2_line:
+                return True
+
+        return False
+
+    @classmethod
+    def get_mzxml_zip_checksums(cls, zip_path: str):
+        """Takes a zip archive filepath and returns a dict of all the mzXML filepaths mapped to their checksums.
+
+        The intended use is to determine of any mzXML files changed inside the archive when compared to another archive.
+
+        Args:
+            zip_path (str): The file path of the zip archive
+        Exceptions:
+            None
+        Returns:
+            checksums (Dict[str, str])
+        """
+        checksums: Dict[str, str] = {}
+        with zipfile.ZipFile(zip_path, "r") as zip_h:
+            # Filter files by extension
+            mzxml_files = [
+                filepath
+                for filepath in zip_h.namelist()
+                if (
+                    filepath.lower().endswith(".mzxml")
+                    # Avoid zip metadata, (that start with "._")
+                    and not os.path.basename(filepath).startswith("._")
+                )
+            ]
+
+            for file_name in mzxml_files:
+                # Open file in-memory without extracting to disk
+                with zip_h.open(file_name) as f:
+                    sha256_hash = hashlib.sha256()
+                    # Read in chunks for memory efficiency with large files
+                    for byte_block in iter(lambda: f.read(4096), b""):
+                        sha256_hash.update(byte_block)
+                    checksums[file_name] = sha256_hash.hexdigest()
+
+        return checksums
 
     def compute_all_package_filename(self, host: str, package_date: str):
         """Given the host name and the package date, returns a zip archive filename representing all data exported on or
@@ -525,3 +760,13 @@ class ExportsOrganizer(ExportBase):
 class ExportParseError(Exception):
     def __init__(self, filename: str):
         super().__init__(f"Unable to parse export filename: '{filename}'.")
+
+
+class NotOneMzxmlMetadataFile(Exception):
+    def __init__(self, zip_archive_file: str, metadata_files: List[str]):
+        message = (
+            f"Zip archive '{zip_archive_file}' was expected to have 1 TSV file (for metadata), but was found to have "
+            f"{len(metadata_files)}"
+        )
+        message += "." if len(metadata_files) == 0 else f": {metadata_files}."
+        super().__init__(message)

--- a/DataRepo/utils/exports_organizer.py
+++ b/DataRepo/utils/exports_organizer.py
@@ -206,7 +206,7 @@ class ExportsOrganizer(ExportBase):
 
                     # Sort the file_dict_list by export date.  (NOTE: Technically, file_dict_list is already sorted by
                     # date because the files were sorted and the filename starts with (the host, then) the date, but
-                    # we're soring here because we don't want to assume the list was constructed correctly.)
+                    # we're sorting here because we don't want to assume the list was constructed correctly.)
                     date_sorted_file_dict_list = sorted(
                         file_dict_list, key=lambda d: d["date"]
                     )
@@ -247,7 +247,7 @@ class ExportsOrganizer(ExportBase):
         Exceptions:
             ValueError: When there's a problem with the file extensions.
         Returns:
-            (bool): Whether TraceBase export the files differ or not (by anoything other than export date)
+            (bool): Whether TraceBase export the files differ or not (by anything other than export date)
         """
         filepath1_basename, ext1 = os.path.splitext(filepath1)
         # Account for the "staged" extension

--- a/DataRepo/utils/studies_exporter.py
+++ b/DataRepo/utils/studies_exporter.py
@@ -128,6 +128,19 @@ class StudiesExporter(ExportBase):
                 f"export file names: {bad_format_names}."
             )
 
+        self.instance_name = host if host else self.default_instance
+        self.date = date
+
+        # A script on a cron-job uses the study ID in the file name to compare exported files with previously exported
+        # versions.  It does this by splitting on dash and taking the study ID from the file name, relative to the end
+        # of the file, thus the format value at the end of the file name may not have dashes.
+        if any("-" in datatype_name for datatype_name in self.all_data_types):
+            bad_format_names = [dtn for dtn in self.all_data_types if "-" in dtn]
+            raise ValueError(
+                "The following SearchGroup format names contain dashes ('-') which are not allowed in order to parse "
+                f"export file names: {bad_format_names}."
+            )
+
     def export(self):
         # For individual traceback prints
         aes = AggregatedErrors()

--- a/DataRepo/utils/studies_exporter.py
+++ b/DataRepo/utils/studies_exporter.py
@@ -141,6 +141,19 @@ class StudiesExporter(ExportBase):
                 f"export file names: {bad_format_names}."
             )
 
+        self.instance_name = host if host else self.default_instance
+        self.date = date
+
+        # A script on a cron-job uses the study ID in the file name to compare exported files with previously exported
+        # versions.  It does this by splitting on dash and taking the study ID from the file name, relative to the end
+        # of the file, thus the format value at the end of the file name may not have dashes.
+        if any("-" in datatype_name for datatype_name in self.all_data_types):
+            bad_format_names = [dtn for dtn in self.all_data_types if "-" in dtn]
+            raise ValueError(
+                "The following SearchGroup format names contain dashes ('-') which are not allowed in order to parse "
+                f"export file names: {bad_format_names}."
+            )
+
     def export(self):
         # For individual traceback prints
         aes = AggregatedErrors()

--- a/DataRepo/utils/studies_exporter.py
+++ b/DataRepo/utils/studies_exporter.py
@@ -115,45 +115,6 @@ class StudiesExporter(ExportBase):
                 f"export file names: {bad_format_names}."
             )
 
-        self.instance_name = host if host else self.default_instance
-        self.date = date
-
-        # A script on a cron-job uses the study ID in the file name to compare exported files with previously exported
-        # versions.  It does this by splitting on dash and taking the study ID from the file name, relative to the end
-        # of the file, thus the format value at the end of the file name may not have dashes.
-        if any("-" in datatype_name for datatype_name in self.all_data_types):
-            bad_format_names = [dtn for dtn in self.all_data_types if "-" in dtn]
-            raise ValueError(
-                "The following SearchGroup format names contain dashes ('-') which are not allowed in order to parse "
-                f"export file names: {bad_format_names}."
-            )
-
-        self.instance_name = host if host else self.default_instance
-        self.date = date
-
-        # A script on a cron-job uses the study ID in the file name to compare exported files with previously exported
-        # versions.  It does this by splitting on dash and taking the study ID from the file name, relative to the end
-        # of the file, thus the format value at the end of the file name may not have dashes.
-        if any("-" in datatype_name for datatype_name in self.all_data_types):
-            bad_format_names = [dtn for dtn in self.all_data_types if "-" in dtn]
-            raise ValueError(
-                "The following SearchGroup format names contain dashes ('-') which are not allowed in order to parse "
-                f"export file names: {bad_format_names}."
-            )
-
-        self.instance_name = host if host else self.default_host
-        self.date = date
-
-        # A script on a cron-job uses the study ID in the file name to compare exported files with previously exported
-        # versions.  It does this by splitting on dash and taking the study ID from the file name, relative to the end
-        # of the file, thus the format value at the end of the file name may not have dashes.
-        if any("-" in datatype_name for datatype_name in self.all_data_types):
-            bad_format_names = [dtn for dtn in self.all_data_types if "-" in dtn]
-            raise ValueError(
-                "The following SearchGroup format names contain dashes ('-') which are not allowed in order to parse "
-                f"export file names: {bad_format_names}."
-            )
-
     def export(self):
         # For individual traceback prints
         aes = AggregatedErrors()

--- a/DataRepo/utils/studies_exporter.py
+++ b/DataRepo/utils/studies_exporter.py
@@ -141,7 +141,7 @@ class StudiesExporter(ExportBase):
                 f"export file names: {bad_format_names}."
             )
 
-        self.instance_name = host if host else self.default_instance
+        self.instance_name = host if host else self.default_host
         self.date = date
 
         # A script on a cron-job uses the study ID in the file name to compare exported files with previously exported

--- a/DataRepo/utils/studies_exporter.py
+++ b/DataRepo/utils/studies_exporter.py
@@ -115,6 +115,19 @@ class StudiesExporter(ExportBase):
                 f"export file names: {bad_format_names}."
             )
 
+        self.instance_name = host if host else self.default_instance
+        self.date = date
+
+        # A script on a cron-job uses the study ID in the file name to compare exported files with previously exported
+        # versions.  It does this by splitting on dash and taking the study ID from the file name, relative to the end
+        # of the file, thus the format value at the end of the file name may not have dashes.
+        if any("-" in datatype_name for datatype_name in self.all_data_types):
+            bad_format_names = [dtn for dtn in self.all_data_types if "-" in dtn]
+            raise ValueError(
+                "The following SearchGroup format names contain dashes ('-') which are not allowed in order to parse "
+                f"export file names: {bad_format_names}."
+            )
+
     def export(self):
         # For individual traceback prints
         aes = AggregatedErrors()


### PR DESCRIPTION
## What

- Partially addresses [GREATS-318](https://princeton-university.atlassian.net/browse/GREATS-318)
- Partially addresses [GREATS-290](https://princeton-university.atlassian.net/browse/GREATS-290)

Add the ability to compare exports on different dates (in chronological order) and remove later exports that have no change compared to the previous export, to the `ExportsOrganizer` class.  The inputs are data structures that are yet to be constructed.  (We're doing this PR stack from the bottom up, to keep the PR size down, but still have working tests.)

Since this partially addresses GREATS-318 and GREATS-290, what you should check in this PR is that:

- An mzXML zip export can be detected to have changed between neighboring export dates by looking at:
  - The mzXML files (any change, including a different number of files or file moves)
  - The tsv metadata file at the root zip directory
    - Export date differences in the commented header are ignored
- A tsv export (for PeakData, PeakGroups, and FCirc) can be detected to have changed between neighboring export dates
  - Export date differences in the commented header are ignored
- Exported files on later dates that don't differ from the previous date are removed from:
  - The input data structure
  - The file system

## Why

Site downloads are broken.  See [GREATS-318](https://princeton-university.atlassian.net/browse/GREATS-318).  The fix is downloading actual files instead of streaming the data.  It makes no sense to stream.  Streaming downloads are only needed for the advanced search, when you're downloading a custom subset of data.

Users should be assured that each download contains unique data.

## How

Added the ability to detect when data in the exported files has changed since the last changed export and remove those unchanged files.

Details:

- ExportsOrganizer
  - Added methods:
    - remove_unchanged_exports
    - files_differ
    - mzxml_zips_differ
    - tsv_files_differ
    - tsv_file_objs_differ
    - get_mzxml_zip_checksums
- Added exception class NotOneMzxmlMetadataFile

## Tests

- Tests added
- CI tests pass
- Manual tests: `organize_exports` was run (with `--staging-mode`) at the end of this stacked PR series and the output files were manually confirmed to be correct.

## Security Concerns

- Exports default to the `DOWNLOADS_DIR`, but all data is accessible already on the website.  Only file names matching the export naming format should (will) be permitted and the ability to list the directory will be restricted.
- No authentication/authorization changes
- No dependencies or third-party libraries introduced
- No potential attack surface increase

## Others

None