### PR TITLE
Added a TESTING environment variable to `prod.py` statically set to `False`

### DIFF
--- a/TraceBase/settings/prod.py
+++ b/TraceBase/settings/prod.py
@@ -4,9 +4,10 @@ from .base import *
 # SECURITY WARNING: keep the secret key used in production secret!
 SECRET_KEY = env("SECRET_KEY")
 
-# NOTE: Explicitly forcing these debug environment variables to false *after* importing from base.  They cannot be
+# NOTE: Explicitly forcing these debug/test environment variables to false *after* importing from base.  They cannot be
 # overridden by the values set in .env.  This is a security issue.
 DEBUG = False
 SQL_LOGGING = False
 DEBUG_TOOLBAR_ENABLED = False
 DEBUG_TOOLBAR = False
+TESTING = False


### PR DESCRIPTION
## What

- [GREATS-351](https://princeton-university.atlassian.net/browse/GREATS-351)

Add a missing/expected environment variable.

## Why

Downloading an mzXML zip from the advanced search was resulting in a 500 error.

## How

Added a TESTING environment variable to prod.py statically set to False.

## Tests

- CI passes
- Production like testing:

- Searched for peak groups where MZ Data Filename has a value
- Searched for a single sample name (to reduce the number of files)
- Clicked the mzXMLs download button

The files download after this PR change.

## Security Concerns

- No Data handling concerns
- No Authentication/authorization changes
- No Dependencies or third-party libraries introduced
- No Potential attack surface increase
- There is 1 more environment variable (`TESTING`) statically set to False and cannot be changed via the `.env` file, which improves security

## Others

None