### PR TITLE
Fixed an issue preventing the Django Debug Toolbar from showing up.

### DIFF
--- a/TraceBase/settings/dev.py
+++ b/TraceBase/settings/dev.py
@@ -69,7 +69,7 @@ if DEBUG_TOOLBAR is True:
         # On the dev site, you need to run `python manage.py collectstatic` to be able to use the toolbar
         # NOTE: Running collectstatic puts the aggregated static files in tracebase/static.  After running it, (which
         # you should only need to do once), run `mv TraceBase/static static`.
-        PROJECT_DIR = os.path.dirname(os.path.abspath(__file__))
+        PROJECT_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
         STATIC_ROOT = os.path.join(PROJECT_DIR, "static")
 
         DEBUG_TOOLBAR_ENABLED = True

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -27,4 +27,5 @@ mkdocs-roamlinks-plugin>=0.1.3
 types-python-dateutil>=2.9.0.20240316
 
 # Tool for debugging
-django-debug-toolbar>=5.0.1
+# NOTE: Version 7.x has a javascript error.  See: https://github.com/django-commons/django-debug-toolbar/issues/2400
+django-debug-toolbar>=6.1,<7

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -18,7 +18,7 @@ yamllint==1.35.1
 types-PyYAML>=6.0.12.12
 
 # For reasonable pylint output on the command line:
-# pylint --rcfile .pylintrc --load-plugins pylint_django --django-settings-module TraceBase.settings -d E1101 ...
+# pylint --rcfile .pylintrc --load-plugins pylint_django --django-settings-module TraceBase.settings.dev -d E1101 ...
 pylint-django>=2.6.1
 
 # MKDocs for building docs
@@ -27,5 +27,5 @@ mkdocs-roamlinks-plugin>=0.1.3
 types-python-dateutil>=2.9.0.20240316
 
 # Tool for debugging
-# NOTE: Version 7.x has a javascript error.  See: https://github.com/django-commons/django-debug-toolbar/issues/2400
-django-debug-toolbar>=6.1,<7
+# NOTE: Clear browser cache if the JavaScript console shows "Uncaught TypeError: Cannot read properties of null (reading 'dataset')"
+django-debug-toolbar>=5.0.1


### PR DESCRIPTION
## What

- [GREATS-358](https://princeton-university.atlassian.net/browse/GREATS-358)

The dev site does not show the Django Debug Toolbar when enabled.

## Why

Note there is no DjDT flag on the right side of the window.

There is an error in the JavaScript console:

```
Uncaught TypeError: Cannot read properties of null (reading 'dataset')
at Object.init (toolbar.js:23:42)
```

## How

Fixed an issue preventing the Django Debug Toolbar from showing up.

Details:

- After the settings split, the PROJECT_DIR setting was wrong.  It ended in the settings folder.  So I just called dirname on it again, since that settings file had moved a level deeper.
- Added a comment in the dev requirements about clearing browser cache.

## Tests

- Manual validation steps:
  - Deployed branch on `tb9-dev`.
  - `sudo apachectl graceful`
  - Cleared browser cache
  - Loaded the main page and the DjDT flag appeared on the right side of the window
- CI tests pass

## Security Concerns

- No Data handling concerns (dev site in debug mode only)
- No Authentication/authorization changes
- Downgraded the django-debug-toolbar dependency
- No Potential attack surface increase
- Mitigation: Only enabled in DEBUG mode and only on the dev site.

## Others

None