### PR TITLE
Bootstrap 5.3.8 broke site rendering

### DIFF
--- a/DataRepo/templates/base/base.html
+++ b/DataRepo/templates/base/base.html
@@ -11,7 +11,7 @@
         <meta name="viewport" content="width=device-width, initial-scale=1">
 
         <!-- Bootstrap CSS -->
-        <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.8/dist/css/bootstrap.min.css" rel="stylesheet"
+        <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.1.3/dist/css/bootstrap.min.css" rel="stylesheet"
             integrity="sha384-1BmE4kWBq78iYhFldvKuhfTAU6auU8tT94WrHftjDbrCEXSU1oBoqyl2QvZ6jIW3"
             crossorigin="anonymous">
 
@@ -58,7 +58,7 @@
         <script src="https://unpkg.com/tableexport.jquery.plugin/tableExport.min.js"></script>
 
         <!-- Bootstrap JS -->
-        <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.8/dist/js/bootstrap.bundle.min.js"
+        <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.1.3/dist/js/bootstrap.bundle.min.js"
             integrity="sha384-ka7Sk0Gln4gmtz2MlQnikT1wXgYsOg+OMhuP+IlRH9sENBO0LRn5q+8nbTov4+1p"
             crossorigin="anonymous">
         </script>

--- a/DataRepo/templates/base/base.html
+++ b/DataRepo/templates/base/base.html
@@ -11,8 +11,8 @@
         <meta name="viewport" content="width=device-width, initial-scale=1">
 
         <!-- Bootstrap CSS -->
-        <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.1.3/dist/css/bootstrap.min.css" rel="stylesheet"
-            integrity="sha384-1BmE4kWBq78iYhFldvKuhfTAU6auU8tT94WrHftjDbrCEXSU1oBoqyl2QvZ6jIW3"
+        <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet"
+            integrity="sha384-QWTKZyjpPEjISv5WaRU9OFeRpok6YctnYmDr5pNlyT2bRjXh0JMhjY6hW+ALEwIH"
             crossorigin="anonymous">
 
         <!--Font Awesome-->
@@ -58,8 +58,8 @@
         <script src="https://unpkg.com/tableexport.jquery.plugin/tableExport.min.js"></script>
 
         <!-- Bootstrap JS -->
-        <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.1.3/dist/js/bootstrap.bundle.min.js"
-            integrity="sha384-ka7Sk0Gln4gmtz2MlQnikT1wXgYsOg+OMhuP+IlRH9sENBO0LRn5q+8nbTov4+1p"
+        <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"
+            integrity="sha384-YvpcrYf0tY3lHB60NNkmXc5s9fDVZLESaAA55NDzOxhy9GkcIdslK1eN7N6jIeHz"
             crossorigin="anonymous">
         </script>
 


### PR DESCRIPTION
## What

- [GREATS-329](https://princeton-university.atlassian.net/browse/GREATS-329)

Set bootstrap to 5.3.3 and update the integrity hash.

## Why

Bootstrap 5.3.8 broke the site rendering.

<img width="1440" height="1030" alt="image" src="https://github.com/user-attachments/assets/63385bbc-0b3c-416c-81df-ea46b17bb77e" />

## How

Updated bootstrap to 5.3.3 with the correct integrity hash. 
 
5.3.3 is the latest version of bootstrap that is confirmed compatible with bootstrap table version 1.27.3.  There is a newer 5.3.8 version that exists, but is not confirmed to work with BST.

I tested the site manually using runserver and shift-reloading the site.  Rendering was good.

## Tests

- CI tests pass
- The downgrade was verified to work manually on multiple systems.  Cleared the cache and did a hard reload.  Result:

<img width="1440" height="1030" alt="image" src="https://github.com/user-attachments/assets/b76a57eb-694c-4e61-be91-d9fd0d86263b" />

## Security Concerns

- No Data handling concerns
- No Authentication/authorization changes
- The bootstrap dependency is 5.1.3 has 1 more minor version update (5.1.4), but it is broken there too.  Bootstrap 5.1.3 does not contain any direct, published, and patched XSS or core code vulnerabilities in its vulnerability database of record.  The latest is 5.3.8, but a number of variables were changed that break the rendering.  The specific changes that break the rendering should be investigated so that we can get to the latest version.
- No Potential attack surface increase

## Others

Not sure why my initial manual testing didn't cause this rendering issue when I upgraded bootstrap in a previous PR.  I can only guess it was a browser caching issue.