### PR TITLE
Remove compatibility settings shim

### DIFF
--- a/.github/linters/.python-lint
+++ b/.github/linters/.python-lint
@@ -82,6 +82,9 @@ limit-inference-results=100
 
 # List of plugins (as comma separated values of python module names) to load,
 # usually to register additional checkers.
+# NOTE: This was commented out in commit a03b8ab because the new superlinter disallows `pip install`, which means that
+# the pylint_django plugin cannot be used, but if you wish to use it locally, uncomment this and other django-commented
+# lines.
 # load-plugins=pylint_django
 
 # Pickle collected data for later comparisons.
@@ -751,5 +754,8 @@ init-import=no
 # builtins.
 redefining-builtins-modules=six.moves,past.builtins,future.builtins
 
+# NOTE: This was commented out in commit a03b8ab because the new superlinter disallows `pip install`, which means that
+# the pylint_django plugin cannot be used, but if you wish to use it locally, uncomment these and other django-commented
+# lines.
 # [DJANGO]
 # django-settings-module=TraceBase.settings.dev

--- a/.github/linters/.python-lint
+++ b/.github/linters/.python-lint
@@ -752,4 +752,4 @@ init-import=no
 redefining-builtins-modules=six.moves,past.builtins,future.builtins
 
 # [DJANGO]
-# django-settings-module=TraceBase.settings
+# django-settings-module=TraceBase.settings.dev

--- a/DataRepo/urls.py
+++ b/DataRepo/urls.py
@@ -1,7 +1,5 @@
 from django.urls import path
 
-from DataRepo.views.nav import settings_test
-
 from .views import (
     AdvancedSearchDownloadMzxmlZIPView,
     AdvancedSearchDownloadView,
@@ -156,7 +154,4 @@ urlpatterns = [
         InfusateDetailView.as_view(),
         name=InfusateDetailView.model.detail_name,
     ),
-    # TODO: Remove this and its imports after verifying the removal of the settings compatibility shim.  GREATS-304.
-    # E.g. Go to http://127.0.0.1:8000/DataRepo/settings-test/
-    path("settings-test/", settings_test, name="settings_test"),
 ]

--- a/DataRepo/urls.py
+++ b/DataRepo/urls.py
@@ -1,5 +1,7 @@
 from django.urls import path
 
+from DataRepo.views.nav import settings_test
+
 from .views import (
     AdvancedSearchDownloadMzxmlZIPView,
     AdvancedSearchDownloadView,
@@ -154,4 +156,7 @@ urlpatterns = [
         InfusateDetailView.as_view(),
         name=InfusateDetailView.model.detail_name,
     ),
+    # TODO: Remove this and its imports after verifying the removal of the settings compatibility shim.  GREATS-304.
+    # E.g. Go to http://127.0.0.1:8000/DataRepo/settings-test/
+    path("settings-test/", settings_test, name="settings_test"),
 ]

--- a/DataRepo/views/nav.py
+++ b/DataRepo/views/nav.py
@@ -1,4 +1,7 @@
+import os
+
 from django.conf import settings
+from django.http import HttpResponse
 from django.shortcuts import render
 from django.urls import reverse
 
@@ -127,3 +130,7 @@ def home(request):
         context["leaderboards"] = Researcher.leaderboard_data()
 
     return render(request, "home/base.html", context)
+
+# TODO: Remove this and its imports after verifying the removal of the settings compatibility shim.  Issue GREATS-304.
+def settings_test(request):
+    return HttpResponse(os.environ.get("DJANGO_SETTINGS_MODULE"))

--- a/DataRepo/views/nav.py
+++ b/DataRepo/views/nav.py
@@ -1,7 +1,4 @@
-import os
-
 from django.conf import settings
-from django.http import HttpResponse
 from django.shortcuts import render
 from django.urls import reverse
 
@@ -130,7 +127,3 @@ def home(request):
         context["leaderboards"] = Researcher.leaderboard_data()
 
     return render(request, "home/base.html", context)
-
-# TODO: Remove this and its imports after verifying the removal of the settings compatibility shim.  Issue GREATS-304.
-def settings_test(request):
-    return HttpResponse(os.environ.get("DJANGO_SETTINGS_MODULE"))

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -259,24 +259,29 @@ Note:
 **WARNING: DO NOT apply this development setting on a production site or any site accessible to the public, as it is a**
 **security risk.**
 
-In addition to the above steps, if a development server is desired using apache/nginx, `DJANGO_SETTINGS_MODULE` must be
-set as a system environment variable with the value `TraceBase.settings.dev`.  NOTE: This only works if all virtual
-hosts on that machine use this same setting.  Also, using `SetEnv` in the virtual host settings will not work.  This is
-how we set the environment variable for apache at Princeton:
+In addition to the above steps, if a development server is desired using Apache, `DJANGO_SETTINGS_MODULE` must be set as
+a system environment variable with the value `TraceBase.settings.dev`.
 
