### PR TITLE
Added the ability to extract scan labels from the beginning of sample names

### DIFF
--- a/.github/linters/.flake8
+++ b/.github/linters/.flake8
@@ -1,4 +1,4 @@
 [flake8]
 max-line-length = 120
-extend-exclude = .venv, migrations, node_modules
+extend-exclude = .venv*, migrations, node_modules, scratch*
 per-file-ignores = TraceBase/settings/*.py:F403,F405

--- a/DataRepo/loaders/msruns_loader.py
+++ b/DataRepo/loaders/msruns_loader.py
@@ -3415,7 +3415,11 @@ class MSRunsLoader(TableLoader):
         pattern = cls.get_scan_pattern(
             scan_patterns=scan_patterns, add_patterns=add_patterns
         )
-        return re.sub(pattern, "", mzxml_basename)
+        # The pattern is applied twice due to the possibility of prepended scan labels,
+        # e.g. "neg-scan2-scan3-sample9-mouse5"
+        # Applied once, it would only result in "scan2-sample9-mouse5"
+        # This is a limitation of re.
+        return re.sub(pattern, "", re.sub(pattern, "", mzxml_basename))
 
     def clean_up_created_mzxmls_in_archive(self):
         """Call this method when rollback did/will happen in order to delete mzXML files added to the archive on disk.

--- a/DataRepo/loaders/msruns_loader.py
+++ b/DataRepo/loaders/msruns_loader.py
@@ -3351,6 +3351,16 @@ class MSRunsLoader(TableLoader):
             r"[\-_]"  # dash or underscore (also removed)
             r"(?=[\-_]|$)"  # followed by dash or underscore or end of string (not removed)
 
+        Examples:
+            pattern = MSRunsLoader.get_scan_pattern(scan_patterns=["pos", "neg", "scan[0-9]+"])
+            re.sub(pattern, "", "sample3_pos_scan25")
+            # -> "sample3"
+            re.sub(pattern, "", "sample5-neg-mouse2")
+            # -> "sample5-mouse2"
+            re.sub(pattern, "", "scan2-sample7")
+            # -> "sample7"
+            re.sub(pattern, "", "neg-sample9-scan3-mouse5")
+            # -> "sample9-mouse5"
         Args:
             scan_patterns (list of regular expression strings)
             add_patterns (boolean): Whether to add the supplied patterns to the defaults or replace them.
@@ -3362,8 +3372,11 @@ class MSRunsLoader(TableLoader):
         delim = cls.DEFAULT_SCAN_DELIM_PATTERN
         scan_labels = cls.DEFAULT_SCAN_LABEL_PATTERNS
 
-        pre_pat = delim
-        post_pat = r"(?=" + delim + r"|$)"
+        pre_pat1 = r"^"
+        post_pat1 = delim
+
+        pre_pat2 = delim
+        post_pat2 = r"(?=" + delim + r"|$)"
 
         if scan_patterns is not None:
             if add_patterns:
@@ -3371,11 +3384,12 @@ class MSRunsLoader(TableLoader):
             else:
                 scan_labels = scan_patterns
 
-        # Examples, if scan_patterns = ["pos", "neg", "scan[0-9]+"]:
-        #   "sample3_pos_scan25" -> "sample3"
-        #   "sample5-neg-mouse2" -> "sample5-mouse2"
         return re.compile(
-            r"(" + "|".join([pre_pat + pat + post_pat for pat in scan_labels]) + r")+"
+            r"("
+            + "|".join([pre_pat2 + pat + post_pat2 for pat in scan_labels])
+            + r"|"
+            + "|".join([pre_pat1 + pat + post_pat1 for pat in scan_labels])
+            + r")+"
         )
 
     @classmethod

--- a/DataRepo/templates/submission/submission.html
+++ b/DataRepo/templates/submission/submission.html
@@ -78,6 +78,10 @@
         <small class="text-muted">
             <br>
             <hr>
+            <i>NOTE: This tool extracts scan labels from sample names (e.g. "-pos", "-neg", "-scan3") in order to associate data from
+            the same biological sample.  This is important to be able to 1. make the Samples sheet represent unique biological
+            samples, and 2. identify multiple representations of compounds per biological sample (i.e. the same compound picked in
+            multiple scans).</i><br><br>
             Feel free to submit data as you generate it.  Your study does not have to be complete for submission.  You can
             iteratively submit <span class="tooltip-hint" text-tooltip="E.g. AccuCor excel file">peak annotation files</span>
             with their metadata described in the <span class="tooltip-hint" text-tooltip="Animal/Sample excel file">study doc</span>,

--- a/DataRepo/tests/loaders/test_msruns_loader.py
+++ b/DataRepo/tests/loaders/test_msruns_loader.py
@@ -311,6 +311,10 @@ class MSRunsLoaderTests(TracebaseTestCase):
         )
         self.assertEqual("mysample_pos", samplename)
 
+    def test_guess_sample_name_default_start(self):
+        samplename = MSRunsLoader.guess_sample_name("pos-scan2-His-M3-T08-small-intes")
+        self.assertEqual("His-M3-T08-small-intes", samplename)
+
     def test_leftover_mzxml_files_exist_true(self):
         """Tests that leftover_mzxml_files_exist finds the existence of un-added mzXML files (i.e. those that were not
         described in the infile because they weren't used in the production of a peak annotation file).

--- a/DataRepo/tests/loaders/test_msruns_loader.py
+++ b/DataRepo/tests/loaders/test_msruns_loader.py
@@ -1836,15 +1836,16 @@ class MSRunsLoaderTests(TracebaseTestCase):
         sp1 = MSRunsLoader.get_scan_pattern()
         self.assertEqual(
             re.compile(
-                "([\\-_]pos(?=[\\-_]|$)|[\\-_]neg(?=[\\-_]|$)|[\\-_]scan[0-9]+(?=[\\-_]|$))+"
+                "([\\-_]pos(?=[\\-_]|$)|[\\-_]neg(?=[\\-_]|$)|[\\-_]scan[0-9]+(?=[\\-_]|$)|"
+                "^pos[\\-_]|^neg[\\-_]|^scan[0-9]+[\\-_])+"
             ),
             sp1,
         )
         sp2 = MSRunsLoader.get_scan_pattern(scan_patterns=["positive"])
         self.assertEqual(
             re.compile(
-                "([\\-_]pos(?=[\\-_]|$)|[\\-_]neg(?=[\\-_]|$)|[\\-_]scan[0-9]+(?=[\\-_]|$)|[\\-_]positive(?=[\\-_]|"
-                "$))+"
+                "([\\-_]pos(?=[\\-_]|$)|[\\-_]neg(?=[\\-_]|$)|[\\-_]scan[0-9]+(?=[\\-_]|$)|[\\-_]positive(?=[\\-_]|$)|"
+                "^pos[\\-_]|^neg[\\-_]|^scan[0-9]+[\\-_]|^positive[\\-_])+"
             ),
             sp2,
         )
@@ -1852,7 +1853,10 @@ class MSRunsLoaderTests(TracebaseTestCase):
             scan_patterns=["positive", "negative"], add_patterns=False
         )
         self.assertEqual(
-            re.compile("([\\-_]positive(?=[\\-_]|$)|[\\-_]negative(?=[\\-_]|$))+"), sp3
+            re.compile(
+                "([\\-_]positive(?=[\\-_]|$)|[\\-_]negative(?=[\\-_]|$)|^positive[\\-_]|^negative[\\-_])+"
+            ),
+            sp3,
         )
 
     # NOTE: check_reassign_peak_groups is tested indirectly by the test_get_or_create_msrun_sample_from_row_* tests


### PR DESCRIPTION
## What

- [GREATS-335](https://princeton-university.atlassian.net/browse/GREATS-335)

On the upload start page, add the ability to remove prepended scan labels from sample names if they are not in the middle or end of the sample.

## Why

On the upload start page, peak annotation files are scanned for samples and compounds to create a template study doc, with as much data automatically filled in as possible.  It also looks for multiple representations of compounds for the same sample (the same compound picked for the same sample from multiple peak annotation files).  To accomplish this, it must remove scan labels, e.g.: -pos, -neg, -scan2, -scan3, etc. in order to be able to tell when 2 different scans are of the same biological sample.  Up until now, all scan labels have been either internal or at the end of a sample name.  When a sample name starts with the scan label, the label is not removed.  This means that multiple representations cannot be identified and creates a bunch of manual, error-prone work for the researcher building the submission.

## How

Accounted for the possibility that scan labels can occur at the beginning of the sample name.

## Tests

- Unit tests added/updated
- CI tests pass
- Manual validation steps:

```
In [1]: from DataRepo.loaders.msruns_loader import MSRunsLoader

In [2]: pattern = MSRunsLoader.get_scan_pattern()

In [6]: print(re.sub(pattern, "", "sample3_pos_scan25"))
   ...: print(re.sub(pattern, "", "sample5-neg-mouse2"))
   ...: print(re.sub(pattern, "", "scan2-sample7"))
   ...: print(re.sub(pattern, "", "neg-sample9-scan3-mouse5"))
sample3
sample5-mouse2
sample7
sample9-mouse5
```

## Security Concerns

- Data handling: scan patterns cannot be input by the user to `get_scan_pattern`, so no possibility of code injection introduced.
- No Authentication/authorization changes
- No Dependencies or third-party libraries introduced
- No Potential attack surface increase

## Others

None