### PR TITLE
Fixed Uncaught AutoFill exception Daniel Encountered

### DIFF
--- a/.github/linters/.flake8
+++ b/.github/linters/.flake8
@@ -1,4 +1,4 @@
 [flake8]
 max-line-length = 120
-extend-exclude = .venv, migrations, node_modules
+extend-exclude = .venv*, migrations, node_modules, scratch*
 per-file-ignores = TraceBase/settings/*.py:F403,F405

--- a/DataRepo/tests/utils/test_exceptions.py
+++ b/DataRepo/tests/utils/test_exceptions.py
@@ -367,6 +367,7 @@ class MultiLoadStatusTests(TracebaseTestCase):
         self.assertFalse(mls.statuses["mykey"]["top"])
 
     def test_merge(self):
+        """Test that MultiLoadStatus.merge can merge the statuses from the supplied MultiLoadStatus object."""
         mls1 = MultiLoadStatus(["mykey1"])
         mls2 = MultiLoadStatus(["mykey2"])
         mls1.merge(mls2)

--- a/DataRepo/tests/utils/test_exceptions.py
+++ b/DataRepo/tests/utils/test_exceptions.py
@@ -366,6 +366,13 @@ class MultiLoadStatusTests(TracebaseTestCase):
         self.assertIsNone(mls.statuses["mykey"]["aggregated_errors"])
         self.assertFalse(mls.statuses["mykey"]["top"])
 
+    def test_merge(self):
+        mls1 = MultiLoadStatus(["mykey1"])
+        mls2 = MultiLoadStatus(["mykey2"])
+        mls1.merge(mls2)
+        self.assertEqual(set(["mykey1", "mykey2"]), set(mls1.statuses.keys()))
+        self.assertEqual(set(["mykey2"]), set(mls2.statuses.keys()))
+
 
 class AggregatedErrorsTests(TracebaseTestCase):
     def test_merge_aggregated_errors_object(self):

--- a/DataRepo/tests/views/upload/test_submission.py
+++ b/DataRepo/tests/views/upload/test_submission.py
@@ -1173,7 +1173,7 @@ class BuildSubmissionViewTests2(TracebaseTransactionTestCase):
         af2key = "accucor2.xlsx"
 
         # Test the get_validation_results function
-        # This call indirectly tests that ValidationView.validate_stody returns a MultiLoadStatus object on success
+        # This call indirectly tests that ValidationView.validate_study returns a MultiLoadStatus object on success
         # It also indirectly ensures that create_yaml(dir) puts a loading.yaml file in the dir
         vo = BuildSubmissionView()
         vo.load_status_data.set_load_exception(

--- a/DataRepo/tests/views/upload/test_submission.py
+++ b/DataRepo/tests/views/upload/test_submission.py
@@ -2,6 +2,7 @@ import base64
 import os
 from copy import deepcopy
 from io import BytesIO
+from typing import List
 
 from django.core.exceptions import PermissionDenied
 from django.core.management import call_command
@@ -1383,22 +1384,28 @@ class BuildSubmissionViewTests2(TracebaseTransactionTestCase):
 
         self.assertFalse(valid)
 
-    def validate_some_files(self, vo: BuildSubmissionView, sample_file, accucor_files):
+    def validate_some_files(
+        self,
+        bld_sbmn: BuildSubmissionView,
+        study_file: str,
+        peak_annot_files: List[str],
+    ):
+        """Validate a study submission and format and return the results."""
         # Test the get_validation_results function
-        vo.set_files(study_file=sample_file, peak_annot_files=accucor_files)
+        bld_sbmn.set_files(study_file=study_file, peak_annot_files=peak_annot_files)
         # Now try validating the load files
-        vo.validate_study()
-        vo.format_results_for_template()
-        valid = vo.valid
-        results = vo.results
-        exceptions = vo.exceptions
+        bld_sbmn.validate_study()
+        bld_sbmn.format_results_for_template()
+        valid = bld_sbmn.valid
+        results = bld_sbmn.results
+        exceptions = bld_sbmn.exceptions
 
         file_keys = []
-        file_keys.append(os.path.basename(sample_file))
-        for afile in accucor_files:
+        file_keys.append(os.path.basename(study_file))
+        for afile in peak_annot_files:
             file_keys.append(os.path.basename(afile))
 
-        for file_key in [os.path.basename(f) for f in [sample_file, *accucor_files]]:
+        for file_key in [os.path.basename(f) for f in [study_file, *peak_annot_files]]:
             self.assertIn(file_key, results)
             self.assertIn(file_key, exceptions)
 

--- a/DataRepo/tests/views/upload/test_submission.py
+++ b/DataRepo/tests/views/upload/test_submission.py
@@ -1142,7 +1142,8 @@ class BuildSubmissionViewTests2(TracebaseTransactionTestCase):
         # Test the get_validation_results function
         # This call indirectly tests that ValidationView.validate_stody returns a MultiLoadStatus object on success
         # It also indirectly ensures that create_yaml(dir) puts a loading.yaml file in the dir
-        [results, valid, exceptions, _, _] = self.validate_some_files(sf, afs)
+        vo = BuildSubmissionView()
+        [results, valid, exceptions, _, _] = self.validate_some_files(vo, sf, afs)
 
         # There is a researcher named "anonymous", but that name is ignored
         self.assertTrue(
@@ -1153,6 +1154,42 @@ class BuildSubmissionViewTests2(TracebaseTransactionTestCase):
         # researchers named "anonymous" (case-insensitive)
         self.assertEqual("PASSED", results[sfkey])
         self.assertEqual(0, len(exceptions[sfkey]))
+
+        # Check the accucor file details
+        self.assert_accucor_files_pass([af1key, af2key], results, exceptions)
+
+    def test_validate_good_files_with_autofill_warnings(self):
+        """Assert that any exceptions present before validating the study are preserved."""
+        # Files/inputs we will test
+        sf = "DataRepo/data/tests/data_submission/animal_sample_good_v3.xlsx"
+        afs = [
+            "DataRepo/data/tests/data_submission/accucor1.xlsx",
+            "DataRepo/data/tests/data_submission/accucor2.xlsx",
+        ]
+
+        sfkey = "animal_sample_good_v3.xlsx"
+        af1key = "accucor1.xlsx"
+        af2key = "accucor2.xlsx"
+
+        # Test the get_validation_results function
+        # This call indirectly tests that ValidationView.validate_stody returns a MultiLoadStatus object on success
+        # It also indirectly ensures that create_yaml(dir) puts a loading.yaml file in the dir
+        vo = BuildSubmissionView()
+        vo.load_status_data.set_load_exception(
+            ValueError("Test"), sfkey, default_is_error=False
+        )
+        [results, valid, exceptions, _, _] = self.validate_some_files(vo, sf, afs)
+
+        # There is a researcher named "anonymous", but that name is ignored
+        self.assertFalse(
+            valid, msg=f"There should be 1 value error in '{sfkey}': {exceptions}"
+        )
+
+        # The sample file's researcher is "Anonymous" and it's not in the database, but the researcher check ignores
+        # researchers named "anonymous" (case-insensitive)
+        self.assertEqual("WARNING", results[sfkey])
+        self.assertEqual(1, len(exceptions[sfkey]))
+        self.assertEqual(exceptions[sfkey][0]["type"], "ValueError")
 
         # Check the accucor file details
         self.assert_accucor_files_pass([af1key, af2key], results, exceptions)
@@ -1187,13 +1224,14 @@ class BuildSubmissionViewTests2(TracebaseTransactionTestCase):
         af2key = "accucor2.xlsx"
 
         # Test the get_validation_results function
+        vo = BuildSubmissionView()
         [
             results,
             valid,
             exceptions,
             num_errors,
             num_warnings,
-        ] = self.validate_some_files(sf, afs)
+        ] = self.validate_some_files(vo, sf, afs)
 
         # NOTE: When the unknown researcher error is raised, the sample table load would normally be rolled back.  The
         # subsequent accucor load would then fail (to find any more errors), because it can't find the same names in
@@ -1242,13 +1280,14 @@ class BuildSubmissionViewTests2(TracebaseTransactionTestCase):
             "DataRepo/data/tests/data_submission/accucor2.xlsx",
         ]
 
+        vo = BuildSubmissionView()
         [
             _,
             valid,
             _,
             _,
             _,
-        ] = self.validate_some_files(sample_file, accucor_files)
+        ] = self.validate_some_files(vo, sample_file, accucor_files)
 
         # Test case is for passing data, so it only works if it passes
         self.assertTrue(valid)
@@ -1281,13 +1320,14 @@ class BuildSubmissionViewTests2(TracebaseTransactionTestCase):
         ]
         sfkey = "small_obob_animal_and_sample_table.xlsx"
         afkey = "small_obob_maven_6eaas_inf_req_prefix.xlsx"
+        vo = BuildSubmissionView()
         [
             results,
             valid,
             exceptions,
             num_errors,
             num_warnings,
-        ] = self.validate_some_files(sample_file, accucor_files)
+        ] = self.validate_some_files(vo, sample_file, accucor_files)
 
         # Sample file should be OK.  It's loaded first.
         self.assertTrue(sfkey in results)
@@ -1343,9 +1383,8 @@ class BuildSubmissionViewTests2(TracebaseTransactionTestCase):
 
         self.assertFalse(valid)
 
-    def validate_some_files(self, sample_file, accucor_files):
+    def validate_some_files(self, vo: BuildSubmissionView, sample_file, accucor_files):
         # Test the get_validation_results function
-        vo = BuildSubmissionView()
         vo.set_files(study_file=sample_file, peak_annot_files=accucor_files)
         # Now try validating the load files
         vo.validate_study()

--- a/DataRepo/utils/exceptions.py
+++ b/DataRepo/utils/exceptions.py
@@ -1786,6 +1786,28 @@ class MultiLoadStatus(Exception):
                     load_key,
                 )
 
+    def merge(self, instance: MultiLoadStatus):
+        """Merge the statuses from the supplied MultiLoadStatus object into this object.
+
+        Args:
+            instance (MultiLoadStatus): An existing MultiLoadStatus object
+        Exceptions:
+            None
+        Returns:
+            None
+        """
+        for load_key in instance.statuses.keys():
+            self.update_load(load_key)
+        for load_key in instance.statuses.keys():
+            if (
+                instance.statuses[load_key]["aggregated_errors"] is not None
+                and len(instance.statuses[load_key]["aggregated_errors"].exceptions) > 0
+            ):
+                self.set_load_exception(
+                    instance.statuses[load_key]["aggregated_errors"],
+                    load_key,
+                )
+
 
 class AggregatedErrorsSet(Exception):
     """Contains multiple AggregatedErrors exceptions in a dict keyed on a string.  The string is arbitrary, but is

--- a/DataRepo/utils/exceptions.py
+++ b/DataRepo/utils/exceptions.py
@@ -1797,16 +1797,16 @@ class MultiLoadStatus(Exception):
             None
         """
         for load_key in instance.statuses.keys():
+            # This initializes the MultiLoadStatus object for the load_key if the load_key is not already present
             self.update_load(load_key)
-        for load_key in instance.statuses.keys():
-            if (
-                instance.statuses[load_key]["aggregated_errors"] is not None
-                and len(instance.statuses[load_key]["aggregated_errors"].exceptions) > 0
-            ):
-                self.set_load_exception(
-                    instance.statuses[load_key]["aggregated_errors"],
-                    load_key,
-                )
+
+            # If the supplied MultiLoadStatus object has exceptions, record them in this object, to merge with any pre-
+            # existing errors for that load key
+            inst_agg_errs: AggregatedErrors = instance.statuses[load_key][
+                "aggregated_errors"
+            ]
+            if inst_agg_errs is not None and len(inst_agg_errs.exceptions) > 0:
+                self.set_load_exception(inst_agg_errs, load_key)
 
 
 class AggregatedErrorsSet(Exception):

--- a/DataRepo/views/upload/submission.py
+++ b/DataRepo/views/upload/submission.py
@@ -955,6 +955,29 @@ class BuildSubmissionView(FormView):
         return study_data
 
     def init_row_group_nums(self):
+        """This validates the row group numbers in the Infusates and Tracers sheets and ensures their type is int.
+
+        It then initializes the next ID for each sheet, in order to be able to add a new tracer/infusate and not
+        duplicate an ID (in self.next_infusate_row_group_num and self.next_tracer_row_group_num).
+
+        These 2 sheets (Infusates and Tracers) are the only sheets where an entry (an infusate or a tracer) can span
+        multiple rows.  It is the IDs that identify the rows that define and individual tracer or infusate.
+
+        NOTE: The values in the ID columns in each sheet are determined by excel formulas, but this ensures users have
+        not manually messed them up.
+
+        Args:
+            None
+        Exceptions:
+            Buffered:
+                AutoFillError - If a pandas type causes a ValueError in the cast to int, this can affect the IDs of the
+                    coming auto-fill rows, as tracers and infusates matching the formulas in the peak annotation files
+                    are added for convenient selection in the Animals sheet dropdown for infusate.
+            Raised:
+                None
+        Returns:
+            None
+        """
         inf_row_group_nums = []
         bad_inf_row_group_nums = []
         # We need to get the next available infusates sheet row group number
@@ -3663,4 +3686,7 @@ class BuildSubmissionView(FormView):
 
 
 class AutoFillError(InfileError):
+    """A generalized error that has to do with a problem with auto-fill of the study doc and links the error to the
+    offending input file location (via InfileError)."""
+
     pass

--- a/DataRepo/views/upload/submission.py
+++ b/DataRepo/views/upload/submission.py
@@ -59,15 +59,16 @@ from DataRepo.utils.exceptions import (
     AllMissingTreatments,
     DuplicatePeakAnnotationFileName,
     FileFromInputNotFound,
+    InfileError,
     InvalidDtypeDict,
     InvalidPeakAnnotationFileFormat,
     InvalidStudyDocVersion,
-    IsotopeParsingError,
     MissingDataAdded,
     MultiLoadStatus,
     MultiplePeakAnnotationFileFormats,
     MultipleStudyDocVersions,
     NoSamples,
+    ParsingError,
     UnknownPeakAnnotationFileFormat,
     UnknownStudyDocVersion,
 )
@@ -866,7 +867,9 @@ class BuildSubmissionView(FormView):
         elif mode == "validate":
             page = "Validate"
         else:
-            raise ProgrammingError(f"Invalid mode: {mode}")
+            raise ProgrammingError(
+                f"Invalid mode: {mode}.  Try force-reloading the page to clear the cache."
+            )
 
         # We need a new regular form (not a formset)
         form_class = self.get_form_class()
@@ -928,8 +931,6 @@ class BuildSubmissionView(FormView):
                 retain_as_warnings=not self.autofill_only_mode,
             )
 
-        self.format_results_for_template()
-
         self.add_extracted_autofill_data()
 
         self.add_dynamic_dropdown_data()
@@ -948,29 +949,80 @@ class BuildSubmissionView(FormView):
 
         study_data = base64.b64encode(study_stream.read()).decode("utf-8")
 
+        # Some of the above methods can buffer errors/warnings, so we process those results last
+        self.format_results_for_template()
+
         return study_data
 
     def init_row_group_nums(self):
+        inf_row_group_nums = []
+        bad_inf_row_group_nums = []
         # We need to get the next available infusates sheet row group number
-        inf_row_group_nums = [
-            int(i)
-            for i in self.dfs_dict[InfusatesLoader.DataSheetName][
+        for row_index, i in enumerate(
+            self.dfs_dict[InfusatesLoader.DataSheetName][
                 InfusatesLoader.DataHeaders.ID
             ].values()
-            if i is not None
-        ]
+        ):
+            try:
+                inf_row_group_nums.append(int(i))
+            except ValueError:
+                bad_inf_row_group_nums.append(row_index + 2)
+
+        if len(bad_inf_row_group_nums) > 0:
+            self.load_status_data.set_load_exception(
+                AutoFillError(
+                    "Invalid values encountered in %s.  Must be an integer.",
+                    file=self.study_filename,
+                    sheet=InfusatesLoader.DataSheetName,
+                    column=InfusatesLoader.DataHeaders.ID,
+                    rownum=bad_inf_row_group_nums,
+                    suggestion=(
+                        "Note, this is an auto-fill warning.  The file still may pass validation if there are no other "
+                        "errors."
+                    ),
+                ),
+                self.study_filename,
+                top=False,
+                default_is_error=False,
+                default_is_fatal=True,
+            )
+
         self.next_infusate_row_group_num = 1
         if len(inf_row_group_nums) > 0:
             self.next_infusate_row_group_num = max(inf_row_group_nums) + 1
 
+        trcr_row_group_nums = []
+        bad_trcr_row_group_nums = []
         # We need to get the next available tracers sheet row group number
-        trcr_row_group_nums = [
-            int(i)
-            for i in self.dfs_dict[TracersLoader.DataSheetName][
+        for row_index, i in enumerate(
+            self.dfs_dict[TracersLoader.DataSheetName][
                 TracersLoader.DataHeaders.ID
             ].values()
-            if str(i) not in self.none_vals
-        ]
+        ):
+            try:
+                trcr_row_group_nums.append(int(i))
+            except ValueError:
+                bad_trcr_row_group_nums.append(row_index + 2)
+
+        if len(bad_trcr_row_group_nums) > 0:
+            self.load_status_data.set_load_exception(
+                AutoFillError(
+                    "Invalid values encountered in %s.  Must be an integer.",
+                    file=self.study_filename,
+                    sheet=TracersLoader.DataSheetName,
+                    column=TracersLoader.DataHeaders.ID,
+                    rownum=bad_trcr_row_group_nums,
+                    suggestion=(
+                        "Note, this is an auto-fill warning.  The file still may pass validation if there are no other "
+                        "errors."
+                    ),
+                ),
+                self.study_filename,
+                top=False,
+                default_is_error=False,
+                default_is_fatal=True,
+            )
+
         self.next_tracer_row_group_num = 1
         if len(trcr_row_group_nums) > 0:
             self.next_tracer_row_group_num = max(trcr_row_group_nums) + 1
@@ -2720,27 +2772,38 @@ class BuildSubmissionView(FormView):
 
         # Get all the tracers from the tracers sheet (which is assumed to have already been populated by
         # add_dynamic_dropdown_tracer_data)
-        tracer_names = dict(
-            (name, 0)
-            for name in list(
-                self.dfs_dict[TracersLoader.DataSheetName][
-                    TracersLoader.DataHeaders.NAME
-                ].values()
-            )
-        )
+        tracer_names = defaultdict(list)
+        # We need to get the next available tracers sheet row group number
+        for index, name in enumerate(
+            self.dfs_dict[TracersLoader.DataSheetName][
+                TracersLoader.DataHeaders.NAME
+            ].values()
+        ):
+            tracer_names[str(name)].append(index + 2)
 
         # Create a list of all the tracer record IDs present in the Tracers sheet
         tracer_ids = []
 
-        for tn in tracer_names.keys():
+        for tn, rows in tracer_names.items():
             try:
                 td = parse_tracer_string(tn)
-            except IsotopeParsingError as ipe:
+            except ParsingError as pe:
                 self.load_status_data.set_load_exception(
-                    ipe,
-                    "Autofill Note",
+                    AutoFillError(
+                        f"{type(pe).__name__}: {pe}",
+                        file=self.study_filename,
+                        sheet=TracersLoader.DataSheetName,
+                        column=TracersLoader.DataHeaders.NAME,
+                        rownum=rows,
+                        suggestion=(
+                            "Note, this is an auto-fill warning.  The file still may pass validation if there is no "
+                            "other error."
+                        ),
+                    ),
+                    self.study_filename,
                     top=False,
-                    default_is_error=True,
+                    # This isn't a load error.  It is autofill.  Might pass validation if the row is otherwise empty.
+                    default_is_error=False,
                     default_is_fatal=True,
                 )
                 continue
@@ -3277,7 +3340,7 @@ class BuildSubmissionView(FormView):
         except MultiLoadStatus as mls:
             load_status_data = mls
 
-        self.load_status_data = load_status_data
+        self.load_status_data.merge(load_status_data)
 
         return dfs_dict
 
@@ -3413,7 +3476,7 @@ class BuildSubmissionView(FormView):
                 self.study_filename, FileFromInputNotFound
             )
 
-        self.load_status_data = load_status_data
+        self.load_status_data.merge(load_status_data)
 
         return self.load_status_data.is_valid
 
@@ -3597,3 +3660,7 @@ class BuildSubmissionView(FormView):
                 ).check_dataframe_headers()
             )
         )
+
+
+class AutoFillError(InfileError):
+    pass

--- a/DataRepo/views/upload/submission.py
+++ b/DataRepo/views/upload/submission.py
@@ -981,7 +981,7 @@ class BuildSubmissionView(FormView):
                         "errors."
                     ),
                 ),
-                self.study_filename,
+                "Autofill Note",
                 top=False,
                 default_is_error=False,
                 default_is_fatal=True,
@@ -1017,7 +1017,7 @@ class BuildSubmissionView(FormView):
                         "errors."
                     ),
                 ),
-                self.study_filename,
+                "Autofill Note",
                 top=False,
                 default_is_error=False,
                 default_is_fatal=True,
@@ -2800,7 +2800,7 @@ class BuildSubmissionView(FormView):
                             "other error."
                         ),
                     ),
-                    self.study_filename,
+                    "Autofill Note",
                     top=False,
                     # This isn't a load error.  It is autofill.  Might pass validation if the row is otherwise empty.
                     default_is_error=False,


### PR DESCRIPTION
## What

- [GREATS-330](https://princeton-university.atlassian.net/browse/GREATS-330)

1. Buffer a warning for any Tracer/Infusate IDs that cannot be cast to an int.
2. Buffer a warning for Tracer/Infusate names that cannot be parsed during autofill operations.

Summary of review comments carried over from PR #1763:

- Added missing docstrings to new helper methods.
- Improved variable naming and type annotations for clarity and consistency (including replacing abbreviated variable names such as `vo` with more descriptive names).
- Removed a redundant duplicate loop in the validation logic to simplify the implementation and improve readability.

## Why

Server 500 error when either the infusates or tracers sheets have empty rows containing invalid formula results for the name column.

## How

These changes were already reviewed once by Rachid and his requested changes were implemented, however, since it was decided that this bug, which had a work-around, should be in the manuscript release branch, I have cherry picked the 4 commits from branch `dev/literal_int_empty_str_exc` and applied them to a new branch off the manuscript release branch: `dev/literal_int_empty_str_exc_manuscript`.  Thus, this PR supplants #1763.

The following commits were cherry-picked from the original branch:

- `cffb925c`
- `6f2c0197`
- `32a339f2`
- `38903d8e`

There was one minor cherry-pick conflict involving an import that is not needed in the 1.0.2 codebase. No functional code changes were made during conflict resolution or after the cherry-pick.

Aside from the different branch base, this PR is functionally equivalent to PR #1763.

For the specific implementation details...

Fixed an uncovered edge case involving auto-fill for tracers and infusates.

The autofill code was assuming the Tracer/Infusate ID columns were valid and that the Tracer name column in the infusates sheet was valid, but if a user pasted a formula column past the last row, an uncaught exception occurred from the ID when it tried to cast and empty string as an int and a parsing error would occur from the tracer name column.

Details:

- Created an AutoFillError class.
- Created MultiLoadStatus.merge (to update 1 MLS object with another).
- Updated the parsing errors to refer to the file location of the offending data.
- Moved the call to format_results_for_template to under the method calls that can add autofill errors.
- Added a suggestion to the ProgrammingError about "Invalid mode".
- Modified validate_some_files so that it doesn't create the BuildSubmissionView object, so I could test that AutoFill errors are preserved.
- Added the ignore of tracebase_files.  (This has been added in multiple branches.)
- Put the AutoFillErrors in the Autofill Note section/check.

## Tests

- Unit tests added/updated
- CI tests pass
- Manual validation steps
  - Ran Daniel's file (attached to GREATS-330) both with and without the errant rows deleted
    - Warnings are added.  See screenshot.  Note the AutoFillErrors were not present before, once the exception was caught and handled.  I'd had to fix some code that was overwriting the autofill warnings.  This screenshot reflects changes since review.

<img width="1223" height="682" alt="fixed_uncaught_autofill" src="https://github.com/user-attachments/assets/cd4c716a-304e-4435-b893-fe6add09f27f" />

## Security Concerns

- No data handling concerns
- No authentication/authorization changes
- No dependencies or third-party libraries introduced
- No potential attack surface increase

## Others

None