### PR TITLE
Updated postgres from 13 to 15

### DIFF
--- a/.github/workflows/tracebase-tests.yml
+++ b/.github/workflows/tracebase-tests.yml
@@ -17,7 +17,7 @@ jobs:
 
     services:
       postgres:
-        image: postgres:13.4
+        image: postgres:15
         env:
           POSTGRES_USER: postgres
           POSTGRES_PASSWORD: postgres

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -31,11 +31,11 @@ Test to make sure that the `python` command now shows your latest python install
 Install Postgres via package installer from [https://www.postgresql.org](https://www.postgresql.org).  Be sure to make
 note of where it installs the `psql` command-line utility, so you can add it to your PATH, e.g. if you see:
 
-    Command Line Tools Installation Directory: /Library/PostgreSQL/13
+    Command Line Tools Installation Directory: /Library/PostgreSQL/15
 
 Then, add this to your PATH:
 
-    /Library/PostgreSQL/13/bin
+    /Library/PostgreSQL/15/bin
 
 Configuration:
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -56,9 +56,7 @@ Manually create the tracebase database (`tracebase`) in postgres:
 
 Create a tracebase postgres user:
 
-    > create user tracebase with encrypted password 'mypass';
-    > ALTER USER tracebase CREATEDB;
-    > grant all privileges on database tracebase to tracebase;
+    createuser --pwprompt --createdb tracebase
 
 ### Setup the TraceBase project
 

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -26,7 +26,7 @@ This document is written for system administrators and software developers.
   - A mount for the archive whose size corresponds to the lab's current rate of mzXML raw file accumulation is advised.
 - Software Requirements:
   - Operating system: RHEL version `9`
-  - Database: PostgreSQL version `13`
+  - Database: PostgreSQL version `15`
   - Web server: Apache version `2.4.62`
   - Language: [Python version `3.11`](https://www.python.org/downloads/)
   - Package manager: pip version `25.3`

--- a/TraceBase/settings/base.py
+++ b/TraceBase/settings/base.py
@@ -100,7 +100,7 @@ DATABASES = {
         "PORT": env("DATABASE_PORT"),
         # Remove the isolation_level option if your DB does not support IsolationLevel.REPEATABLE_READ.
         "OPTIONS": {
-            # See: https://www.postgresql.org/docs/13/transaction-iso.html#XACT-REPEATABLE-READ
+            # See: https://www.postgresql.org/docs/15/transaction-iso.html#XACT-REPEATABLE-READ
             # NOTE: Django's default isolation_level is READ_COMMITTED.  REPEATABLE_READ is a stricter isolation level.
             # SERIALIZABLE is even stricter still (the highest isolation).  They ostensibly cause concurrent database
             # writes to not block, and if there is a conflict, the winner is the first one to write.  The loser


### PR DESCRIPTION
## What

- [GREATS-313](https://princeton-university.atlassian.net/browse/GREATS-313)

Update postgres from 13.4 to 15.

## Why

Postgres 13.4 is EOL.  No more security patches.

## How

Updated to postgres 15 (from 13.4).

I tested in my sandbox.  I'd already had postgres 15 running.  I just dumped and loaded all the data from 13 into 15 and ran runserver.  I explored the site without issue.  Upon pushing this, loading tests will run.

Details:

- I updated the postgres version from 13.4 to 15.  I decided not to pin a minor version (yet).
- I updated the documentation wherever postgres 13 was called out.

## Tests

- CI/CD pipeline verification
- Manual sandbox tests:

I tested in my sandbox.  I'd already had postgres 15 running.  I just dumped and loaded all the data from 13 into 15 and ran runserver.  I explored the site without issue.

- Manual `tb9-dev` and `tb9-pub` tests:

1. tb9-{dev,pub} were upgraded to Python 3.11, Postgres 15, and Django 5.2
2. virtual environments were rebuilt
3. Cache table was cleared (due to error log reports about Django 4.2 pickled querysets)
4. Fixed 2 bugs (ZeroDivisionError in cached functions and a column switch dropdown issue on adv. srch)
5. Ran the [verification for 1.0.2](https://princeton-university.atlassian.net/wiki/x/UgDMNg) (using tb9-dev for upload and load and tb9-pub for everything else) and it passed

## Security Concerns

- No Data handling concerns
- No Authentication/authorization changes
- Postgres was updated from 13.4 to 15.  I didn't pin a minor version so that security updates will be automatically applied.  PostgreSQL 15 is supported until November 2027.
- No Potential attack surface increase

## Others

None