### PR TITLE
Upped the python version from 3.10 to 3.11

### DIFF
--- a/.github/workflows/tracebase-tests.yml
+++ b/.github/workflows/tracebase-tests.yml
@@ -41,7 +41,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v1
         with:
-          python-version: '3.10'
+          python-version: '3.11'
       - name: psycopg2 prerequisites
         run: |
           sudo apt-get update

--- a/.gitignore
+++ b/.gitignore
@@ -135,6 +135,7 @@ dmypy.json
 # Pyre type checker
 .pyre/
 archive
+tracebase_files
 
 # Node linters
 node_modules

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,22 +9,22 @@ developing/contributing.
 
 #### Python
 
-TraceBase has been tested with Python 3.7 through 3.10.  TraceBase may work with later Python versions, but currently
+TraceBase has been tested with Python 3.7 through 3.11.  TraceBase may work with later Python versions, but currently
 there are dependency issues with Python 3.14.
 
-Install a Python version that is 3.9.1 or greater (3.10 is the current recommendation) from:
+Install a Python version that is 3.9.1 or greater (3.11 is the current recommendation) from:
 
     https://www.python.org/downloads/
 
 Make sure that version of python is in your path:
 
     $ python --version
-    Python 3.10.11
+    Python 3.11.9
 
 Test to make sure that the `python` command now shows your latest python install:
 
     $ python --version
-    Python 3.10.11
+    Python 3.11.9
 
 #### Postgres
 

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -28,7 +28,7 @@ This document is written for system administrators and software developers.
   - Operating system: RHEL version `9`
   - Database: PostgreSQL version `13`
   - Web server: Apache version `2.4.62`
-  - Language: [Python version `3.10`](https://www.python.org/downloads/)
+  - Language: [Python version `3.11`](https://www.python.org/downloads/)
   - Package manager: pip version `25.3`
 
 ## Installation
@@ -40,10 +40,10 @@ Create a `tracebase` user account that belongs to a `tracebase` group that we wi
 
 ### Environment Setup
 
-Ensure you are using Python 3.10, e.g.:
+Ensure you are using Python 3.11, e.g.:
 
     python3 --version
-    # Python 3.10.11
+    # Python 3.11.9
 
 Create a virtual environment (from a Bash shell) in `/usr/local` and activate it, for example:
 


### PR DESCRIPTION
## What

- [GREATS-326](https://princeton-university.atlassian.net/browse/GREATS-326)

Upgrade to Python 3.11.

## Why

Support for Python 3.10 ends this October, meaning after that, there will be no more security patches.

## How

Upped the python version from 3.10 to 3.11.

Details:

- Updated the python version references in the documentation.
- Updated the python version in .github/workflows/tracebase-tests.yml.
- Added tracebase_files to the .gitignore (due to parallel efforts).


## Tests

- CI tests pass
- Once the additional Django and Postgres version updates are done, as described in [GREATS-321](https://princeton-university.atlassian.net/browse/GREATS-321), the verification for v1.0.2 will be rerun in a production-like environment for `release/1_0_2_manuscript`.
- Manual validation steps

Installed Python 3.11.9 locally from https://www.python.org/ftp/python/3.11.9/python-3.11.9-macos11.pkg

```
deactivate
/Library/Frameworks/Python.framework/Versions/3.11/bin/python3  -m venv .venv311
source .venv311/bin/activate
python -m pip install -U pip
python -m pip install -r requirements/dev.txt
python manage.py test --settings=TraceBase.settings.test
```

## Security Concerns

- No data handling concerns
- No authentication/authorization concerns
- Updating to python 3.11 extends support and security patches through October 2027.
- Be aware that macos installers for 3.11 only go through 3.11.9.  The latest is 3.11.15 and must be built from source.

## Others

None