-    vi /lib/systemd/system/httpd.service
+> **Note:** This configuration affects the entire Apache service, so it is only appropriate if all virtual hosts hosted
+> by that Apache instance should use the development settings.
 
-Change/add this setting to the file:
+Create a `systemd` override for the Apache service:
+
+    sudo systemctl edit httpd
+
+Add the following to the override file:
 
     [Service]
     Environment="DJANGO_SETTINGS_MODULE=TraceBase.settings.dev"
 
-Then restart apache.
+Then reload the `systemd` configuration and restart Apache:
 
-Doing this provides access to the Django Debug Toolbar and a few debug messages (notably in the advanced search).
+    sudo systemctl daemon-reload
+    sudo systemctl restart httpd
 
-NOTE: There is no need to set `DJANGO_SETTINGS_MODULE` on any production server.  It's default is
-`TraceBase.settings.prod`.
+This configuration enables the Django Debug Toolbar and additional debugging output (notably in the Advanced Search).
+
+Note: There is no need to set `DJANGO_SETTINGS_MODULE` on a production server. The default is `TraceBase.settings.prod`.
 
 ## Authorization and Security
 

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -4,11 +4,11 @@
 
 ### Overview
 
-This document will walk you through setting up your own private instance of TraceBase for the private use of an entire
+This document will walks through setting up a private instance of TraceBase for the private use of an entire
 metabolomics lab that does tracing experiments.  This document is for installation and configuration only.  Maintaining
 a TraceBase instance (e.g. loading data) is covered in MAINTENANCE.md.  For a local development version of TraceBase
-installed on a workstation (if you want to try it out before going through this for rigorous setup), see our
-`CONTRIBUTING.md` document.
+installed on a workstation (to try it out before going through this for rigorous setup), see our `CONTRIBUTING.md`
+document.
 
 ### Target Audience
 
@@ -40,7 +40,7 @@ Create a `tracebase` user account that belongs to a `tracebase` group that we wi
 
 ### Environment Setup
 
-Ensure you are using Python 3.11, e.g.:
+Ensure Python version 3.11 is active, e.g.:
 
     python3 --version
     # Python 3.11.9
@@ -81,8 +81,7 @@ During installation, use these settings for a postgres user for admin privileges
     Password: ########
     Port: 5432
 
-If you use the same strategy, the `psql` command-line utility will be in the PATH.  Just make sure that the `tracebase`
-user has it in their PATH.
+Ensure the `psql` command-line utility is in the `PATH` for personal and the `tracebase` user accounts.
 
 ### Installing Application Dependencies
 
@@ -98,7 +97,7 @@ Save the file in:
 
     /var/www/
 
-Decompress the download.  E.g., if you download the tarballed gzip file:
+Decompress the download:
 
     tar -zxvf tracebase-v1.0.2.tar.gz
 
@@ -139,7 +138,8 @@ See **TraceBase Setup** below for adding these `tracebase` user credentials to t
 
 ### TraceBase Setup
 
-Ensure you are the `tracebase` user, the environment is activated, and that you are in the repository directory:
+Ensure the `tracebase` user is active, the environment is activated, and that the current directory is the repository
+directory:
 
     sudo -iu tracebase
     source /usr/local/tracebase/bin/activate
@@ -156,14 +156,15 @@ Create a secret token for secure API access.  This will be saved in the `.env` f
 Update the `.env` file to:
 
 - Add the new `SECRET_KEY` that was just generated above.
-- Add the `tracebase` user database credentials you used in the **Postgres Setup** section.
+- Add the `tracebase` user database credentials used in the **Postgres Setup** section.
 - Set `DEBUG` to `False`
 - Set the `ARCHIVE` location (must match the `alias` in the **Apache Setup** section).
 
 Each lab must have their own way of submitting large amounts of study data (the study doc, peak annotation files, and
 mzXML raw files).  The following `SUBMISSION` environment variables must be defined and a shared drive (not managed by
 TraceBase) must be set up for lab members to deposite their submission data.  This is where administrators will go to
-retrieve data for loading.  The environment variables are for your own internal documentation for drive access.
+retrieve data for loading.  The environment variables are used for access on the Upload Submit page and for internal
+documentation for drive access.
 
 - `SUBMISSION_DRIVE_DOC_URL` - A URL to documentation about access to the shared drive where submissions are deposited.
 - `SUBMISSION_DRIVE_TYPE` - This is a display name for the drive, e.g. "MS Data Shre", for display of the doc URL.
@@ -175,12 +176,12 @@ submission interface.
 
 The submission process is described in
 [the user documentation](https://princeton-lsi-researchcomputing.github.io/tracebase/Upload/How%20to%20Build%20a%20Submission/4%20-%20How%20to%20Submit%20Data/),
-however since each setup is different, the TraceBase
-codebase does not provide a study submission form.  You must create one and save it in this environment variable:
+however since each setup is different, the TraceBase codebase does not provide a study submission form.  An
+administrator must create one and save it in this environment variable:
 
 - `SUBMISSION_FORM_URL`
 
-You can do so by creating a copy of our
+See our
 [example google submission form](https://docs.google.com/forms/d/1XBTUwweS0cEhsBoVxgu7aSAUsypeW4xay93jHGnPznk/copy).
 
 #### TraceBase Database Migration
@@ -225,7 +226,7 @@ The following is an example `/etc/httpd/conf.d/tracebase.conf` file:
         WSGIDaemonProcess tracebase processes=2 threads=4 display-name=tracebase python-home=/usr/local/tracebase python-path=/var/www/tracebase
         WSGIProcessGroup tracebase
         WSGIScriptAlias / /var/www/tracebase/TraceBase/wsgi.py
-        # If you are using CAS for authentication for a private TraceBase instance
+        # If using CAS for authentication for a private TraceBase instance
         # <Location />
         #     AuthType CAS
         #     CASScope /
@@ -246,8 +247,8 @@ The following is an example `/etc/httpd/conf.d/tracebase.conf` file:
 
 Note:
 
-- This creates an alias for the archive, which should be independent of any other tracebase instances (if you intend to
-  run a public instance for sharing data).
+- This creates an alias for the archive, which should be independent of any other tracebase instances (if a public
+  instance for sharing data is desired).
   - Be sure that the ARCHIVE_DIR variable in `/var/www/tracebase/.env` matches the alias.
 - This creates an `alias` to match the `/var/www/tracebase/static` directory.
 - This sets the gateway timeout to match what's in the `.env` file.  This allows the software to end gracefully if
@@ -258,10 +259,10 @@ Note:
 **WARNING: DO NOT apply this development setting on a production site or any site accessible to the public, as it is a**
 **security risk.**
 
-In addition to the above steps, if you want to set up a development server using apache/nginx, `DJANGO_SETTINGS_MODULE`
-must be set as a system environment variable to `TraceBase.settings.dev`.  Note: this only works if all virtual hosts on
-that machine use this same setting.  Also note: Using `SetEnv` in the virtual host settings will not work.  This is how
-we set the environment variable for apache at Princeton:
+In addition to the above steps, if a development server is desired using apache/nginx, `DJANGO_SETTINGS_MODULE` must be
+set as a system environment variable with the value `TraceBase.settings.dev`.  NOTE: This only works if all virtual
+hosts on that machine use this same setting.  Also, using `SetEnv` in the virtual host settings will not work.  This is
+how we set the environment variable for apache at Princeton:
 
     vi /lib/systemd/system/httpd.service
 
@@ -270,11 +271,11 @@ Change/add this setting to the file:
     [Service]
     Environment="DJANGO_SETTINGS_MODULE=TraceBase.settings.dev"
 
-The restart apache.
+Then restart apache.
 
-Doing this gives you access to the Django Debug Toolbar and a few debug messages (notably in the advanced search).
+Doing this provides access to the Django Debug Toolbar and a few debug messages (notably in the advanced search).
 
-NOTE: You do not need to set `DJANGO_SETTINGS_MODULE` on any production server.  It's default is
+NOTE: There is no need to set `DJANGO_SETTINGS_MODULE` on any production server.  It's default is
 `TraceBase.settings.prod`.
 
 ## Authorization and Security
@@ -286,7 +287,7 @@ NOTE: You do not need to set `DJANGO_SETTINGS_MODULE` on any production server. 
 TraceBase does not provide differential public versus private access.  To "publish" any study data, a separate public
 instance of TraceBase must be created that must be separately loaded with the studies that have been selected to be
 "public"/published.  To create a public instance, follow these installation instructions, but do not apply any
-authentication mechanism.  It is also recommended that you set the `READONLY` environment variable in `.env` to True.
+authentication mechanism.  It is also recommended to set the `READONLY` environment variable in `.env` to True.
 
 NOTE: Retain copies of submitted study docs and all associated data for this purpose.
 
@@ -302,7 +303,8 @@ Add superusers for admin access.  This allows select lab users to login to the a
 each TraceBase page.  This is a limited interface that is yet to be fully featured and contains currently, only the
 ability to edit Compound records.
 
-You can create multiple admin users, each with this command, which will prompt for a username, email, and password:
+It is possible to create multiple admin users, each with this command, which will prompt for a username, email, and
+password:
 
     python manage.py createsuperuser
 
@@ -315,7 +317,7 @@ Verify the installation by checking the Django version:
     python3 -m django --version
     5.2.15
 
-You can check your environment to ensure it is set up securely using the following command:
+Check the environment to ensure it is set up securely using the following command:
 
     python manage.py check --deploy
 
@@ -336,8 +338,8 @@ regularly.
         sudo -iu tracebase
         cd /var/www/
 
-2. As tracebase user, download, decompress, and replace the tracebase directory, copying in the `.env` file.  (This
-   assumes you have not modified the TraceBase codebase and that the archive is not under `/var/www/tracebase`.)
+2. As the tracebase user; download, decompress, and replace the tracebase directory, copying in the `.env` file.  (This
+   assumes that the TraceBase codebase has not been modified and that the archive is not under `/var/www/tracebase`.)
 
         mv tracebase tracebase-old
         tar -zxvf tracebase-vX.X.X.tar.gz
@@ -357,13 +359,13 @@ regularly.
         diff --side-by-side .env .env.example
         vi .env
 
-8. Check the deployment for security issues.
+6. Check the deployment for security issues.
 
         python manage.py check --deploy
 
-9. Restart the web server.
+7. Restart the web server.
 
-        exit  # logout of sudo tracebase to your user account
+        exit  # Logout of the tracebase user account to a regular user account
         sudo apachectl graceful
 
 ### Load Supporting Data
@@ -382,9 +384,9 @@ All available fixtures are located in `DataRepo/fixtures`.
 
 Some of the other supporting data, such as compounds, tissues, and animal treatments tend to vary from lap to lab.  Many
 researchers have their prefered compound names, for example, so we do not provide fixtures for this data, but compiling
-that data can be a time consuming endeavor.  If you would like to get a jump start on this data resource, you can
-download that data from [tracebase.princeton.edu](http://tracebase.princeton.edu), format it for the Study doc format,
-and put it in a 3-sheet study doc (Compounds, Tissues, and Treatments) named `underlying_data.xlsx` and load it into
-your tracebase instance with:
+that data can be a time consuming endeavor.  To get a jump start on this data resource, download the data from
+[tracebase.princeton.edu](http://tracebase.princeton.edu), format it for the Study doc format, and put it in a 3-sheet
+study doc (Compounds, Tissues, and Treatments) named `underlying_data.xlsx` and load it into the tracebase instance
+with:
 
     python manage.py load_study --invile underlying_data.xlsx

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -252,9 +252,30 @@ Note:
 - This creates an `alias` to match the `/var/www/tracebase/static` directory.
 - This sets the gateway timeout to match what's in the `.env` file.  This allows the software to end gracefully if
   submission processing takes too long.
-- If you want to set up a development server using apache/nginx, `DJANGO_SETTINGS_MODULE` must be set as a system
-  environment variable to "`TraceBase.settings.dev`", but this only works if all virtual hosts on that machine use this
-  same setting.  Using `SetEnv` in the virtual host settings will not work.
+
+### Optional Development Server Apache Setup
+
+**WARNING: DO NOT apply this development setting on a production site or any site accessible to the public, as it is a**
+**security risk.**
+
+In addition to the above steps, if you want to set up a development server using apache/nginx, `DJANGO_SETTINGS_MODULE`
+must be set as a system environment variable to `TraceBase.settings.dev`.  Note: this only works if all virtual hosts on
+that machine use this same setting.  Also note: Using `SetEnv` in the virtual host settings will not work.  This is how
+we set the environment variable for apache at Princeton:
+
+    vi /lib/systemd/system/httpd.service
+
+Change/add this setting to the file:
+
+    [Service]
+    Environment="DJANGO_SETTINGS_MODULE=TraceBase.settings.dev"
+
+The restart apache.
+
+Doing this gives you access to the Django Debug Toolbar and a few debug messages (notably in the advanced search).
+
+NOTE: You do not need to set `DJANGO_SETTINGS_MODULE` on any production server.  It's default is
+`TraceBase.settings.prod`.
 
 ## Authorization and Security
 

--- a/TraceBase/settings/__init__.py
+++ b/TraceBase/settings/__init__.py
@@ -1,6 +1,0 @@
-from .dev import *  # noqa: F401
-
-# TODO: The import from .dev is temporary.  See ticket: https://princeton-university.atlassian.net/browse/GREATS-304 for
-# the plan for its removal.  The import is a backward-compatibility shim.  It makes it possible for the dev site to work
-# while remaining compatible with old branches.  I.e. Both old and new branches can work on the dev site in DEBUG mode
-# by setting DJANGO_SETTINGS_MODULE in the system environment settings that apache picks up and passes to wsgi.py.

--- a/TraceBase/settings/base.py
+++ b/TraceBase/settings/base.py
@@ -221,9 +221,3 @@ CACHES: Dict[str, Dict[str, object]] = {
         "KEY_PREFIX": "PROD",
     }
 }
-
-# For backward compatibility with older branches...  This gets overwritten in prod.py.  The development site must have
-# `SetEnv DJANGO_SETTINGS_MODULE TraceBase.settings.dev` in the httpd.service settings (See INSTALL.md, Optional
-# Development Server Apache Setup), but do not put it in the production site's httpd.service settings (so it defaults to
-# prod).
-DEBUG = True

--- a/TraceBase/settings/base.py
+++ b/TraceBase/settings/base.py
@@ -223,6 +223,7 @@ CACHES: Dict[str, Dict[str, object]] = {
 }
 
 # For backward compatibility with older branches...  This gets overwritten in prod.py.  The development site must have
-# `SetEnv DJANGO_SETTINGS_MODULE TraceBase.settings`. in the virtual host settings, but do not put it in the production
-# site's virtual host settings (so it defaults to prod).
+# `SetEnv DJANGO_SETTINGS_MODULE TraceBase.settings.dev` in the httpd.service settings (See INSTALL.md, Optional
+# Development Server Apache Setup), but do not put it in the production site's httpd.service settings (so it defaults to
+# prod).
 DEBUG = True

--- a/TraceBase/settings/test.py
+++ b/TraceBase/settings/test.py
@@ -63,3 +63,5 @@ elif CACHES_SETTING != "PROD_CACHES":
 # https://docs.djangoproject.com/en/5.2/topics/testing/advanced/#using-different-testing-frameworks
 # NOTE: This is implicitly used by TraceBase/runner.py
 TEST_RUNNER = "TraceBase.runner.TraceBaseTestSuiteRunner"
+
+TESTING = True

--- a/TraceBase/tests/settings/test_base.py
+++ b/TraceBase/tests/settings/test_base.py
@@ -1,0 +1,13 @@
+import importlib
+import unittest
+
+
+class TestBaseSettings(unittest.TestCase):
+    def test_import(self):
+        """Tests that base can be imported."""
+        importlib.import_module("TraceBase.settings.base")
+
+    def test_secret_key_not_defined(self):
+        """Tests that using TraceBase.settings.base will fail because it does not have a secret key."""
+        base = importlib.import_module("TraceBase.settings.base")
+        self.assertFalse(hasattr(base, "SECRET_KEY"))

--- a/TraceBase/tests/settings/test_dev.py
+++ b/TraceBase/tests/settings/test_dev.py
@@ -9,13 +9,11 @@ class TestDevSettings(unittest.TestCase):
             "TraceBase.settings.dev",
             "DEBUG",
             "SQL_LOGGING",
-            "DEBUG_TOOLBAR_ENABLED",
             "DEBUG_TOOLBAR",
             "TESTING",
             env_overrides={
                 "DEBUG": "True",
                 "SQL_LOGGING": "True",
-                "DEBUG_TOOLBAR_ENABLED": "True",
                 "DEBUG_TOOLBAR": "True",
                 "TESTING": "True",  # Cannot override
             },
@@ -23,6 +21,5 @@ class TestDevSettings(unittest.TestCase):
 
         self.assertTrue(settings["DEBUG"])
         self.assertTrue(settings["SQL_LOGGING"])
-        self.assertTrue(settings["DEBUG_TOOLBAR_ENABLED"])
         self.assertTrue(settings["DEBUG_TOOLBAR"])
         self.assertFalse(settings["TESTING"])

--- a/TraceBase/tests/settings/test_dev.py
+++ b/TraceBase/tests/settings/test_dev.py
@@ -1,0 +1,28 @@
+import unittest
+
+from .utils import get_setting_values
+
+
+class TestDevSettings(unittest.TestCase):
+    def test_debug_is_true(self):
+        settings = get_setting_values(
+            "TraceBase.settings.dev",
+            "DEBUG",
+            "SQL_LOGGING",
+            "DEBUG_TOOLBAR_ENABLED",
+            "DEBUG_TOOLBAR",
+            "TESTING",
+            env_overrides={
+                "DEBUG": "True",
+                "SQL_LOGGING": "True",
+                "DEBUG_TOOLBAR_ENABLED": "True",
+                "DEBUG_TOOLBAR": "True",
+                "TESTING": "True",  # Cannot override
+            },
+        )
+
+        self.assertTrue(settings["DEBUG"])
+        self.assertTrue(settings["SQL_LOGGING"])
+        self.assertTrue(settings["DEBUG_TOOLBAR_ENABLED"])
+        self.assertTrue(settings["DEBUG_TOOLBAR"])
+        self.assertFalse(settings["TESTING"])

--- a/TraceBase/tests/settings/test_prod.py
+++ b/TraceBase/tests/settings/test_prod.py
@@ -1,0 +1,29 @@
+import unittest
+
+from .utils import get_setting_values
+
+
+class TestProdSettings(unittest.TestCase):
+    def test_debug_vars_false(self):
+        """Ensures that the debug variables cannot be turned on in production."""
+        settings = get_setting_values(
+            "TraceBase.settings.prod",
+            "DEBUG",
+            "SQL_LOGGING",
+            "DEBUG_TOOLBAR_ENABLED",
+            "DEBUG_TOOLBAR",
+            "TESTING",
+            env_overrides={
+                "DEBUG": "true",
+                "SQL_LOGGING": "true",
+                "DEBUG_TOOLBAR_ENABLED": "true",
+                "DEBUG_TOOLBAR": "true",
+                "TESTING": "true",
+            },
+        )
+
+        self.assertFalse(settings["DEBUG"])
+        self.assertFalse(settings["SQL_LOGGING"])
+        self.assertFalse(settings["DEBUG_TOOLBAR_ENABLED"])
+        self.assertFalse(settings["DEBUG_TOOLBAR"])
+        self.assertFalse(settings["TESTING"])

--- a/TraceBase/tests/settings/test_test.py
+++ b/TraceBase/tests/settings/test_test.py
@@ -20,7 +20,7 @@ class TestTestSettings(unittest.TestCase):
         settings = get_setting_values(
             "TraceBase.settings.test",
             "CACHES_SETTING",
-            env_overrides={"CACHES_SETTING": "PROD_CACHES"},
+            env_overrides={"CACHES": "PROD_CACHES"},
         )
 
         self.assertEqual(

--- a/TraceBase/tests/settings/test_test.py
+++ b/TraceBase/tests/settings/test_test.py
@@ -1,0 +1,48 @@
+import unittest
+
+from .utils import get_setting_values
+
+
+class TestTestSettings(unittest.TestCase):
+    def test_installed_apps(self):
+        """Tests that "DataRepo.tests.apps.test_apps.LoaderTestConfig" was added to the installed apps."""
+        settings = get_setting_values(
+            "TraceBase.settings.test",
+            "INSTALLED_APPS",
+        )
+
+        self.assertIn(
+            "DataRepo.tests.apps.test_apps.LoaderTestConfig",
+            settings["INSTALLED_APPS"],
+        )
+
+    def test_caches_setting(self):
+        settings = get_setting_values(
+            "TraceBase.settings.test",
+            "CACHES_SETTING",
+            env_overrides={"CACHES_SETTING": "PROD_CACHES"},
+        )
+
+        self.assertEqual(
+            "PROD_CACHES",
+            settings["CACHES_SETTING"],
+        )
+
+    def test_test_env_variables_present(self):
+        settings = get_setting_values(
+            "TraceBase.settings.test",
+            "TEST_MEDIA_ROOT",
+            "TEST_STORAGES",
+            "TEST_FILE_STORAGES",
+            "TEST_CACHES",
+            "TEST_RUNNER",
+            "TESTING",
+            env_overrides={"TESTING": "false"},  # Cannot override
+        )
+
+        self.assertIn("TEST_MEDIA_ROOT", settings)
+        self.assertIn("TEST_STORAGES", settings)
+        self.assertIn("TEST_FILE_STORAGES", settings)
+        self.assertIn("TEST_CACHES", settings)
+        self.assertIn("TEST_RUNNER", settings)
+        self.assertTrue(settings["TESTING"])

--- a/TraceBase/tests/settings/utils.py
+++ b/TraceBase/tests/settings/utils.py
@@ -43,7 +43,7 @@ print(json.dumps({{
         [sys.executable, "-c", python_code],
         cwd=REPO_ROOT,
         env=env,
-        check=True,
+        check=False,
         capture_output=True,
         text=True,
     )

--- a/TraceBase/tests/settings/utils.py
+++ b/TraceBase/tests/settings/utils.py
@@ -25,6 +25,10 @@ def get_setting_values(
     env = os.environ.copy()
     env["DJANGO_SETTINGS_MODULE"] = settings_module
 
+    # Provide a dummy SECRET_KEY so production settings can be imported during tests and so that GitHub Actions using
+    # TraceBase.settings.test won't fail.
+    env.setdefault("SECRET_KEY", "test-secret-key")
+
     if env_overrides:
         env.update(env_overrides)
 
@@ -43,7 +47,7 @@ print(json.dumps({{
         [sys.executable, "-c", python_code],
         cwd=REPO_ROOT,
         env=env,
-        check=False,
+        check=False,  # Only false for tests - otherwise, we cannot get STDERR output for debugging
         capture_output=True,
         text=True,
     )

--- a/TraceBase/tests/settings/utils.py
+++ b/TraceBase/tests/settings/utils.py
@@ -1,0 +1,54 @@
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+from typing import Dict, Optional
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+
+
+def get_setting_values(
+    settings_module, *setting_names, env_overrides: Optional[Dict[str, str]] = None
+):
+    """Start a fresh Django process using the requested settings module and return the requested settings as a dict.
+
+    Args:
+        settings_module (str): E.g. 'TraceBase.settings.prod'
+        setting_names (List[str]): The environment variables to return in the dict.
+        env_overrides (Optional[Dict[str, str]]): E.g. {'DEBUG': True}
+    Exceptions:
+        RuntimeError - If the settings module fails to load.
+    Returns:
+        (dict): The environment variable names and their values.
+    """
+    env = os.environ.copy()
+    env["DJANGO_SETTINGS_MODULE"] = settings_module
+
+    if env_overrides:
+        env.update(env_overrides)
+
+    # The '!r' in '{setting_names!r}' puts quotes around the values
+    python_code = f"""
+import json
+from django.conf import settings
+
+print(json.dumps({{
+    name: getattr(settings, name)
+    for name in {setting_names!r}
+}}, default=str))
+"""
+
+    result = subprocess.run(
+        [sys.executable, "-c", python_code],
+        cwd=REPO_ROOT,
+        env=env,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+    if result.returncode != 0:
+        raise RuntimeError(result.stderr)
+
+    return json.loads(result.stdout)

--- a/TraceBase/tests/test_asgi.py
+++ b/TraceBase/tests/test_asgi.py
@@ -1,0 +1,20 @@
+from pathlib import Path
+
+from django.test import SimpleTestCase
+
+
+class TestASGI(SimpleTestCase):
+    def test_uses_prod_settings(self):
+        asgi = Path(__file__).resolve().parents[2] / "TraceBase" / "asgi.py"
+
+        source = asgi.read_text()
+
+        self.assertIn(
+            '"TraceBase.settings.prod"',
+            source,
+        )
+
+        self.assertNotIn(
+            '"TraceBase.settings"',
+            source,
+        )

--- a/TraceBase/tests/test_manage.py
+++ b/TraceBase/tests/test_manage.py
@@ -1,0 +1,20 @@
+from pathlib import Path
+
+from django.test import SimpleTestCase
+
+
+class TestManage(SimpleTestCase):
+    def test_uses_dev_settings(self):
+        manage = Path(__file__).resolve().parents[2] / "manage.py"
+
+        source = manage.read_text()
+
+        self.assertIn(
+            '"TraceBase.settings.dev"',
+            source,
+        )
+
+        self.assertNotIn(
+            '"TraceBase.settings"',
+            source,
+        )

--- a/TraceBase/tests/test_wsgi.py
+++ b/TraceBase/tests/test_wsgi.py
@@ -1,0 +1,20 @@
+from pathlib import Path
+
+from django.test import SimpleTestCase
+
+
+class TestWSGI(SimpleTestCase):
+    def test_uses_prod_settings(self):
+        wsgi = Path(__file__).resolve().parents[2] / "TraceBase" / "wsgi.py"
+
+        source = wsgi.read_text()
+
+        self.assertIn(
+            '"TraceBase.settings.prod"',
+            source,
+        )
+
+        self.assertNotIn(
+            '"TraceBase.settings"',
+            source,
+        )

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -18,7 +18,7 @@ yamllint==1.35.1
 types-PyYAML>=6.0.12.12
 
 # For reasonable pylint output on the command line:
-# pylint --rcfile .pylintrc --load-plugins pylint_django --django-settings-module TraceBase.settings -d E1101 ...
+# pylint --rcfile .pylintrc --load-plugins pylint_django --django-settings-module TraceBase.settings.dev -d E1101 ...
 pylint-django>=2.6.1
 
 # MKDocs for building docs


### PR DESCRIPTION
## What

This PR is intended to complete the work started in PR #1744 for ticket [GREATS-293](https://princeton-university.atlassian.net/browse/GREATS-293).

- [GREATS-304](https://princeton-university.atlassian.net/browse/GREATS-304)

Once the settings PR is merged into both the 1.0.2 release branch and `main` and all parallel branches are similarly merged:

- Remove the `TraceBase/.env` symlink on `tb9-dev`
- Empty out `TraceBase/settings/__init__.py`
- Change the `tb9-dev` `DJANGO_SETTINGS_MODULE` environment variable to `TraceBase.settings.dev`
- Restart apache on `tb9-dev`

### Scope Expansion

Based on review items, this PR's scope has expanded to addressing documentation improvements in `INSTALL.md`.

## Why

The settings split and .env move made TraceBase.settings.prod the default settings for security purposes, but parallel branch work does not have a TraceBase/settings/prod.py file, nor a root level .env file.  In order for tb9-dev to work in debug mode when these parallel branches are checked out, the `DJANGO_SETTINGS_MODULE` environment variable had to be set to something that would work in all branches, so it was set to `TraceBase.settings` (which is the old strategy).  And in order to temporarily support that in the split settings branch, `TraceBase/settings/__init__.py` does this: `from .dev import *`.  Also a temporary symlink was made from `TraceBase/.env` to .env (in the root directory) on `tb9-dev`.
Note: the location of the `.env` is deterministic, based on the location of the base settings file using:

```
BASE_DIR = Path(__file__).resolve().parent.parent.parent
ENV_FILE = BASE_DIR / ".env"
```

These settings are not entirely secure.  They defeat the purpose of setting production as the default.
Summary:

- Only `tb9-dev` needs `DJANGO_SETTINGS_MODULE=TraceBase.settings`
- `tb9-dev` cannot use `TraceBase.settings.dev` because checking out other parallel branches would cause the `apachectl restart` command to fail because those branches don't have `TraceBase/settings/dev.py`
- `tb9` and `tb9-pub` do not explicitly set `TraceBase.settings.prod` because that's the default
- The `TraceBase/.env` symlink to `.env` is necessary so that parallel branches, if deployed on `tb9-dev`
  - The symlinks will not be needed on `tb9` and `tb9-pub`
  - The symlink will be removed once the blocking tickets are done

## How

### Code Changes

Removed settings compatibility shim.

Details:

- Emptied the contents of `TraceBase/settings/__init__.py`.
- Added instructions to `INSTALL.md` for the `DJANGO_SETTINGS_MODULE` for setting up a development site.
- Updated mentions of `TraceBase.settings` in comments. 

Added tests for the settings and entry points.

Details:

- Since the settings are already in place when the CI tests run, added a `utils.py` file that uses child processes to run `manage.py`.
- Added the tests under `TraceBase/tests`.
- Removed the overlooked setting of `DEBUG` in `base.py`
- Added checks of the code for the entry points.
- Added a test for the `manage.py` entry point in `TraceBase/tests`.
- Tested settings exclusive to each settings file and ensured they could not be overridden by the `.env` file.
- Added a missing setting for `TESTING` in `test.py`.
- Added a test to check that `base.py` has no secret key setting and will thus fail.

Documentation quality and typo issues addressed.

### Apache environment changes (by Mark):

Execute: sudo systemctl edit httpd
then add:
[Service]
Environment="DJANGO_SETTINGS_MODULE=TraceBase.settings.dev
Then restarted the Apache server.

### Env changes:

Removed the symlink to `../.env`:

```
rm -f TraceBase/.env
```

## Tests

- Added 10 tests for ensuring valid settings are used and that sensitive environment variables are statically set
- Integration tests
- CI tests pass
- Manual validation steps (see subheadings below)

### Manual Test 1

Temporarily added to `DataRepo/views/nav.py`:
```
def settings_test(request):
    return HttpResponse(os.environ.get("DJANGO_SETTINGS_MODULE"))
```

Temporarily added to `DataRepo/urls.py`:
```
    path("settings-test/", settings_test, name="settings_test"),
```

Deployed the branch of `tb9-dev` and went to: http://tracebase-dev.princeton.edu/DataRepo/settings-test/

This is what it showed **before** Mark updated the environment variable:

<img width="1088" height="247" alt="settingstestexample" src="https://github.com/user-attachments/assets/efc6555f-d35a-49d4-9842-2bbeb5db86e6" />

And this is what it showed after:

<img width="1046" height="247" alt="settingstestafter" src="https://github.com/user-attachments/assets/311a7047-6781-4e6e-80ec-2b249e7bc152" />

### Manual Test 2

After Mark updated the environment, I deployed this branch on `tb9-dev` (with the removed shim), I removed the `TraceBase/.env`, restarted apache, and loaded the site's main page.  The page loaded fine, with the yellow/black striped header background.  Had the removed shim have caused a problem, there would have been a 500 error of the header background would have been green.

## Security Concerns

- No Data handling concerns
- No Authentication/authorization changes
- No Dependencies or third-party libraries introduced
- No Potential attack surface increase

## Others

None